### PR TITLE
Accuracy pass: three verifiers over the swept docs, sixteen fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,9 +147,10 @@ broken, believe the hardware and go looking for what the harness omits.
 LEVEL.** The auto-gain divides the accumulator by the number of registered
 clients, so a writer that registers unconditionally and then writes zero
 dilutes the real senders by N/(N+1) — **−6 dB with a single sender.** Two
-instances found the same day, 17 Aug: ChonVerb registers for its `→DEL` send
-even when `→DEL` is off (still open — the gate is 5 words and payload A has
-FREE 4), and BongDelay's own `IN` knob would have done it too if its default
+instances found the same day, 17 Aug: ChonVerb registered for its `→DEL` send
+even when `→DEL` was off (since gated on the knob, measured −6.02 → +0.00 dB;
+the send itself was later retired), and BongDelay's own `IN` knob would have
+done it too if its default
 had stayed non-zero on a return track with no audio to send. **Gate the
 registration on the knob, and remember the level knob is usually decoded
 LATER in the block than the registration runs** — read it from `r6` directly,

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ verify-bus: ## Prove a bus-layout change is behaviour-preserving. STAMP FIRST: m
 	python3 tools/verify_bus.py $(if $(SAVE),--save) $(if $(SELFTEST),--selftest)
 
 .PHONY: burn
-burn: ## Build the cycle-burn probe -- CURRENTLY DOES NOT PLACE (plain layout overruns by 70 words)
+burn: ## Build the cycle-burn probe -- CURRENTLY DOES NOT PLACE (plain layout overruns by 10 words)
 	XBUS=1 BURN=1 python3 tools/build_bus.py
 
 .PHONY: check

--- a/PLAN.md
+++ b/PLAN.md
@@ -17,13 +17,17 @@ audible on the unit.
 What ships:
 
 - **ChonVerb** — an eight-line FDN reverb (ROOM/PLATE/BIG), shimmer, a gated
-  mode, mid/side width, and a MOD speed select. Serves **tracks 5–8**
-  (payload A / core 0). `docs/REVERB.md`.
-- **BongDelay** — a five-mode delay: CLEAN, PITCH (a once-per-repeat
-  harmoniser), TAPE (wow/flutter with in-loop saturation), GRAIN (a granular
-  cloud), REVERSE — plus a FREEZE hold that works across modes. Serves
-  **tracks 1–4** (payload B / core 1). Its wet is hardwired into the reverb
-  over the bus (`→VERB`), the topology the stock hardware has no path for.
+  mode, mid/side width, and a MOD speed select. Hosted on a track **5–8**
+  (payload A / core 0); any track can send into it. `docs/REVERB.md`.
+- **BongDelay** — a multi-mode delay: CLEAN, PITCH (a once-per-repeat
+  harmoniser), GRAIN (a granular cloud), REVERSE — with tape-style
+  wow/flutter modulation (DPTH/RATE), drive (DRV, doubling as GRAIN's
+  scatter depth) and a FREEZE hold available in **every** mode. (MODE still
+  counts five positions; the former TAPE slot aliases CLEAN now that the
+  tape character is global.) Hosted on a track **1–4** (payload B / core 1);
+  any track can send into it. Its wet can be sent on into the reverb over
+  the bus (`-VRB`, p4, default 0) — the delay→reverb series topology the
+  stock hardware has no path for.
 - **The send bus** — any track can select SEND and drive `→DELAY` /
   `→REVERB` (two separate knobs — driving the wrong one renders silence).
   Auto-gain divides by registered client count, so eight senders drive a
@@ -33,9 +37,12 @@ What ships:
   (default 0 — a return track with `IN` at 0 and nothing sent is silent by
   design).
 
-The track↔core mapping is **measured, and inverted from what you'd guess**:
-payload A serves the high tracks. Test the reverb on track 5, the delay on
-tracks 1–4.
+**Hosting is bank-bound; serving is not.** Either effect serves all eight
+tracks over the bus, but each can only be *hosted* on its own core's bank —
+and picking one on the wrong bank runs a SEND instead (the absent server's
+id is deliberately aliased to SEND on that payload). The track↔core mapping
+is **measured, and inverted from what you'd guess**: payload A runs the high
+tracks. Host the reverb on track 5, the delay on tracks 1–4.
 
 ---
 
@@ -85,20 +92,23 @@ payloads are effectively full; new work needs a lever first.
 - **FX1 consolidation** (work order §2) frees ~550–650 per payload as a side
   effect, but is its own project.
 
-### Cycles — per core, 4,535/sample ✅ measured
+### Cycles — per core, 4,535/sample ✅ arithmetic (200 MIPS ÷ 44.1 kHz)
 
 Cycles are not the current constraint, with one caveat. The number
 `make cycles` prints is a **single-core floor**: it sums reverb + delay +
 sends on one core, but on hardware no core ever pays both engines. The
-delay's worst path (GRAIN, ~1,750 cycles) plus sends fits core 1's ~2,150 🟡
-spare with a ~17% margin.
+delay's worst path (GRAIN, ~2,000 cycles by the tool's count) plus sends
+runs against core 1's ~2,150 🟡 *derived* spare — a thin paper margin, while
+the unit runs every mode clean; only the burn sweep can measure the real
+ceiling.
 
 - ⚠️ **FX1 cycles are paid ×4 per core** — a 300-cycle FX1 effect costs
   1,200 cycles/core. *This*, not program space, is the ceiling on FX1
   ambition.
 - ⚠️ **Only the `BURN=1` hardware sweep can re-measure the real per-core
   spare, and the probe currently does not build**: the plain layout overruns
-  the region (2,734 > 2,724 — ~70 words short). `verify_burn` reports
+  the region (2,734 > 2,724 — 10 words short; an older ~70-word figure
+  predates the delay shrinking). `verify_burn` reports
   SKIPPED in `make check` until words are found.
 - **Priced cycle lever**: GRAIN 4 grains → 2 returns ~300 cycles for ~100
   words, at the voicing cost of half the simultaneous voices.
@@ -120,11 +130,12 @@ capability: 70 ms lines per track — doublers, short slaps, wide chorus.
 
 ### 1. Voicing polish — ear items, none blocking
 
-- **Per-mode gain structure.** The modes are 7–9 dB apart at the output:
-  BIG crosses the clip knee at a 0.25–0.5 FS input, ROOM only approaches it
-  near 0.9, PLATE never reaches it. The honest fix is per-mode headroom,
-  set from measurement — the numbers are in `docs/REVERB.md`. Interim
-  practice: back BIG off by hand.
+- **Per-mode gain structure.** The modes are 7–9 dB apart at the output
+  (`docs/TESTPASS.md`: ROOM −23.0 / PLATE −24.9 / BIG −16.1 dBFS at
+  defaults), and an input sweep (in this file's git history) put BIG across
+  the clip knee at a 0.25–0.5 FS input while PLATE never reached it. The
+  honest fix is per-mode headroom, set from measurement. Interim practice:
+  back BIG off by hand.
 - Reopeners from the reverb's "done for now" call, live only if a listening
   round asks: the pad's last forwardness, the 6–9 k crest, the TIME refit,
   a PLATE ear pass.
@@ -139,7 +150,7 @@ a MODE select.
 
 | cluster | stock words | one engine | freed **per payload** |
 |---|---|---|---|
-| PHASER + FLANGER + CHORUS + COMB | **1,052** | ~400–500 🟡 | **~550–650** |
+| PHASER + FLANGER + CHORUS + COMB | **1,102** (PHASER's true extent is 207, past its 157-word record — `DSP.md`) | ~400–500 🟡 | **~550–650** |
 | EQUALIZER + DJ EQ | **627** | ~300 🟡 | **~325** |
 
 All four in row 1 are the same structure — a short modulated delay with
@@ -152,7 +163,7 @@ cycles ×4, and the spare has never been measured per core.
 
 ### 3. Unblock the burn probe
 
-Find ~70 words in the plain layout so `BURN=1` places, flash it once, and
+Find ~10 words in the plain layout so `BURN=1` places, flash it once, and
 sweep the real per-core cycle ceiling from the front panel. Everything in §2
 prices off that number.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ What runs today:
 | | |
 |---|---|
 | **ChonVerb** | An eight-line FDN reverb with ROOM/PLATE/BIG modes, modulated taps, shimmer, a gate, and mid/side width. Voiced by ear, confirmed on hardware. It takes over the three stock FX2 reverb slots, which is where the program space for it came from. |
-| **BongDelay** | A five-mode delay — CLEAN, PITCH (a once-per-repeat harmoniser), TAPE (wow/flutter + saturation), GRAIN and REVERSE — plus a FREEZE hold, routed *into* the reverb over the bus. Its program space is the **other core's copy of the same three donor slots** — the stock FX2 delay itself has no DSP code to take. Confirmed on hardware, every knob live and audible. |
+| **BongDelay** | A multi-mode delay — CLEAN, PITCH (a once-per-repeat harmoniser), GRAIN (a granular cloud) and REVERSE — with tape-style wow/flutter (DPTH/RATE), drive (DRV) and a FREEZE hold available in **every** mode, routable *into* the reverb over the bus (`-VRB`, default 0). Its program space is the **other core's copy of the same three donor slots** — the stock FX2 delay itself has no DSP code to take. Confirmed on hardware, every knob live and audible. |
 | **The send bus** | All eight tracks feed one shared reverb and one shared delay, across both DSP cores. Both effects are **returns**: a track running one outputs wet only, fed by the other tracks' SEND knobs. This is the part the hardware was not designed to do. |
 
 The reverse-engineering in `docs/` is infrastructure, not the product. It
@@ -36,9 +36,9 @@ The costs are all measured, not estimated:
 
 | resource | per core | state (Aug 2026 build) |
 |---|---|---|
-| Cycles | 4,535/sample | measured ceiling; worst mode fits its core with margin |
+| Cycles | 4,535/sample | derived budget (200 MIPS ÷ 44.1 kHz); every mode runs clean on hardware, true per-core ceiling unmeasured |
 | Program space | 8,192 words | donor region 2,724 words/payload: A 55 free, B 1 free |
-| Delay memory | 65,536 words | 1.49 s per server |
+| FX2 memory | 65,536 words/server | 1.49 s, pooled from private slots + the shared window |
 
 `docs/CHIP.md` carries every one of these numbers with a confidence marker —
 measured or inferred, and what would falsify it.
@@ -52,7 +52,7 @@ chip has more, stock runs the map that grants the least):
 
 ```
               DSP56721 — two cores @ 200 MHz, 44.1 kHz audio
-              4,535 cycles per sample per core (measured)
+              4,535 cycles per sample per core (200 MIPS ÷ 44.1 kHz)
 
    CORE 0 / payload A · tracks 5–8      CORE 1 / payload B · tracks 1–4
    ─────────────────────────────────    ─────────────────────────────────
@@ -89,8 +89,8 @@ The bus itself lives in that scratch block — and it is the whole trick:
    SEND ──→DELAY ─────────►┌────────────────┐
    SEND ──→REVERB ────┐    │ DELAY bus acc  │──► BONGDELAY ─► wet out on its
                       │    └────────────────┘        │         track (1–4)
-                      ▼                              │ →VERB, hardwired —
-              ┌────────────────┐                     ▼ this write CROSSES CORES
+                      ▼                              │ -VRB send — this
+              ┌────────────────┐                     ▼ write CROSSES CORES
               │ REVERB bus acc │◄────────────────────┘
               └────────────────┘──► CHONVERB ─► wet out on its track (5–8)
 ```
@@ -100,9 +100,9 @@ accumulator buffers** (the cross-core race fix — see `docs/XBUS.md`)
 plus client counts for the ÷N auto-gain, so eight senders drive a server
 exactly as hard as one. Cycles follow the same split: a core pays its one
 server (role-locked, charged once per bank however many tracks select it)
-plus its tracks' send taps; the delay's worst mode (GRAIN, ~1,750 cycles) is
-the deepest path, and FX1 inserts pay **×4 per core** — which is the real
-ceiling on FX1 ambition, not program space.
+plus its tracks' send taps; the delay's worst mode (GRAIN, ~2,000 cycles by
+`make cycles`) is the deepest path, and FX1 inserts pay **×4 per core** —
+which is the real ceiling on FX1 ambition, not program space.
 
 ---
 

--- a/docs/CHIP.md
+++ b/docs/CHIP.md
@@ -51,7 +51,7 @@ core that track lives on.
 
 | | scoped to | spent when | this build |
 |---|---|---|---|
-| **Program space** (P) | **per core** | once at load — same cost whether 1 track or 8 use the effect | 2 724 words, **32 free** ✅ (an earlier build read 11 free) |
+| **Program space** (P) | **per core** | once at load — same cost whether 1 track or 8 use the effect | 2 724 words; **55 free** in the current build report ✅ (earlier snapshots read 11 and 32 — the build report is the live ledger) |
 | **Cycles** | **per core** | **every frame, per track, per slot** — up to 8 effect calls per core | ~1 392 spare ✅ measured; the bank has grown 573 since that measurement, so **~819/sample** remains for new work |
 | **Y memory** | **per track, per slot** | allocated always, used or not | 16 384 per FX2 slot |
 
@@ -175,9 +175,11 @@ still spare on top of all of it.
 📄 **The reference manual HAS now been read** — `DSP56720RM.pdf`, 575 pages,
 at `downloads/datasheets/` (gitignored; third-party). Extract with
 `pdftotext -layout`; `file` misreports it as 27 pages. It settled §3's memory
-questions without a flash, including Ch. 3's five
+questions without a flash — including reading Ch. 3's five
 OMR-selectable memory maps (`MS`, `MSW0`, `MSW1`), which set the per-core X/Y/P
-extents — read those before trusting any *internal* extent.
+extents — read those before trusting any *internal* extent. (Read is not
+exploited: actually *switching* the OMR map remains an untested lever —
+`XBUS.md`.)
 
 ### "Spare" is only meaningful attached to a configuration
 
@@ -446,7 +448,7 @@ bisect); do not design around it.
 | | | |
 |---|---|---|
 | The donor region (PLATE + SPRING + DARK, contiguous) | **2 724 words** | ✅ |
-| Used by a normal build | 2 692 — **32 free** (an earlier build read 2 713 — 11 free) | ✅ |
+| Used by a normal build | 2 669 — **55 free** in the current build report (earlier snapshots read 2 713/11 and 2 692/32) | ✅ |
 | Reachability sweep | payload A 95.8 %, B 98.5 % | ✅ `tools/dsp_reach.py` |
 | Free pool elsewhere | **none** | ✅ |
 | Only reclaimable space | **3 384 words held by ten stock effects** — costs those effects (earlier reading: ~3 100 / nine) | ✅ |

--- a/docs/DSP.md
+++ b/docs/DSP.md
@@ -1101,9 +1101,14 @@ Slot 6 moves `$c` bits 16-22 and slot 7 moves `$c` bits
 > **All six page-2 slots can be full-range knobs — measured on hardware.**
 > The "three knobs plus three companion selects" split reflects how *stock*
 > uses the fields; it is not a hardware limit. Five full 0–127 controls, two
-> of them in companion fields, have run on the unit at once. (ChonVerb
-> currently chooses otherwise: WIDTH and →DEL are 4-step selects on companion
-> low-byte fields, and `$e` carries GATE.)
+> of them in companion fields, have run on the unit at once. (Both shipping
+> effects nonetheless give every companion field a small-count select —
+> ChonVerb WIDTH/RATE, BongDelay MODE/PTCH/FRZE — following an on-unit
+> reading that a count-128 companion publishes **near-boolean**;
+> `build_bus.py`'s `PAGE2_COUNTS` carries that rationale. That reading and
+> the full-range measurement above have not been reconciled against each
+> other — re-test before designing a smooth companion knob. `$e`'s knob
+> field carries GATE.)
 >
 > What makes a companion field *look* like a two-state control is the
 > **per-parameter display formatter at `P+0x0ca`**, inherited from the donor
@@ -1121,12 +1126,13 @@ the knob fields of `$b`/`$d`/`$e` (or `$c`), plus three companion fields
 | knob B | `x:(r6+$d)` | value<<16 |
 | knob C | `x:(r6+$e)` | value<<16 |
 | select A | `x:(r6+$c)` | `and #>$00ff00` then `asr #$8` |
-| select B | `x:(r6+$d)` | `and #>$0000ff` (low field) |
-| select C | `x:(r6+$e)` | `and #>$0000ff` (low field) |
+| select B | `x:(r6+$d)` | `and #>$7f00` then `asr #$8` (**bits 8–15**) |
+| select C | `x:(r6+$e)` | `and #>$7f00` then `asr #$8` (**bits 8–15**) |
 
-The selects were exercised with count 3 and responded on positions 1 and 2, so
-at least three states are distinguishable; the exact value-to-bit encoding
-within each field has not been enumerated beyond "zero vs non-zero per state".
+⚠️ An earlier version of this table decoded selects B/C from the LOW field
+(bits 0–7) — everything that read bits 0–7 had never worked on hardware.
+The settled map is bits 8–15 for every companion field
+(`PARAM_PAGES.md`), and the shipping code reads them that way.
 
 All four offsets (`$b`, `$c`, `$d`, `$e`) and all six display slots are
 reachable. A probe that watches only the knob field concludes that `$c` is

--- a/docs/FLASHING.md
+++ b/docs/FLASHING.md
@@ -153,8 +153,9 @@ container before it will produce a modified one.
    should read **`OCTABAM<NNN>`** — the `-V` stamp from `make image`. If it
    still says `1.40C`, the official OS is running, not your build.
 2. **The reverb, on track 5.** Assign ChonVerb to an FX2 slot on one of
-   **tracks 5–8** (payload A serves the high tracks — measured, and inverted
-   from what you'd guess). Feed it audio via `IN` and step **MODE**: you
+   **tracks 5–8** (payload A runs the high tracks — measured, and inverted
+   from what you'd guess; on tracks 1–4 the pick falls back to a SEND).
+   Feed it audio via `IN` and step **MODE**: you
    should hear distinct ROOM → PLATE → BIG spaces. Both effects are
    **returns** (wet-only output): a reverb track with `IN` at 0 is silent by
    design.
@@ -207,8 +208,10 @@ something else:
 2. **Old stored MIX values load as IN** (p5). On a pure return track this is
    inaudible — but it silently registers the host as a bus client and dilutes
    the real senders. Zero it, or use step 4.
-3. **Old stored VRBW values load as `-VRB`** (delay p5). An old project's
-   VRBW=127 will wash the delay into the reverb on load.
+3. **The delay's p4/p5 have both changed meaning.** An old project's stored
+   MIX (p4) loads as `-VRB` — a typical MIX value washes the delay into the
+   reverb on load — and stored VRBW (p5) loads as `IN`, silently registering
+   the host as a bus client.
 4. **The one-step fix per track: re-select the effect** (switch the FX2 away
    and back). The id-store fires on change and applies fresh defaults.
 

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -549,12 +549,12 @@ published.
 
 | slot | word | field | example |
 |---|---|---|---|
-| 6 | `$c` | knob, bits 16–23 | SHMR / WOW |
+| 6 | `$c` | knob, bits 16–23 | SHMR / DPTH |
 | 7 | `$c` | **bits 8–15** | MODE |
-| 8 | `$d` | knob, bits 16–23 | DIFF |
+| 8 | `$d` | knob, bits 16–23 | DIFF / RATE |
 | 9 | `$d` | **bits 8–15** | WIDTH / PTCH |
-| 10 | `$e` | knob, bits 16–23 | GATE / SPRAY |
-| 11 | `$e` | **bits 8–15** | FRZE (→DEL retired) |
+| 10 | `$e` | knob, bits 16–23 | GATE / DRV |
+| 11 | `$e` | **bits 8–15** | RATE / FRZE |
 
 ⚠️ **Slot 6 is on `$c`, not `$b`.** `$b` is not a page-2 parameter word at all.
 

--- a/docs/REVERB.md
+++ b/docs/REVERB.md
@@ -11,9 +11,12 @@ bank. Built by `tools/build_bus.py`; source `dsp/reverb_server.asm`.
 > in-loop allpasses describe the **deleted engine**. The shipping engine is
 > eight lines, 8×8 FWHT, **three** modes (ROOM/PLATE/BIG), ER removed in
 > favour of a short Dattorro-scale input diffuser (taps 179/293/419/547 =
-> 4.1–12.4 ms), and 512-word **modulated** in-loop allpasses. The signal path
-> and parameter table here are current; deeper sections are corrected where
-> marked, historical otherwise.
+> 4.1–12.4 ms), and 512-word **modulated** in-loop allpasses — and it is a
+> **RETURN**: the output is the wet alone, and p5 is **IN** (this track's own
+> send into its reverb), not a MIX crossfade. The signal path and parameter
+> table here are current; deeper sections are corrected where marked,
+> historical otherwise — in particular, anything describing MIX describes
+> the retired insert-era law.
 
 > **The old standalone DARK REV replacement is retired.** Earlier builds
 > (`dsp/reverb88.asm` via `tools/build_reverb.py`) replaced stock DARK REV in
@@ -26,8 +29,9 @@ bank. Built by `tools/build_bus.py`; source `dsp/reverb_server.asm`.
 > select all work on the unit; the tail crackle is fixed; the modes are
 > genuinely distinct (RT60 2.7 / 4.7 / 7.7 / 10.0 s across ROOM→BIG on the
 > four-mode engine of the time, plus per-mode ER arrivals, diffuser taps, tap
-> spread, LFO rate and damping); and MIX holds dry at unity to half-travel
-> before crossfading.
+> spread, LFO rate and damping); and the then-MIX held dry at unity to
+> half-travel before crossfading (MIX has since become IN — see the banner
+> above).
 >
 > Per-mode voicing is not the blocking work. What remains is measured but
 > unacted-on: modal prominence 8–11 dB over the local envelope, whose only
@@ -43,14 +47,17 @@ For the reverse-engineering that got us here, `REVERB_LOG.md` (historical).
 ## Signal path
 
 ```
-in ─► pre-delay ─► 4 series allpasses ─► ┌─ FDN tank ──────────┐ ─► width ─► mix ─► out
-        (PRE)        (input diffusion,   │ 8 lines, modulated  │
-                      4–13 ms Dattorro)  │ 8x8 FWHT            │
-                                         │ HI damping          │  all inside the
-                                         │ LO cut              │  feedback loop
-                                         │ 2 in-loop allpasses │
-                                         └─────────────────────┘
+bus Σ + IN ─► 4 series allpasses ─► ┌─ FDN tank ──────────┐ ─► width ─► wet out
+              (input diffusion,     │ 8 lines, modulated  │    (RETURN —
+               4–13 ms Dattorro)    │ 8x8 FWHT            │     no dry path)
+                                    │ HI damping          │
+                                    │ LO cut              │  all inside the
+                                    │ 2 in-loop allpasses │  feedback loop
+                                    └─────────────────────┘
 ```
+
+(The pre-delay stage that used to open this chain is retired with the PRE
+knob; its buffer is still mapped but never read.)
 
 * **Pre-delay** — up to 4096 samples (93 ms), modulo buffer on r6.
 * **Diffusers** — four series allpasses, taps 179/293/419/547 (4.1–12.4 ms,
@@ -90,7 +97,7 @@ was **measured**, not inferred (`DSP.md` §9). Hardware-confirmed.
 | 1 | 2 | SIZE | `r6+$2` | scales all four tap lengths, within the current MODE |
 | 1 | 3 | HP | `r6+$3` | **LO** — high-pass inside the feedback path |
 | 1 | 4 | LP | `r6+$4` | **HI** — high-cut damping inside the feedback path |
-| 1 | 5 | MIX | `r6+$5` | dry held to half-travel, then crossfaded (see below) |
+| 1 | 5 | IN | `r6+$5` | **this track's own send** into the reverb (default 0). The output is wet-only; IN>0 also registers the host as a bus client, so a non-zero default would dilute real senders |
 | 2 | 6 | SHMR | `r6+$c` knob \| `$b` | shimmer amount (read from the `$c` knob field OR'd with `$b`; the panel publishes slot 6 to `$c` — DSP.md §9) |
 | 2 | 7 | MODE | `$c` bits 8-15 | **stepped select**: 0 ROOM, 1 PLATE, 2 BIG |
 | 2 | 8 | DIFF | `r6+$d` knob | allpass coefficient, ~0.38–0.80 |
@@ -816,7 +823,9 @@ Two concrete cautions that came out of it:
   bug recorded above — fixing something correct exposed what it had been
   masking — but here what it exposed does not matter.
 
-**MIX: a plain crossfade is the wrong shape here.** A first fix made it a
+**MIX: a plain crossfade is the wrong shape here** *(historical — the MIX
+knob no longer exists; the reverb is a return and p5 is IN. Kept for the
+level-law reasoning.)* A first fix made it a
 straight `dry*(1-MIX) + wet*MIX` crossfade, because the old additive law left
 dry at full scale forever and the top of the knob was never actually *wet*.
 That motive was sound and the result was not: measured, the knob got **7 dB

--- a/docs/XBUS.md
+++ b/docs/XBUS.md
@@ -139,11 +139,14 @@ music untouched (top-8 bins 95.3% before and after)**.
 
 ### The fix, and its state
 
-**The shimmer is now excised BY DEFAULT.** `build_bus.py` cuts everything
-between `; SHIMMER_BEGIN` and `; SHIMMER_END` in `dsp/reverb_server.asm` unless
-`SHIMMER=1` is set, which prints a do-not-ship warning. Excising rather than
-zeroing matters: a zeroed coefficient still leaves the shifter reading and
-writing its buffer every sample.
+**The defective shimmer was excised; the artifact went with it.** The
+shimmer was then rewritten, and the rewrite **ships IN by default** —
+`NOSHIM=1` excises it (`build_bus.py` cuts everything between
+`; SHIMMER_BEGIN` and `; SHIMMER_END` in `dsp/reverb_server.asm`), and
+`SHMR` now defaults to **0**, so it is silent until the knob comes up —
+unlike the stuck-at-48 default that caused this whole episode. Excising
+rather than zeroing matters when it does come out: a zeroed coefficient
+still leaves the shifter reading and writing its buffer every sample.
 
 - Verified **bit-identical** to a `SHMR=0` render, so no side effects.
 - **2040 → 1950 words**, and the payload region's free space **11 → 101 words**.
@@ -229,7 +232,9 @@ once). `tools/send_probe.py` and `tools/capture_hw.py` drive and analyse it.
    unturnoffable; excised by default, hardware-confirmed gone.
 1. ~~Relocated bus, same core.~~ **DONE** at `0x36000`.
 2. ~~Does a cross-core send arrive?~~ **DONE — cross-core works.**
-3. Synchronisation — ⚠️ **NEEDED, and it is the load-bearing step.** An
+3. Cross-core timing — ⚠️ **the load-bearing step, and the early all-clear
+   was wrong.** (The shipped fix turned out to be buffering, not
+   synchronisation — see below.) An
    earlier "not needed; the ICC stays unused" conclusion was drawn from
    step 2, "does a cross-core send arrive?", which was validated **through
    the reverb**. A reverb is the one consumer that physically cannot reveal
@@ -373,7 +378,9 @@ once). `tools/send_probe.py` and `tools/capture_hw.py` drive and analyse it.
 
    🟡 **It probably explains the reverb static too, and that is inferred, not
    measured.** BongDelay's `→VERB` is a **core-1 writer into the REVERB
-   accumulator**, hardwired on, so it should jitter exactly the same way.
+   accumulator** — hardwired on at the time of this diagnosis (it has since
+   become the `-VRB` knob, default 0) — so it should jitter exactly the same
+   way.
    ChonVerb then consumes a per-block-jittering sum. It would explain why the
    static appeared the moment a ChonVerb was added (the corruption always
    existed; a reverb gave it a consumer) and why PLATE and BIG show it while
@@ -465,7 +472,7 @@ That rule is now **backwards**.
 | cycles, core 0 (reverb + 3 sends, FX1 filters off) | ~2,432 spare ✅ | **~2,576 spare** 🟡 estimate; ✅ 1,392 spare measured, of which **819**/sample remains for new work (the bank has since consumed 573) | ~3.4× the engine's 763 |
 | cycles, core 1 (delay + 3 sends) | — | **~3,176 spare** 🟡 | ~19× the placeholder's 163 |
 | Y memory per server | 32,768 words / 743 ms ✅ | **65,536 / 1.486 s** ✅ | 2× |
-| **program space, payload A** | **1 word** ✅ | **494 words** ✅ at specialization; **32** now (later reverb work spent the LFO-roll's 178) | — |
+| **program space, payload A** | **1 word** ✅ | **494 words** ✅ at specialization; the build report is the live ledger (**55** in the current build) | — |
 | **program space, payload B** | **1 word** ✅ | **2,005 words** ✅ | — |
 
 (Cycle figures are the measured 2,432 spare — filters off, full bank live —
@@ -597,7 +604,7 @@ free word today, that is an extraordinary rate of exchange — but it is a trade
 not the free lunch the alias makes it look like.
 
 **Do not confuse this with specialization.** Specialization (494 / 2,005 free
-words at landing; **32** / ~1,998 now) is real, costs
+words at landing; the current build report reads **55** / **1**) is real, costs
 nothing, and needs no new hypothesis. This is the lever
 *after* that one, and it should be tested only if the reverb's 494 words (now
 32) prove too tight — which rolling the tank loop may well prevent.
@@ -955,8 +962,9 @@ exactly, except for the scratch, which both cores must touch by definition:
 
 ~~**Hard constraint: the payload region is FULL, one spare word.**~~
 **No longer true under specialization** — 494 free on A, 1,998 on B at
-`SPEC=1` landing. A has since been spent down to **32 free**
-(the LFO-roll's 178 consumed); B still ~1,998.
+`SPEC=1` landing. Both have since been spent nearly full again: the current
+build report reads A **55 free**, B **1 free** — the build report is the
+live ledger.
 
 ## Constraints that shape it
 

--- a/tools/verify_burn.py
+++ b/tools/verify_burn.py
@@ -182,7 +182,8 @@ def burn_fits():
 
     It cannot, as of R16-R18 (measured 11 Aug 2026): the bus-plain layout
     the probe needs packs BOTH servers into one 2,724-word region and DELAY
-    SERVER overruns it by 70 words (2,794 > 2,724). SPEC=1 is not an escape:
+    SERVER overruns it (2,734 > 2,724 as of the TAPE retirement; it was
+    2,794 when first blocked). SPEC=1 is not an escape:
     the build guards SPEC-with-BURN, because those both replace a server.
     (The 8 Aug reading -- "about 10 words short" -- predates the reverb LFO
     roll landing AND the R16-R18 growth; the roll landed and was not enough.)
@@ -225,7 +226,7 @@ def burn_fits():
         for l in over:
             print(f"    {l.strip()}")
         print("    NOTHING about the burn probe was verified here. Blocks the")
-        print("    BURN=1 hardware sweep (PLAN: find ~70 words in the plain")
+        print("    BURN=1 hardware sweep (PLAN: find ~10 words in the plain")
         print("    layout; the reverb LFO roll already landed and was not enough),")
         print("    not local work.")
         print("=" * 72)


### PR DESCRIPTION
Answering "any other inaccuracies?" properly: three independent verification passes — a claim-by-claim fact-check of README + PLAN against the code and build report, and hunk-by-hunk diffs of all six swept reference docs against their pre-sweep versions (179 hunks reviewed in total). Everything they found is fixed here; `make check` is green after.

**The bigger finds:**
- **"Serves tracks 5–8 / 1–4" was misleading** — hosting is bank-bound, serving is not: any track sends into either effect over the bus, and picking an effect on the wrong bank deliberately runs a SEND (the absent server's id aliases to SEND on that payload).
- **TAPE is not a mode** — R35 made DPTH/RATE global modulation in every mode (DRV likewise, doubling as GRAIN's SPRA); TAPE's MODE position aliases CLEAN bit-identically. README, PLAN, and the PARAM_PAGES slot map now say so.
- **`→VERB` is not hardwired** — R30 re-knobbed it (`-VRB`, default 0) and it then swapped to p4, which had also silently inverted FLASHING.md's old-project p4/p5 inheritance note.
- **REVERB.md never got the RETURN conversion** — p5 was still documented as a MIX crossfade and the signal path showed a pre-delay and mix stage. Now: IN, wet-only path, MIX law marked historical.
- **The docs sweep's date-stripping had minted false present-tense ledger claims** (XBUS ×3, CHIP ×2) — all now cite the build report as the live ledger (A 55 / B 1 free). The shimmer-excision polarity in XBUS was also backwards (it ships IN by default; `NOSHIM=1` excises).
- **DSP.md's companion-select decode showed the low field**; the settled map is bits 8–15. The near-boolean hardware caveat is restored beside the full-range measurement, flagged as unreconciled rather than adjudicated.
- **The burn-probe deficit is 10 words, not ~70** (2,734 > 2,724 today; the 70 was the 2,794-word era) — fixed in PLAN, the Makefile help line, and verify_burn's docstring.
- Smaller: 4,535 cycles/sample relabeled *arithmetic* (200 MIPS ÷ 44.1 kHz) per CHIP.md's own marker; gain-structure numbers now point at TESTPASS.md; PHASER's corrected 207-word extent propagated into the FX1 table; GRAIN worst path updated to the tool's current ~2,000; CLAUDE.md's phantom-client example no longer claims the fix is "still open".

🤖 Generated with [Claude Code](https://claude.com/claude-code)