### PR TITLE
Retraction: MKI and MKII run the same OS image — measured by hash

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,6 +60,11 @@ SHA256 `164f3122…`, ColdFire code).
 **OS validation on update** (`FUN_4007f748`), with its error codes:
 `-1` IO · `-2` not a valid OS · `-3` length · `-4` checksum · `-5` MK1 not allowed (`<"0156"`)
 · `-6` cannot downgrade version (`<"0178"`).
+(On `-5`: the comparison is against the *incoming file's* version code, and
+the MKI and MKII download pages serve the byte-identical 1.40C file —
+measured, SHA256 `370c55a3…` — so this reads as a floor rejecting
+pre-unification MK1-era OS *files*, not MK1 *units*. 🟡 inferred from the
+unified image; the check itself is decompiled fact.)
 
 **UI → write flow** (all decompiled):
 ```

--- a/docs/FLASHING.md
+++ b/docs/FLASHING.md
@@ -28,18 +28,21 @@ MIDI. Read §1 first.
 
 ## 0. What you need (checklist)
 
-- [ ] **Octatrack MKII.** The base image is OS 1.40C **for the MKII** — the
-      built image will not work on the MKI, because the MKI runs its own
-      1.40C binary (Elektron ships separate downloads per model) and every
-      ColdFire patch address here was derived from the MKII image; the
-      updater also enforces the model split (`docs/ARCHITECTURE.md`: error
-      −5, "MK1 not allowed"). The *effects* are a different question — both
-      marks share the same-family ColdFire and the same two-core DSP56721
-      audio engine, so a port against the MKI image is plausible: the
-      DSP-side payloads likely carry over, and the recon tooling
-      (`make recon`, `tools/find_base.py`, `tools/verify_menu.py`) is
-      exactly what re-deriving the ColdFire addresses would take. Nobody
-      has attempted it; if you do, you are the test pilot.
+- [ ] **An Octatrack — every test so far has been on an MKII.** The base
+      image is OS 1.40C, and ✅ measured: **Elektron's MKI and MKII download
+      pages serve the byte-identical file** (SHA256 `370c55a3…`, both pages,
+      compared 19 Aug 2026) — the OS is one unified image for both marks.
+      ❌ This retracts two earlier claims here: "will NOT work on the MKI"
+      (asserted without a reason) and "the MKI runs its own 1.40C binary"
+      (asserted from a wrong inference, falsified by the hash comparison).
+      What remains true: **octabam has only ever been flashed on an MKII.**
+      Since the MKI runs the same stock image, the patched image is
+      plausibly compatible as-is 🟡 — but an MKI owner flashing it is the
+      test pilot. (The updater's decompiled error −5 "MK1 not allowed"
+      compares the *incoming file's* version code against "0156", so it
+      rejects pre-unification MK1-era OS files, not MK1 units 🟡 inferred;
+      octabam images keep 1.40C's internal code 0178 and validate normally.
+      `docs/ARCHITECTURE.md`.)
 - [ ] **The built image**: `make image` produces both delivery formats —
       `out/OCTATRACK_OCTABAM<NNN>.bin` (CF-card path, recommended) and
       `out/OCTATRACK_OS1.40C_OCTABAM<NNN>.syx` (MIDI path).


### PR DESCRIPTION
Follow-up correcting #7, which was wrong. Downloading OS 1.40C from both the MKI and MKII support pages yields **byte-identical files** (SHA256 `370c55a3…`, also identical to the copy this repo's results derive from). Separate download pages do not mean separate binaries — the hash comparison was the check that should have been run before #7 asserted otherwise.

- FLASHING.md's checklist now records the measurement, retracts both prior claims ("will NOT work on the MKI" and "the MKI runs its own binary"), and states what actually stands: octabam has only ever been flashed on an MKII; with a unified stock image the patched image is plausibly MKI-compatible as-is (🟡 inferred), and an MKI owner who tries is the test pilot.
- ARCHITECTURE.md's decompiled `-5 "MK1 not allowed"` error gets an interpretation note: the comparison is against the *incoming file's* version code, so with a unified image it reads as a floor rejecting pre-unification MK1-era OS files, not MK1 units (🟡 inferred; the check itself is decompiled fact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)