### PR TITLE
FLASHING: explain the MKII-only restriction and MKI porting outlook

### DIFF
--- a/docs/FLASHING.md
+++ b/docs/FLASHING.md
@@ -28,8 +28,18 @@ MIDI. Read §1 first.
 
 ## 0. What you need (checklist)
 
-- [ ] **Octatrack MKII.** The base image is OS 1.40C for the MKII — it will
-      NOT work on the MKI.
+- [ ] **Octatrack MKII.** The base image is OS 1.40C **for the MKII** — the
+      built image will not work on the MKI, because the MKI runs its own
+      1.40C binary (Elektron ships separate downloads per model) and every
+      ColdFire patch address here was derived from the MKII image; the
+      updater also enforces the model split (`docs/ARCHITECTURE.md`: error
+      −5, "MK1 not allowed"). The *effects* are a different question — both
+      marks share the same-family ColdFire and the same two-core DSP56721
+      audio engine, so a port against the MKI image is plausible: the
+      DSP-side payloads likely carry over, and the recon tooling
+      (`make recon`, `tools/find_base.py`, `tools/verify_menu.py`) is
+      exactly what re-deriving the ColdFire addresses would take. Nobody
+      has attempted it; if you do, you are the test pilot.
 - [ ] **The built image**: `make image` produces both delivery formats —
       `out/OCTATRACK_OCTABAM<NNN>.bin` (CF-card path, recommended) and
       `out/OCTATRACK_OS1.40C_OCTABAM<NNN>.syx` (MIDI path).


### PR DESCRIPTION
The checklist said the image "will NOT work on the MKI" without saying why. Now it does: the MKI runs its own OS 1.40C binary (separate Elektron download per model), every ColdFire patch address in this repo is derived from the MKII image, and the updater itself enforces the model split (ARCHITECTURE.md's decompiled validator error −5, "MK1 not allowed").

It also now says what that restriction is *not*: the audio hardware is the same architecture on both marks (same-family ColdFire — CHIP.md's CPU evidence photo is of an MKI board — and the same two-core DSP56721), so porting the effects against the MKI image is plausible with the repo's existing recon tooling. Untested, and flagged as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)