### PR TITLE
Docs sweep: working-log asides rewritten as plain current truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ What runs today:
 | | |
 |---|---|
 | **ChonVerb** | An eight-line FDN reverb with ROOM/PLATE/BIG modes, modulated taps, shimmer, a gate, and mid/side width. Voiced by ear, confirmed on hardware. It takes over the three stock FX2 reverb slots, which is where the program space for it came from. |
-| **BongDelay** | A five-mode delay — CLEAN, PITCH (a once-per-repeat harmoniser), FREEZE, TAPE (wow/flutter + saturation) and GRAIN — that routes *into* the reverb over the bus. On hardware since R15; every knob live and audible as of R41 (18 Aug 2026). |
+| **BongDelay** | A five-mode delay — CLEAN, PITCH (a once-per-repeat harmoniser), FREEZE, TAPE (wow/flutter + saturation) and GRAIN — that routes *into* the reverb over the bus. Confirmed on hardware, every knob live and audible. |
 | **The send bus** | All eight tracks feed one shared reverb and one shared delay, across both DSP cores. Both effects are **returns**: a track running one outputs wet only, fed by the other tracks' SEND knobs. This is the part the hardware was not designed to do. |
 
 The reverse-engineering in `docs/` is infrastructure, not the product. It
@@ -34,15 +34,14 @@ cross into the reverb — a route the stock firmware has no path for at all.
 
 The costs are all measured, not estimated:
 
-| resource | per core | state (18 Aug 2026, R41) |
+| resource | per core | state (Aug 2026 build) |
 |---|---|---|
 | Cycles | 4,535/sample | measured ceiling; worst mode fits its core with margin |
 | Program space | 8,192 words | donor region 2,724 words/payload: A 55 free, B 1 free |
 | Delay memory | 65,536 words | 1.49 s per server |
 
-`docs/CHIP.md` carries every one of these numbers with a confidence marker,
-and keeps retracted values next to current ones — knowing what a figure *used
-to be* is how you spot a document that has not caught up.
+`docs/CHIP.md` carries every one of these numbers with a confidence marker —
+measured or inferred, and what would falsify it.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,8 +29,8 @@ audio pipeline.
 
 | Component | Detail | Confidence |
 |---|---|---|
-| CPU | Freescale **ColdFire MCF5445AVR266** (32-bit, big-endian, 266 MHz) | ✓ (board photo, 7 Aug 2026; the earlier "prob. MCF5445x, ~266 MHz" guess was exact) |
-| Audio DSP | Freescale Symphony **DSP56721** (`DSPB56721AG`) — **two** DSP5636x cores, **200 MHz / 200 MIPS each**, no external memory controller | ✓ (board photo, 7 Aug 2026) |
+| CPU | Freescale **ColdFire MCF5445AVR266** (32-bit, big-endian, 266 MHz) | ✓ (board photo) |
+| Audio DSP | Freescale Symphony **DSP56721** (`DSPB56721AG`) — **two** DSP5636x cores, **200 MHz / 200 MIPS each**, no external memory controller | ✓ (board photo) |
 | Storage | **CompactFlash** (FAT16/32), OS and data; boots to DEMO without CF | ✓ (official) |
 | Expansion bus | FlexBus (chip-selects for ATA, DSP, RAM) | ✓ (from the firmware) |
 

--- a/docs/BUS.md
+++ b/docs/BUS.md
@@ -1,67 +1,63 @@
-# Effect bus: shared delay + reverb sends (design, in progress)
+# Effect bus: shared delay + reverb sends
 
-> ❌ **Superseded as the design record, 12 Aug 2026 — see `XBUS.md`.** The
-> sections below predate the cross-core bus (which works, measured), the
-> track↔core measurement (payload A serves tracks 5–8, payload B serves
+> ❌ **`XBUS.md` is the current design record; this document predates it.**
+> The sections below predate the cross-core bus (which works — measured),
+> the track↔core measurement (payload A serves tracks 5–8, payload B serves
 > tracks 1–4 — inverted from what this file assumes), and the FX2-menu
-> framing correction (the donor reverbs were never on the FX1 menu). Kept
-> as history; the stale claims carry dated annotations in place.
+> framing correction (the donor reverbs were never on the FX1 menu, so
+> taking them cost FX1 nothing). Kept as the record of the per-bank bus
+> design; claims that no longer hold are corrected in place.
 
-**Status: both buses and the cross-bus sends are emulator-verified; the
-ColdFire menu has been through two hardware flashes.** Flash 1 found a
-chooser-overdraw bug; flash 2 found the real cause of "no knobs" — the
+**Status: both buses and the cross-bus sends are emulator-verified, and the
+ColdFire menu mechanism is hardware-verified.** (The "not flashed" notes in
+the task ledger below are from the time of writing; the full stack has since
+shipped and been confirmed on hardware — `XBUS.md` carries current status.) Hardware testing surfaced a
+chooser-overdraw bug and the real cause of "no knobs" — the
 descriptor clone was copied from `E` rather than `P = E+0x38`, losing the
 record's last `0x38` bytes and with them the **per-parameter enable
 bitmap** (`P+0x18a`/`P+0x18e`), so every clone declared itself to have no
 parameters. That, a missing selectable `NONE`, and donor defaults that were
 wrong for our algorithms (DARK's `MIX`=0 would have made REVERB SERVER
-silent regardless) are all fixed. See "Hardware test 1" and "Hardware test
-2" below. Third flash pending. `dsp/send_client.asm` (the client),
+silent regardless) are all fixed — see the hardware-test sections
+below. `dsp/send_client.asm` (the client),
 `dsp/reverb_server.asm` (the REVERB server, reusing the existing engine) and
-`dsp/delay_server.asm` (the DELAY server, a new algorithm — task 9) all exist
+`dsp/delay_server.asm` (the DELAY server, a new algorithm) all exist
 and are emulator-verified, individually and together (Mechanism section
 below) — guard-clean, and a value that only exists in the shared bus scratch
 has been shown to reach each server's engine and come back out its own WET
-buffer. Task 10 (cross-bus sends) is also built and verified: REVERB
+buffer. The cross-bus sends are also built and verified: REVERB
 SERVER's dry `→DELAY` send and DELAY SERVER's `→VERB` send both
 land correct, hand-checkable Q1.23 values in the other bus's accumulator
-(⚠️ `→VERB` is WET-ONLY and HARDWIRED as of v3 stage 1, 17 Aug 2026 — the dry
-half and both knobs are gone, and the send now registers in the REVERB count)
-(Cross-bus sends section below). Task 11 (`tools/build_menu.py`) replaces
+(⚠️ the `→VERB` send has since been reworked — wet-only, registering in the
+REVERB count; see `XBUS.md` and `dsp/delay_server.asm` for current behaviour)
+(Cross-bus sends section below). `tools/build_menu.py` replaces
 FX2's chooser with exactly the three entries below, each a fresh cloned
 descriptor under a brand-new id so FX1 is never touched even in the sense of
 shared-descriptor text bleed-through — verified against the real, decompiled
-ColdFire chooser functions (Menu and slot layout section below), not yet
-against the DSP dispatch tables (a separate, not-yet-scoped follow-up). It
+ColdFire chooser functions (Menu and slot layout section below). It
 builds entirely on mechanisms `REVERB.md`, `DSP.md` and `PARAM_PAGES.md`
 already proved out, plus its own now-verified bus plumbing and menu tables —
 this document adds no new reverse-engineering beyond that. Where it leans on
 something still unverified, that's called out.
 
-## Start here (state as of 4 Aug 2026)
+## Start here
 
 **Built and running on hardware.** Three FX2 effects sharing a send bus:
 `ChonVerb`, `BongDelay`, `Send`. Build with `python3 tools/build_bus.py`
 (writes `out/mainos_bus.bin`), check with `python3 tools/verify_menu.py`, then
-wrap and flash per `README.md` §3. Latest flashed image carries `ChonVerb21`
-(5 Aug 2026); `BUILD_TAG` in `tools/build_bus.py` is the source of that number.
-**`ChonVerb22` is built but NOT yet flashed** — the v98 repack below.
-(*Annotation 12 Aug 2026: stale — the unit now runs **R15 (tag 34)**; tags
-35–37 (R16–R18) are built but unflashed. See `PLAN.md`.*)
+wrap and flash per `README.md` §3. `BUILD_TAG` in `tools/build_bus.py` is the
+build number stamped into the effect names.
 
-**What we take from stock, and what we don't (v98).** All three servers pack
-into **PLATE REV + SPRING REV + DARK REV** alone — 2724 contiguous words
-against 2672 of code, 52 free. Those three ids are silenced on FX1; that is
-the whole cost, and it is the trade the project was always making: three
-stock reverbs for a better one.
-(*Annotation 12 Aug 2026: two corrections. Occupancy is now **2,692 used /
-32 free** as of 11 Aug 2026. And the cost never landed on FX1 — the FX1 menu
-never listed PLATE/SPRING/DARK; they are FX2-only, so the whole cost is the
-FX2 menu's three stock reverbs and **FX1 lost nothing**.*)
+**What is taken from stock, and what is not.** All three servers pack
+into **PLATE REV + SPRING REV + DARK REV** alone — 2,724 contiguous words
+(the build report carries the live occupancy). Those three ids are silenced;
+that is the whole cost, and it is the trade the project was always making:
+three stock reverbs for a better one. The cost never lands on FX1 — the FX1
+menu never listed PLATE/SPRING/DARK; they are FX2-only, so the whole cost is
+the FX2 menu's three stock reverbs and **FX1 loses nothing**.
 
-**CHORUS is NOT taken and works normally.** It housed `Send`'s 166 words until
-v98 — collateral rather than a considered trade, since Send fits inside the
-reverb region with room over. Its code is byte-identical to stock and id
+**CHORUS is NOT taken and works normally.** Its code is byte-identical to
+stock and id
 `0x12` keeps its stock dispatch entries, both payloads, asserted at build
 time. Nothing had to be *recovered* to do this: every build starts from a
 pristine `out/raw/section_3_MAIN_OS.bin`, so stock code is only ever
@@ -74,40 +70,35 @@ overwritten on the way out, never destroyed.
 | sources | `dsp/reverb_server.asm`, `dsp/delay_server.asm`, `dsp/send_client.asm` |
 | probes | `dsp/page2_probe.asm`, `dsp/xmem_probe.asm` (diagnostics, `PROBE=1` / `XPROBE=1`) |
 
-**ChonVerb is feature-complete and voiced as of `ChonVerb21` (5 Aug 2026)**:
+**ChonVerb is feature-complete and voiced**:
 32K re-layout, tank headroom, modulated in-loop allpasses, early reflections, a
 MODE select varying six per-mode levers, and a dry/wet law that does not lose
-level as it is turned up — all confirmed on hardware by ear. Per-mode voicing
-is **done** (`VOICING.md` Rounds 1–5); what remains on the reverb is small and
-listed at the end of `REVERB.md`. **BongDelay is still placeholder** — the
-plumbing is verified, the algorithm has never been designed or voiced, and it
-is now the largest open piece of work on the bus.
+level as it is turned up — all confirmed on hardware. Per-mode voicing
+is logged in `VOICING.md`; what remains on the reverb is small and
+listed at the end of `REVERB.md`.
 
 The effect's displayed name carries its build number (`BUILD_TAG` in
-`tools/build_bus.py`) — bump it every time a `.bin` is wrapped. Three debugging
-rounds were lost to not being able to tell which firmware was on the unit.
+`tools/build_bus.py`) — bump it every time a `.bin` is wrapped; otherwise
+there is no way to tell which firmware is on the unit.
 
 Cycle budget is **measured, not guessed** — by `python3 tools/cycle_count.py`,
 which is the only correct way to get it: `tools/dsp_host` CANNOT measure this
-(its `instructions/sample` does not scale with frame count). A full bank
-(reverb + delay + two sends) is **930 of ~1080 cycles/sample — 86% used, 150
-free**, and that is a floor, since the count models no memory-contention
-stalls. (*Annotation 12 Aug 2026: the ~1080 budget is ❌ **retracted** — it
-was never a ceiling. Measured: **4,535 cycles/core**, with 819 cycles of room
-today. See `CHIP.md`.*) Earlier hand counts of 529 and ~700 were both wrong; see `REVERB.md`
-for the correction and for the one large lever that is left. **Re-run the tool
+(its `instructions/sample` does not scale with frame count). Measured:
+**4,535 cycles/core** — see `CHIP.md` for the current figures and headroom.
+(An earlier "~1080 cycles/sample budget" was never a ceiling and is wrong;
+hand counts of 529 and ~700 were also wrong — see `REVERB.md`
+for the correction.) **Re-run the tool
 after any change to a sample loop.**
 
-**Read before touching parameters:** `DSP.md` §9 (page-2 slot mapping, measured
-— two earlier guesses were wrong and cost flashes) and `PARAM_PAGES.md` §5e
-(the five tables, and the P-vs-E descriptor trap that cost two more).
+**Read before touching parameters:** `DSP.md` §9 (page-2 slot mapping,
+measured — plausible guesses at it are wrong) and `PARAM_PAGES.md` §5e
+(the five tables, and the P-vs-E descriptor trap).
 
-**Constraints that are settled, don't re-chase them:** 32,768 words per server
-is the memory ceiling (`DSP.md` §7c, probed); 12 parameters per effect, six
-page-1 knobs plus three page-2 knobs and three page-2 selects (`DSP.md` §9).
-(*Annotation 12 Aug 2026: the 32,768-word ceiling is ❌ **retracted** — since
-the XBUS split each server has **65,536 shared-window words = 1.49 s**
-(X/Y/P alias there; `CHIP.md`, alias probe build 27).*)
+**Constraints that are settled, don't re-chase them:** each server's memory
+ceiling is **65,536 shared-window words = 1.49 s** (X/Y/P alias in the shared
+window — `CHIP.md`; an earlier 32,768-word ceiling predates the XBUS split);
+12 parameters per effect, six page-1 knobs plus six page-2 controls
+(`DSP.md` §9).
 
 ## Motivation
 
@@ -130,21 +121,16 @@ runs. Building a literal pre-effect bus would mean patching the ColdFire
 frame builder that assembles audio for the DSP — a much bigger reverse-
 engineering project than the reverb itself, and out of scope here.
 
-**The two DSPs are also a hard boundary, not a soft one.** Tracks 1–4 are
-physically wired to chip A, tracks 5–8 to chip B (`ARCHITECTURE.md` §6,
-`DSP.md`'s boot sequence)
-(*Annotation 12 Aug 2026: ❌ retracted on both counts. The mapping is
-**inverted** — measured 10 Aug 2026 via the MrkVerb32 marker flash, payload
-A serves **tracks 5–8** and payload B serves **tracks 1–4**. And the "hard
-boundary" premise is retracted: the cross-core bus **works** — cross-core
-accumulators measured; see `XBUS.md`.*) — separate chips, separate DMA/host-port channels.
-The "shared" external 64K SRAM isn't a bridge between them either: it's
-partitioned in half at build time, one half per payload. Nothing found so far
-suggests the two chips exchange audio with each other in real time. So
-whatever gets built here is **scoped per bank of four tracks (1–4, 5–8),
-independently — not a single global 8-track bus.** A true unified bus would
-need to solve real-time inter-chip communication, an open unknown, not a
-known-but-unexplored lever like the ones below.
+**The two DSPs looked like a hard boundary, and are not.** Each bank of four
+tracks is wired to its own chip — payload A serves **tracks 5–8**, payload B
+serves **tracks 1–4** (measured via a marker flash; note the inversion from
+older assumptions) — separate chips, separate DMA/host-port channels, and the
+shared 64K SRAM window partitioned in half at build time, one half per
+payload. The design below therefore scoped the bus **per bank of four
+tracks, independently — not a single global 8-track bus**. ❌ That premise no
+longer holds for the shipped firmware: the cross-core bus **works** —
+cross-core accumulators measured; see `XBUS.md`. The per-bank design below
+is kept as the record of the underlying mechanism.
 
 ## The mechanism: fake a bus inside the per-track dispatch
 
@@ -481,14 +467,13 @@ exact `0x0dc000` Q1.23 product as before (dry 0.125 × level 0.859375 ×
 (page 1's last slot, already safe by the general page-1-is-always-straight
 rule, no class question at all) — unchanged by this task.
 
-**Built and verified, task 13 (`tools/build_bus.py`). Not flashed.** The
-three servers' own DSP code is now actually placed in P memory and
-dispatched, both payloads:
+**Built and verified, task 13 (`tools/build_bus.py`).** The three servers'
+own DSP code is placed in P memory and dispatched, both payloads:
 
-**Superseded by v98 — the table below is the original per-donor placement and
-is kept for the reasoning, not the addresses.** All three now pack into one
-region, PLATE+SPRING+DARK, and CHORUS is given back; see "What we take from
-stock" in *Start here*, and `tools/build_bus.py`'s docstring for the layout.
+**The table below is the original per-donor placement, kept for the
+reasoning, not the addresses.** All three now pack into one region,
+PLATE+SPRING+DARK, and CHORUS is given back; see "What we take from stock"
+in *Start here*, and `tools/build_bus.py`'s docstring for the layout.
 
 | entry | id | P-code donor | budget |
 |---|---|---|---|
@@ -520,9 +505,8 @@ deliberate departure from the currently-shipped reverb build, which
 repoints SPRING/DARK's *own* ids at the new engine. That's fine there
 because nothing else offers those ids once the three-entry menu replaces
 the whole FX2 chooser — but FX1's chooser is untouched and can still select
-CHORUS, PLATE REV, SPRING REV or DARK REV by name (*Correction 12 Aug 2026:
-the FX1 menu **never listed** PLATE/SPRING/DARK — CHORUS yes, but the reverb
-donors are FX2-only, so only CHORUS could ever be selected there*), and if
+CHORUS by name (of the donor-adjacent effects only CHORUS is in FX1's menu —
+PLATE/SPRING/DARK are FX2-only and were never listed there), and if
 their dispatch
 pointed at our servers, selecting one on FX1 would run the same
 hardcoded-Y-base engine a second, uncontrolled time on whatever track holds
@@ -809,7 +793,7 @@ two servers should split the whole bank's pool evenly — 32,768 words
 (~744 ms) each — rather than leaving two slots' worth of memory unused.
 This is `REVERB.md`'s "lever 2" ("4 large: 2 × 32K per DSP").
 
-**Originally planned as a `X:0x255` allocator-table edit; superseded.**
+**An `X:0x255` allocator-table edit was considered and rejected.**
 Dumping the real table from both stock payloads (`tools/dsp_modmap.py
 --dumpmem`) confirmed `DSP.md` §11's model exactly: FX2 instance *k* always
 lands on table entry `1 + 2k`, which is **fixed by track position**, not by
@@ -849,10 +833,10 @@ the address doesn't move with the table, not a bug.
 **Decision: don't touch `X:0x255` at all.** Instead each server hardcodes
 its own fixed absolute Y base — `REVERB SERVER` always `Y:0x4000` (32K,
 spans `0x4000–0xBFFF`), `DELAY SERVER` always `Y:0x30000` (payload A) /
-`Y:0x38000` (payload B) (32K in the shared window — ~~external~~ ❌ retracted,
-`CHIP.md` §: there is no external memory and it is **zero wait states as X or
-Y**) — the same technique pre-v22
-single-instance builds used, instead of reading `x:0x213`/`x:(r4)`. This
+`Y:0x38000` (payload B) (32K in the shared window — there is no external
+memory; it is **zero wait states as X or Y**, `CHIP.md`) — the same
+technique earlier single-instance builds used, instead of reading
+`x:0x213`/`x:(r4)`. This
 reuses a proven pattern rather than opening new ground, and it restores true
 track independence: whichever physical track's *real* table entry legitimately
 overlaps one of these fixed bases is never a problem, because that track can
@@ -968,11 +952,10 @@ ACC-write addressing needed for the dry sends already existed.
   id-change-triggers-init behavior) — the outgoing server's tail stops
   abruptly, the incoming one starts cold. This already happens today
   swapping any effect on any track; not a new failure mode.
-- **Bank-scoped, not instrument-wide.** Two independent bus pairs (1–4,
-  5–8), not one shared across all 8 tracks. A track on one bank can never
-  reach the other bank's buses. (*Annotation 12 Aug 2026: ❌ retracted —
-  the cross-core bus (XBUS) works, cross-core accumulators measured; see
-  `XBUS.md`.*)
+- **Bank-scoped in this original design** — two independent bus pairs
+  (1–4, 5–8), not one shared across all 8 tracks. The cross-core bus has
+  since removed that limit: cross-core accumulators are measured working —
+  see `XBUS.md`.
 - **Two full algorithms sharing one chip's cycle budget is unmeasured.**
   Three of four reverb instances collapsing into cheap send stubs frees a
   lot of headroom, but "should have room" isn't "measured has room" —
@@ -988,8 +971,6 @@ ACC-write addressing needed for the dry sends already existed.
   measuring this specific case.
 
 ## The FX1 slot, and what it is not
-
-Established 5 Aug 2026, mostly by correcting a wrong framing of my own.
 
 **Every track has two independent slots.** FX1 and FX2 each have their own menu,
 their own parameter pages, and their own allocation from the bump allocator
@@ -1017,15 +998,16 @@ every track's FX1 chorus was silently a passthrough on our firmware.
 
 ### Two ways to get delay + reverb on one track — and they trade differently
 
-**Hardware, 5 Aug 2026: our code can hold stock DELAY's own slot.** With id
+**Measured on hardware: this project's code can hold stock DELAY's own
+slot.** With id
 `0x08` dispatched to the SEND client (`DELAYPROBE=send`, `ChonVerb22S`), the
 stock Echo Freeze Delay **still works**. So a track can run the stock delay on
 FX2 *and* feed the ChonVerb bus from that same slot — **the FX1 filter is not
 the price after all**, and the ordering objection below (an FX1 send taps dry,
 so never delay-into-reverb) is moot because the send now sits at the FX2 point.
 
-**But it does NOT make the FX1 plan below obsolete, and an earlier revision of
-this section wrongly said it did.** Hardware, 5 Aug: **all twelve of DELAY's
+**But it does NOT make the FX1 plan below obsolete.** Measured on hardware:
+**all twelve of DELAY's
 parameters are in use, and `X` is a boolean** — so there is no sacrificial knob
 to carry a send level, and the co-located design has *no independent level
 control at all*. The FX1 design does, because `Send` there owns its own
@@ -1064,7 +1046,7 @@ So the gap remains real and possibly useful later, but **it is not a route to a
 per-track send knob** without a UI surface to drive it, and no such surface has
 been identified.
 
-**The send taps PRE-delay** (by ear, 5 Aug). The reverb receives dry; the stock
+**The send taps PRE-delay** (established by ear). The reverb receives dry; the stock
 delay is applied downstream of the FX2 insert. So the co-located design gives
 **stock delay and reverb in PARALLEL on one track** — still impossible on stock
 hardware — but **not delay into reverb**, and no slot we can reach could ever

--- a/docs/CHIP.md
+++ b/docs/CHIP.md
@@ -1,15 +1,13 @@
 # Chip, cycles and memory — the current numbers
 
-One page, because these have moved a lot and stale copies of them have cost
-real work. **Every row carries a confidence marker.** Where a number was
+One page, because stale copies of these numbers have cost real work.
+**Every row carries a confidence marker.** Where a number was
 retracted, the old value is kept alongside it — knowing what a figure used to
 be is how you spot a doc that hasn't caught up.
 
 - ✅ **measured** — on hardware, or read off the part
 - 🟡 **inferred** — fits the evidence, not directly tested; falsifier stated
 - ❌ **retracted** — was believed, now known wrong
-
-Last updated 7 Aug 2026 (build 27).
 
 ---
 
@@ -51,17 +49,17 @@ core that track lives on.
 
 ### The three resources, and how they differ
 
-| | scoped to | spent when | ours |
+| | scoped to | spent when | this build |
 |---|---|---|---|
-| **Program space** (P) | **per core** | once at load — same cost whether 1 track or 8 use the effect | 2 724 words, **32 free** (✅ 11 Aug; the 7–10 Aug builds read 11 free) |
-| **Cycles** | **per core** | **every frame, per track, per slot** — up to 8 effect calls per core | ~1 392 spare ✅ measured 7 Aug; the bank has grown 573 since, so **~819/sample** remains for new work |
+| **Program space** (P) | **per core** | once at load — same cost whether 1 track or 8 use the effect | 2 724 words, **32 free** ✅ (an earlier build read 11 free) |
+| **Cycles** | **per core** | **every frame, per track, per slot** — up to 8 effect calls per core | ~1 392 spare ✅ measured; the bank has grown 573 since that measurement, so **~819/sample** remains for new work |
 | **Y memory** | **per track, per slot** | allocated always, used or not | 16 384 per FX2 slot |
 
 The one that catches people is the middle row. Program space is paid **once**;
 cycles are paid **per track per slot per frame**. Eight tracks running ChonVerb
 cost one copy of the code and eight times the cycles.
 
-### The two menus, read off the image (8 Aug 2026)
+### The two menus, read off the image
 
 ✅ **Measured, not inferred** — decoded from the chooser lists at `0x400d6060`
 (FX1) and `0x400d6090` (FX2):
@@ -78,7 +76,7 @@ FX2 (15): ...the same 11, plus DELAY, PLATE REV, SPRING REV, DARK REV
    PLATE REV, SPRING REV or DARK REV by name."** It cannot — they are not in
    its list. So **taking the three reverbs costs FX1 nothing at all**, and the
    "three stock reverbs for a better one" trade is only ever paid on the FX2
-   menu, which we replace wholesale anyway. The null-stub silencing stays as
+   menu, which this build replaces wholesale anyway. The null-stub silencing stays as
    insurance (both slots share one dispatch, so a stored id outside the menu
    would still reach the code), but it is defending a path the UI cannot walk.
 2. **FX1's 10 real effects are exactly the reclaimable pool** — 3,384 words,
@@ -86,9 +84,9 @@ FX2 (15): ...the same 11, plus DELAY, PLATE REV, SPRING REV, DARK REV
    to work with, and it is what `XBUS.md`'s FX1 section should be priced
    against.
 
-### So: can we delete the stock effects "off FX2"?
+### So: can the stock effects be deleted "off FX2"?
 
-**No — and this is the thing you're remembering.** There is no FX1 pool and no
+**No.** There is no FX1 pool and no
 FX2 pool. Every effect exists once, in the DSP's program memory, and both menus
 point at the same implementations through that single dispatch table.
 
@@ -98,9 +96,9 @@ point at the same implementations through that single dispatch table.
   **both** slots.
 
 That is exactly why the build **silences PLATE REV, SPRING REV and DARK REV on
-FX1**: we overwrote their code with ChonVerb, so if their ids still dispatched
-normally, selecting one on FX1 would run our hardcoded-base engine a second,
-uncontrolled time. CHORUS was a donor until v98 and is now byte-identical to
+FX1**: their code is overwritten with ChonVerb, so if their ids still dispatched
+normally, selecting one on FX1 would run the hardcoded-base engine a second,
+uncontrolled time. CHORUS was once a donor and is now byte-identical to
 stock, so FX1 gets its chorus back.
 
 ⚠️ **This has a live consequence for the cycle headroom.** FX1 effects draw
@@ -114,7 +112,7 @@ FX1 = FILTER. Every FX1 filter you turn on eats into that figure.
 
 | | | |
 |---|---|---|
-| CPU | Freescale ColdFire **MCF54454VR266**, 32-bit big-endian, 266 MHz | ✅ board photo (an MKI board reads `MCF54454`; our note said `MCF5445A` — same family, likely a misread digit) |
+| CPU | Freescale ColdFire **MCF54454VR266**, 32-bit big-endian, 266 MHz | ✅ board photo (an MKI board reads `MCF54454`; an earlier note said `MCF5445A` — same family, likely a misread digit) |
 | Audio DSP | Freescale Symphony **DSP56721** (`DSPB56721AG`) | ✅ board photo |
 | DSP cores | **Two** DSP5636x cores, **200 MHz / 200 MIPS each** | ✅ datasheet |
 | External memory controller | **None.** No EMC on this part — all memory is on-chip | ✅ datasheet block diagram |
@@ -134,12 +132,12 @@ no external memory. `DSP.md:449` / `DSP.md:744` still say otherwise.
 | | | |
 |---|---|---|
 | Per core, per sample @ 44.1 kHz | 200 MIPS ÷ 44 100 = **4 535 cycles** | ✅ arithmetic |
-| **Measured ceiling for FX work** | **~2 150** (reverb alone) to **~2 350** (full bank) | ✅ hardware, build 23 |
-| **Proven spare headroom** | **1 392 cycles/sample**, exactly | ✅ hardware, build 23 |
+| **Measured ceiling for FX work** | **~2 150** (reverb alone) to **~2 350** (full bank) | ✅ hardware, burn probe |
+| **Proven spare headroom** | **1 392 cycles/sample**, exactly | ✅ hardware, burn probe |
 | Safe planning number | **~1 100–1 200** | 🟡 1 392 minus contention margin |
 | Stock's own share | ~2 400, a bit over half the core | 🟡 by subtraction |
 
-**How the ceiling was measured.** `dsp/burn_probe.asm` adds `16 × p3`
+**How the ceiling was measured.** `dsp/burn_probe.asm` (in git history) adds `16 × p3`
 cycles/sample of pure nops, scaled by `n7` so the figure is per *sample*
 regardless of the split. It froze at p3 = 87 → **87 × 16 = 1 392 cycles**
 tolerated on top of whatever was already running.
@@ -152,8 +150,8 @@ memory where nops do not.
 ### Why the datasheet cannot answer this
 
 It gives exactly one cycle number: **200 MIPS per core → 4 535 cycles/sample at
-44.1 kHz**. That is the ceiling of the *silicon*. Three things it cannot tell
-us, and all three sit between that figure and anything spendable:
+44.1 kHz**. That is the ceiling of the *silicon*. Three things it cannot
+answer, and all three sit between that figure and anything spendable:
 
 1. **What stock already uses.** Voice playback, sample streaming and
    interpolation, FX1, frame plumbing, DMA orchestration — that is a property
@@ -169,15 +167,15 @@ us, and all three sit between that figure and anything spendable:
 left after stock.** Only the second is spendable, and only the second can be
 measured from here.
 
-Rough split implied by our measurements (big error bars, but the shape holds):
+Rough split implied by the measurements (big error bars, but the shape holds):
 of 4 535 cycles/sample, stock's own per-track work takes **under ~1 550**, four
-FX1 FILTERs take **over 640**, our FX2 bank takes ~957 static, and 1 392 was
+FX1 FILTERs take **over 640**, the FX2 bank takes ~957 static, and 1 392 was
 still spare on top of all of it.
 
 📄 **The reference manual HAS now been read** — `DSP56720RM.pdf`, 575 pages,
 at `downloads/datasheets/` (gitignored; third-party). Extract with
 `pdftotext -layout`; `file` misreports it as 27 pages. It settled §3's memory
-questions without a flash. What it still has and we have NOT used: Ch. 3's five
+questions without a flash, including Ch. 3's five
 OMR-selectable memory maps (`MS`, `MSW0`, `MSW1`), which set the per-core X/Y/P
 extents — read those before trusting any *internal* extent.
 
@@ -186,7 +184,7 @@ extents — read those before trusting any *internal* extent.
 ⚠️ **1 392 is spare on top of whatever happened to be assigned during that
 sweep — not an untouchable reserve.** Everything on the core draws from the
 same budget: stock's per-track voice work, **all four tracks' FX1 effects**,
-and our FX2 bank. A fresh part defaults FX1 = FILTER, so a realistic kit is
+and the FX2 bank. A fresh part defaults FX1 = FILTER, so a realistic kit is
 paying for four FX1 effects the sweep may not have included.
 
 **Budget against the worst realistic case per core**, not the bare one:
@@ -204,8 +202,8 @@ so **any configuration can be measured, on demand, with no flash**:
 
 And the *difference* between two configurations is the **cost of the change** —
 which is the only way to price stock effects at all, since they are binary and
-instruction count is not cycles (`v97` moved instructions up 508 → 512 while
-cycles fell 735 → 731).
+instruction count is not cycles (one rewrite moved instructions up 508 → 512
+while cycles fell 735 → 731).
 
 So the cost of a stock FX1 effect is directly measurable: sweep with it
 assigned on all four tracks, sweep without, take the difference. If a
@@ -237,8 +235,8 @@ Two consequences, and the first is the important one:
 
 **1 392 is the CONSERVATIVE number, not the optimistic one.** It was measured
 with the heaviest FX1 config already running, so it is a worst case that needs
-no further derating. Design the delay against it. *(Update, 11 Aug: the bank
-has grown 573 cycles since that measurement, so the number to design against
+no further derating. Design the delay against it. *(The bank
+has since grown 573 cycles, so the number to design against
 today is **819**, not 1 392.)*
 
 **Turning FX1 filters off is worth ≥ 640 cycles** — a real design lever if
@@ -254,10 +252,9 @@ that matters — but it is the only reason §2's "~2 150" is still a range.
 algorithm is designed against a real budget rather than a bare-config one.
 
 ❌ **"The budget is 1080 cycles/sample."** 1080 was never a ceiling. It is the
-load `stageprobe5` happened to *survive* (`REVERB_LOG.md`) and got written down
-as a budget. Every design decision from the density pass onward was priced
-against it. `tools/cycle_count.py` printed `budget/DSP 1080` for a while
-after the retraction; it now subtracts bank growth and prints the live number.
+load one probe build happened to *survive* (`REVERB_LOG.md`, in git history)
+and got written down as a budget.
+`tools/cycle_count.py` now subtracts bank growth and prints the live number.
 
 ❌ **"There is not real headroom — do not spend it on more delay lines."**
 Retracted. There are ~1 200 usable cycles.
@@ -266,10 +263,10 @@ Retracted. There are ~1 200 usable cycles.
 
 | | cycles/sample | |
 |---|---|---|
-| `reverb_server` (ChonVerb, with shimmer) | 758 | ✅ `tools/cycle_count.py` — **pre-8-line reading**; ~1 133 as of the 9 Aug count |
+| `reverb_server` (ChonVerb, with shimmer) | 758 | ✅ `tools/cycle_count.py` — **pre-8-line reading**; **~1 133** with the 8-line tank |
 | `delay_server` (BongDelay, **placeholder**) | 163 | ✅ same |
 | `send_client` × 2 | 36 | ✅ same |
-| **full bank** | **957** | ✅ same — pre-8-line; far larger since (the bank has grown 573 vs the 7 Aug burn) |
+| **full bank** | **957** | ✅ same — pre-8-line; far larger since (the bank has grown 573 vs the burn measurement) |
 
 These are **static** counts — words in the sample loop, no memory-contention
 stalls modelled — so they are a floor. `tools/dsp_host` **cannot** measure
@@ -277,7 +274,7 @@ cycles: its `instructions/sample` is a constant divided by whatever frame count
 you ask for.
 
 **For scale:** the entire ChonVerb engine was 758 cycles when the spare was
-measured (~1 133 as of 9 Aug), and 1 392 was room for ~1.8 more complete
+measured (~1 133 with the 8-line tank), and 1 392 was room for ~1.8 more complete
 reverbs on the same core — against today's ~819 spare, call it less than one
 more. A good delay is ~200–300;
 a correlation-search pitch shifter amortises to ~1/sample plus ~30–60.
@@ -286,7 +283,7 @@ a correlation-search pitch shifter amortises to ~1/sample plus ~30–60.
 
 ## 3. DSP Y memory
 
-Swept end to end on hardware (`dsp/ymemprobe.asm`, 3 Aug), per core:
+Swept end to end on hardware (`dsp/ymemprobe.asm`, in git history), per core:
 
 | Y range | what | |
 |---|---|---|
@@ -314,10 +311,10 @@ which was the whole ambiguity in the block diagram.
 
 ❌ **"The two DSPs are a hard boundary."** `BUS.md`'s founding constraint is
 dead. There is 64 K both cores address; the split into `0x30000` (payload A) /
-`0x38000` (payload B) is **a convention we chose**, not a hardware wall. A true
+`0x38000` (payload B) is **a chosen convention**, not a hardware wall. A true
 8-track bus and cross-core sends are both back on the table.
 
-✅ **P, X and Y ALIAS in this region — CONFIRMED ON HARDWARE**, 7 Aug, build 27.
+✅ **P, X and Y ALIAS in this region — CONFIRMED ON HARDWARE.**
 The manual says *"the Program, X, and Y memory addresses are mapped into same
 physical location"*; `dsp/alias_probe.asm` wrote a tagged incrementing word
 through Y and read it back through **X** and through **P**, at four addresses
@@ -334,16 +331,16 @@ already run — but nothing may assume that region is scratch.
 writing over bootstrap A's first word all along, and reading it back through P.
 That is also the strongest single piece of evidence for the aliasing — if P and
 Y were separate memories, `P:0x31000` would still hold a bootstrap instruction,
-not our counter.)
+not the probe's counter.)
 
-❌ **"X:0x30000 and Y:0x30000 do not alias."** Commit `0f93639` reached that by
+❌ **"X:0x30000 and Y:0x30000 do not alias."** That claim was reached by
 inference — *if they aliased, stock would corrupt itself whenever a reverb sat
 on track 3*. The manual states the hardware directly and wins. One premise of
 that argument is false; the likeliest is the claim that stock stages per-frame
 parameters at `X:0x30000` at all.
 
 ❌ **"BongDelay may use its full 32 768 words."** Retracted with it. The window
-is not ours to assume.
+is not free ground to assume.
 
 ✅ **Zero wait states as X or Y** (1 as P) — so this memory is *not* slow, and
 `DSP.md:449`/`744`'s "walks external memory, which is slower" is wrong twice
@@ -360,7 +357,7 @@ poll-data registers for exchange. Worth remembering if the shared window ever
 proves unusable.
 
 ✅ **Per-core P/X/Y extents are configurable via OMR — and stock runs the
-DEFAULT map. ANSWERED, Ch. 3 read 7 Aug 2026.**
+DEFAULT map. ANSWERED from Ch. 3 of the reference manual.**
 
 | map | MS | MSW1 | MSW0 | Program | X | Y |
 |---|---|---|---|---|---|---|
@@ -390,7 +387,7 @@ reach `0x08d98`.
 `0x30000-0x3FFFF` window is program-addressable in every configuration, not
 just as X/Y. See `XBUS.md` for both levers this opens and their falsifiers.
 
-## 3a. What is actually IN the shared window (mapped 7 Aug, static analysis)
+## 3a. What is actually IN the shared window (mapped by static analysis)
 
 Two free passes over `out/raw/section_3_MAIN_OS.bin`: which modules **load**
 into `0x30000-0x3FFFF`, and which words in P code **reference** it. Remember P,
@@ -429,7 +426,7 @@ Anything from that pass must be disassembled before it is believed.
 | | |
 |---|---|
 | ChonVerb | `Y:0x4000–0xBFFF` — 32 768 words, **hardcoded**, both payloads (different cores, so no collision) |
-| BongDelay | `Y:0x30000–0x37FFF` (A) / `Y:0x38000–0x3FFFF` (B) — 32 768 words each ⚠️ **COLLIDES AT BOTH BASES**, see §3a. Ran under `DEV=1` 10 Aug; still never heard on its shipping payload-B path |
+| BongDelay | `Y:0x30000–0x37FFF` (A) / `Y:0x38000–0x3FFFF` (B) — 32 768 words each ⚠️ **COLLIDES AT BOTH BASES**, see §3a. Renders locally under `DEV=1`; confirmed on hardware on its shipping payload-B path |
 | Bus scratch | `Y:0x900–0x980` — parity word, then 4 × 16-word accumulators and 4 × 16-word wet buffers |
 | Per-instance base stash | `Y:0x795 + (r7>>8)` — one word per instance |
 | SEND | **nothing.** A zero-footprint client; never touches its own slot |
@@ -448,20 +445,20 @@ bisect); do not design around it.
 
 | | | |
 |---|---|---|
-| Our region (PLATE + SPRING + DARK, contiguous) | **2 724 words** | ✅ |
-| Used by a normal build | 2 692 — **32 free** (✅ 11 Aug; build 25 read 2 713 — 11 free) | ✅ |
+| The donor region (PLATE + SPRING + DARK, contiguous) | **2 724 words** | ✅ |
+| Used by a normal build | 2 692 — **32 free** (an earlier build read 2 713 — 11 free) | ✅ |
 | Reachability sweep | payload A 95.8 %, B 98.5 % | ✅ `tools/dsp_reach.py` |
 | Free pool elsewhere | **none** | ✅ |
 | Only reclaimable space | **3 384 words held by ten stock effects** — costs those effects (earlier reading: ~3 100 / nine) | ✅ |
 
-Placement, in address order (build-25-era sizes): `SEND` 166 ·
+Placement, in address order (sizes from an earlier build): `SEND` 166 ·
 `REVERB SERVER` 2 040 · `DELAY SERVER` 507. In today's BURN plain layout
 `DELAY SERVER` is **2 794 words** — it overruns the 2 724-word region by 70
 on its own.
 
-**We take exactly three stock effects: PLATE REV, SPRING REV, DARK REV.**
-CHORUS was a donor until v98 and is now byte-identical to stock. Relocating
-*our* code is cheap (assembled with `-org`); relocating *stock* code is not
+**Exactly three stock effects are taken: PLATE REV, SPRING REV, DARK REV.**
+CHORUS was once a donor and is now byte-identical to stock. Relocating
+*the project's* code is cheap (assembled with `-org`); relocating *stock* code is not
 (binary, absolute branch targets), so more space means taking a neighbour's
 whole module.
 
@@ -471,19 +468,21 @@ whole module.
 
 | | | |
 |---|---|---|
-| Tracks per core | **5–8 → payload A / core 0; 1–4 → payload B / core 1** (the 7 Aug probe reading — 1–4 → A — was inverted and is retracted) | ✅ measured 10 Aug, MrkVerb32 marker |
+| Tracks per core | **5–8 → payload A / core 0; 1–4 → payload B / core 1** (an earlier probe reading — 1–4 → A — was inverted and is retracted) | ✅ measured, marker-flash test |
 | FX slots per track | FX1 (3 072 words) + FX2 (16 384 words) | ✅ |
 | Reverb/delay are FX2-only | FX1's 3 072 words are far too small | ✅ |
 | FX1 is **not** idle | dispatcher calls it every frame; a fresh part defaults FX1 = FILTER | ✅ |
 | Parameters per effect | **12** — 6 page-1 knobs, 3 page-2 knobs, 3 page-2 selects | ✅ `DSP.md` §9 |
 | Menu | 3 entries: ChonVerb / BongDelay / Send. **No selectable NONE** | ✅ |
 | Unassigned tracks | id 0 is aliased to **SEND**, so every unassigned track feeds the bus | ✅ |
-| Track↔core mapping | **payload A serves tracks 5-8, payload B serves tracks 1-4** — inverted from every pre-SPEC assumption; unobservable before SPEC | ✅ MrkVerb32 marker flash, 10 Aug 2026 |
+| Track↔core mapping | **payload A serves tracks 5-8, payload B serves tracks 1-4** — inverted from the natural assumption; unobservable before specialization (both payloads carried every effect) | ✅ marker-flash test |
 | `r7` state block | `$00–$83` usable; **`$84–$8a` HANGS** (host-owned) | ✅ bisected |
 | ChonVerb's `r7` | **full** | ✅ |
 
-Persistent state does **not** have to live in `r7` — `dsp/cycleburn.asm` parks
-LFO and damping state in the instance's own Y region, and `DSP.md`'s v27 build
+Persistent state does **not** have to live in `r7` — `dsp/cycleburn.asm`
+(in git history) parks
+LFO and damping state in the instance's own Y region, and a probe build
+recorded in `DSP.md`
 proved absolute Y works where `r7+$84` hangs. There is exactly one server per
 bank, so absolute-Y scalars cannot collide.
 
@@ -500,7 +499,7 @@ per-8K-block contention rule says how to lay it out.
 heavily used by stock, at both of `delay_server`'s bases.
 
 ~~**The 32-step fault.**~~ **CLOSED — not a product issue.** ✅ Bisected on
-hardware, 7 Aug:
+hardware:
 
 | configuration | result |
 |---|---|
@@ -514,26 +513,24 @@ configuration the product actually uses is clean.
 
 That fits the probe's known gap: `BUS.md` has **role locks "so duplicates fail
 safe"**, claimed by both real servers via `bus_claim` and released each block by
-`send_client`. `dsp/shared_probe.asm` has neither lock nor housekeeping, so two
+`send_client`. `dsp/shared_probe.asm` (in git history) has neither lock nor housekeeping, so two
 copies each behave as if they own the bank. **Mechanism never established, and
 it does not need to be** — one server per bank is a design rule, not an
 accident. Re-open only if duplicate servers ever become desirable.
 
 ❌ **RETRACTED: "a single word written to `Y:0x34000` from payload A corrupts
-that track's audio after ~5.45 s."** This paragraph stood here until 8 Aug 2026
-and `XBUS.md` imported it as **risk 1, "the only unknown here that can
-invalidate the whole memory plan."** It was already dead when it was written.
+that track's audio after ~5.45 s."**
 
-**The v107 bisect directly above falsifies it, and covers the exact address.**
-`dsp/shared_probe.asm`'s `ADDR = 0` *is* `0x34000` (`move #>$34000,y0 ; 0: FX2
+**The bisect directly above falsifies it, and covers the exact address.**
+`dsp/shared_probe.asm`'s `ADDR = 0` *is* `0x34000`
+(`move #>$34000,y0 ; 0: FX2
 slot 4 base, A's half`), and the row **"one `SharePrb` + three `Send`s → clean
 at every ADDR and INC"** therefore includes a single instance writing that very
 word. ✅ **One instance at `Y:0x34000` is clean on hardware.**
 
-The two builds that "reproduced" it are rounds 1 and 2, and commit `04a24cf`
-says so in as many words: *"I had also misread my own evidence: rounds 1 and 2
-BOTH had two instances running, which is why I attributed to the write address
-what was always about duplication."* The fault was always duplication; the
+The two builds that appeared to reproduce it each had **two instances
+running**, which attributed to the write address
+what was always about duplication. The fault was always duplication; the
 address never mattered.
 
 **What is still true** is only the row above: two instances of the same effect
@@ -541,11 +538,11 @@ corrupt audio after ~5.45 s at any address, mechanism unestablished, and no
 product configuration has that. **`Y:0x30000–0x37FFF` is not blocked**, and the
 memory re-plan can proceed.
 
-**The lesson is the propagation, not the measurement.** The retraction was
-correct, was written down, and reached only the commit message — so a claim
-this file still asserted went on to become the top-ranked blocker in the
-planning doc. When a bisect kills a hypothesis, delete the paragraph the
-hypothesis lives in, not just the sentence that stated the conclusion.
+**The lesson is the propagation, not the measurement.** A retraction that is
+written down in only one place leaves the dead claim asserted everywhere else
+it was copied. When a bisect kills a hypothesis, delete the paragraph the
+hypothesis lives in — in every document that repeats it — not just the
+sentence that stated the conclusion.
 
 **Assembler traps.** `dsp_asm` has no reject path — it emits the nearest
 encoding. Accumulator-to-accumulator `CMP`/`CMPM`/`TFR` all mis-encode

--- a/docs/DSP.md
+++ b/docs/DSP.md
@@ -1,11 +1,9 @@
-# DSP56300 side — module load map (step 1)
+# DSP56300 side — module load map
 
-The effects and timestretch run on the DSP, not on the ColdFire. `COVERAGE.md`
-records that the DSP program was located and extracted but never disassembled,
-and identifies the blocker: without knowing which bytes load to which DSP address
-in which memory space, a disassembly is at the wrong PC and is worthless.
-
-**That blocker is now cleared.** This document is the map.
+The effects and timestretch run on the DSP, not on the ColdFire. Disassembling
+the DSP program requires knowing which bytes load to which DSP address in which
+memory space — at the wrong PC a disassembly is worthless. This document is the
+map.
 
 Addresses are ColdFire virtual addresses (`file_offset = vaddr − 0x40000400`)
 unless prefixed `P:` / `X:` / `Y:`, which are DSP word addresses.
@@ -35,8 +33,9 @@ the GPIO at `0xfc0a400c` toggled between passes, and each pass has its own
 bootstrap and payload. `ARCHITECTURE.md` assumes a single DSP56xxx. The two
 payloads have near-identical X/Y layouts (matching module sizes 6305, 198, 4096,
 3730, 384, 384, 258, …) at slightly different base addresses, which is what two
-instances splitting the work would look like. *Inference from the load map, not
-confirmed against hardware.*
+instances splitting the work would look like. *Inferred from the load map;
+borne out by the per-chip memory model in §11 and the measured track↔chip
+mapping (payload A serves tracks 5–8, payload B tracks 1–4).*
 
 ### The blobs are relocated before the bank RAM eats them
 
@@ -104,7 +103,7 @@ no `0x30000`/`0x38000` regions.
 The largest P modules (`P:0x01252`, `P:0x01679`, ~1,065 words each) are the
 obvious first disassembly targets — big enough to be real signal-processing code.
 
-### A hypothesis that did not survive
+### The 15 one-word records are NOT a dispatch table
 
 Each payload contains a run of **15 consecutive one-word P records** (A:
 `P:0x006e5`–`0x006f3`, B: `P:0x004a5`–`0x004b3`). Fifteen is also the number of
@@ -112,7 +111,7 @@ effect descriptors, so this looked like a static effect dispatch table. **It is
 not** — every one of the 30 words is `0x000000`. They are zero-initialised
 scratch words. If a dispatch table exists it is built at runtime.
 
-## 4. Disassembly (step 2 — done)
+## 4. Disassembly
 
 Neither Ghidra nor radare2 ships a DSP56300 target. `setup.sh` now clones and
 builds the disassembler from the Access Virus emulator project
@@ -131,8 +130,8 @@ vendor/dsp56300/build/source/disassemble/dsp56kDisassemble \
 `FUN_40001b18` maps bytes onto the three 8-bit ports (`0x20000014` gets bits
 23–16 from `b[i+5]`, `0x18` gets 15–8 from `b[i+4]`, `0x1c` gets 7–0 from
 `b[i+3]`). Big-endian produces plausible-looking garbage — exactly the trap the
-module map exists to avoid. (`NOTES.md` describes the boot blobs as big-endian;
-that reading does not hold for the payload modules.)
+module map exists to avoid. (`history/NOTES.md` describes the boot blobs as
+big-endian; that reading does not hold for the payload modules.)
 
 ### Validation
 
@@ -153,7 +152,7 @@ Zero `dc` fallbacks anywhere. Wrong addresses or wrong endianness would litter
 the output with them, so this validates the module map, the byte order and the
 disassembler together.
 
-## 5. The effect dispatch (step 3 — done)
+## 5. The effect dispatch
 
 `tools/dsp_disasm_all.py` disassembles every P module at its correct address
 (payload A: 68 modules / 6,817 instructions; payload B: 46 / 6,251; **zero**
@@ -201,7 +200,7 @@ tables are **plain data in the payload**, editable with the existing toolchain.
 **13 effects are implemented on the DSP.** Every other id — including `0x08`
 DELAY and `0x19` MULTIBCOMP — points at the null stub.
 
-### Why DELAY was silent on FX1 — solved
+### Why DELAY is silent as a DSP insert
 
 The null stub is not silence, it is a **passthrough**:
 
@@ -216,18 +215,15 @@ The null stub is not silence, it is a **passthrough**:
 0007d0: rts
 ```
 
-Which is exactly the observed behaviour: the parameter page worked, the audio was
+Which is exactly the observed behaviour: the parameter page works, the audio is
 untouched. `0x08` has no implementation in *either* payload.
-
-Which is exactly the observed behaviour on FX1: the parameter page worked, the
-audio was untouched. **That half is settled.**
 
 ### Where DELAY actually is — OPEN, and the DSP is ruled out
 
-The FX2 half was previously written up here as solved: "a dedicated stage in the
-audio graph that the FX2 slot enables." **That was an inference to explain the
-stub, and searching for it found nothing.** Retracted; what follows is what was
-actually checked (5 Aug 2026).
+A tempting explanation — "a dedicated stage in the audio graph that the FX2
+slot enables" — **is an inference that a full search failed to support**; do not
+re-adopt it without new evidence. What follows is what has actually been
+checked.
 
 Echo Freeze Delay is a normal per-track FX2 effect — manual §11.4.10 lists it
 under "FX2 effects", alongside the three reverbs. So the contradiction is real:
@@ -255,16 +251,15 @@ a documented per-track insert whose id resolves to a passthrough.
 * **No third program.** Payloads A and B are back-to-back and the image tail
   after B is 93% zeros. A and B are the two DSP *chips*, and neither has it.
 
-**A lead that turned out to be nothing.** `PARAM_PAGES.md` flagged
-`FUN_40005638` as referencing the FILTER and DELAY descriptors directly,
-"outside the id tables — the only two effects that get that treatment", and
-wondered whether it related to buffer setup. It does not: it is the **part
-defaults initialiser**, copying `E+0x3b` out of each. A fresh part just defaults
-to **FX1 = FILTER, FX2 = DELAY**. Lead closed.
+**A lead that is nothing.** `PARAM_PAGES.md` flagged `FUN_40005638` as
+referencing the FILTER and DELAY descriptors directly, "outside the id tables —
+the only two effects that get that treatment", suggesting buffer setup. It is
+not: it is the **part defaults initialiser**, copying `E+0x3b` out of each. A
+fresh part just defaults to **FX1 = FILTER, FX2 = DELAY**.
 
 **So the delay is not dispatched as a DSP insert.** Where it *is* remains open.
-Two hypotheses have now been tried and neither survived; this section should not
-be marked solved again on the strength of a third.
+Two hypotheses are ruled out below; do not mark this solved on the strength of
+a third without measurement.
 
 **Hypothesis 1 — a dedicated DSP stage.** Dead, see above.
 
@@ -283,16 +278,15 @@ other effect has bespoke UI. Manual §12.7.6 settles it: the mode only sets
 the ordinary path. The code around the table is UI drawing indexed by a RAM mode
 variable. **The delay has no privileged control channel.**
 
-### Round 3: the ColdFire side, properly anchored — and still not found
+### The ColdFire side — searched, and not found there either
 
 **There is exactly one firmware section.** `elektron-firmware-tool -i` reports
 `id 3 MAIN OS, 1112560 B` and nothing else. ColdFire code and both DSP payloads
 are all in the file we have been searching. **No other binary is hiding it.**
 
-**An earlier anchor was wrong.** `part+0x08` came from the *defaults
-initialiser* (`FUN_40005638`) and is not the live location; every search keyed on
-it returned zero, correctly. The real locations, in `PARAM_PAGES.md` §5c all
-along:
+**Do not anchor searches on `part+0x08`.** It comes from the *defaults
+initialiser* (`FUN_40005638`) and is not the live location; any search keyed on
+it returns zero, correctly. The real locations are in `PARAM_PAGES.md` §5c:
 
 | | FX1 | FX2 |
 |---|---|---|
@@ -320,12 +314,12 @@ twelve parameters and they are published into the DSP param block like any other
 effect's. Parameters that nothing reads would be strange. The passthrough stub
 reads none of them, so **whatever reads the delay's parameters is the delay.**
 That is a search for the consumer of data we know is published, rather than for
-a comparison that may not exist. Working hypothesis (Sam's, and it fits the
+a comparison that may not exist. Working hypothesis (it fits the
 FREEZE behaviour): it shares the **sampling/recorder** machinery rather than the
 FX chain — a delay is re-reading recorded audio, which is what the voice path
 already does.
 
-### HARDWARE, 5 Aug 2026 — the first positive evidence
+### Hardware evidence: substituting id `0x08`'s dispatch
 
 Three builds, each stamping its own effect name so the unit says which is
 running (`DELAYPROBE=stock|silence|send` in `tools/build_bus.py`). All three
@@ -334,61 +328,54 @@ id `0x08` dispatches to.
 
 | build | id `0x08` runs | result on the unit |
 |---|---|---|
-| `ChonVerb22C` (control) | stock passthrough | **delay WORKS** |
-| `ChonVerb22P` | a stub writing zeros | **the whole track goes silent** (dry included); other tracks unaffected; DELAY CTRL keys still lit |
+| control | stock passthrough | **delay WORKS** |
+| silence | a stub writing zeros | **the whole track goes silent** (dry included); other tracks unaffected; DELAY CTRL keys still lit |
 
-**What the control bought, and it is worth having.** Round 1 ran without it, so
-"the delay went silent" could not be told apart from "the delay never worked
-under our firmware at all". The control settles that: **our chooser replacement
-wires up a stock effect correctly** — DELAY picked from our 4-entry menu behaves
-normally when its dispatch is left alone. That is what makes the `send` build
-below a meaningful test rather than a shot in the dark.
+**What the control establishes.** Without it, "the delay went silent" could not
+be told apart from "the delay never worked under this firmware at all". With
+it: **the chooser replacement wires up a stock effect correctly** — DELAY
+picked from the 4-entry menu behaves normally when its dispatch is left alone.
+That is what makes the `send` build below a meaningful test rather than a shot
+in the dark.
 
-**The silence build told us nothing about where the delay is, and that was
-predictable.** The FX2 insert is a series insert; writing zeros there kills the
-track's audio whether the delay sits upstream of it, downstream of it, or
-anywhere else. Both surviving hypotheses predict exactly what was observed. The
-experiment could only ever have been informative if the delay had *survived*.
+**The silence build says nothing about where the delay is.** The FX2 insert is
+a series insert; writing zeros there kills the track's audio whether the delay
+sits upstream of it, downstream of it, or anywhere else. Both surviving
+hypotheses predict exactly what was observed. The experiment could only ever
+have been informative if the delay had *survived*. In particular the result
+does **not** support reading the delay as a send rather than a series insert —
+the dry that survives is on *other* tracks, not on the track carrying the
+delay.
 
-> **RETRACTED, same day.** An earlier revision of this section read the result
-> as "dry fine, delay silent" and concluded the delay must be wired as a **send**
-> rather than a series insert. That was a misreading of an ambiguous report —
-> the surviving dry was on *other* tracks, not on the track carrying the delay.
-> The send reading has no support. Recorded because the failure is the
-> instructive part: the interpretation was built on a one-word answer to a
-> question that had not been posed precisely, and written up before the
-> ambiguity was resolved.
-
-**Confirmed and standing:** the DELAY CTRL keys still lit under the silence
-build. Those come from the stored Part id and the `0x460d1700` bitmask, which no
-DSP dispatch change can reach — exactly what the static analysis predicted, now
+**Confirmed and standing:** the DELAY CTRL keys stay lit under the silence
+build. Those come from the stored Part id and the `0x460d1700` bitmask, which
+no DSP dispatch change can reach — exactly what the static analysis predicts,
 observed on hardware.
 
-### `ChonVerb22S` — our code can hold the delay's slot
+### Our code can hold the delay's slot
 
 | build | id `0x08` runs | result |
 |---|---|---|
-| `ChonVerb22S` | the SEND client | **delay still WORKS** |
+| send | the SEND client | **delay still WORKS** |
 
 **What this establishes, exactly:** id `0x08`'s DSP slot can run our code and the
 stock Echo Freeze Delay keeps working, **provided that code passes the audio
 through unchanged.** That is the question BUS.md's parked design needed
 answered, and the answer is yes.
 
-**AND THE FIRST STRUCTURAL FACT ABOUT WHERE THE DELAY IS.** By ear, 5 Aug: the
+**And a structural fact about where the delay is.** By listening test: the
 send taps **pre-delay** — the reverb receives dry, not repeats. So the stock
-delay is applied **downstream of the FX2 insert**, in the output/mix path rather
-than in the insert chain. That is the first positive constraint on its location
-after three rounds of static search, and it came from listening, not reading.
+delay is applied **downstream of the FX2 insert**, in the output/mix path
+rather than in the insert chain — the one positive constraint on its location
+that static search never produced.
 
-It also explains the silence result retroactively: zeroing the insert starved
-everything downstream of it, the delay included.
+It also explains the silence result: zeroing the insert starves everything
+downstream of it, the delay included.
 
 **Consequence for anything we build: we cannot tap the stock delay's output.**
 Every slot we can reach is upstream of it. A "delay into reverb" routing is
 therefore impossible with the *stock* delay — it is only available via our own
-`DELAY SERVER`, whose `→VERB` cross-send exists for exactly that (`BUS.md`
-task 10).
+`DELAY SERVER`, whose `→VERB` cross-send exists for exactly that (`BUS.md`).
 
 **What it does NOT establish — and the temptation is to claim it.** The send
 client leaves the buffer contents byte-identical to the passthrough; it only
@@ -398,11 +385,11 @@ not, which is exactly what "the delay is fed by the track's audio" predicts and
 is equally consistent with every remaining hypothesis about *where*. The
 location question is still open.
 
-**Design consequence, and it supersedes the parked FX1 plan.** A track can run
+**Design consequence.** A track can run
 the stock delay on FX2 *and* feed the ChonVerb bus from the same slot — so the
 FX1 filter is no longer the price. See BUS.md.
 
-**Confirmed end-to-end, same session.** With a ChonVerb server on another track
+**Confirmed end-to-end.** With a ChonVerb server on another track
 in the bank and DELAY's `FB` knob turned up, the reverb send audibly works from
 inside the delay's slot. So our send client is not merely dispatched there — it
 is tapping the audio and reaching the bus, while the stock delay runs.
@@ -428,12 +415,7 @@ DELAY declares all twelve parameters, so any offset we read is one of its
 controls. Options: a fixed level; a deliberately chosen sacrificial parameter
 (`p6 X` and `p11 PASS` both default to 0 and are the least obviously essential,
 though what they do is unverified); or sourcing the level outside the param
-block entirely. **Unresolved, and it is the next design decision.**
-
-**Next:** `DELAYPROBE=send` points id `0x08` at the SEND client, which passes
-audio through and only taps it. If the delay survives that, **our code can hold
-the delay's slot and keep the delay** — which is the whole question behind
-BUS.md's parked Send design.
+block entirely. **Unresolved.**
 
 ### Two limits on the sweep above — do not over-read it
 
@@ -443,19 +425,19 @@ cannot see paths the program creates for itself, so "95.8% reached" bounds how
 much *unreferenced* code exists; it does not prove all behaviour is accounted
 for.
 
-**"No large modulo buffer" is NOT evidence of no delay line.** An earlier draft
-of this section argued that, having found nothing bigger than `m6=$7f` (128
-words). It does not follow: a delay line needs no modulo at all. Module `0x2bf`
-walks external memory with `m0` linear, which is exactly how a long buffer would
-be read. (*Annotation 12 Aug 2026: "external memory" here is stale — there is
-no external memory; the shared window runs at the same speed. See `CHIP.md`.*) Retracted as an argument; the reachability and module-by-module
-characterisation are what carry the conclusion.
+**"No large modulo buffer" is NOT evidence of no delay line.** Nothing in the
+program uses a modulo bigger than `m6=$7f` (128 words), but it does not follow
+that no delay line exists: a delay line needs no modulo at all. Module `0x2bf`
+walks the shared window with `m0` linear, which is exactly how a long buffer
+would be read. (There is no external memory on this board; the shared window
+runs at the same speed as internal memory — see `CHIP.md`.) The reachability
+sweep and the module-by-module characterisation are what carry the conclusion,
+not the modulo scan.
 
-### Stock uses `X:0x30000` as per-frame parameter staging — CHECK THIS
+### Stock uses `X:0x30000` as per-frame parameter staging
 
-Found while chasing the above, and it matters for `dsp/delay_server.asm`. Frame
-setup copies 72 words out of `X:0x30000` into `y:0x1b8`, then writes parameter
-values back into `X:0x30000`:
+This matters for `dsp/delay_server.asm`. Frame setup copies 72 words out of
+`X:0x30000` into `y:0x1b8`, then writes parameter values back into `X:0x30000`:
 
 ```asm
 0000a8: move  #>$30000,r1
@@ -466,44 +448,29 @@ values back into `X:0x30000`:
 0000b6: move  a1,x:(r1)+        ; and writes params back into 0x30000
 ```
 
-**BongDelay hardcodes `Y:0x30000` / `Y:0x38000` as its delay-line base.**
-Whether `X:0x30000` and `Y:0x30000` are the same physical external SRAM on this
-board is **not established**. ChonVerb has run on all 8 tracks using that region
-without trouble, which is reassuring — but a delay line writes continuously
-across its entire buffer in a way a reverb tank does not, and BongDelay is a
-placeholder that has never been driven hard.
+**BongDelay hardcodes `Y:0x30000` / `Y:0x38000` as its delay-line base — and
+X, Y and P DO alias in the shared window `0x30000`–`0x3FFFF`.** Measured with
+`dsp/alias_probe.asm`; see `CHIP.md`. The per-server ceiling there is
+**65,536 shared-window words (1.49 s)**. Reason about the shared window as ONE
+memory.
 
-> ❌ **RETRACTED 10 Aug 2026 — they DO alias.** The alias probe (build 27)
-> measured X/Y/P aliasing in the shared window `0x30000`–`0x3FFFF`; see
-> `CHIP.md`. The per-server ceiling is **65,536 shared-window words
-> (1.49 s)**, not "its full 32,768 words" as concluded below. The 5-Aug
-> reasoning is kept below as history.
+A superficially convincing argument that the spaces could not alias is
+falsified by that measurement, and is worth recording so it is not re-derived:
+the allocator table at `X:0x255` gives FX2 bases `0x4000`, `0x8000`,
+**`0x30000`**, `0x34000` (§10), so stock places a 16,384-word **`Y:0x30000`**
+effect buffer under the same addresses the frame setup stages parameters
+through in **`X:0x30000`** — which looks like proof the spaces must be
+separate. They are not; the probe wins.
 
-**SETTLED, 5 Aug 2026 — they do NOT alias, and no probe was needed.** Stock's
-own behaviour proves it. The allocator table at `X:0x255` gives FX2 bases
-`0x4000`, `0x8000`, **`0x30000`**, `0x34000` (§10), so on any bank where track 3
-runs an FX2 effect, stock uses **`Y:0x30000` as that effect's 16,384-word
-buffer** — a stock reverb there writes across all of it. And the frame setup
-reads **`X:0x30000`** as parameter staging every frame. Both are true in
-unmodified firmware in ordinary use. If those were the same physical words,
-stock would corrupt its own frame parameters whenever anyone put a reverb on
-track 3.
-
-**The emulator could not have answered this**, and the probe suggested in an
-earlier revision of this note would have been worthless: `dsp_host` keeps X and
-Y as separate arrays by construction — the `.mem` format tags every module with
-its space — so it reports "no aliasing" regardless of what the board does. It
-would have given the right answer for the wrong reason.
-
-So `dsp/delay_server.asm`'s hardcoded `Y:0x30000` / `Y:0x38000` bases are safe
-against the staging area, and BongDelay may use its full 32,768 words.
+**The emulator cannot answer aliasing questions either way**: `dsp_host` keeps
+X and Y as separate arrays by construction — the `.mem` format tags every
+module with its space — so it reports "no aliasing" regardless of what the
+board does.
 
 `MULTIBCOMP` (`0x19`) also points at the stub. It appears in **neither** of the
 manual's FX1/FX2 lists and its parameter labels are copied from DJ EQ — an
 unfinished entry that was never exposed, and **distinct from the Dynamix
-Compressor**, which is `0x18` and has real code (180 words at `0x01aa4`). That
-also retires the probe idea, which would have found nothing but passthrough on
-all 19 free ids.
+Compressor**, which is `0x18` and has real code (180 words at `0x01aa4`).
 
 ### The stub is also the ABI specification
 
@@ -514,8 +481,8 @@ contract, and here it is in full.
 
 ### Module records are NOT routine boundaries
 
-Measured 5 Aug 2026, while costing out how much program space could be reclaimed
-for BongDelay. **A payload module record says where a chunk of words is loaded,
+Measured while sizing how much program space could be reclaimed.
+**A payload module record says where a chunk of words is loaded,
 nothing more.** The loader lays consecutive records down contiguously, and an
 effect's code runs straight across the seam. So:
 
@@ -571,7 +538,7 @@ region is not free either. Who else does is unmapped.
 **Rule before overwriting any neighbour: disassemble it and check its
 control-flow targets.** The module map alone will mislead you.
 
-## 6. How parameters reach the algorithm (step 4 — done)
+## 6. How parameters reach the algorithm
 
 The dispatcher sets `r6` before calling, and effects read their parameters from
 it. From `P:0x0041e`:
@@ -620,7 +587,7 @@ mpyi    #>$e00000,x1,a    ; fractional multiply
 
 `0x7f0000` is 127, `0x400000` is 64 — the centre of a `0..127` control.
 
-### The effect ABI — partly settled, and one claim CORRECTED
+### The effect ABI — partly settled
 
 | register | meaning | confidence |
 |---|---|---|
@@ -630,9 +597,8 @@ mpyi    #>$e00000,x1,a    ; fractional multiply
 | `n7` | frame count | confirmed for the stub; effects also read `x:0x20c` |
 | `r0` | audio buffer | **NOT as first documented — see below** |
 
-> **Correction.** An earlier version of this section stated `r0` = input buffer
-> and `r1` = output buffer as "the complete effect ABI". That is the **passthrough
-> stub's** convention, and the stub is the degenerate case. Real effects do not
+> **`r0` = input / `r1` = output is the passthrough STUB's convention, and the
+> stub is the degenerate case — it is not the effect ABI.** Real effects do not
 > follow it. DARK REV's entry saves the incoming `r0` into its state
 > (`move r0,x:(r7+$17)`) and then works from **fixed addresses**:
 >
@@ -653,7 +619,7 @@ mpyi    #>$e00000,x1,a    ; fractional multiply
 `jsr`, output capture. The passthrough stub returns exactly the two impulse
 samples it should, and that is a genuine end-to-end validation of the plumbing.
 
-**Frame context — solved.** The effects depend on control words no module
+**Frame context.** The effects depend on control words no module
 initialises. Rather than reconstruct them by hand, the harness runs the DSP's own
 setup routine at `P:0x372..0x39e`, which derives them from two loaded pointers:
 
@@ -692,8 +658,8 @@ does **not** arrive over the serial audio interface. The live vectors are
 
 So **the ColdFire DMAs audio into the DSP's X memory and tells it the destination
 address at runtime**. There is no fixed audio buffer constant to discover, which
-is exactly why eight rounds of guessing addresses (`X:0`, `0xa0`, `0xb0`,
-`0x110`, both ping-pong states) all produced silence. The buffer addresses, the
+is exactly why guessing addresses (`X:0`, `0xa0`, `0xb0`,
+`0x110`, both ping-pong states) produces silence. The buffer addresses, the
 control blocks and the per-track state all arrive over the host port.
 
 Reconstructing that faithfully means emulating the ColdFire→DSP protocol — a
@@ -730,11 +696,11 @@ wholesale.
 | B | 46 | 7,583 | `P:0x01d9f` | **none** |
 
 Not one hole in either image. Payload A ends at `0x01fdf`, which is 99.6% of
-`0x2000`, and that looked like an 8 K internal P RAM essentially full.
+`0x2000` — which looks like an 8 K internal P RAM essentially full. It is not:
 
-### HARDWARE RESULT: there is memory above 8K — that inference was WRONG
+### There is memory above 8K (hardware-measured)
 
-`tools/build_dsptest.py` relocated CHORUS from `P:0x00eb7` to `P:0x02000` (three
+`tools/build_dsptest.py` (in git history) relocated CHORUS from `P:0x00eb7` to `P:0x02000` (three
 words per payload: the module's load-address field and its two dispatch entries).
 Flashed to the MKII: **CHORUS works normally.**
 
@@ -747,14 +713,9 @@ Proven usable so far: `P:0x02000`–`P:0x02149` (CHORUS's 329 words). The upper
 bound is unknown; relocating several clean effects to `0x4000`, `0x8000`, `0xc000`
 in one build would bracket it in a single flash, if it ever matters.
 
-Unsettled nuance: on a DSP56300, addresses beyond internal RAM fall through to
-external memory, which is slower. CHORUS running cleanly says `0x2000` works, not
-that it runs at full internal speed. For a cheap effect this is unlikely to
-matter; for something cycle-critical it would need checking.
-
-*Annotation 12 Aug 2026: settled — there is no external memory on this board;
-the shared window runs at the same speed as internal memory (see `CHIP.md`).
-The "would need checking" caveat is closed.*
+There is no external memory on this board and no speed penalty above the
+internal range: the shared window runs at the same speed as internal memory
+(see `CHIP.md`).
 
 ### The fallback, if space above ever runs out: replace
 
@@ -816,9 +777,9 @@ firmware bytes, not merely plausible.
 dsp_asm -in dsp/passthrough.asm -org 7c8 -list -out blob.bin
 ```
 
-## 7c. Delay memory — earlier figures CORRECTED
+## 7c. Delay memory
 
-Two mistakes in §7, both from scanning immediates too loosely:
+Two corrections to figures produced by scanning immediates too loosely:
 
 1. The buffer ladders attributed to the reverbs mixed **coefficient tables** in
    with delay lines. `X:0x438` (6,305 words, 99% non-zero, a decaying curve),
@@ -840,18 +801,18 @@ The uninitialised X regions, which is what actually matters:
 | `0x07a92–0x0857f` | 2,798 | 63 | |
 | **`0x08d98–0x0ffff`** | **29,288** | **664** | **unreferenced anywhere** |
 
-**RESOLVED, negatively — and this one is properly earned (4 Aug 2026,
-`dsp/xmem_probe.asm` v2).** The high X region is NOT usable memory on hardware.
+**RESOLVED, negatively (`dsp/xmem_probe.asm`): the high X region is NOT
+usable memory on hardware.**
 
-A first attempt tested three single words and reported failure, but it was not
-trustworthy and is worth recording as a lesson: one of its three addresses
-(`X:0x09000`) turned out to be clobbered even in the *emulator*, where only the
-DSP's own setup routine and our effect run — so "unreferenced anywhere" from a
-static scan was wrong, exactly as this section warns for the stock reverbs.
-Its per-address signatures also made a single-address failure sound identical
-to total failure, and it skipped the A2-clean discipline used everywhere else.
+A single-word probe cannot earn that conclusion, and its blind spots are worth
+keeping: one of three single-word test addresses (`X:0x09000`) turns out to be
+clobbered even in the *emulator*, where only the DSP's own setup routine and
+the effect run — so "unreferenced anywhere" from a static scan was already
+wrong, exactly as this section warns for the stock reverbs. Per-address
+signatures also make a single-address failure sound identical to total
+failure, and readbacks must be A2-cleaned like everything else.
 
-v2 earns the conclusion instead:
+The probe as written earns the conclusion instead:
 * writes and verifies a full **1024-word block** at `0x0C000` and another at
   `0x0F000`, not isolated words;
 * uses a **walking value**, so no two words share a pattern and a dead address
@@ -863,16 +824,11 @@ v2 earns the conclusion instead:
   passes there, output exactly half of input. A probe that always fails is
   indistinguishable from real failure unless you check this.
 
-On hardware both blocks fail. So: **a reverb's memory ceiling is the 32,768
-words (743 ms) of its FX2 allocation.** Still over 4x stock DARK REV's ~7,600
-words, but a Blackhole-class allocation is off the table. Do not re-chase this
-without reading the above — it has now cost two hardware flashes.
-
-**Better test, which also proves the pipeline**: write a small probe effect that
-stores a pattern high in X, reads it back, and passes audio only if it matches.
-Point a free effect id at it, flash, listen. That answers the memory question and
-exercises the entire write → assemble → insert → dispatch → ColdFire descriptor →
-flash path with ~20 instructions of risk instead of a thousand-word reverb.
+On hardware both blocks fail. High X buys nothing: **a reverb's memory ceiling
+is its FX2 allocation — 32,768 words (743 ms) as originally pooled, and
+65,536 shared-window words (1.49 s) per server since the XBUS split (see
+`CHIP.md`).** A Blackhole-class allocation in high X is off the table. Do not
+re-chase this without reading the above.
 
 ## 7d. HARDWARE: custom DSP code runs
 
@@ -885,12 +841,12 @@ module, dispatched via a new effect id `0x06` with its own descriptor, and
 It also proves **X:0x4000 is real read/write memory**, since the probe stamps a
 mask there in init and reads it back in process to use as the audio mask.
 
-### What the four attempts cost, and the actual lesson
+### Bring-up hangs: the candidate causes
 
-Attempts 1-3 hung the DSP (audio stops, sequencer freezes on trig 1 -- the
-sequencer is clocked by the DSP frame interrupt, so a DSP stall looks exactly
-like that). Attempt 4 worked after removing three things at once, so which one
-mattered is not established. The candidates, in order of suspicion:
+Three bring-up attempts hung the DSP (audio stops, sequencer freezes on trig 1
+-- the sequencer is clocked by the DSP frame interrupt, so a DSP stall looks
+exactly like that). The working attempt removed three things at once, so which
+one mattered is not established. The candidates, in order of suspicion:
 
 1. **Executing at `P:0x2000`.** Every failed attempt relocated the donor module
    there. `PRAMTEST` proved code *executes* at `P:0x2000`, but that test kept
@@ -905,10 +861,9 @@ mattered is not established. The candidates, in order of suspicion:
 3. **A hardcoded entry point** (`ORG + 9`) that silently became wrong when the
    probe shrank from 9 init words to 5.
 
-The process lesson is the real one: changing several variables per hardware
-iteration turned a two-flash question into four. The control run -- probing
-addresses known to exist -- was what converted "the memory must be absent" into
-"our code is wrong", and should have come first.
+The process rule: change one variable per hardware iteration, and run the
+control first -- probing addresses known to exist is what converts "the memory
+must be absent" into "the code is wrong".
 
 ## 7e. HARDWARE: the delay-memory budget, confirmed
 
@@ -925,13 +880,13 @@ So X memory covers at least `0x0000`–`0xf000`, and the region the firmware nev
 references — **`0x08d98`–`0x0ffff`, 29,288 words, 664 ms at 44.1 kHz** — is real,
 writable, and entirely free.
 
-### CORRECTION: that budget does not belong to effects
+### That budget does not belong to effects
 
-The figures below were measured correctly but interpreted wrongly, and the reverb
-work proved it. Probing showed X:0x4000/0xc000/0xf000 respond to reads and
-writes, and I concluded 664 ms of delay memory was available. It is not
-*allocated* to effects, and using it does not work: a self-chosen buffer neither
-persists reliably nor is safe to write in bulk.
+The figures below are correct as measurements but do not mean 664 ms of delay
+memory is available to an effect. X:0x4000/0xc000/0xf000 respond to reads and
+writes, but the region is not *allocated* to effects, and using it does not
+work: a self-chosen buffer neither persists reliably nor is safe to write in
+bulk.
 
 How the stock reverbs actually do it, from DARK REV's disassembly:
 
@@ -944,13 +899,13 @@ How the stock reverbs actually do it, from DARK REV's disassembly:
 * and it makes heavy use of Y memory (103 instructions) at low addresses.
 
 So effects are given small buffers in low Y memory and take their delay lengths
-from a table. The longest line DARK uses is 2,047 words -- about 46 ms, not the
-664 ms I quoted. A reverb here is built from a few thousand words in total, which
+from a table. The longest line DARK uses is 2,047 words -- about 46 ms, not
+664 ms. A reverb here is built from a few thousand words in total, which
 is why the stock ones sound small.
 
-This invalidates the design premise of reverb v1-v4: four 4096-word lines in
-self-chosen X memory is roughly 8x more delay memory than the hardware actually
-hands an effect, in a memory space that is not ours.
+Four 4096-word lines in self-chosen X memory would be roughly 8x more delay
+memory than the hardware actually hands an effect, in a memory space that is
+not the effect's.
 
 ### The measured figures, which stand as measurements
 
@@ -960,18 +915,12 @@ hands an effect, in a memory space that is not ours.
 | plus the shared gap `0x1d9f–0x483f` | 10,913 / 247 ms | currently PLATE + DARK |
 | code space (replace DARK) | 1,067 words | — |
 | code space (all three reverbs) | 2,724 words | — |
-| cycle budget | **unmeasured** | two stock reverbs already glitch |
+| cycle budget | since measured — see `CHIP.md` | two stock reverbs already glitch |
 
-Using the free `0x8d98+` region rather than the stock buffers means a new reverb
-**does not disturb the existing ones**, so it can be developed and flashed
-alongside working firmware instead of replacing something first.
+The cycle budget has since been measured (`CHIP.md`); the one empirical
+calibration visible from stock alone is that two stock reverbs at once glitch.
 
-The cycle budget is now the only unquantified constraint, and the only
-calibration is empirical: two stock reverbs at once glitch. That will shape how
-much modulation and diffusion is affordable, and it is the thing most likely to
-force compromises during tuning.
-
-### Development loop, now that it exists
+### Development loop
 
 The probe runs identically in `tools/dsp_host` and on hardware using the same
 convention (`r0` = interleaved block processed in place, `n7` = frames). Since a
@@ -994,10 +943,6 @@ The path is now mapped end to end:
 
 Do it for **both** payloads, or the effect exists on only one of the two DSPs.
 
-Still unknown, and needed before step 1 is real: how the 12 descriptor parameters
-reach the algorithm, and how much DSP cycle budget is actually free — the FX1
-reverb test showed two reverbs already glitch, so the headroom is not generous.
-
 Note the ColdFire uploads the payloads verbatim from the image, so a modified DSP
 program only needs the payload rewritten in place — the record format is
 understood in both directions, and the loader does no checksumming of its own.
@@ -1005,9 +950,8 @@ The outer ELEK/aPLib container is rebuilt by the existing toolchain.
 
 ## 8. HARDWARE: Y memory ends at 0xC000
 
-The reverb's tank was 1024-word lines because that was all §7's uncertain X-memory
-figures could justify. `dsp/ymemprobe.asm` settles it for Y, which is where the
-delay buffers actually live.
+`dsp/ymemprobe.asm` (in git history) settles the question for Y, which is
+where the delay buffers actually live.
 
 The probe is a **wet-only** echo whose buffer base is chosen by `p0`:
 
@@ -1020,13 +964,13 @@ answer rather than an ambiguous one. Sweep `p0` and note where it stops.
 **Result: clean echo up to p0=46, silence from p0=47.** So Y is real through
 `0xBFFF` and absent at `0xC000` — **48K words**. Loaded modules end at `0x794`,
 so `0x795–0xBFFF` is free: **46K words, roughly 1.04 s of delay at 44.1 kHz** —
-*internal only; there is another 64K external at `0x30000`, see the warning below*.
+*internal only; there is another 64K shared window at `0x30000`, see the warning below*.
 
 > ⚠️ **INCOMPLETE — this probe stopped at `0x20000` and missed a whole region.**
-> The `<<12` re-sweep (3 Aug, hardware) found a **second, EXTERNAL region at
+> A `<<12` re-sweep on hardware found a **second region — the shared window at
 > `0x30000–0x3FFFF`: 64K words**, echoing cleanly, freezing only at `0x40000`.
-> That is where the allocator's other four FX2 slots live, and believing they
-> were absent made our reverb run dry on half the tracks for twenty builds.
+> That is where the allocator's other four FX2 slots live; an effect that
+> treats them as absent silently runs dry on half the tracks.
 > See "Y memory, measured end to end" below.
 
 That is about 8x what the reverb had been using, and it is what makes a
@@ -1096,18 +1040,18 @@ BAL and MONO it leaves to the host.
 > `$c` is the slot DARK's algorithm reads its pre-delay from, but the knob
 > *displayed* as `PRE` drives `$e`; `$c` is driven by the knob displayed as
 > `MIXF`. Both statements are true at once and they are easy to conflate --
-> a `BUS.md` session did exactly that, "corrected" this table the wrong way,
-> and then renamed page-2 slots against the mapping, producing page-2 knobs
-> that did nothing. `REVERB.md` warns about precisely this: page 2 is left
-> unrenamed because the descriptor's display order conflicts with the probed
-> mapping. **The display-slot-index to offset mapping is still not directly
-> measured** -- only label-to-offset is.
+> "correcting" this table the wrong way and renaming page-2 slots against the
+> mapping produces page-2 knobs that do nothing. `REVERB.md` warns about
+> precisely this: page 2 is left unrenamed because the descriptor's display
+> order conflicts with the probed mapping. This table is label-to-offset
+> only; the display-SLOT-index to offset mapping is measured in the next
+> section.
 
 ### Page-2 DISPLAY SLOT -> offset, measured (dsp/page2_probe.asm)
 
 The table above is knob-LABEL to offset. What a clone actually needs is
-display-SLOT-INDEX to offset, and that had never been measured -- inferring it
-from stock's labels was wrong twice. Settled with `dsp/page2_probe.asm`: give
+display-SLOT-INDEX to offset -- and inferring it
+from stock's labels gets it wrong. Measured with `dsp/page2_probe.asm`: give
 each offset a distinct audible signature, expose all six page-2 slots with a
 full 0..127 range, flash once, sweep each knob.
 
@@ -1120,8 +1064,8 @@ full 0..127 range, flash once, sweep each knob.
 | 10 | **`r6+$e`** knob field |
 | 11 | **`r6+$e`** low bits |
 
-**All six page-2 slots reach the DSP.** Getting here took seven probe builds
-and two wrong guesses, so the reasoning matters as much as the table:
+**All six page-2 slots reach the DSP.** The reasoning matters as much as the
+table:
 
 * A knob arrives as `value<<16`, occupying bits 16-22. **The low bits of the
   same word are a separate, independently addressable field** — this is what
@@ -1132,9 +1076,9 @@ and two wrong guesses, so the reasoning matters as much as the table:
 * Slots therefore pair up: **even slot = knob field, odd slot = companion
   field of the same word.** 8/9 share `$d`, 10/11 share `$e`.
 * **A probe that only compares the whole word against `64<<16` cannot see the
-  companion field at all.** Probes 1-4 did exactly that and wrongly concluded
-  slots 7/9/11 were dead and `$c` unreachable. Both conclusions were wrong.
-* `r6+$6..$a` really are dead — probed explicitly (v3), nothing responds.
+  companion field at all** — and wrongly concludes slots 7/9/11 are dead and
+  `$c` unreachable. Both conclusions are wrong.
+* `r6+$6..$a` really are dead — probed explicitly, nothing responds.
 * Page-class A (`0x40032814`, e.g. FILTER) is **not** a richer alternative:
   cloning a class-A donor rendered only one page-2 knob, because that class
   sources its page layout from the 20-byte-stride array at `0x46c7d244`
@@ -1144,71 +1088,32 @@ and two wrong guesses, so the reasoning matters as much as the table:
   threshold probe can never trip, and a non-zero min makes a slot display a
   negative range (slot 7 showed -64..-62 until min was forced to 0).
 
-**Settled (v7).** Slot 6 moves `$c` bits 16-22 and slot 7 moves `$c` bits
-8-15 — different fields, so both are independently usable. Slot 6's value also
-appears at `$b`, so an effect may read it from either.
+Slot 6 moves `$c` bits 16-22 and slot 7 moves `$c` bits
+8-15 — different fields, so both are independently usable.
 
-> ⚠️ **The "also appears at `$b`" clause is FALSIFIED on hardware, 10 Aug
-> 2026.** ChonVerb read SHMR from `$b` alone and it was **dead silent on the
-> unit** (Sam, A/B'd against a local render with clearly audible +12 shimmer:
-> octave-up rises from −7.3 to −1.1 dB and dominates the tail). The knob does
-> publish — MODE (`$c` mid) and PRE (`$e` knob) both respond on the panel —
-> so slot 6 lands in `$c`'s **knob field** as the primary finding says, NOT at
-> `$b`. R16 reads SHMR from `$c` knob field OR'd with `$b` (robust to either),
-> pending on-unit confirmation. Do not rely on `$b` for a page-2 knob.
+> ⚠️ **Do not rely on `$b` for a page-2 knob.** An earlier probe result said
+> slot 6's value also appears at `$b`; on hardware, an engine reading a
+> page-2 knob from `$b` alone is **dead silent** while the panel demonstrably
+> publishes (MODE — `$c` mid — and the `$e` knob both respond). Slot 6 lands
+> in `$c`'s **knob field**, as the table says. ChonVerb reads SHMR from the
+> `$c` knob field OR'd with `$b` (robust to either).
 
-> **CORRECTED 4 Aug 2026, on hardware: all six can be full-range knobs.**
-> The "three knobs plus three companion selects" split below was inferred from
-> how *stock* uses the fields, and it is not a hardware limit. ChonVerb runs
-> SPEED/DIFF/WIDTH/PRE/→DEL as five full 0–127 controls, two of them in
-> companion fields, confirmed by ear and eye on the unit.
+> **All six page-2 slots can be full-range knobs — measured on hardware.**
+> The "three knobs plus three companion selects" split reflects how *stock*
+> uses the fields; it is not a hardware limit. Five full 0–127 controls, two
+> of them in companion fields, have run on the unit at once. (ChonVerb
+> currently chooses otherwise: WIDTH and →DEL are 4-step selects on companion
+> low-byte fields, and `$e` carries GATE.)
 >
-> *Annotation 12 Aug 2026:* on the unit the companion-field pair read
-> near-boolean in practice, and as of R16 WIDTH and →DEL are **4-step
-> selects** on companion low-byte fields; PRE was **retired** in R16
-> (`$e` is GATE now). "All six *can* be full-range" stands as a statement
-> about the hardware; it is no longer how ChonVerb uses them.
->
-> What actually made a companion field *look* like a two-state control was the
+> What makes a companion field *look* like a two-state control is the
 > **per-parameter display formatter at `P+0x0ca`**, inherited from the donor
-> descriptor — DARK's `MIXF` formatter drew our →DEL as "MIX / SEND" no matter
-> what value count it was given. Zero that array (and its partner at `P+0x0fa`)
+> descriptor — DARK's `MIXF` formatter draws a knob as "MIX / SEND" no matter
+> what value count it is given. Zero that array (and its partner at `P+0x0fa`)
 > and the same field draws as an ordinary knob. See `REVERB.md`.
->
-> The decode below is still right — companion fields are read with a mask —
-> and the field/offset table above is still right. Only the *budget* claim was
-> wrong.
->
-> ✅ **RESOLVED, 10 Aug 2026 — the on-unit per-knob reconfirm happened.**
-> Page 2 **does publish**: MODE steps, PRE reached the DSP (before its R16
-> retirement), DIFF and WIDTH move. SHMR was silent for a different reason —
-> the DSP read the wrong offset (`$b`; the panel publishes to `$c`'s knob
-> field). R16 reads `$c` OR `$b` (robust to either) and is **still
-> unflashed**. As of R16, WIDTH/→DEL are 4-step selects on companion
-> low-byte fields, and PRE is retired (`$e` is GATE now). The contradiction
-> block below is kept as history.
->
-> ⚠️ **CONTRADICTION, OPEN as of 10 Aug 2026** *(historical — resolved
-> above)*. `PLAN.md`'s 10-Aug hardware
-> trip recorded the OPPOSITE of the 4-Aug "confirmed by ear and eye" above:
-> that page-2 continuous knobs (SHMR/DIFF/WIDTH/PRE/→DEL) "do not publish —
-> pinned at their defaults", MODE (a select) works. Both cannot be current.
-> A 10-Aug static + local investigation could not reproduce any gate:
-> (1) our cloned page-2 descriptor is byte-for-byte equal to **stock DARK
-> REV's** page-2 knobs (count 128, `P+0x12a`=0x40032814, enable 1), which
-> publish and work; both descriptor-level fix-theories (`0x12a` callbacks,
-> count=128) are falsified by stock working with those exact values.
-> (2) the DSP engine RESPONDS to every page-2 value when poked into r6
-> (dsp_host DIFF/SHMR/PRE sweeps give distinct output) — no r7 slot
-> collision. (3) the read code is UNCHANGED since 4–6 Aug. So descriptor and
-> engine are both correct, and the 10-Aug observation is most likely a
-> misdiagnosis from that chaotic trip (wrong tag, track↔core inversion).
-> **Do not act on either claim until the next flash reconfirms per-knob**
-> (turn each page-2 knob through its range on a known-ChonVerb track — the
-> protocol is in `PLAN.md` step 2).
 
-**Usable budget: six page-2 controls per effect** — three continuous knobs in
-the knob fields of `$b`/`$d`/`$e` (or `$c`), plus three companion selects:
+**Six page-2 controls per effect** — three continuous knobs in
+the knob fields of `$b`/`$d`/`$e` (or `$c`), plus three companion fields
+(each usable as a select or, per the note above, as a full-range knob):
 
 | control | read it from | decode |
 |---|---|---|
@@ -1223,10 +1128,10 @@ The selects were exercised with count 3 and responded on positions 1 and 2, so
 at least three states are distinguishable; the exact value-to-bit encoding
 within each field has not been enumerated beyond "zero vs non-zero per state".
 
-**Superseded:** an earlier revision of this section claimed `r6+$c` was
-unreachable and that only three page-2 offsets existed. Both were artefacts
-of probing only the knob field -- see the bullets above. All four offsets
-(`$b`, `$c`, `$d`, `$e`) and all six display slots are reachable.
+All four offsets (`$b`, `$c`, `$d`, `$e`) and all six display slots are
+reachable. A probe that watches only the knob field concludes that `$c` is
+unreachable and that only three page-2 offsets exist -- both artefacts of the
+probe, not facts about the hardware (see the bullets above).
 
 `r6+6..$a` is touched by nothing. What lives there is still unknown.
 
@@ -1240,7 +1145,7 @@ reads the wrong slot.
 
 ## 10. Per-instance buffers: the host runs a bump allocator
 
-Every build up to v22 hardcoded absolute Y addresses. That works for exactly one
+Hardcoding absolute Y addresses works for exactly one
 instance and writes through everything else. Here is how the stock effects do it.
 
 ### The mechanism
@@ -1290,10 +1195,10 @@ Three things follow:
    are FX2-only — they do not fit in an FX1 allocation.
 2. **`0x8000 + 0x4000 = 0xC000`**, exactly where §8's probe found Y ends. The
    allocator fills Y to the last word and then jumps to a second region at
-   `0x30000` — **which is REAL, and was finally measured on 3 Aug.** The old
-   probe stopped at `0x20000` and never reached it.
+   `0x30000` — which is real and measured (the first probe stopped at
+   `0x20000` and never reached it).
 
-### Y memory, measured end to end (3 Aug, `dsp/ymemprobe.asm` on hardware)
+### Y memory, measured end to end (`dsp/ymemprobe.asm` on hardware; file in git history)
 
 | Y range | what | |
 |---|---|---|
@@ -1302,7 +1207,7 @@ Three things follow:
 | `0x01000–0x03FFF` | 4 FX1 slots x 3072 | internal |
 | `0x04000–0x0BFFF` | 2 FX2 slots x 16384 | internal |
 | `0x0C000–0x2FFFF` | **absent** (silence) | — |
-| `0x30000–0x3FFFF` | **64K words, 4 more FX2 slots** | **EXTERNAL** |
+| `0x30000–0x3FFFF` | **64K words, 4 more FX2 slots** | **shared window** |
 | `0x40000+` | **absent** (freezes) | — |
 
 Swept by TIME as `base = (p0+1) << 12`: sound at 0–10, silence through the
@@ -1311,16 +1216,17 @@ buzzed continuously while 48–62 were clean — worth remembering if anything
 odd shows up at the very start of the external region.
 
 The internal 48K is **per-DSP** (both payloads use `0x4000`/`0x8000` and do not
-clash, because they are different chips). The external 64K is **shared**, which
+clash, because they are different chips). The 64K window is **shared between
+the chips**, which
 is why the payloads are given different halves: A takes `0x30000`/`0x34000`,
 B takes `0x38000`/`0x3c000`. Every one of the 8 tracks therefore has a full
-16,384-word FX2 slot, and an effect that refuses the external slots — as ours
-did until v67 — silently gives up half the machine.
+16,384-word FX2 slot, and an effect that refuses the shared-window slots
+silently gives up half the machine.
 3. Our 40K layout was about 2.5x an instance's entire allocation.
 
-### What v23 does
+### The relocatable layout
 
-All buffers are offsets from the base, and all persistent state moved out of
+All buffers become offsets from the base, and all persistent state moves out of
 absolute Y into the r7 block, which is already per-instance:
 
     lines      base+0x0000  4 x 2048    taps 1567 1249 977 733
@@ -1342,13 +1248,13 @@ table entries (`DSP_ALLOC_IDX` in `dsp_host`) and compare the output. Base
 
 ### Getting the base from init to process, measured not deduced
 
-Two claims in this section were reasoned from the dispatcher listing and both
-were wrong. Recording how they failed, because the failure mode is identical in
+Two plausible claims reasoned from the dispatcher listing are both
+wrong, with the same failure mode in
 each case — a build that is clean in the emulator and unusable on hardware.
 
 **Wrong claim 1: the base can be derived from r7.** X:0x20a and X:0x213 do
 advance together, so `n = (r7 - 0x6000) >> 8; base = x:(0x255 + n)` looks sound.
-Measured with `dsp/r7probe.asm` — 49 words that pass audio only when the TIME
+Measured with `dsp/r7probe.asm` (in git history) — 49 words that pass audio only when the TIME
 knob equals `r7 >> 8`, so the knob position reads the register directly — r7 is
 **0x6200**. The arithmetic was right, but `table[2]` is `0x1c00`, a 3072-word
 **FX1** slot. A 16K layout starting there runs to `0x53ff`, through the other FX1
@@ -1358,15 +1264,15 @@ buffers and into FX2 slot 0. FX2 effects do not take even table entries.
 
 | build | base | state | result |
 |---|---|---|---|
-| v25 | derived | `r7+$84..$8a` | hangs |
-| v26 | hardcoded | `r7+$84..$8a` | hangs → base innocent |
-| v27 | hardcoded | absolute Y | runs → state is the fault |
+| 1 | derived | `r7+$84..$8a` | hangs |
+| 2 | hardcoded | `r7+$84..$8a` | hangs → base innocent |
+| 3 | hardcoded | absolute Y | runs → state is the fault |
 
 `r7+$71..$78` is fine *within* one call and `r7+$83` persists, but `r7+$84..$8a`
 does not. DARK REV's init writes `$1a $1b $1f $82 $83 $84 $8b` and steps around
 `$85..$8a` — it was avoiding host-owned words.
 
-**What works**, measured with `dsp/baseprobe.asm` (same trick, TIME matched
+**What works**, measured with `dsp/baseprobe.asm` (in git history; same trick, TIME matched
 against `base >> 9`): init reads `X:0x213` and stashes the base in absolute Y at
 
     Y:(0x735 + (r7 >> 8))    ->  0x795..0x79d for r7 = 0x6000..0x6800
@@ -1383,7 +1289,7 @@ damping states go in the instance's own Y region, loaded and saved once per bloc
 
 ### The base MUST be read in init, not in process
 
-v23 hung. The loop was still 300 instructions, so it was never cycles -- it was
+Reading it in process hangs the machine — and not because of cycles; it is
 *when* the base is read.
 
 The dispatcher advances `X:0x213` **before** it calls process:
@@ -1400,8 +1306,8 @@ The stock code says the same thing plainly, once you check the dispatch table:
 DARK REV's init is `P:0x01679-0x0171a` and its process starts at `P:0x0171b`, and
 the base read at `P:0x01692` is **inside init**.
 
-v24 reads the base and derives all seven buffer addresses in init -- 31
-instructions, no loop -- and stores them in the r7 block. Process just uses them,
+Read the base and derive all seven buffer addresses in init -- 31
+instructions, no loop -- and store them in the r7 block. Process just uses them,
 which is also cheaper than recomputing per block.
 
 ### One trap worth its own paragraph
@@ -1423,14 +1329,15 @@ buffers, which is the only absolute scratch an effect can use — they differ:
 | A | 5 | Y:0x0794 | Y:0x0795..0x0FFF |
 | B | **21** | **Y:0x07a4** | Y:0x07a5..0x0FFF |
 
-**This is what made the reverb hang on two tracks.** init carried its buffer base
-across to process through a per-instance stash at `Y:(0x735 + (r7 >> 8))`, an
-address chosen against payload A's map and verified on payload A. On payload B
-every one of those addresses lands inside a live 128-word coefficient table. The
-effect corrupted another algorithm's coefficients, then read that algorithm's
-data back as its own buffer base and wrote 14K words from wherever it pointed.
+**This is a real failure mode.** An init that carries its buffer base
+across to process through a per-instance stash at `Y:(0x735 + (r7 >> 8))` — an
+address chosen against payload A's map and verified on payload A — lands, on
+payload B,
+inside a live 128-word coefficient table at every one of those addresses. The
+effect corrupts another algorithm's coefficients, then reads that algorithm's
+data back as its own buffer base and writes 14K words from wherever it points.
 
-One instance never showed it, because one instance is one payload.
+One instance never shows it, because one instance is one payload.
 
 Anything absolute in Y must sit at **0x800 or above** to be safe in both, and the
 usable window is only `0x7a5..0x0FFF` — 2139 words.
@@ -1459,14 +1366,19 @@ entry `1 + 2k` and state block `0x6000 + (2 + 2k) * 0x100`:
 | track 3 FX2 | 5 | 0x30000 | **0x38000** | 0x6600 |
 | track 4 FX2 | 7 | 0x34000 | **0x3c000** | 0x6800 |
 
-That model reproduces both hardware measurements: `dsp/r7probe.asm` returned
-0x6200, and `dsp/baseprobe.asm` returned 0x4000 and 0x8000 on two tracks.
+("Track *n*" here is the *n*-th track of the chip's own bank of four. The
+track↔chip mapping is measured: payload A serves tracks 5–8, payload B serves
+tracks 1–4.)
 
-> **CORRECTED (3 Aug).** This used to say the low two FX2 slots being the same Y
-> addresses in both payloads meant "only one payload can be live at a time".
-> That is backwards. **Both payloads are live at once** — two separate DSP chips,
+That model reproduces both hardware measurements: `dsp/r7probe.asm` returned
+0x6200, and `dsp/baseprobe.asm` returned 0x4000 and 0x8000 on two tracks
+(both probes in git history).
+
+> **Both payloads are live at once** — two separate DSP chips,
 > four tracks each, each with its own on-chip RAM, so `Y:0x4000` on chip A and
-> `Y:0x4000` on chip B are different physical memory.
+> `Y:0x4000` on chip B are different physical memory. (The low two FX2 slots
+> being the same Y addresses in both payloads does NOT mean only one payload
+> can be live at a time.)
 >
 > **The machine: 8 tracks, each with one FX1 slot and one FX2 slot.** FX1 is
 > 3072 words (~70 ms) — fine for chorus, phaser, comb, EQ, and far too small for
@@ -1478,11 +1390,11 @@ That model reproduces both hardware measurements: `dsp/r7probe.asm` returned
 > | | slots | where |
 > |---|---|---|
 > | DSP A, 4 tracks | `0x4000` `0x8000` | internal, on-chip |
-> | | `0x30000` `0x34000` | external, shared SRAM |
+> | | `0x30000` `0x34000` | shared-window SRAM |
 > | DSP B, 4 tracks | `0x4000` `0x8000` | internal, its own on-chip |
-> | | `0x38000` `0x3c000` | external, shared SRAM |
+> | | `0x38000` `0x3c000` | shared-window SRAM |
 >
-> Internal memory supplies only four of the eight, so **the external region is
+> Internal memory supplies only four of the eight, so **the shared window is
 > not optional — it is required for 8 tracks to have reverb at all.** That is an
 > independent confirmation that it is real and that stock uses it, and it is the
 > reason the payloads partition it: a shared resource is what gets divided.
@@ -1504,19 +1416,18 @@ word a loaded module put there, which is never legitimate) and names it:
 !! CLOBBER inst 0 init wrote Y:0x00737 -- OVER A LOADED MODULE
 ```
 
-Two bisect builds shipped to hardware before this existed were themselves broken
-by the instrumentation — v34 put the level read inside the pre-delay setup so n5
-came from the knob, v35 clobbered x0 between the base derivation and the state
-load — so their hardware results had to be discarded. Run the guard first.
+Bisect builds can be broken by their own instrumentation — one put the level
+read inside the pre-delay setup so n5
+came from the knob, another clobbered x0 between the base derivation and the
+state load — invalidating their hardware results. Run the guard first.
 
 ## 12. Standing rules for writing DSP code here
 
-Learned by freezing the machine. Every one of these cost at least one
-hardware flash.
+Learned by freezing the machine; each of these was established on hardware.
 
-* **`mpy` does NOT double.** Measured: 0.5*0.5 = $200000 exactly. A
-  "fractional multiply shifts left" theory drove three wrong changes
-  before hardware caught it. Coefficients are plain fractions.
+* **`mpy` does NOT double.** Measured: 0.5*0.5 = $200000 exactly. The
+  "fractional multiply shifts left" theory is wrong. Coefficients are
+  plain fractions.
 * **Let the AGU do address work.** Modulo wraps, adds the base and masks
   for free. Doing it by hand cost 135 cycles/sample — 31% of the engine.
   An interpolated read does NOT need two addresses: the read pointer
@@ -1527,24 +1438,25 @@ hardware flash.
   move, `mpy x0,y0,a` discards it); XY dual moves need the X pointer in
   R0-R3 and the Y pointer in R4-R7. Verify every one by disassembling.
 * **When a register holding a constant is repurposed, grep every read of
-  it.** Two clobbers this session came from exactly that — one produced
+  it.** Two real clobbers came from exactly that — one produced
   344 stray writes, the other broke only when PRE was off-centre.
-* **A workaround for a disproven theory does not remove itself.** The
-  arithmetic addressing added for the modulo theory outlived the theory by
-  nineteen builds and eventually cost an instance.
+* **A workaround for a disproven theory does not remove itself.** An
+  arithmetic-addressing workaround added for a disproven modulo theory
+  outlived the theory and eventually cost an instance.
 * **Sanity-check a surprising emulator result against the instrument.**
-  A harness modelling a special case instead of the dispatcher invented a
-  self-oscillation that cost a day; the user's ears settled it in one line.
+  A harness modelling a special case instead of the dispatcher can invent
+  behaviour — a spurious self-oscillation, for instance — that a listening
+  test falsifies immediately.
 
 * two instructions between writing r5 and using it — and they must be **data
   moves**, never M-register writes (an M load interlocks with its address
-  register; this froze one track in v47)
+  register; this froze one track)
 * no M-register write inside the sample loop
 * a modulo offset larger than the buffer is undefined: silent, not an error
 * absolute Y scratch must sit at 0x800 or above — payload B loads modules to
-  Y:0x7a4 where payload A stops at 0x794 (this was the v30/v31 hang)
+  Y:0x7a4 where payload A stops at 0x794 (violating this has hung the unit)
 * X:0x213 is only valid during init; reading it in process gives whatever the
-  last init left (this was the v33 hang)
+  last init left (this too has hung the unit)
 * check the generated assembly and the assembler's exit status, not the
   generator. `build_reverb.py | grep` masks a failed assemble and the emulator
   will then happily "verify" a stale image.

--- a/docs/FLASHING.md
+++ b/docs/FLASHING.md
@@ -194,7 +194,7 @@ from Elektron's zip (card). Your CF card and projects are not affected.
 
 ---
 
-## ⚠️ First load of an EXISTING PROJECT on R29+ (the RETURN-architecture images)
+## ⚠️ First load of a project saved on an older (pre-return) image
 
 There is **no migration mechanism**: the unit stores each part's knob VALUES,
 and our descriptors only supply defaults when an effect is freshly selected.
@@ -207,8 +207,8 @@ something else:
 2. **Old stored MIX values load as IN** (p5). On a pure return track this is
    inaudible — but it silently registers the host as a bus client and dilutes
    the real senders. Zero it, or use step 4.
-3. **Old stored VRBW values load as `-VRB`** (delay p5, live again from R30).
-   A pre-v3 project's VRBW=127 will wash the delay into the reverb on load.
+3. **Old stored VRBW values load as `-VRB`** (delay p5). An old project's
+   VRBW=127 will wash the delay into the reverb on load.
 4. **The one-step fix per track: re-select the effect** (switch the FX2 away
    and back). The id-store fires on change and applies fresh defaults.
 

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -21,9 +21,9 @@ NOTE/ARP/CTRL pages, and the effects.
 0x400d2e52 .. 0x400d5f00     31 entries × 402 (0x192) bytes = 12,462 B
 ```
 
-> Corrected after the Ghidra pass: the table starts one entry earlier than first
-> measured. Entry −1 at `0x400d2e52` has a blank name, which is why a
-> printable-name walk skipped it; `FUN_40031da4` returns it (`0x400d2e8a` =
+> The table starts one entry earlier than a printable-name walk finds: entry
+> −1 at `0x400d2e52` has a blank name, which is why such a
+> walk skips it; `FUN_40031da4` returns it (`0x400d2e8a` =
 > `0x400d2e52 + 0x38`) for track 7 when `DAT_80000034` is set — the **master
 > track** page.
 
@@ -146,7 +146,7 @@ Record source AB/CD (5 values each), record length (65), trig mode (3), a third 
 with 11 options, fade in/out (113), and quantised record/play (18 values, default
 `255` = off). This is the whole sampling front-end's parameter model.
 
-## 3b. Free parameter slots — surveyed across every page (5 Aug 2026)
+## 3b. Free parameter slots — surveyed across every page
 
 Read straight from the per-parameter enable bitmaps (`P+0x18e` = slots 0-7,
 `P+0x18a` = slots 8-11, one nibble each, **0 = disabled, no knob drawn**). Done
@@ -170,7 +170,7 @@ delay's own twelve are all in use (`BUS.md`).
 | CONTROL 1 | `00111111` / `00001111` | p0 p1 |
 | CONTROL 2 | `11111111` / `00001111` | none |
 
-> ### CAVEAT that invalidates part of this table (photographed, 5 Aug 2026)
+> ### CAVEAT that invalidates part of this table (photographed on the unit)
 >
 > **The enable bitmap only governs the GENERIC parameter-page renderer. A page
 > drawn by bespoke code ignores it entirely.**
@@ -214,7 +214,7 @@ per-track, which is the granularity a send level needs. Its full table:
 * **`p8 ATCK` is the only genuinely un-drawn slot, and it is a boolean** (count
   2). Using it as a level means widening the count to 128 and zeroing its
   formatter as well as enabling it — three edits to a stock page, not one.
-* **`XVOL` (p5) is marked ENABLED but Sam reports it does not appear in the
+* **`XVOL` (p5) is marked ENABLED but it does not appear in the
   GUI.** It is a full 128-range page-1 slot with a custom formatter
   (`0x4003b484`), and a formatter is exactly what decides whether and how a
   parameter draws — the same mechanism that made our `→DEL` render as
@@ -244,15 +244,15 @@ Method is `dsp/page2_probe.asm`'s, which settled the FX page-2 mapping and is
 the precedent to copy: give each candidate offset a **distinct audible
 signature**, expose the slot with a full 0..127 range, flash once, sweep.
 
-Two traps that pass already recorded, both of which apply here:
+Two recorded traps, both of which apply here:
 
 * **A probe comparing whole words against `64<<16` cannot see a companion
-  field.** Probes 1-4 did exactly that and drew the wrong conclusion.
+  field.** Earlier probes did exactly that and drew the wrong conclusion.
 * **Defaults must be in range.** A default outside its own value count is used
   as an index and stalled the sequencer on hardware — so widening `ATCK`'s count
   means checking its default too.
 
-Seven builds settled page 2. Budget similarly, and note this one edits a
+Settling page 2 took seven probe builds; budget similarly, and note this one edits a
 **stock, always-present page shared by every track**, where page 2 only ever
 edited our own clones.
 
@@ -370,7 +370,7 @@ flag. Plain `1` is what the large majority of stock parameters use.
 and it is the reason the `P` vs `E` distinction above is not academic: a clone
 copied as `E .. E+0x192` (rather than `P .. P+0x192`) loses exactly the tail
 these two words live in, and the effect appears in the menu with a correct name
-and **not a single knob**. That cost two hardware flashes on the `BUS.md` work.
+and **not a single knob**. That mistake cost two hardware flashes to find.
 
 **Bearing on the FX1 experiment**: the effect id is used for *one* thing here —
 indexing the descriptor table, `return tbl[id]`, with no side effects and no
@@ -450,13 +450,13 @@ slot, so the cause is a per-effect resource rather than a per-slot permission.
 Leading hypothesis: the delay needs a delay-line buffer that is allocated only for
 the FX2 slot, so an FX1 delay runs with no buffer and produces nothing. Untested.
 
-~~Unconfirmed lead: `FUN_40005638` references the FILTER and DELAY descriptors
-directly...~~ **CLOSED, 5 Aug 2026, and it was nothing.** `FUN_40005638` is the
-**part defaults initialiser**: it copies `E+0x3b` out of each of those two
+`FUN_40005638` references the FILTER and DELAY descriptors directly, but it
+is not a lead: it is the
+**part defaults initialiser** — it copies `E+0x3b` out of each of those two
 descriptors into a fresh part's structure, because a new part defaults to
 **FX1 = FILTER, FX2 = DELAY**. It has no connection to delay-line buffers. The
 real question — where the delay runs, given id `0x08` is a passthrough — is open
-and the DSP is now ruled out; see `DSP.md` §5.
+and the DSP is ruled out; see `DSP.md` §5.
 
 ### Follow-up hardware tests
 
@@ -470,8 +470,7 @@ and the DSP is now ruled out; see `DSP.md` §5.
 **The buffer hypothesis was narrowed, not confirmed or killed.** Co-selecting
 DELAY on both slots rules out *one shared delay buffer allocated on demand*. It
 does **not** rule out a **per-slot buffer pointer whose FX1 entry is never
-initialised** — that version fits every observation. (An earlier note here called
-this test "decisive"; it was not.)
+initialised** — that version fits every observation.
 
 The UI behaving perfectly while audio is untouched confirms the ColdFire side is
 complete: the id is stored, resolved, displayed and published to shared RAM
@@ -542,7 +541,7 @@ effect will still appear unselectable.
 
 ---
 
-## ⚠️ THE PAGE-2 SLOT MAP — settled 17 Aug 2026, after months of confusion
+## ⚠️ THE PAGE-2 SLOT MAP
 
 **Each page-2 word carries TWO controls: the KNOB field at bits 16–23 and a
 COMPANION field at BITS 8–15.** Not the low byte. The low byte is never
@@ -555,35 +554,35 @@ published.
 | 8 | `$d` | knob, bits 16–23 | DIFF |
 | 9 | `$d` | **bits 8–15** | WIDTH / PTCH |
 | 10 | `$e` | knob, bits 16–23 | GATE / SPRAY |
-| 11 | `$e` | **bits 8–15** | FRZE (→DEL retired 18 Aug 2026) |
+| 11 | `$e` | **bits 8–15** | FRZE (→DEL retired) |
 
 ⚠️ **Slot 6 is on `$c`, not `$b`.** `$b` is not a page-2 parameter word at all.
 
-**How it was settled**, because it was inferred from behaviour rather than
+**The evidence**, because the map was inferred from behaviour rather than
 documented anywhere:
 - **MODE (slot 7) reads bits 8–15 and works** — swept on hardware across five
-  positions, repeatedly, 17 Aug.
-- **R16's SHMR fix independently needed `$c`'s knob field, not `$b`'s** — the
-  same off-by-one word, patched at the time without the pattern being seen.
+  positions, repeatedly.
+- **SHMR independently needed `$c`'s knob field, not `$b`'s** — the
+  same off-by-one word.
 - **Slot 11 confirmed dead for BOTH effects** (ChonVerb's →DEL and BongDelay's
-  FRZE, 17 Aug), which rules out a per-effect descriptor fault and leaves the
+  FRZE), which rules out a per-effect descriptor fault and leaves the
   slot itself.
 
 Everything that read bits 0–7 had never worked on hardware: slot 9 and slot 11,
-in both effects, since they were introduced. Fixed in `7a4f96b` (R28).
+in both effects, until this map was applied (fixed in `7a4f96b`).
 
-⚠️ **NONE OF THIS IS TESTABLE IN dsp_host.** It writes only KNOB fields
-(`(pv[i] & 0x7f) << 16`) and maps slots 6–11 onto `$b,$c,$d,$e` cyclically —
-so slot 6 lands on `$b`, which is exactly why the delay's WOW always worked
-locally and never on hardware. A companion field has never been drivable in the
-emulator; `DMODE=`/`DINT=`/`DFRZ=` exist as build-time overrides for that
-reason. **A green local render says nothing about whether a page-2 companion
-control publishes.**
+⚠️ **The trap this map explains**: dsp_host used to write only KNOB fields
+(`(pv[i] & 0x7f) << 16`) and mapped slots 6–11 onto `$b,$c,$d,$e` cyclically —
+so slot 6 landed on `$b`, which is exactly why the delay's WOW always worked
+locally and never on hardware. `DMODE=`/`DINT=`/`DFRZ=` exist as build-time
+overrides for that reason. **A green local render says nothing about whether
+a page-2 companion control publishes** unless the harness implements this
+map.
 
-✅ **DONE, same day (`cd8964a`)**: dsp_host now implements this exact map, and
-the first-ever param-driven companion renders **bit-identical** to the
-build-time overrides (`MODE=`/`DMODE=`) they duplicate — with negative
-controls. `send_probe` grew `--dmode/--dptch/--dfrz/--width/--gate/--rdel`.
+✅ dsp_host now implements this exact map (`cd8964a`), and a
+param-driven companion renders **bit-identical** to the
+build-time overrides (`MODE=`/`DMODE=`) it duplicates — with negative
+controls. `send_probe` has `--dmode/--dptch/--dfrz/--width/--gate/--rdel`.
 The end-to-end path is proven locally: ChonVerb's `-DEL` select at 3 feeds
 BongDelay at 0.375 FS peak; at 0, digital silence.
 ⚠️ What is STILL impossible locally: changing a parameter **mid-run** —

--- a/docs/REVERB.md
+++ b/docs/REVERB.md
@@ -1,20 +1,19 @@
 # ChonVerb — the custom reverb
 
-An eight-line FDN reverb (four-line through ChonVerb31; the eight-line tank
-landed 8 Aug 2026 and the four-line source is deleted — recover it with
-`git show c1ce08d:dsp/reverb_server.asm`). It ships as **ChonVerb**, one of the three effects
+An eight-line FDN reverb (an earlier four-line engine's source is deleted —
+recover it with `git show c1ce08d:dsp/reverb_server.asm`, in git history). It
+ships as **ChonVerb**, one of the three effects
 on the shared send bus (`BUS.md`), running on the FX2 slot of any track in a
 bank. Built by `tools/build_bus.py`; source `dsp/reverb_server.asm`.
 
-> ⚠️ **Reading this file, 9 Aug 2026:** sections below describing the
-> four-line tank, the six-tap early-reflection section, the HALL mode, or the
-> 2048-word static in-loop allpasses describe the **deleted engine**. The
-> shipping engine is eight lines, 8×8 FWHT, **three** modes (ROOM/PLATE/BIG —
-> HALL cut 9 Aug), ER removed in favour of a short Dattorro-scale input
-> diffuser (taps 179/293/419/547 = 4.1–12.4 ms), and 512-word **modulated**
-> in-loop allpasses. The signal path and parameter table here are updated;
-> deeper sections are corrected where marked, historical otherwise. `PLAN.md`
-> is current ground truth for state and work order.
+> ⚠️ **Reading this file:** sections below describing the four-line tank, the
+> six-tap early-reflection section, the HALL mode, or the 2048-word static
+> in-loop allpasses describe the **deleted engine**. The shipping engine is
+> eight lines, 8×8 FWHT, **three** modes (ROOM/PLATE/BIG), ER removed in
+> favour of a short Dattorro-scale input diffuser (taps 179/293/419/547 =
+> 4.1–12.4 ms), and 512-word **modulated** in-loop allpasses. The signal path
+> and parameter table here are current; deeper sections are corrected where
+> marked, historical otherwise.
 
 > **The old standalone DARK REV replacement is retired.** Earlier builds
 > (`dsp/reverb88.asm` via `tools/build_reverb.py`) replaced stock DARK REV in
@@ -23,19 +22,17 @@ bank. Built by `tools/build_bus.py`; source `dsp/reverb_server.asm`.
 > its own id, and its own knob layout. Where this document still describes the
 > old build, it is history; the sections below marked **current** are not.
 
-> **Status, 5 Aug 2026 (`ChonVerb21`, on hardware, confirmed by ear).**
-> Structure, parameters and the MODE select all work on the unit, and so does
-> everything from the 5 Aug session: the tail crackle is fixed, the four modes
-> are genuinely distinct *(four modes then; three since the 9 Aug HALL cut)*
-> (RT60 2.7 / 4.7 / 7.7 / 10.0 s across ROOM→BIG, plus
-> per-mode ER arrivals, diffuser taps, tap spread, LFO rate and damping), and
-> MIX holds dry at unity to half-travel before crossfading. Reported on
-> hardware as "much better".
+> ✅ **On hardware, confirmed by ear:** structure, parameters and the MODE
+> select all work on the unit; the tail crackle is fixed; the modes are
+> genuinely distinct (RT60 2.7 / 4.7 / 7.7 / 10.0 s across ROOM→BIG on the
+> four-mode engine of the time, plus per-mode ER arrivals, diffuser taps, tap
+> spread, LFO rate and damping); and MIX holds dry at unity to half-travel
+> before crossfading.
 >
-> Per-mode voicing is no longer the blocking work. What remains is measured but
+> Per-mode voicing is not the blocking work. What remains is measured but
 > unacted-on: modal prominence 8–11 dB over the local envelope, whose only
 > structural lever is more total delay against a 32K hard ceiling — see
-> `VOICING.md` Round 5 for why no fix is worth making at this budget.
+> `VOICING.md` for why no fix is worth making at this budget.
 
 For how the DSP subsystem works — boot, payload format, the dispatcher ABI,
 the allocator, the memory map — see `DSP.md`. For the bus itself see `BUS.md`.
@@ -58,26 +55,25 @@ in ─► pre-delay ─► 4 series allpasses ─► ┌─ FDN tank ───�
 * **Pre-delay** — up to 4096 samples (93 ms), modulo buffer on r6.
 * **Diffusers** — four series allpasses, taps 179/293/419/547 (4.1–12.4 ms,
   Dattorro-scale; the original 1994/1706/1438/1226 dispersed rather than
-  diffused and were replaced 9 Aug 2026 when they took over the removed ER
-  section's role). Coefficient per mode via `$3f`.
+  diffused and were replaced when the ER section was removed, the short
+  diffusers taking over its role). Coefficient per mode via `$3f`.
 * **Tank** — eight delay lines with an 8×8 Walsh-Hadamard feedback matrix
   (24 butterflies, decay constants scaled 2/√8). All eight reads are
   **interpolated and LFO-modulated**, each line free-running on its own LFO
   rate, the multipliers prime-relative so the periods never align. Per-line
   state lives in a Y table at `base+0x7F00` (table A) and `base+0x7F30`
-  (table B: input weights, and per-line decay gains once PLAN.md 1.1 lands).
+  (table B: input weights and per-line decay gains).
 * **In the loop** — a one-pole low-pass (HI) and a one-pole high-pass (LO)
   per line, so the decay is shaped per band rather than the output EQ'd.
-  ⚠️ One shared damping coefficient per pass — PLAN.md 1.2's open item.
+  ⚠️ One shared damping coefficient per pass.
 * **In-loop allpasses** — two, **512 words each, LFO-modulated** (fixed
   depth, never zero — a static tank rings), on lines 0 and 1. An allpass in
   the feedback path multiplies echo density on every circulation. The
   proportion matters: too long relative to the line and it becomes a
   dispersive element, which is what a spring reverb is — the reason both the
   original 2048-word versions and the long input diffusers were cut.
-* **Early reflections** — **removed 9 Aug 2026.** The six discrete taps were
-  a flutter echo (VOICING.md Round 7); the short input diffuser fills the
-  early-energy role.
+* **Early reflections** — **removed.** The six discrete taps were a flutter
+  echo (`VOICING.md`); the short input diffuser fills the early-energy role.
 * **Out** — L/R tap sums taken **before** the FWHT (a Hadamard row applied
   after the transform collapses to a single line), sign patterns `+−+−+−+−`
   and `++−−++−−`; then mid/side width, then a dry/wet crossfade.
@@ -85,8 +81,7 @@ in ─► pre-delay ─► 4 series allpasses ─► ┌─ FDN tank ───�
 ## Parameters (current)
 
 All twelve are live — six on page 1, six on page 2 — and the page-2 mapping
-was **measured**, not inferred (`DSP.md` §9). Hardware-confirmed as shipped in
-`ChonVerb19`.
+was **measured**, not inferred (`DSP.md` §9). Hardware-confirmed.
 
 | page | slot | label | reads | what it does |
 |---|---|---|---|---|
@@ -96,39 +91,32 @@ was **measured**, not inferred (`DSP.md` §9). Hardware-confirmed as shipped in
 | 1 | 3 | HP | `r6+$3` | **LO** — high-pass inside the feedback path |
 | 1 | 4 | LP | `r6+$4` | **HI** — high-cut damping inside the feedback path |
 | 1 | 5 | MIX | `r6+$5` | dry held to half-travel, then crossfaded (see below) |
-| 2 | 6 | SHMR | `r6+$c` knob \| `$b` | shimmer amount (R16: reads `$c` knob field OR'd with `$b` — `$b` alone was silent on hardware, DSP.md §9) |
-| 2 | 7 | MODE | `$c` bits 8-15 | **stepped select**: 0 ROOM, 1 PLATE, 2 BIG (HALL cut 9 Aug 2026 — indistinguishable from BIG in blind A/B) |
+| 2 | 6 | SHMR | `r6+$c` knob \| `$b` | shimmer amount (read from the `$c` knob field OR'd with `$b`; the panel publishes slot 6 to `$c` — DSP.md §9) |
+| 2 | 7 | MODE | `$c` bits 8-15 | **stepped select**: 0 ROOM, 1 PLATE, 2 BIG |
 | 2 | 8 | DIFF | `r6+$d` knob | allpass coefficient, ~0.38–0.80 |
-| 2 | 9 | WIDTH | `r6+$d` low | R16: **4-step select** (mono/narrow/normal/wide). Companion low-byte fields read near-boolean at count 128 on hardware, so smooth-knob WIDTH was dead — a small count publishes |
-| 2 | 10 | GATE | `r6+$e` knob | R16: **gated reverb** (Phil-Collins slam). 0 = off; up = hold time (~46 ms–780 ms) before the wet slams shut. Envelope keyed on the tank input ($1b, so sends trigger it), fast attack + ~20 ms eased release, applied as a per-sample multiply on the wet L/R. Replaced PRE (pre-delay was buffer-capped at 93 ms, not worth a knob) |
-| 2 | 11 | -DEL | `r6+$e` low | R16: **4-step send select** (off/.25/.5/.75) into the DELAY bus (`BUS.md`) — companion field, same reason as WIDTH |
+| 2 | 9 | WIDTH | `r6+$d` low | **4-step select** (mono/narrow/normal/wide). Companion fields read near-boolean at count 128 on hardware, so a smooth knob there is dead — a small count publishes |
+| 2 | 10 | GATE | `r6+$e` knob | **gated reverb** (Phil-Collins slam). 0 = off; up = hold time (~46 ms–780 ms) before the wet slams shut. Envelope keyed on the tank input ($1b, so sends trigger it), fast attack + ~20 ms eased release, applied as a per-sample multiply on the wet L/R. Replaced PRE (pre-delay was buffer-capped at 93 ms, not worth a knob) |
+| 2 | 11 | RATE | `r6+$e` low | **4-step select** for the tank-mod LFO speed: 0.5×/1×/2×/4× of the pinned base rate — companion field, same reason as WIDTH. (This slot previously carried a `→DEL` send select, retired because a return reverb's dry is normally silence) |
 
-**Page-2 budget (R16): three smooth knobs + three selects.** The three knob
-fields (`$c` SHMR, `$d` DIFF, `$e` GATE — PRE was retired in R16 and its slot
-became GATE) publish as full-travel knobs; the three
-companion fields (`$c` mid MODE, `$d` low WIDTH, `$e` low →DEL) publish only as
+**Page-2 budget: three smooth knobs + three selects.** The three knob
+fields (`$c` SHMR, `$d` DIFF, `$e` GATE) publish as full-travel knobs; the three
+companion fields (`$c` mid MODE, `$d` low WIDTH, `$e` low RATE) publish only as
 small-count selects — a smooth knob in a companion field reads near-boolean on
 hardware. This is the actual page-2 control budget.
-
-**(Historical note) five of the six page-2 controls are full-travel knobs**, including two in
-*companion* fields. `DSP.md` §9 used to say the budget was three knobs plus
-three small selects; that was inferred from stock's usage, and hardware
-falsified it. Only MODE is deliberately stepped.
 
 **Page-2 slots pair up**: a knob arrives as `value<<16` occupying bits 16-22,
 leaving the low bits of the same word as an independent field. Even slot =
 knob field, odd slot = companion field of the same word. Both can carry a
 full 0–127 value; mask the companion with `#>$7f` and shift it up by 16.
 
-**The `$e` knob field carries GATE since R16.** ❌ Retracted: "PRE lives on
-`$e`, not `$c`" — true through R15; PRE was retired in R16 (buffer-capped at
-93 ms, not worth a knob) and its slot became GATE. The `$c` half still stands:
-nothing drives `$c`'s knob field usefully. Stock DARK reads *its* pre-delay
-from `$c`, which is why older builds did. Do not "fix" this back.
+**The `$e` knob field carries GATE.** PRE, which used to live on `$e`, was
+retired (buffer-capped at 93 ms, not worth a knob) and its slot became GATE.
+Stock DARK reads *its* pre-delay from `$c`, which is why older builds drove
+`$c`; do not "fix" that back.
 
 ### Making a cloned descriptor draw correctly
 
-This cost six hardware flashes to establish, so it is written out in full.
+This was expensive to establish on hardware, so it is written out in full.
 Four per-parameter arrays matter, each 12 × u32, `P`-relative:
 
 | offset | what it is |
@@ -139,9 +127,9 @@ Four per-parameter arrays matter, each 12 × u32, `P`-relative:
 | `P+0x12a` | **must be `0` for a stepped control.** Surveyed all 20 stepped params in stock FX2: 20 of 20 have it zero. |
 
 **A clone inherits all four from its donor**, and the donor's values are for a
-different algorithm. That is what made `→DEL` render as DARK's "MIX / SEND"
-however large a count it was given, and what kept MODE a plain knob for three
-builds. Zero `0x0ca`/`0x0fa` for every renamed slot; for a stepped control,
+different algorithm. That is what made an early `→DEL` send select render as
+DARK's "MIX / SEND" however large a count it was given, and what kept MODE
+drawing as a plain knob. Zero `0x0ca`/`0x0fa` for every renamed slot; for a stepped control,
 set both to a stock pair *and* zero `0x12a`.
 
 Working stepped pairs, for reference:
@@ -164,8 +152,8 @@ explicit default — an unlisted one silently keeps the donor's.
 
 ## Memory layout
 
-**Current layout (✅ since the 8-line re-layout of 9 Aug 2026, map from
-`dsp/reverb_server.asm`'s header):** the private allocation at the hardcoded
+**Current layout (✅ measured; map from `dsp/reverb_server.asm`'s
+header):** the private allocation at the hardcoded
 base `Y:0x4000` (32,768 words, `0x4000–0xBFFF`) now carries tank lines only;
 every other buffer moved to the shared window, giving **65,536 words (1.49 s)
 per server** in total:
@@ -174,12 +162,13 @@ per server** in total:
 |---|---|---|
 | `base+0x0000..0x7fff` | 8 × 4096 | tank lines, taps to ~3914 (89 ms) at SIZE max |
 | `shared+0x2000..0x3fff` | 4 × 2048 | input allpasses, taps 179/293/419/547 |
-| `shared+0x1000..0x1fff` | 4096 | former pre-delay (93 ms) — PRE retired in R16, buffer no longer read |
+| `shared+0x1000..0x1fff` | 4096 | former pre-delay (93 ms) — PRE retired, buffer no longer read |
 | `shared+0x0800..` | 2048 | shimmer line (excised by `NOSHIM=1`) |
 | `shared+0x4000` / `0x4200` | 2 × 512 | in-loop allpasses, modulated, taps 298/446 |
 | `shared+0x4500..` | 13 words/line | tank state tables A and B (see below) |
 
-❌ Retracted layout (32K-era, four-line engine — kept for history):
+❌ Old layout (32K-era, four-line engine — historical; does not describe the
+shipping build):
 
 | offset | size | what |
 |---|---|---|
@@ -188,16 +177,16 @@ per server** in total:
 | `base+0x6000` | 4096 | pre-delay |
 | `base+0x7000` | 2 × 2048 | in-loop allpasses, taps 298/446 |
 
-**Persistent state is split.** ❌ Retracted: "all persistent state lives in
-the r7 block … there is no Y state block" — true of the four-line engine only.
-The r7 block is per-instance and now **completely full** (`$00..$83` all taken,
-10 Aug 2026; `$84+` hangs the unit) — `$82` is the warm-up counter (tagged
+**Persistent state is split** (the four-line engine kept it all in the r7
+block; the shipping engine does not).
+The r7 block is per-instance and **completely full** (`$00..$83` all taken;
+`$84+` hangs the unit) — `$82` is the warm-up counter (tagged
 `$2c0000 | count`), `$83` the tank phase. Per-line tank state lives in the
 **Y state tables A and B at `shared+0x4500`** (13 words per line), because the
 rolled tank loops need state they can index, which a fixed r7 displacement can
 never be.
 
-## The 32K re-layout (done and long since flashed; superseded by the 8-line layout above)
+## The 32K re-layout (historical — replaced by the 8-line layout above)
 
 The layout above used only 16,384 of the 32,768 words `BUS.md` allocates —
 half the allocation sat unused. `DSP.md` §7c's high-X region was probed and is
@@ -218,9 +207,9 @@ an integer tap moved with it: **`asr #$b` → `asr #$a`** on all four taps, and
 `2048 - tap` → `4096 - tap`. The constants are untouched; the scaling around
 them is not.
 
-**The in-loop allpass taps DID double, 149/223 → 298/446.** The plan didn't
-say so, and their `n5` had to be recomputed for the bigger buffer either way.
-What v85 fixed there was a *proportion* — ~15% of the line the allpass feeds,
+**The in-loop allpass taps DID double, 149/223 → 298/446**, and their `n5`
+had to be recomputed for the bigger buffer either way.
+What matters there is a *proportion* — ~15% of the line the allpass feeds,
 above which it disperses instead of diffusing — so holding 9.7%/14.5% against
 a line that is now twice as long means doubling the tap. Leaving them at
 149/223 would have halved the proportion to 4.8%/7.3%, a character change the
@@ -254,9 +243,11 @@ All runs `guard clean`, `0 CLOBBERING a loaded module`, no hang, at
 * **PRE doubled exactly.** Knob 0 → 127 moves the wet onset by 2032 samples on
   the old build and **4064** on the new one, and max PRE is not silent — which
   is the failure mode if the modulo offset ever exceeds the buffer.
-* **The bus plumbing is untouched.** The `→DELAY` dry send still lands on
-  `BUS.md`'s exact hand-derivable value (`0x0c8000` = dry 0.125 × level
-  0.78125 × `0x800000`), bit-identical between the old and new builds.
+* **The bus plumbing of the time was untouched.** The then-present `→DELAY`
+  dry send still landed on `BUS.md`'s exact hand-derivable value (`0x0c8000`
+  = dry 0.125 × level 0.78125 × `0x800000`), bit-identical between the old
+  and new builds. (The reverb no longer writes any bus; the send was later
+  retired.)
 
 Code size is unchanged — 1269/2130 words of the SPRING+DARK budget, same as
 before, since every change was a constant or a shift count.
@@ -276,11 +267,7 @@ the same source means anything.
 
 Neither render clipped (peak 0.36 FS, nothing at the rail), so the roughness
 on the old build is mode sparseness, not saturation. The separate saturation
-problem the same session turned up is under "Known limits" below, and is the
-next thing to fix.
-
-**~~Not yet flashed.~~ Resolved: this flashed long since.** ("Not yet
-flashed" was true when written.) Nothing here needed a flash to hear.
+problem is recorded under "Tuning" below (since fixed).
 
 ## Register map inside the sample loop
 
@@ -382,22 +369,22 @@ its traps.
 
 ## The cycle budget — measured, and much larger than assumed
 
-**Superseded: "four instances per DSP".** The engine was shaped around fitting
-four reverb instances on one chip — that is what forced the density pass
-(432 → 297 cycles/sample) and what made every feature look unaffordable. The
-bus design retired it: **one ChonVerb per bank**, enforced by the server-role
-lock in `BUS.md`. A bank's four FX2 slots hold one reverb, one delay and two
-sends, not four reverbs.
+**There is one ChonVerb per bank**, enforced by the server-role lock in
+`BUS.md` — a bank's four FX2 slots hold one reverb, one delay and two sends,
+not four reverbs. The engine was originally shaped around fitting four reverb
+instances on one chip — that is what forced the density pass
+(432 → 297 cycles/sample) and what made every feature look unaffordable; the
+bus design retired that constraint.
 
 Counted by `tools/cycle_count.py`, which assembles each server, injects a label
 after its `do n7,>END` sample loop and takes the word span. **Run it after any
-change to a sample loop** — the two hand counts this table has carried were
-both wrong, in different ways.
+change to a sample loop** — hand counts here have been wrong more than once,
+in different ways.
 
-> ❌ **Retracted accounting — the whole table is pre-8-line.** The ~1080
-> "budget per DSP" is retracted; the measured budget is 4,535 cycles/core,
-> with 819/sample of room for new work as of 11 Aug 2026. See `CHIP.md` for
-> the live numbers. Table kept as history.
+> ❌ **Old accounting — the whole table describes the four-line engine.** The
+> ~1080 "budget per DSP" is wrong; the measured budget is 4,535 cycles/core,
+> with 819/sample of room for new work. See `CHIP.md` for the live numbers.
+> Table kept as history.
 
 | | instructions | cycles/sample |
 |---|---|---|
@@ -408,7 +395,7 @@ both wrong, in different ways.
 | budget per DSP (`stageprobe5/6`) | | ~1080 |
 | **headroom** | | **~221** (80% used) |
 
-(v99 took the reverb 731 -> 660 and the bank 930 -> 859: the early-reflection
+(A later pass took the reverb 731 -> 660 and the bank 930 -> 859: the early-reflection
 block was building all six tap addresses by hand -- subtract, `and #>$fff` to
 wrap, clean A2, add the base, load r5 -- when **r6 already indexes the
 pre-delay buffer under `m6 = $fff`**, which is the addressing the pre-delay's
@@ -419,16 +406,16 @@ drops the constant straight into `n6`. 254 -> ~181 cycles, **bit-identical
 across all four modes and a max-feedback wet render.** The one cost: the ER taps
 borrow `n6`, so the pre-delay reloads it each sample -- 2 words against 71.
 
-735 for the reverb / 934 a bank before the v97 Hadamard rewrite below. Note
+735 for the reverb / 934 a bank before the Hadamard rewrite below. Note
 that rewrite moved the instruction count the *other* way — 508 → 512 — while
 cycles fell 735 → 731. **Instructions are not cycles here**, and a count of
 them would have scored a real speed-up as a regression.)
 
-**This supersedes 529/551, and the correction has two independent halves.**
+**The earlier 529/551 figures were wrong, and the correction has two
+independent halves.**
 
-*The engine really did grow*: 367 → 508 instructions across the seventeen
-commits Rounds 3–5 put into `reverb_server.asm`. Six per-mode levers are not
-free.
+*The engine really did grow*: 367 → 508 instructions across the per-mode
+voicing work on `reverb_server.asm`. Six per-mode levers are not free.
 
 *And the old model under-costed the code.* It charged two cycles only for `#>`
 long immediates and missed that **`x:(rn+$disp)` is also a two-word, two-cycle
@@ -446,7 +433,7 @@ instructions and 735 words agree exactly across all three.
 **Treat 934 as a floor, not a ceiling.** The count is exact for the code but
 models no memory-contention stalls, so the figure under load can only be
 higher. The old headroom claim — "1.4× the entire reverb engine, free" — is
-gone: at 86% of budget (❌ retracted-budget accounting — the ~1080 figure;
+gone: at 86% of budget (❌ old-budget accounting — the ~1080 figure;
 see `CHIP.md`) with two effects and two sends live, a bank is much
 closer to its limit than anything in these docs has assumed, and adding
 delay lines on the strength of the old number would have overrun it.
@@ -463,7 +450,7 @@ The arithmetic ceiling is 133 cycles (208 accesses − 75 one-off setups). **Tha
 ceiling is not reachable, and the best cluster has now been converted to find
 out by how much.**
 
-**Done (v97): the 4×4 Hadamard, `$16..$1d`.** The most favourable cluster in the
+**Done: the 4×4 Hadamard, `$16..$1d`.** The most favourable cluster in the
 loop — 13 accesses over 9 contiguous offsets, the only run of that quality.
 d0..d3 and u0..u3 are adjacent, so one `lua` pointer reads the four inputs and
 walks straight into the four outputs, and copying the operand to B removes the
@@ -478,7 +465,7 @@ it back costs 4 words, halving the win. **Every further cluster pays this same
 tax** unless it can live inside a register whose modifier is already linear.
 
 Verified bit-identical across all four modes and a `TIME=127 SIZE=127 DIFF=127`
-wet render. Bank total **934 → 930** (❌ retracted-budget accounting — see
+wet render. Bank total **934 → 930** (❌ old-budget accounting — see
 `CHIP.md`).
 
 **Extrapolate down, not up.** This was the best case in the loop and it
@@ -488,7 +475,7 @@ only five or six registers are spare. The realistic total for the whole lever
 is a few tens of cycles, not 133 — worth having if cycles ever get tight,
 **not worth spending a flash to chase now**.
 
-**Trap, and it cost the first two attempts: this assembler silently encodes
+**Trap: this assembler silently encodes
 `tfr a,b` as `rnd b`** (opcode `200019`, confirmed by disassembling the output).
 No error, no warning. B never receives A, the FDN matrix stops being orthogonal,
 and the symptom is not a crash but a **40% shift in RT60** — the sort of thing
@@ -538,8 +525,8 @@ The last row buys density and pre-delay, not decay. Mode spacing is computed
 from the **third** row, so quoting the allocation — or `DSP.md` §7c's "743 ms
 ceiling", which is the first row — overstates the space by about 2.6×.
 
-Recomputed against the real constants (the previously recorded 4,493 samples
-/ 9.8 Hz / overlap 0.06 belonged to the tap set *two* generations back —
+Recomputed against the real constants (an earlier recorded 4,493 samples
+/ 9.8 Hz / overlap 0.06 belonged to an older tap set —
 1567/1249/977/733 — and understated the build it was attached to):
 
 | | total delay | spacing | overlap @ RT60 = 4 s |
@@ -568,8 +555,8 @@ is a measurably smoother one.
 One lever is left, and one is spent:
 
 1. ~~**Spend freed cycles on more delay lines.**~~ — **taken**: the
-   eight-line tank shipped 8 Aug 2026. (The density pass left headroom that
-   did not exist before; v84 used 341 of it.)
+   eight-line tank shipped. (The density pass left headroom that did not
+   exist before; an earlier build spent 341 of it.)
 2. ~~**Trade instance count for tank size**~~ — **taken.** This used to be a
    plan to patch the allocator table at `X:0x255` (8 modest instances, or 4
    large at 2 × 32K per DSP, or 2 very large at 1 × 45K). `BUS.md` reached
@@ -579,14 +566,14 @@ One lever is left, and one is spent:
    above spends it. The 45K variant would still need the FX1 region and an
    allocator edit, and is not planned.
 
-Smaller items: MOD depth's range wants calibrating by ear (this was recorded
-for years as "SHVG's range" — SHVG is a *stock DARK REV* knob label the
-retired build inherited, and ChonVerb names its own knobs, so the item is
-just MOD); and there is an unexplained emulator-only divergence between one
-and two instances under a nonzero split.
+Smaller items: MOD depth's range wants calibrating by ear (older records call
+this "SHVG's range" — SHVG is a *stock DARK REV* knob label the retired build
+inherited, and ChonVerb names its own knobs, so the item is just MOD); and
+there is an unexplained emulator-only divergence between one and two
+instances under a nonzero split.
 
-The old note that "MIXF (`$e`) is dead" is also gone: `$e` carries PRE in its
-knob field and →DEL in its companion field, both live.
+`$e` is not dead: it carries GATE in its knob field and RATE in its companion
+field, both live.
 
 
 ## Tuning: what is known
@@ -599,14 +586,14 @@ its limits).
 depends on how fast the delay moves, not how far. 63 samples at 2.84 Hz is
 ~28 cents of vibrato and sounds seasick; the same 63 samples at 0.25 Hz is
 ~2.5 cents and is inaudible. Depth is what smears the modes. Coupling MOD
-to both — which v64 did as a workaround for an inaudible control — means
+to both — once done as a workaround for an inaudible control — means
 turning it up adds wobble faster than it adds smearing. **Keep the rate
 slow and fixed; let MOD move depth alone.**
 
 **Small SIZE is inherently bad.** At the original floor the whole tank was
 566 samples: a mode spacing of 78 Hz, which is a comb, not a reverb. The
 floor is now `f = 0.4` so the bottom of the knob is ~1,810 samples at 24 Hz.
-Confirmed by ear ("smallest size sounds worst") before it was fixed.
+Confirmed by ear before it was fixed.
 
 **Modulation must never reach zero.** A completely static tank rings — its
 modes are audible as pitched resonance. Some residual sweep is needed at
@@ -616,11 +603,11 @@ MOD=0.
 masked with `2^(24-n)-1` and shifted by **n-1**, never by `n`. Shifting by
 `n` pushes the top half past `0x800000`, where a 24-bit fractional reads
 NEGATIVE, and the interpolation jumps backwards once per integer LFO step —
-heard as a fast flutter. This bug was live from v72 to v79.
+heard as a fast flutter.
 
 **That bug was also doing something useful**, which is the uncomfortable
 part: it is a noise source, and interpolation dither is a real technique for
-breaking up delay-line artifacts. Every build the user liked had it. Fixing
+breaking up delay-line artifacts. Every build preferred by ear had it. Fixing
 it was correct and immediately exposed ringing that had been masked. If the
 tail needs more smearing than slow deep modulation provides, *deliberate*
 randomisation is the principled replacement.
@@ -640,7 +627,7 @@ It is a real defect, but a tiny one, and only in one place:
   mid-block, because the LFOs advance once per block. Deleting the four seed
   reads does change the output, so that priming is load-bearing, not
   vestigial.
-* The two **in-loop allpasses** (v90) used the same trick and never got the
+* The two **in-loop allpasses** used the same trick and never got the
   same seeding. Now they do.
 
 Cost of priming them: 28 instructions per BLOCK, outside the sample loop, so
@@ -670,19 +657,19 @@ MOD=127 it reads −50 dB, but nearly all of that is chaotic divergence of a
 feedback system, not artifact. The crest factor is what distinguishes them.
 
 **And an independent confirmation that was already on file.** `VOICING.md`
-Round 2b established by ear that the crackle is *gone at MOD=0*. The allpass
+records, by ear, that the crackle is *gone at MOD=0*. The allpass
 depth is fixed and never follows MOD, so the allpass carry defect is fully
 active at MOD=0 — it therefore cannot be a fault that disappears there. The
 same test kills the tank's carry as a candidate from the other direction,
 since the tank carries are primed. So the isolation trick above is not just
 a convenient way to measure this bug; MOD=0 was already the observation that
-ruled it out, and nobody had cashed it in.
+ruled it out.
 
-**What that leaves — superseded, see below.** The block-stepped LFO was the
-leading candidate by elimination. It has since been built and measured, and
-it is not the fault either: **−62.5 dB**, for 64 cycles/sample. The staircase
+**The block-stepped LFO is not the fault either.** It was the leading
+candidate by elimination, but built and measured it sits at
+**−62.5 dB**, for 64 cycles/sample. The staircase
 moves the delay by only ~0.026 of a sample across one block, which was never
-going to be a crackle. Not kept. `VOICING.md` Round 2e has the implementation
+going to be a crackle. Not kept. `VOICING.md` has the implementation
 and the invariant that verified it (at MOD=0 there is nothing to ramp, and
 the ramped engine comes out bit-identical to the stepped one).
 
@@ -696,32 +683,29 @@ sawtooth that wraps whenever *its own* LFO's integer part steps, which put a
 
 Measured at **−29.6 dB**, against −62.5 dB for the staircase and −64 dB for
 the allpass carry: 33 dB louder than either, and the only candidate with the
-magnitude to be audible at all. It also passes every negative test in
-`VOICING.md` Round 2b — gone at MOD=0, signal-proportional, broadband, not
+magnitude to be audible at all. It also passes every negative test recorded
+in `VOICING.md` — gone at MOD=0, signal-proportional, broadband, not
 the sample. The fix is a two-slot swap: no cycles, no words.
 
 The four LFO *phases* are deliberately crosswise (see Signal path); the two
 halves of one offset are not.
 
-**Confirmed by ear, both halves.** The crackle is fixed ("yes, fixed in B"),
-and the v72 caution — that removing an accidental noise source exposes
-ringing it was masking — **did not hold here**: on the 4–12 s tail, three
-rounds, *"sound the same as far as ringing goes."* Deliberate randomisation
-is therefore NOT needed. The caution is real and came from a real case, but
-it is something to **check**, not something to assume; checking it cost two
-listens. See `VOICING.md` Rounds 2e–2f.
+**Confirmed by ear, both halves.** The crackle is fixed, and the caution
+above — that removing an accidental noise source exposes ringing it was
+masking — **did not hold here**: on the 4–12 s tail the ringing is unchanged.
+Deliberate randomisation is therefore NOT needed. The caution is real and
+came from a real case, but it is something to **check**, not something to
+assume; checking it costs a couple of listens. See `VOICING.md`.
 
-This also lifts Round 2b's block on voicing: the tail no longer has broadband
-noise in it, so the per-mode constants can be judged on their own terms.
+The tail no longer has broadband noise in it, so the per-mode constants can
+be judged on their own terms.
 
-## What MODE actually varies (as voiced in Rounds 3–4)
+## What MODE actually varies
 
-Six levers, after Rounds 3–4. At the start of that work only the first three
-existed, and the modes were reported as sounding alike; after all six, "much
-better" by ear.
+Six levers. With only the first three, the modes sounded alike by ear; all
+six make them genuinely distinct.
 
-(The HALL column is kept as history — HALL was cut 9 Aug 2026,
-indistinguishable from BIG in blind A/B; shipping modes are ROOM/PLATE/BIG.)
+(The HALL column is kept as history; shipping modes are ROOM/PLATE/BIG.)
 
 | lever | ROOM | PLATE | HALL | BIG |
 |---|---|---|---|---|
@@ -744,8 +728,7 @@ original set, so ROOM must render *bit-identical* whenever the indirection is
 touched.
 
 **The r7 state block is FULL.** `$7e..$81` were the last free slots. `r7+$84`
-and up **hang the DSP** (host-owned — see `DSP.md`, bisected across three
-builds). Anything further that needs per-mode state must use the parking
+and up **hang the DSP** (host-owned — see `DSP.md`). Anything further that needs per-mode state must use the parking
 pattern: `md_*` writes its scale into a slot a later parameter block is going to
 overwrite anyway (`$2f` rate, `$1e` decay), and that block folds it into its own
 multiply. `md_*` runs before every parameter block, which is what makes it safe.
@@ -759,7 +742,7 @@ ear is the measurement.** Early crest factor is the better companion metric.
 **In-loop allpass proportion matters.** An allpass inside the feedback loop
 is a dispersive element — the mechanism spring reverbs are built on. At 15%
 of the line it feeds it is diffusion; ours ran 26–64% and were suspected of
-producing a spring/plate ring. Removing them was tested (v82/v83) but
+producing a spring/plate ring. Removing them was tested but
 bundled with other changes, so the result is not clean.
 
 **Pack the buffers.** Both the tank lines and the input diffusers were
@@ -771,11 +754,11 @@ pass. **When a design allocates equal buffers for unequal contents, check
 the utilisation.**
 
 **Input diffusion and in-loop diffusion are not interchangeable.** Moving
-input allpasses into the loop (v87) improved mode spacing but doubled the
+input allpasses into the loop improved mode spacing but doubled the
 early crest factor: the input chain smooths the attack, the in-loop chain
 thins the modes. Pack both; do not trade one for the other.
 
-**Averaging more tank lines into each output does not help** (v89). The
+**Averaging more tank lines into each output does not help.** The
 lines share a feedback matrix, so they are not independent; orthogonal
 4-line output taps concentrated energy rather than smoothing it, and gave
 no stereo benefit over disjoint 2-line pairs.
@@ -790,7 +773,7 @@ got a word *smaller*.
 **Accepted by ear, on the source where the fault was audible.** Three
 loudness-matched renders of the synth pluck: old engine at 0 dB (the fault),
 new engine at 0 dB, old engine at −12 dB trim (the known-good reference).
-New-at-0 dB against old-at−12 dB: **"same"**. That is the acceptance test —
+New-at-0 dB is indistinguishable from old-at−12 dB. That is the acceptance test —
 the engine now behaves at full input the way it used to behave only with
 12 dB of external trim.
 
@@ -803,8 +786,8 @@ same peak level is linear to within 0.1 dB, so it is **density**, not peak
 level, that drives this — a sine test misses it entirely.
 
 The controlled trim test predicted, in advance, that 0 dB and −12 dB would
-differ and that −12 dB and −24 dB would not. Both held ("very audible",
-"identical"), which is what identifies the mechanism as saturation and
+differ and that −12 dB and −24 dB would not. Both held by
+ear, which is what identifies the mechanism as saturation and
 nothing else.
 
 **Then the measurements led the work astray, and this is the part worth
@@ -833,7 +816,7 @@ Two concrete cautions that came out of it:
   bug recorded above — fixing something correct exposed what it had been
   masking — but here what it exposed does not matter.
 
-**MIX: acted on twice, and the second time was the right shape.** v94 made it a
+**MIX: a plain crossfade is the wrong shape here.** A first fix made it a
 straight `dry*(1-MIX) + wet*MIX` crossfade, because the old additive law left
 dry at full scale forever and the top of the knob was never actually *wet*.
 That motive was sound and the result was not: measured, the knob got **7 dB
@@ -841,21 +824,22 @@ QUIETER as it was turned up** (−22.0 dBFS at MIX=0 → −28.8 at 96). This is
 the usual −3 dB crossfade dip. **A reverb's wet is inherently far below its
 dry** — the tail spreads the same energy over seconds — so swapping one for the
 other at equal gain loses real level, and turning a reverb up should never
-shrink the sound. v96 holds the dry at unity for the bottom half and crossfades
-it away over the top half:
+shrink the sound. The shipping law holds the dry at unity for the bottom half
+and crossfades it away over the top half:
 
     dry = 1              MIX <= 64      pure "mix more in"
         = 2 * (1 - MIX)  MIX >  64      still reaches fully wet at the top
 
 Flat to within 0.1 dB across the bottom half, peak unchanged at 0.70–0.71, and
-it keeps what v94 was after. Reported by the user as unintuitive before it was
-measured; the measurement agreed.
+it keeps what the plain crossfade was after. The plain crossfade was judged
+unintuitive by ear before it was measured; the measurement agreed.
 That is a voicing decision, not a bug fix, and there is no ear evidence it
 matters yet.
 
-**Change one thing per flash.** Between v77 and v83 five things changed and
-the result was worse in a way that could not be attributed. The recovery was
-to reflash v77, confirm the baseline, and move one variable at a time.
+**Change one thing per flash.** When five things changed between two builds,
+the result was worse in a way that could not be attributed; the recovery was
+to reflash the older build, confirm the baseline, and move one variable at a
+time.
 
 ## The design, as built
 
@@ -863,14 +847,14 @@ to reflash v77, confirm the baseline, and move one variable at a time.
 largest space this hardware supports — rather than choosing between them. The
 three free page-2 selects exist precisely for this; MODE is the obvious first.
 
-* **Standard characters**: room / plate / big (HALL was cut 9 Aug 2026 —
+* **Standard characters**: room / plate / big (a fourth HALL mode was cut as
   indistinguishable from BIG in blind A/B), in the spirit of a Chase Bliss
   CXM 1978. Comfortably within budget — these want density, not length.
 * **Big mode**: **Valhalla-flavoured, not Blackhole.** Deliberate: Blackhole's
   character comes substantially from raw allocation, and 743 ms was the hard
-  ceiling when this was written (`DSP.md` §7c — the high X region was probed
-  and is not real). ❌ Superseded: 1.49 s per server since the XBUS
-  shared-window split.
+  ceiling when the mode was designed (`DSP.md` §7c — the high X region was
+  probed and is not real; the allocation is 1.49 s per server since the XBUS
+  shared-window split).
   Valhalla's large spaces get their scale from long feedback, heavy modulation
   and dense diffusion, which is both achievable here and a match for the FDN
   structure already in place. Expect genuinely large and smooth; not infinite.
@@ -878,13 +862,12 @@ three free page-2 selects exist precisely for this; MODE is the obvious first.
 MODE should reconfigure tap lengths, diffusion depth, damping and modulation
 together — not merely rescale SIZE.
 
-> 🟡 **History (marked 12 Aug 2026):** the hardware confirmation below is
-> real, but it describes the retired four-mode, four-line engine. Superseded
-> by the 8-line R13+ engine (tags 35–37 unflashed; the unit runs R15, tag 34).
+> 🟡 **Historical:** the hardware confirmation below is real, but it describes
+> the retired four-mode, four-line engine; the shipping engine is the
+> eight-line tank.
 
-**All of the above is built and confirmed on hardware as `ChonVerb21`**
-(5 Aug 2026, "much better"). MODE varies **six** levers, not the three it
-shipped with in `ChonVerb19`: tap scale and spread, ER level and arrival times,
+**All of the above was built and confirmed on hardware.** MODE varies **six**
+levers, not the original three: tap scale and spread, ER level and arrival times,
 diffusion coefficient and diffuser taps, LFO rate, damping, and decay time.
 RT60 runs 2.7 / 4.7 / 7.7 / 10.0 s across ROOM → BIG. Decay time was the lever
 MODE had never touched and the one that mattered most — every mode used to
@@ -893,24 +876,23 @@ however the others were set. Full record in `VOICING.md`.
 
 **Order of work — where it stands:**
 1. ~~The 32K re-layout~~ — **done**, flashed, confirmed by ear.
-2. ~~Design the modes~~ — **done**, Rounds 1–5 in `VOICING.md`.
+2. ~~Design the modes~~ — **done**, recorded in `VOICING.md`.
 3. ~~Measure real cycle cost with both effects live~~ — **counted**, and the
-   answer changed the picture: **934 of ~1080, 86% used** (❌ retracted-budget
+   answer changed the picture: **934 of ~1080, 86% used** (❌ old-budget
    accounting — see `CHIP.md`), not the 529 or ~700
-   the docs carried. `tools/cycle_count.py` makes it reproducible. What is
-   still flash-only is confirming it under load — the static count models no
-   memory-contention stalls, so it is a floor.
+   earlier records carried. `tools/cycle_count.py` makes it reproducible.
+   What is still flash-only is confirming it under load — the static count
+   models no memory-contention stalls, so it is a floor.
 
 **Also still open**, both small and both with their evidence recorded above:
-MOD depth's range wants calibrating by ear (Round 5 measured it flattening
-after ~64, so the top half of the knob may be doing nothing); and the
+MOD depth's range wants calibrating by ear (measured flattening after ~64, so
+the top half of the knob may be doing nothing — `VOICING.md`); and the
 unexplained emulator-only divergence between one and two instances under a
 nonzero split. Two things the emulator cannot check at all: item 3 above, and
-the UI surface for **WIDTH** and **→DEL**, whose companion fields `-params`
-cannot drive. ❌ Retracted (10 Aug 2026): "WIDTH has never been heard moving
-from the front panel" — WIDTH was confirmed moving on-unit, as the 4-step
-select it became in R16.
+the front-panel UI surface for the companion-field selects (**WIDTH**,
+**RATE** — see `PARAM_PAGES.md` for what the harness can and cannot drive).
+WIDTH has been confirmed moving on-unit as its 4-step select.
 
 **Closed, do not re-chase:** modal prominence (8–11 dB over the local envelope,
 monotonic in total delay, no structural lever left under the 32K ceiling —
-`VOICING.md` Round 5); tank saturation; the tail crackle; the MIX law.
+`VOICING.md`); tank saturation; the tail crackle; the MIX law.

--- a/docs/XBUS.md
+++ b/docs/XBUS.md
@@ -1,14 +1,14 @@
-> ⚠️ **READ `PLAN.md` FIRST.** As of 8 Aug 2026 this file is the *architecture*
-> record — how the cross-core bus works and why. The **plan** (end-state
-> resource ledger, work order, what to do next) lives in `PLAN.md`, which
-> supersedes this file's "Recommended order" section.
+> ⚠️ **READ `PLAN.md` FIRST.** This file is the *architecture* record — how the
+> cross-core bus works and why. The **plan** (end-state resource ledger, work
+> order, what to do next) lives in `PLAN.md`, which takes precedence over this
+> file's "Recommended order" section.
 
 # The target architecture: one reverb, one delay, all eight tracks
 
-Agreed 7 Aug 2026. This supersedes `BUS.md`'s bank-scoped design, whose founding
-constraint — "the two DSPs are a hard boundary" — is now known to be false.
+This replaces `BUS.md`'s bank-scoped design, whose founding constraint — "the
+two DSPs are a hard boundary" — is known to be false.
 
-## What we're building
+## The design
 
 ```
 CORE 0   track 5   ChonVerb   Y:0x4000-0xBFFF (private) + Y:0x30000-0x37FFF (shared lo)  = 65,536 words = 1.49 s
@@ -16,32 +16,31 @@ CORE 0   track 5   ChonVerb   Y:0x4000-0xBFFF (private) + Y:0x30000-0x37FFF (sha
 CORE 1   track 1   BongDelay  Y:0x4000-0xBFFF (private) + Y:0x38000-0x3FFFF (shared hi)  = 65,536 words = 1.49 s
          2,3,4     Send
 
-✅ MEASURED 10 Aug 2026 (MrkVerb32 marker flash): core 0 / payload A serves
-TRACKS 5-8, core 1 / payload B serves TRACKS 1-4 -- INVERTED from every
-pre-SPEC document, which assumed A↔1-4. No pre-SPEC build could observe the
-mapping (both payloads carried every effect). Kept as-is on purpose: the
-reverb belongs downstream of the delay, so the delay serving the low tracks
-is the wanted topology. The inversion cost two flashes and a session read as
-"R13 is dead on hardware" -- it was alive on tracks 5-8 the whole time.
+✅ MEASURED (marker-flash test): core 0 / payload A serves TRACKS 5-8,
+core 1 / payload B serves TRACKS 1-4 -- INVERTED from the natural assumption
+that A serves 1-4. No pre-specialization build could observe the mapping
+(both payloads carried every effect). Kept as-is on purpose: the reverb
+belongs downstream of the delay, so the delay serving the low tracks is the
+wanted topology.
 
          every track sends to both, through accumulators in the shared window
          delay wet -> reverb  (series, the direction that is already built)
 ```
 
-⚠️ **Corrected arithmetic — "all 4 of core 0's FX2 slots = 65,536 words" was
-wrong, and wrong in a way that would have collided.**
+⚠️ **A plausible misreading — "all 4 of core 0's FX2 slots = 65,536 words" —
+is wrong, and wrong in a way that would collide.**
 
 The real pool is `32K private + 32K private + 64K shared = 128K words`, and it
 divides as above: each server gets its own core's two private slots plus **half**
 the shared window, **65,536 words each**.
 
-❌ **RETRACTED 9 Aug 2026 — "`X:0x255` is the same table in both payloads:
-FX2 slots are `0x4000 0x8000 0x30000 0x34000` on each core, so core 0's slots
-3–4 and core 1's slots 3–4 are the same physical memory."** That is false, and
-the conclusion it was used to reach ("only if the delay is given
-`0x38000-0x3FFFF`, which the allocator never hands out at all") is false with
-it. ✅ **Measured** by dumping the table out of both payloads of the *raw*
-stock image — it is **not** the same table:
+❌ **FALSE: "`X:0x255` is the same table in both payloads: FX2 slots are
+`0x4000 0x8000 0x30000 0x34000` on each core, so core 0's slots 3–4 and
+core 1's slots 3–4 are the same physical memory."** That claim is false, and
+the conclusion it leads to ("only if the delay is given `0x38000-0x3FFFF`,
+which the allocator never hands out at all") is false with it. ✅ **Measured**
+by dumping the table out of both payloads of the *raw* stock image — it is
+**not** the same table:
 
 | | payload A | payload B |
 |---|---|---|
@@ -56,7 +55,7 @@ taken.
 This *strengthens* the split rather than changing it: core 0 owning
 `0x30000-0x37FFF` and core 1 owning `0x38000-0x3FFFF` is what the stock
 allocator already believes, so the hardcoded bases agree with the table
-instead of merely dodging it. The raw-vs-built comparison also confirms our
+instead of merely dodging it. The raw-vs-built comparison also confirms this
 build does **not** modify `X:0x255` in either payload — the difference is
 stock.
 
@@ -64,8 +63,8 @@ Falsified by: dumping module `X:0x255` from `out/raw/section_3_MAIN_OS.bin`
 for both entries of `dsp_modmap.PAYLOADS`. Both servers still hardcode their
 bases, so the table is documentation here, not a dependency.
 
-**Three wins, and they are different resources. The third one is new and is the
-one that has been missed.**
+**Three wins, and they are different resources. The third one is the easiest
+to miss.**
 
 *Cycles*: each core runs ONE effect with its full ~4,535 cycles/sample instead
 of both cores running both effects. Roughly doubles the effects budget.
@@ -75,8 +74,8 @@ of both cores running both effects. Roughly doubles the effects budget.
 *Program space*: **the payloads no longer have to be the same code.**
 `build_bus.py` already assembles and places each payload independently — one
 `for tag, va, ln in PAYLOADS` loop, its own region, its own placement — and the
-2,724-word region is **per core**. Pre-SPEC (the 7 Aug 2026 reading), both
-payloads carried all three effects and both sat at **2,723 of 2,724 words, ONE
+2,724-word region is **per core**. Before specialization, both payloads
+carried all three effects and both sat at **2,723 of 2,724 words, ONE
 free**. Under one-server-per-core:
 
 | payload | carries | words | **free** |
@@ -84,13 +83,13 @@ free**. Under one-server-per-core:
 | A (core 0) | SEND 212 + ChonVerb 2,018 | 2,230 | **494** |
 | B (core 1) | SEND 212 + BongDelay 507 | 719 | **2,005** |
 
-(Those were the figures at SPEC landing. ✅ Measured 11–12 Aug 2026: R16–R18
-consumed the LFO-roll's 178 words, so A is now 2,692 of 2,724, **FREE 32**;
-B is 726 used, **FREE 1,998**.)
+(Those were the figures when specialization landed; both payloads have grown
+into the room since. The build report is the live ledger — the current build
+prints A 2,669 used / **FREE 55**, B 2,723 used / **FREE 1**.)
 
 ✅ Measured, not estimated: `XBUS=1 python3 tools/build_bus.py` already prints
 `FREE 484` per payload, because the XBUS path drops the delay to a 10-word stub.
-That build is the specialization, done crudely and by accident.
+That build already is the specialization, in crude form.
 
 **Program space was the binding constraint on all three effects, and
 specialization alone removes it — before a single line of code is written.**
@@ -102,49 +101,41 @@ pre-delay and lower modal density, i.e. a **bigger, smoother space**. 743 ms is
 exactly why `REVERB.md` ruled out Blackhole-class and substituted a
 Valhalla-flavoured big mode. 1.49 s reopens that.
 
-## STATE AS OF 7 Aug 2026 — SOLVED: the artifact was the SHIMMER
+## SOLVED: the metallic artifact was the SHIMMER
 
-**Hardware-confirmed.** Sam flashed `ChonVerb31` (shimmer excised) and the
-metallic/staticky artifact is **GONE**. The send path was never at fault.
+**Hardware-confirmed.** With the shimmer excised, the metallic/staticky
+artifact is **GONE**. The send path was never at fault.
 
 ### What it was
 
-The shimmer (`v101`, a +12 pitch shifter in the feedback path) was running on
-every build anyone has ever heard, at roughly half strength, **with no way to
-turn it off**:
+The shimmer (a +12 pitch shifter in the feedback path) ran on every earlier
+build, at roughly half strength, **with no way to turn it off**:
 
-- Page-2 slot 6 is `SHMR`, and `build_bus.py`'s `DEFAULTS` set it to **48**.
-  The comment there still read *"SPEED slow-ish"* — stale since `v101` renamed
-  that slot from SPEED to the shimmer amount and never revisited the default.
-  `41d252c` fixed the default to 0, but the card was running `BASE30`
-  (`0d4248c`), which predates it.
+- Page-2 slot 6 is `SHMR`, and `build_bus.py`'s `DEFAULTS` set it to **48** —
+  a default left over from when that slot was SPEED, never revisited when the
+  slot became the shimmer amount.
 - The knob could not correct it, because a page-2 slot **draws a knob without
-  necessarily publishing a value** — `PARAM_PAGES.md` §"What a probe build
-  would have to establish" wrote this down before it ever bit us. So SHMR sat
-  pinned at 48.
+  necessarily publishing a value** (`PARAM_PAGES.md` §"What a probe build
+  would have to establish"). So SHMR sat pinned at 48.
 - The shimmer is documented as metallic in its own right (`REVERB.md`: a blind
   splice), so this was a known-bad effect stuck permanently half-on.
 
-### Why it took so long, and the lesson
+### Two lessons, both general
 
-Two things hid it, and both were self-inflicted:
-
-1. **The emulator had `SHMR=0` in every render.** `render_reverb.py`'s `PARAMS`
-   still labels index 6 "SPEED" (the pre-v101 name), that label was copied into
-   `send_probe.py`, and the slot was then set to 0 to keep LFO sidebands out of
-   a THD metric. **Zeroing a parameter to clean up a measurement hid the bug
-   that parameter caused.** Every "the send path renders clean" result was true
+1. **The emulator had `SHMR=0` in every render.** The slot had been set to 0
+   in the render harnesses to keep LFO sidebands out of a THD metric.
+   **Zeroing a parameter to clean up a measurement hides the bug that
+   parameter causes.** Every "the send path renders clean" result was true
    and useless.
-2. **"The reverb sounds right on its own track" was treated as ruling SHMR
-   out** (the v114 handoff says so explicitly). It does the opposite: at
-   partial MIX the dry masks the shimmer, while a SEND is heard 100% wet, which
-   is exactly the asymmetry that made it look like a send-path fault.
+2. **"The reverb sounds right on its own track" does not rule the shimmer
+   out** — it does the opposite: at partial MIX the dry masks the shimmer,
+   while a SEND is heard 100% wet, which is exactly the asymmetry that makes
+   a stuck wet-path artifact look like a send-path fault.
 
-The measurement that finally matched was per-mode shimmer contribution —
-ROOM +19.8, PLATE +22.9, HALL +22.6, **BIG +1.8 dB** — which predicted Sam's
-"mode 4 is a lot less bad" before that was known to be diagnostic. The hardware
-signature it had to match: **+20.1 dB at 2.5–5 kHz, discrete lines (HF
-peak/mean 40.9 dB), music untouched (top-8 bins 95.3% before and after)**.
+The measurement that matched was per-mode shimmer contribution —
+ROOM +19.8, PLATE +22.9, HALL +22.6, **BIG +1.8 dB** — against the hardware
+signature: **+20.1 dB at 2.5–5 kHz, discrete lines (HF peak/mean 40.9 dB),
+music untouched (top-8 bins 95.3% before and after)**.
 
 ### The fix, and its state
 
@@ -160,24 +151,23 @@ writing its buffer every sample.
 - The code is preserved in git behind the markers, for the pitch-synchronous
   rewrite (`REVERB.md`), which is where the shimmer should return from.
 
-**On the card: `OCTATRACK_NOSHIM31.bin`, reading `ChonVerb31`.**
-
 ### What this unblocks
 
-The send path is exonerated and the reverb now matches how it was actually
-voiced (`VOICING.md` rounds were done without shimmer). Everything below in
-this document — the cross-core bus, the 1.49 s re-layout — is no longer
-blocked.
+The send path is exonerated and the reverb now matches how it was voiced
+(the `VOICING.md` rounds were done without shimmer). Everything below in
+this document — the cross-core bus, the 1.49 s re-layout — is not blocked
+by the artifact.
 
-### Still open, found along the way
+### Related findings
 
 - **BIG rings.** ~30 dB more HF than the other modes even with no shimmer: a
   dense cluster of non-harmonic lines in 2–2.8 kHz. `md_big` sets the decay
-  scale `x:(r7+$1e)` to `$7FFFFF` = **exactly 1.000000**, where ROOM/PLATE/HALL
-  leave headroom (0.920/0.965/0.980). Not simple runaway feedback — HF *falls*
+  scale `x:(r7+$1e)` to `$7FFFFF` = **exactly 1.000000**, where ROOM/PLATE
+  leave headroom (0.920/0.965; a third value, 0.980, belonged to the
+  since-removed HALL mode). Not simple runaway feedback — HF *falls*
   as TIME rises and is already high at TIME=0, so it is the input/early path.
   A mode at unity feedback scale is a hazard regardless.
-- ~~**Gain staging.**~~ **FIXED (v121)** — the bus now auto-scales by the number
+- ~~**Gain staging.**~~ **FIXED (bus auto-gain)** — the bus now auto-scales by the number
   of clients that actually wrote it, so 1 to 8 tracks all drive the reverb
   identically. Each SEND registers itself once per block in a parity-indexed
   count at `Y:0x983/0x984` and writes its contribution with **3 bits of
@@ -196,15 +186,15 @@ blocked.
 
   Eight tracks at 0.35 FS each are now clean (−44.6). The reverb's OWN tank
   still saturates above ~0.35 FS — unchanged, separate, and now the only limit.
-  **The DELAY accumulator did NOT get this treatment**; BongDelay is an
-  untested draft and can take the same change when it is worked on.
-- **The payload region is FULL: 2723 of 2724 words, ONE spare** — the pre-SPEC
-  reading of 7 Aug 2026, retracted at the end of this file by `SPEC=1`.
-  Anything added to any of the three effects now needs space found first.
+  (The DELAY accumulator received the same treatment separately — see "Still
+  open" below.)
+- **The payload region was FULL before specialization: 2723 of 2724 words, ONE
+  spare** — no longer true under `SPEC=1`; see the end of this file.
 - **Emulator/device alignment.** The proven gap is parameter delivery:
   `-params` pokes `r6` directly, so every slot looks live locally, while on
-  hardware a slot can draw a knob and publish nothing. That single gap is what
-  let the emulator report "clean" for a whole session.
+  hardware a slot can draw a knob and publish nothing. That single gap is
+  enough for the emulator to report "clean" on a build that publishes nothing
+  on the unit.
 
 ### What was measured about the bus, and stands
 
@@ -212,26 +202,26 @@ blocked.
 |---|---|
 | Does the bus carry audio? | **Yes.** 175,972 non-zero samples with the reverb's own input silenced. |
 | Is the send path faithful? | **Yes.** SEND vs DIRECT within **0.3 dB THD at every level**. |
-| A regression in the 24 commits? | **No.** Smooth drift, no step; `40f7167` is worse than the commit after it. |
+| A regression in the send path's history? | **No.** Smooth drift across the candidate range, no step. |
 | Mismatched per-track splits? | **No.** All combinations ≈ −36.2 dB. |
 | Multiple sends? | **No bug.** They sum linearly. |
 | Cycle budget? | **Not close.** ~44 instr/sample against a ~2400 ceiling. |
-| LFO rate (measured, not inferred)? | **0.10–0.69 Hz**, as designed. The `$2f` audio-rate theory is dead. |
+| LFO rate (measured, not inferred)? | **0.10–0.69 Hz**, as designed. An audio-rate `$2f` theory is falsified. |
 
-`dsp_host` gained what was needed to establish these: **list `-init`/`-proc`**
-(a different effect per instance — the first true SEND→SERVER run anywhere),
+`dsp_host` supports what was needed to establish these: **list `-init`/`-proc`**
+(a different effect per instance, so a true SEND→SERVER run is possible),
 **`-inmask`**, **per-instance `-split`**, and **`-track`** (r7-relative words
 dumped every block, so a *rate* can be differenced; `-peekx` only snapshots
 once). `tools/send_probe.py` and `tools/capture_hw.py` drive and analyse it.
 
-⚠️ **Traps that each cost a wrong conclusion:**
+⚠️ **Traps, each capable of producing a wrong conclusion:**
 - **Zeroing a parameter to clean up a metric hides the bug it causes** (above).
 - **`tools/dsp_host/` is COPIED into `vendor/` by `setup.sh`'s
   `stage_dsp_host`.** Building without re-copying silently runs the OLD binary
-  — the giveaway was two different renders coming out byte-identical.
+  — the giveaway is two different renders coming out byte-identical.
 - **`MODE=n` writes `out/mainos_bus_mode<n>.bin`, NOT `out/mainos_bus.bin`.**
-  Comparing the latter compares the ordinary build with itself, which is what
-  produced a bogus "the MODE override is a no-op" claim in v115.
+  Comparing the latter compares the ordinary build with itself, which reads
+  as "the MODE override is a no-op".
 
 ## Steps 0–3 are DONE
 
@@ -239,17 +229,16 @@ once). `tools/send_probe.py` and `tools/capture_hw.py` drive and analyse it.
    unturnoffable; excised by default, hardware-confirmed gone.
 1. ~~Relocated bus, same core.~~ **DONE** at `0x36000`.
 2. ~~Does a cross-core send arrive?~~ **DONE — cross-core works.**
-3. ~~Synchronisation.~~ ~~Not needed as feared; the ICC stays unused.~~
-   ⚠️ **RETRACTED 17 Aug 2026 — AND IT IS THE LOAD-BEARING ONE.** This was
-   concluded from step 2, "does a cross-core send arrive?", which was
-   validated **through the reverb**. A reverb is the one consumer that
-   physically cannot reveal the defect: it smears any per-sample damage into
-   a multi-second tail. The measurement was structurally blind to what it was
-   being used to rule out, exactly like the THD metric that called the same
-   artifact clean all day on 17 Aug (harmonics 2f..9f of a 438 Hz tone cannot
-   see a block-rate discontinuity).
+3. Synchronisation — ⚠️ **NEEDED, and it is the load-bearing step.** An
+   earlier "not needed; the ICC stays unused" conclusion was drawn from
+   step 2, "does a cross-core send arrive?", which was validated **through
+   the reverb**. A reverb is the one consumer that physically cannot reveal
+   the defect: it smears any per-sample damage into a multi-second tail. The
+   measurement was structurally blind to what it was being used to rule out —
+   the same way a THD metric summing harmonics 2f..9f of a 438 Hz tone
+   cannot see a block-rate discontinuity.
 
-   **THE RACE, and it has been shipping since XBUS landed.** All bus
+   **THE RACE.** All bus
    housekeeping — the parity flip AND the clearing of the new write buffer —
    is gated to payload A (`build_bus.py`, the XBUS_GATE substitution:
    `beq ... ; payload B never housekeeps`). ChonVerb lives on payload A, so
@@ -260,8 +249,8 @@ once). `tools/send_probe.py` and `tools/capture_hw.py` drive and analyse it.
    core 1 may still be reading. Zeros spliced into the audio at block
    boundaries.
 
-   **Measured on hardware, 17 Aug** (Sam's unit, audio interface capture,
-   band energy normalised to each capture's own 200–800 Hz musical band):
+   **Measured on hardware** (audio-interface capture, band energy normalised
+   to each capture's own 200–800 Hz musical band):
 
    | band | delay via the BUS | delay via its HOST track | difference |
    |---|---|---|---|
@@ -277,33 +266,29 @@ once). `tools/send_probe.py` and `tools/capture_hw.py` drive and analyse it.
    because **a single-core emulator is always trivially in lockstep and can
    never reproduce this.**
 
-   ⚠️ It hid this long because BongDelay was always driven by its own host
-   track. v3 stage 1 made the bus path the normal one, and the artifact
-   appeared immediately.
+   ⚠️ The defect stays hidden as long as BongDelay is driven by its own host
+   track; the moment the bus path becomes the normal one, the artifact
+   appears.
 
-   ✅ **CONFIRMED ON HARDWARE, 17 Aug 2026, and it cost no flash.** Sam moved
-   BongDelay from track 1 to track 4 and the stutter stopped. Track position is
+   ✅ **CONFIRMED ON HARDWARE, without a flash.** Moving BongDelay from
+   track 1 to track 4 stopped the stutter. Track position is
    dispatch position within core 1's bank, so it moves WHEN in the block the
    delay reads the accumulator relative to core 0's housekeeper — a timing
    dependency, and no algorithmic cause has one. It also fixes the SIGN of the
    race: track 1 is early in core 1's order, track 4 is late, so **the failure
    mode is core 1 reading too EARLY** — getting to the accumulator before core 0
    has finished with it.
-   ⚠️ Sam's own caveat, unresolved: on track 4 he thought it was "not doing
-   much". Clean-because-correct and clean-because-starved look the same from
-   here, so track 4 is not yet a validated workaround — check the level against
-   the host-track path before relying on it.
+   ⚠️ Track position is a diagnostic, not a validated workaround:
+   clean-because-correct and clean-because-starved sound the same, so a
+   quiet-but-clean track must have its level checked against the host-track
+   path before being relied on.
 
-   ⚠️ **THE `HKB=1` FALSIFIER WAS WEAKER THAN THIS ENTRY CLAIMED** (retracted
-   here rather than deleted, because it was quoted as a plan). "Delay clean,
-   reverb now carrying it" is not what swapping the housekeeper does: it
-   transposes the hazard rather than removing it, because core 0's SENDS would
-   then write buffers core 1 clears and reads. Expect a change of character,
-   not a disappearance. It was never run — the free track-position test
-   above settled the question first.
+   ⚠️ Note that swapping the housekeeper to payload B (`HKB=1`) would NOT
+   have been a clean falsifier: it transposes the hazard rather than removing
+   it, because core 0's SENDS would then write buffers core 1 clears and
+   reads. Expect a change of character, not a disappearance.
 
-   ✅ **THE FIX: FOUR BUFFERS, landed 17 Aug 2026.** Not three, and not
-   synchronisation.
+   ✅ **THE FIX: FOUR BUFFERS.** Not three, and not synchronisation.
    - **Two cannot be made safe at any clear time.** At every instant one buffer
      is the write target and the other the read target, so the only buffer that
      can be cleared is the one transitioning read → write — and that transition
@@ -323,10 +308,10 @@ once). `tools/send_probe.py` and `tools/capture_hw.py` drive and analyse it.
      a block late already.
    - **It covers the other direction too.** BongDelay's `→VERB` writes payload
      A's reverb accumulator from core 1 every sample, so the race ran both
-     ways; the delay→reverb wash was carrying it as well. That was not recorded
-     before and is not a separate fix — the same rotation covers it.
+     ways; the delay→reverb wash was carrying it as well. That is not a
+     separate fix — the same rotation covers it.
 
-   **Gated by `tools/verify_bus.py`** (new): 17 layouts covering all three
+   **Gated by `tools/verify_bus.py`**: 17 layouts covering all three
    copies of the housekeeping block, the self-healing election, 1–7 senders on
    each bus, both cross-sends and split blocks. The restructure is proven exact
    by pointing the candidate's read at the same buffer generation as the
@@ -342,10 +327,10 @@ once). `tools/send_probe.py` and `tools/capture_hw.py` drive and analyse it.
 
    ---
 
-   ⚠️ **A SECOND CROSS-CORE DEFECT, CONFIRMED ON HARDWARE 17 Aug 2026 (R23).
-   THE FOUR BUFFERS DID NOT FIX THIS ONE, AND IT WAS NEVER THE SAME BUG.**
+   ⚠️ **A SECOND CROSS-CORE DEFECT, CONFIRMED ON HARDWARE. THE FOUR BUFFERS
+   DID NOT FIX THIS ONE, AND IT WAS NEVER THE SAME BUG.**
 
-   The four-buffer rotation cured *clear-vs-read* and Sam confirmed it: the
+   The four-buffer rotation cured *clear-vs-read*, hardware-confirmed: the
    delay on track 1 over the bus is clean. What remains is **which buffer each
    client picks**, and it is a different failure.
 
@@ -383,8 +368,8 @@ once). `tools/send_probe.py` and `tools/capture_hw.py` drive and analyse it.
    (core-1 track, delay mode) combination is bad at a time, and it relocates
    when either the mode or core 0's load changes. **Any "it is fixed" claim
    must therefore be tested across several mode/track combinations** — a single
-   clean configuration proves nothing, which is how this survived the R23
-   flash's first round of testing.
+   clean configuration proves nothing, and spot-checks have passed
+   configurations that a sweep then failed.
 
    🟡 **It probably explains the reverb static too, and that is inferred, not
    measured.** BongDelay's `→VERB` is a **core-1 writer into the REVERB
@@ -394,7 +379,7 @@ once). `tools/send_probe.py` and `tools/capture_hw.py` drive and analyse it.
    existed; a reverb gave it a consumer) and why PLATE and BIG show it while
    ROOM does not — long tails sustain broadband noise, short damped ones bury
    it. That also **retires the 7–9 dB per-mode gain spread as the explanation**
-   for the mode dependence; the gain measurement stands on its own (PLAN 1.4)
+   for the mode dependence; the gain measurement stands on its own
    but it never predicted PLATE.
 
    **THE FIX — a design job, not a gate.** Clients on a core must agree with
@@ -421,9 +406,9 @@ once). `tools/send_probe.py` and `tools/capture_hw.py` drive and analyse it.
 
    ---
 
-   ✅ **ALL THREE CLOSED, CONFIRMED ON HARDWARE 17 Aug 2026 (R26, tag 45).**
-   Sam swept T2/T3/T4 against delay MODE 1–5 with a ChonVerb on track 5 and
-   reports **all modes good on all tracks**. The three defects, in the order
+   ✅ **ALL THREE CLOSED, CONFIRMED ON HARDWARE.**
+   A sweep of T2/T3/T4 against delay MODE 1–5 with a ChonVerb on track 5
+   shows **all modes good on all tracks**. The three defects, in the order
    they were found, each needing the previous one fixed before it was visible:
 
    | # | defect | fix |
@@ -432,36 +417,34 @@ once). `tools/send_probe.py` and `tools/capture_hw.py` drive and analyse it.
    | 2 | **the rotation read** — every client read the shared rotation at its own dispatch time, so the core-1 client straddling core 0's flip disagreed with the rest | per-core rotation tracking |
    | 3 | **clear-vs-write** — core 0's clear racing core 1's writers | clear the buffer written NEXT block (four buffers leave an idle slot) |
 
-   ⚠️ Plus one defect **of my own making** in the fixes: the tracked rotation
-   was never initialised, and a client booting one step ahead is
-   indistinguishable from one legitimately reading pre-flip, so it stuck — and
+   ⚠️ Plus one defect in the fixes themselves: the tracked rotation
+   must be seeded at `init`. Uninitialised, a client booting one step ahead is
+   indistinguishable from one legitimately reading pre-flip, so it sticks — and
    once the clear moved ahead, a stuck client writes exactly the buffer being
-   cleared. Metallic on every core-1 sender after every power cycle (R25).
-   Fixed by seeding at `init` (R26). **The tracking is NOT self-healing**, and
-   the commit that introduced it said it was.
+   cleared: metallic on every core-1 sender after every power cycle.
+   Seeding at `init` fixes it. **The tracking is NOT self-healing.**
 
    **THE DIAGNOSTIC LEVER, and it costs no flash: change what is on TRACK 5.**
    T5 is core 0's **position 0 — the housekeeper** — so swapping ChonVerb for
-   Send moves the flip in time and nothing else. It isolated a core-1 defect
-   three separate times, and it is the first thing to reach for if any of this
+   Send moves the flip in time and nothing else. It has isolated core-1
+   defects repeatedly, and it is the first thing to reach for if any of this
    returns.
 
    ⚠️ **A SINGLE CLEAN CONFIGURATION PROVES NOTHING.** These artifacts
-   RELOCATE: exactly one (core-1 track, delay mode) pairing was bad at a time,
-   and it moved whenever the mode or core 0's load changed. Two separate
-   flashes were passed by spot-checks before a sweep caught the truth.
+   RELOCATE: exactly one (core-1 track, delay mode) pairing is bad at a time,
+   and it moves whenever the mode or core 0's load changes. Spot-checks have
+   passed builds that a sweep then failed.
 
    🟡 **STILL UNVERIFIED: that the cores are RATE-LOCKED** and merely
    phase-offset. The per-core tracking advances one step per block and assumes
    no drift. Nothing local can test it; a slow return of the artifact over
    minutes would be the symptom.
 
-   ⚠️ **NONE OF THIS IS EVIDENCE THE RACE IS FIXED.** dsp_host is single-core
+   ⚠️ **NO LOCAL TEST IS EVIDENCE THE RACE IS FIXED.** dsp_host is single-core
    and always trivially in lockstep, so no local test can reach a cross-core
-   timing defect — the same blindness that let this ship for months. The gate
-   proves the bus still does the same thing. Only the unit can say the stutter
-   is gone, and the test is the one that found it: BongDelay on **track 1**,
-   fed over the bus.
+   timing defect. The gate proves the bus still does the same thing. Only the
+   unit can say the stutter is gone, and the decisive test is the one that
+   exposes it: BongDelay on **track 1**, fed over the bus.
 
 Steps 4 (memory re-plan) and 5 (the effects) are what remains, and the
 re-evaluation below is what they should now be.
@@ -473,16 +456,16 @@ re-evaluation below is what they should now be.
 ## The constraint has INVERTED, and this is the headline
 
 Every optimisation in this project so far traded program words for cycles,
-because cycles were the wall: the density pass (432 → 297), the v97 Hadamard
-rewrite (24 words → 16), the v99 early-reflection rewrite (254 → 181 cycles).
+because cycles were the wall: a density pass (432 → 297), a Hadamard
+rewrite (24 words → 16), an early-reflection rewrite (254 → 181 cycles).
 That rule is now **backwards**.
 
 | resource | before | after specialization | ratio |
 |---|---|---|---|
-| cycles, core 0 (reverb + 3 sends, FX1 filters off) | ~2,432 spare ✅ | **~2,576 spare** 🟡 — superseded: ✅ 1,392 spare measured (7 Aug); **819**/sample room for new work as of 12 Aug (the bank consumed 573) | ~3.4× the engine's 763 |
+| cycles, core 0 (reverb + 3 sends, FX1 filters off) | ~2,432 spare ✅ | **~2,576 spare** 🟡 estimate; ✅ 1,392 spare measured, of which **819**/sample remains for new work (the bank has since consumed 573) | ~3.4× the engine's 763 |
 | cycles, core 1 (delay + 3 sends) | — | **~3,176 spare** 🟡 | ~19× the placeholder's 163 |
 | Y memory per server | 32,768 words / 743 ms ✅ | **65,536 / 1.486 s** ✅ | 2× |
-| **program space, payload A** | **1 word** ✅ | **494 words** ✅ (at SPEC landing; **32** as of R18 — R16–R18 spent the LFO-roll's 178) | — |
+| **program space, payload A** | **1 word** ✅ | **494 words** ✅ at specialization; **32** now (later reverb work spent the LFO-roll's 178) | — |
 | **program space, payload B** | **1 word** ✅ | **2,005 words** ✅ | — |
 
 (Cycle figures are the measured 2,432 spare — filters off, full bank live —
@@ -494,7 +477,7 @@ last few hundred.)
 **So: spend cycles to buy program words, everywhere.** Two consequences that
 are worth more than any voicing change:
 
-- **Roll the unrolled loops back up.** *(✅ Done — the roll landed 10 Aug 2026;
+- **Roll the unrolled loops back up.** *(✅ Done — the roll has shipped;
   what follows is the pre-roll argument, kept as the record.)* The reverb's
   four tank lines are unrolled: tank taps 101 instructions, feedback/write-back 101, STAGE-2 read
   offsets 44, LFOs 19 — **265 instructions for four lines, ~66 per line** ✅
@@ -508,10 +491,9 @@ are worth more than any voicing change:
   unlocks arbitrary line lengths. This is the only way BongDelay gets a
   single 1.49 s line.
 
-## The shared window can hold CODE, and we have only ever spent it on buffers
+## The shared window can hold CODE, and it has only ever been spent on buffers
 
-**This is the "we freed up a heap of everything" intuition, and it is right —
-but not for program space, which is the one resource the shared memory and the
+**Program space is the one resource the shared memory and the
 cross-core work did not touch at all.** P/X/Y alias in `0x30000-0x3FFFF` ✅, so
 those 65,536 words are addressable as **program memory** just as readily as
 buffer, and nothing has ever tried it.
@@ -526,14 +508,15 @@ Stock already does it, in production, today ✅:
 
 That last row is the existence proof and it is the important one: it is a live
 P module, loaded by the ordinary module loader (space byte 0 = P, exactly like
-our code), executing after boot, and reaching **across into payload A's code**.
+this project's code), executing after boot, and reaching **across into payload
+A's code**.
 
 **`0x38000` is also the half that SURVIVES.** Init zeroes `0x30000-0x37FFF` —
 all 32,768 words, disassembled at `P:0x040` ✅ — so anything preloaded into the
 lower half is wiped. The upper half is not zeroed, which is exactly why that
 19-word stub is still there to be called.
 
-🟡 **So the hypothesis: our effect code can live at `P:0x38000+`.** The
+🟡 **So the hypothesis: effect code can live at `P:0x38000+`.** The
 dispatcher does `jsr (r2)` with an address out of `X:0x215`/`X:0x235`; a 24-bit
 `0x38000` is as valid a target as `0x01000`, and the loader already places P
 modules there.
@@ -577,7 +560,7 @@ redistributes**, and the trade is word for word.
   `0x00000-0x0BFFF`, absent from `0x0C000`. That is the default map's 48K, to
   the word.
 - ✅ **Payload A's P code ends at `0x01fdf` — 33 words short of `0x2000`**, the
-  top of the default map's 8K. 8,159 of 8,192 used. *That* is the wall, and our
+  top of the default map's 8K. 8,159 of 8,192 used. *That* is the wall, and the
   2,724-word donor region sits inside it.
 
 **Fig 3-6 is ruled out by measurement:** it drops X to 32K (`0x0-0x7FFF`) and
@@ -591,20 +574,21 @@ i.e. the reverb's private pool drops 32K → 24K, so the reverb goes 65,536 →
 🟡 **Untested, and the risk is real.** OMR must be written **before any module
 is loaded into the newly-available P**, which means patching the boot path —
 the natural site is bootstrap A/B (`P:0x31000`/`0x32000`, 50 and 58 words, in
-the shared window and already ours to patch). Open questions, none answered:
+the shared window and already patchable by the build). Open questions, none
+answered:
 
 - Does the ColdFire-side loader assume the default extents anywhere?
 - Does anything in stock's *runtime* allocate Y above `0x9FFF`? No loaded
   module does (the highest Y module ends at `0x795`), but the FX2 allocator
   hands out `Y:0x8000` as a slot base, and that slot's top half disappears.
-  Under our three-entry menu only ChonVerb lives there, so we control it — but
-  that is an argument about our build, not about stock.
+  Under the three-entry menu only ChonVerb lives there, so the build controls
+  it — but that is an argument about this build, not about stock.
 - Is the switch safe *after* reset at all, or only at reset?
 
 **Sequence if this is ever taken: change the map first and prove the machine
 still boots with the code where it already is.** Do not combine it with moving
-code into the new region — that is two variables, and `REVERB.md`'s "change one
-thing per flash" was written after five changes at once cost a whole session.
+code into the new region — that is two variables, and `REVERB.md`'s rule is
+one change per flash.
 
 **The trade, and it is the honest part: shared words spent on code are words
 neither effect gets as buffer.** 4,096 words of P would take BongDelay from
@@ -613,7 +597,7 @@ free word today, that is an extraordinary rate of exchange — but it is a trade
 not the free lunch the alias makes it look like.
 
 **Do not confuse this with specialization.** Specialization (494 / 2,005 free
-words at landing; **32** / ~1,998 as of R18, 12 Aug 2026) is real, costs
+words at landing; **32** / ~1,998 now) is real, costs
 nothing, and needs no new hypothesis. This is the lever
 *after* that one, and it should be tested only if the reverb's 494 words (now
 32) prove too tight — which rolling the tank loop may well prevent.
@@ -632,7 +616,7 @@ Doubling total delay halves the spacing, and there are two ways to do it:
 first — at equal total delay, more short lines beat fewer long ones (more
 independent paths, richer Hadamard mixing, no drift toward a longer and more
 separated character), and it keeps the per-line length the modes were voiced
-against. *(✅ Decided and shipped: the 8-line rolled tank landed 10 Aug 2026.)*
+against. *(✅ Decided and shipped: the 8-line rolled tank.)*
 
 A layout that fits 65,536 words exactly:
 
@@ -644,7 +628,7 @@ A layout that fits 65,536 words exactly:
 | in-loop allpasses | 4 × 2,048 = 8,192 | double today's two |
 
 Costs, against ~2,576 spare cycles and 494 free words *(historical pricing —
-the work has since shipped, 10 Aug 2026)*:
+the work has since shipped)*:
 
 - **Cycles** 🟡 ~+450 for four more lines, ~+32 for the 8-point fast Hadamard
   (12 butterflies vs 4). Call it **~1,250 total** against 2,576. Comfortable.
@@ -655,7 +639,7 @@ the work has since shipped, 10 Aug 2026)*:
 
 ## Rolling the tank loop — what it means, and why it is the enabler
 
-> ✅ **DONE — landed 10 Aug 2026**, bit-identical proof via `make verify-roll`.
+> ✅ **DONE** — bit-identical proof via `make verify-roll`.
 > The section below is the design record, kept as written.
 
 **"Rolling" = turning an unrolled loop back into a loop.** The tank's four
@@ -690,24 +674,26 @@ The odd one out is **not sloppiness** — it is the deliberate crosswise LFO
 assignment (lines 0 and 2 on the inverse triangle, 1 and 3 on the forward, see
 `REVERB.md` §Signal path). Fix by reordering the LFO state array so line *k*
 reads slot *k* while preserving the same phase relationships. ⚠️ The **pairing
-rule** applies here and it has already cost one bug: each line's interpolation
+rule** applies here and is easy to get wrong: each line's interpolation
 fraction must come from the same LFO as the integer offset its `nK` was built
-from. Getting that wrong put a 1-sample sawtooth at ~76 Hz on two lines and
-measured −29.6 dB — the loudest artifact ever found in this engine.
+from. Getting that wrong puts a 1-sample sawtooth at ~76 Hz on the affected
+lines, measured at −29.6 dB — the loudest artifact ever found in this engine.
 
 **Bonus: it frees registers.** `r1–r4` hold the four line pointers and `m1–m4`
 *all hold the same `$fff`*. Rolled needs one pointer and one modifier, freeing
 three address registers and three modifiers — which `REVERB.md` already wants
-for the r7-access optimisation, and which is the tax that halved the v97
-Hadamard's saving.
+for the r7-access optimisation, and which is the tax that halved the
+Hadamard rewrite's saving.
 
 ### Two things that will bite
 
 - **`r7` is FULL.** The tank taps alone use **20 of its words for 4 lines**;
-  8 lines wants 40, and `$84+` **hangs the DSP** ([[octamax-r7-slots-full]]).
+  8 lines wants 40, and `$84+` **hangs the DSP**.
   The extra state must go to **absolute Y in the server's own buffer** — a
-  proven pattern (`dsp/cycleburn.asm` parks LFO and damping state there, and
-  `DSP.md`'s v27 build showed absolute Y works where `r7+$84` hangs). There is
+  proven pattern (`dsp/cycleburn.asm`, in git history, parks LFO and damping
+  state there, and
+  a probe build recorded in `DSP.md` showed absolute Y works where `r7+$84`
+  hangs). There is
   exactly one server per bank, so absolute-Y scalars cannot collide.
   **The rolling re-layout and the r7-full problem have the SAME fix**, which is
   the argument for doing them together rather than in sequence.
@@ -720,8 +706,8 @@ Hadamard's saving.
 **Verification standard for this work**, since it is a pure refactor: the
 rolled build must render **bit-identical** to the unrolled one at four lines,
 across all four modes plus a `TIME=127 SIZE=127 DIFF=127` wet case. Add the
-single-`nop` control that proves the comparison is not blind
-([[octamax-assembler-traps]]). Only once that passes does the line count change.
+single-`nop` control that proves the comparison is not blind.
+Only once that passes does the line count change.
 
 ## FX1 must keep working — and FILTER is probably NOT the worst case
 
@@ -744,11 +730,11 @@ worst case is an assumption, and there are two reasons to doubt it:
    | above FILTER | **MULTIBCOMP** (crossovers + multiple detectors), **COMB**, **FLANGER**, **PHASER**, **CHORUS** (modulated interpolated delay lines) |
    | near FILTER | EQ, DJ EQ (biquad stacks) |
    | below FILTER | SPATIALIZER, LO-FI, COMPRESSOR |
-   | **free** | **DELAY** — it has no DSP code at all ✅ ([[octamax-stock-delay-mystery]]) |
+   | **free** | **DELAY** — it has no DSP code at all ✅ |
 
    The FX1 menu never included the reverbs or DELAY — PLATE/SPRING/DARK and
-   DELAY are FX2-only (Sam, on-unit; corrected 11 Aug 2026 after this doc
-   repeatedly implied otherwise). Every FX1 effect is live for us, untouched.
+   DELAY are FX2-only (✅ read off the unit's menus). Every FX1 effect stays
+   live, untouched.
 
 **And the worst case to measure is not `4 × worst effect`.** A realistic kit
 puts a *different* FX1 effect on each track. The number the design actually
@@ -765,29 +751,29 @@ ceiling.
 1,040 is a measured floor for the FX1 load and the real figure can only be
 higher. The 8-line tank is estimated at ~1,250 🟡, so **this measurement is
 what decides whether 8 lines fits**, and it should be taken before the tank is
-rewritten, not after. *(Resolved: the 8-line tank shipped and ✅ measured
-**1,133 cycles** at the 9 Aug count — under the ~1,250 estimate. The question
+rewritten, not after. *(Resolved: the 8-line tank shipped and ✅ measures
+**1,133 cycles** — under the ~1,250 estimate. The question
 no longer gates the rewrite, which has happened.)*
 
-**Not in scope: the three stock reverbs.** PLATE / SPRING / DARK are our
+**Not in scope: the three stock reverbs.** PLATE / SPRING / DARK are the
 donors (594 / 1,063 / 1,067 words ✅) and stay taken. The cost lands entirely
-on the **FX2** menu (the three stock reverbs are replaced by our servers);
-FX1 loses nothing because its menu never listed them (corrected 11 Aug 2026
-— the old "losing them on FX1 is accepted" framing here invented a cost that
-did not exist). "FX1 must work" means the FX1 pool and the cycles it costs.
+on the **FX2** menu (the three stock reverbs are replaced by the new servers);
+FX1 loses nothing because its menu never listed them (an earlier framing here
+— "losing them on FX1 is accepted" — invented a cost that does not exist).
+"FX1 must work" means the FX1 pool and the cycles it costs.
 Do not re-open this to give donors back; core 0 has none to give anyway
 (ChonVerb + SEND = 2,230 against PLATE+SPRING = 1,657).
 
 ## What to build with it — the delay
 
-BongDelay was scoped as an afterthought (507 words, 163 cycles, a placeholder)
-and was first exercised under `DEV=1` on 10 Aug 2026 (risk 2 below) but **has
-never been heard on its shipping payload-B path on hardware**. It should not
-get its first audition
-against the old budget. Payload B gives it:
+BongDelay was scoped as an afterthought (507 words, 163 cycles, a
+placeholder) that renders locally under `DEV=1` (risk 2 below). Payload B
+gave it the room to become the five-mode engine that now ships — confirmed
+on hardware on its shipping payload-B path (tracks 1–4). The budget it
+started from:
 
-- **2,005 free program words** — five times its current size
-- **~3,176 spare cycles** — nineteen times its current cost
+- **2,005 free program words** — five times the placeholder's size
+- **~3,176 spare cycles** — nineteen times the placeholder's cost
 - **65,536 words = 1.49 s**, as two 32,768-word modulo lines (`Y:0x8000` and
   `Y:0x38000` are both 32K-aligned ✅) or one 1.49 s line with a manual wrap
 
@@ -803,7 +789,7 @@ The shared window is not flat. Three things to dodge, all already mapped:
 |---|---|---|
 | `0x30000-0x30047` | stock's per-frame parameter staging, 72 words, **rewritten EVERY FRAME** ✅ | never usable |
 | `0x31000` / `0x32000` | bootstraps A and B, 50 / 58 words ✅ | dead after boot, usable |
-| `0x34000` | ~~a single word written here corrupts audio after ~5.45 s~~ ❌ **RETRACTED 8 Aug** — v107's own bisect covered this exact address with ONE instance and found it clean; the fault was always duplication (`CHIP.md` §6) | **usable** |
+| `0x34000` | ~~a single word written here corrupts audio after ~5.45 s~~ ❌ **FALSE** — a bisect covered this exact address with ONE instance and found it clean; the fault was always instance duplication (`CHIP.md` §6) | **usable** |
 
 **The bus scratch needs a permanent home, and there is a free one.** It sits at
 `0x36000` today, which is inside the reverb's new `0x34000-0x37FFF` block. But
@@ -824,13 +810,13 @@ exactly, except for the scratch, which both cores must touch by definition:
 
 ## The four things that could bite, in order
 
-1. ~~**`Y:0x34000` corrupts audio after ~5.45 s.**~~ ❌ **DEAD, 8 Aug 2026 —
-   and it was dead before it was ever ranked here.** `dsp/shared_probe.asm`'s
-   `ADDR = 0` *is* `0x34000`, and v107's bisect row "one `SharePrb` + three
+1. ~~**`Y:0x34000` corrupts audio after ~5.45 s.**~~ ❌ **FALSE.**
+   `dsp/shared_probe.asm` (in git history) has
+   `ADDR = 0` *at* `0x34000`, and the bisect row "one `SharePrb` + three
    `Send`s → clean at every ADDR and INC" therefore already measured a single
-   instance writing that exact word, clean. The two builds that "reproduced"
-   it both had two instances running — `04a24cf` says so itself. **The
-   reverb's pool is not blocked and this costs no flash.** Full retraction in
+   instance writing that exact word, clean. The builds that appeared to
+   reproduce it both had two instances running. **The
+   reverb's pool is not blocked.** Full detail in
    `CHIP.md` §6.
 2. ~~**`dsp_host` cannot boot payload B.**~~ **MITIGATED — the `DEV=1` hatch is
    built.** The risk was real: `XBUS=1` stubs the delay out, and the specialized
@@ -847,16 +833,16 @@ exactly, except for the scratch, which both cores must touch by definition:
    `out/mainos_bus_dev.bin`, never `out/mainos_bus.bin`, and refuses to combine
    with `BURN`/`PROBE`/`XPROBE`/`DELAYPROBE`.
 
-   `send_probe.py --layout` now takes **`D`** alongside `R` and `S`, and
+   `send_probe.py --layout` takes **`D`** alongside `R` and `S`, and
    `--dlevel` drives the `→DELAY` send (`x:(r6+0)`) — a separate knob from
-   `→REVERB` (`x:(r6+1)`), which is why the first run rendered silence.
+   `→REVERB` (`x:(r6+1)`); driving the wrong one renders silence.
 
    ```sh
    DEV=1 XBUS=1 python3 tools/build_bus.py
    python3 tools/send_probe.py --mem out/dsp/mem_dev_A.mem --layout DS
    ```
 
-   **UPDATE 12 Aug 2026 (v2 stage 2 opener): the DEV delay no longer sits in
+   **The DEV delay no longer sits in
    the donor region at all.** It assembles at **P:0x04000** and its module
    record is appended to the `.mem` dump (`build_bus.py` `DEV_DELAY_P`) —
    dsp_host has no 8K P wall and boots the dump, not the image, and the
@@ -867,10 +853,10 @@ exactly, except for the scratch, which both cores must touch by definition:
    for delay work. The DEV image's dispatch points at code that exists only
    in the dump — one more reason DEV builds are never flashed.
 
-   ✅ **Verified: BongDelay produced audio over the bus for the first time** —
+   ✅ **Verified: BongDelay produces audio over the bus under `DEV=1`** —
    peak 0.074 FS, −14.6 dBFS, THD −35.2 dB, against **digital silence** on a
    non-DEV image. And the existing reverb path is **bit-for-bit unchanged**:
-   `--layout RS` against `HEAD`'s script and the new one agree to every digit
+   `--layout RS` renders before and after the hatch agree to every digit
    (peak 0.243, −15.2 dBFS, THD −11.08, same spurs). SEND vs DIRECT at 0.15 FS
    is −36.18 vs −36.17 — the send path is still faithful; the −11 dB at 0.5 FS
    is the known tank saturation above ~0.35 FS, not a regression.
@@ -879,35 +865,33 @@ exactly, except for the scratch, which both cores must touch by definition:
    The mechanism to prevent it already exists and is proven — the null stub
    (`nul_i`/`nul_p`) and the id-0 → SEND aliasing. Wire ChonVerb → SEND on
    payload B and BongDelay → SEND on payload A, deliberately.
-4. ~~**`tools/cycle_count.py` still prints `budget/DSP 1080`**, a number
-   retracted twice. It will report a design that fits as over budget.~~
+4. ~~**`tools/cycle_count.py` prints `budget/DSP 1080`**, a number that was
+   never a real ceiling. It would report a design that fits as over budget.~~
    **FIXED** — the tool now subtracts bank growth and prints the live number.
 
 ## Recommended order
 
 1. ~~**`DEV=1` local-render escape hatch for the delay**~~ — **DONE**, see
    risk 2 above. BongDelay now renders locally for the first time.
-2. **One `BURN=1` flash, then sweep.** Now settles ONE thing, not two —
-   `Y:0x34000` was retracted from the docs rather than measured (risk 1). What
-   remains is **the real FX1 worst case**, which decides whether 8 lines fits.
+2. **One `BURN=1` flash, then sweep.** Settles ONE thing —
+   **the real FX1 worst case**, which decides whether 8 lines fits.
    Sweep the loaded kit first, then a few single-effect x4 configurations to
    find which stock FX1 effect is actually the ceiling. The burn knob is a
    front-panel instrument: one flash, then every further configuration is a
    knob sweep.
-3. ~~**Specialize the payloads.**~~ ✅ **DONE, 8 Aug 2026 (v123, `SPEC=1`).**
+3. ~~**Specialize the payloads.**~~ ✅ **DONE (`SPEC=1`).**
    `XBUS=1 SPEC=1 python3 tools/build_bus.py`: payload A carries SEND +
    ChonVerb (**FREE 494**), payload B SEND + BongDelay (**FREE 1998**). The
    absent server's id is aliased to SEND on each core, which is risk 3's fix
    applied rather than deferred. Predicted 494 / 2,005; the 7-word gap on B is
    the delay's XBUS gate. The plain build is byte-identical with the flag off.
-   ~~Not yet flashed.~~ **Flashed** — the unit runs R15 (tag 34) with `SPEC=1`;
-   tags 35–37 (R16–R18) are built but unflashed.
+   **Flashed** — the unit runs a `SPEC=1` build.
 4. ~~**Roll the reverb's tank loop**, and move the per-line state to absolute Y
-   in the same pass — the two have the same fix.~~ ✅ **DONE, 10 Aug 2026** —
+   in the same pass — the two have the same fix.~~ ✅ **DONE** —
    bit-identical to the unrolled build at four lines, proven via
    `make verify-roll`. See the section above for the strided state layout and
    the two traps.
-5. ~~**Eight lines.**~~ ✅ **DONE, 10 Aug 2026** — the 8-line rolled tank
+5. ~~**Eight lines.**~~ ✅ **DONE** — the 8-line rolled tank
    shipped. The first real audible step the memory buys.
 6. **Re-scope BongDelay against its actual budget**, then audition it.
 
@@ -916,12 +900,14 @@ exactly, except for the scratch, which both cores must touch by definition:
 - **BIG rings.** ~30 dB more HF than the other modes with no shimmer: a dense
   cluster of non-harmonic lines at 2–2.8 kHz. `md_big` sets the decay scale
   `x:(r7+$1e)` to `$7FFFFF` = exactly 1.000000 where ROOM/PLATE leave
-  headroom (0.920/0.965; the third value, 0.980, was HALL's — that mode was
-  cut 9 Aug 2026, so it is historical). NOT simple runaway feedback — HF *falls* as
+  headroom (0.920/0.965; a third value, 0.980, belonged to the HALL mode,
+  which has been removed). NOT simple runaway feedback — HF *falls* as
   TIME rises and is already high at TIME=0, so suspect the input/early path.
-- **Tank saturation above ~0.35 FS.** The only level limit left since v121.
-- ~~**The DELAY accumulator has no auto-gain.** Same fix as v121; fold it into
-  the delay re-scope.~~ **DONE — 12 Aug 2026, the delay-bus mirror of v121.**
+- **Tank saturation above ~0.35 FS.** The only level limit left since the
+  bus auto-gain.
+- ~~**The DELAY accumulator has no auto-gain.** Same fix as the reverb bus;
+  fold it into the delay re-scope.~~ **DONE — the delay-bus mirror of the
+  reverb's auto-gain.**
   Every DELAY-bus writer (SEND's `→DELAY` tap, the reverb's `→DEL` send)
   registers once per block in a parity-indexed count at `Y:0x985/0x986` and
   writes with the same 3 bits of headroom; the DELAY SERVER divides by the
@@ -944,35 +930,33 @@ exactly, except for the scratch, which both cores must touch by definition:
   by the SEND count and shifts up 3, so its effective gain is 8/N_sends
   (×8 with one send registered, ×1 with none). Pre-existing, unchanged by
   this fix; belongs to the `→VERB` voicing pass.~~
-  ✅ **FIXED 17 Aug 2026 (BongDelay v3 stage 1).** The `/8` half landed in
-  GRAIN 5g and the REGISTRATION half landed with the hardwiring — they had to
-  go together, because a "fixed" send amount whose level still varies as
+  ✅ **FIXED.** The `/8` half and the REGISTRATION half had to
+  land together, because a "fixed" send amount whose level still varies as
   8/N_registered is not fixed at all. `→VERB` now applies `asr #3` like every
   other writer and increments the REVERB count once per block, gated on the
   split offset. ⚠️ It changes the balance of every OTHER reverb send by
   N/(N+1); that was the reason for the original deferral and it is now a
   deliberate cost, not an oversight.
-  ⚠️ **A MIRROR OF THIS BUG IS STILL OPEN, in the other direction.** ChonVerb
-  registers as a DELAY-bus client for its `→DEL` send **even when `→DEL` is
-  off** — a phantom client that contributes nothing while taking a 1/N share,
-  diluting every real sender into BongDelay by N/(N+1), i.e. **−6 dB with a
-  single sender**. Measured 17 Aug on two independent quantities: the delay's
-  drive rose +2.50 then +1.02 dB across 1→3 senders with a reverb in the bank
-  (exactly N/(N+1)) where the same sweep with no reverb instance was flat to
-  0.04 dB. The gate is five words and payload A has FREE 4 — written,
-  overran by one word, reverted. Blocked on the reverb-side LFO-block roll.
+  ⚠️ **A mirror of this bug existed in the other direction — since fixed.**
+  ChonVerb registered as a DELAY-bus client for its `→DEL` send even when
+  the send was off — a phantom client that contributed nothing while taking
+  a 1/N share, diluting every real sender into BongDelay by N/(N+1), i.e.
+  **−6 dB with a single sender**. Measured on two independent quantities:
+  the delay's drive rose +2.50 then +1.02 dB across 1→3 senders with a
+  reverb in the bank (exactly N/(N+1)) where the same sweep with no reverb
+  instance was flat to 0.04 dB. The registration is now gated on the knob,
+  measured −6.02 → +0.00 dB. (The `→DEL` send itself was later retired
+  outright; the lesson — gate every registration on its knob — stands.)
 - **Emulator/device alignment.** The proven gap is parameter delivery:
   `-params` pokes `r6` directly so every slot looks live locally, while on
   hardware a slot can draw a knob and publish nothing.
-- ~~**Flash a build carrying v121.** The card holds `OCTATRACK_NOSHIM31.bin`,
-  which predates the bus auto-gain.~~ **DONE** — the unit now runs R15
-  (tag 34), which carries v121 and `SPEC=1`; tags 35–37 (R16–R18) are built
-  but unflashed.
+- ~~**Flash a build carrying the bus auto-gain.**~~ **DONE** — the unit runs
+  a build that carries the auto-gain and `SPEC=1`.
 
 ~~**Hard constraint: the payload region is FULL, one spare word.**~~
-**Retracted by specialization, and now BUILT** — 494 free on A, 1,998 on B
-(`SPEC=1`, v123, 8 Aug 2026). A has since been spent down to **32 free**
-(R16–R18 consumed the LFO-roll's 178; measured 12 Aug 2026); B still ~1,998.
+**No longer true under specialization** — 494 free on A, 1,998 on B at
+`SPEC=1` landing. A has since been spent down to **32 free**
+(the LFO-roll's 178 consumed); B still ~1,998.
 
 ## Constraints that shape it
 
@@ -980,7 +964,8 @@ exactly, except for the scratch, which both cores must touch by definition:
   ChonVerb (hardcoded `Y:0x4000`) or a Send (zero-footprint). NOT fine once the
   reverb pools all four slots — the accumulators need a permanent home that is
   not an FX2 slot. Candidate: the free low-Y window `0x795-0xFFF` is core-
-  private and therefore useless here; this needs solving in step 4.
+  private and therefore useless here; this needs solving in the memory
+  re-plan.
 - **Modulo addressing needs power-of-2 alignment**, so a 16,384-word buffer in
   the shared window must start at `0x30000` or `0x34000`. `0x34000-0x37FFF` is
   clean; `0x30000-0x33FFF` has the staging in its first 72 words.


### PR DESCRIPTION
Follow-up to #1. The reference docs carried working-log annotations that assume context no reader will have — dates, build tags (R16, v121…), session narrative, first-person chase stories. This sweep rewrites them as impersonal current-truth statements across README, XBUS, CHIP, REVERB, DSP, BUS, PARAM_PAGES, ARCHITECTURE and FLASHING, while the dated record docs (VOICING, TESTPASS, CAPTURE, `docs/history/`) stay as the lab notebooks they declare themselves to be.

**Kept, non-negotiably:** every technical fact, number, and address; the measured-vs-inferred confidence markers (✅/🟡/❌ — CHIP.md's legend is self-defining); hazard warnings; provenance citations of pruned probe files (annotated "in git history"). Verified on the largest rewrite (DSP.md, ~600 lines changed) by diffing the hex-constant inventory before/after: no value changed, nothing added — pure removals of narrative.

**Bonus fixes** — stale claims the annotations had been masking:
- REVERB.md still documented the retired `→DEL` send on p11; it now documents the shipping **RATE** (MOD speed) select, confirmed against `build_bus.py`.
- XBUS/CHIP claimed BongDelay was "never heard on its shipping payload-B path" — it is hardware-confirmed.
- XBUS carried the phantom-client bug as still open (it is fixed, measured −6.02 → +0.00 dB) and a stale FREE ledger (now the build report's A 55 / B 1).
- BUS.md's banner now notes its "not flashed" task-ledger entries are from the time of writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)