### PR TITLE
Mutable-flavoured insert collection: six modules, a remix workbench, and remix-aware cycles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,22 @@ for a new `mpy` whose second operand can go negative. A related family bit
 us in shipping code: `cmp a,b` had encoded as `max a,b`, which updates only
 the C bit while `blt` tests N^V.
 
+**READING `a0` EXPOSES THE FRACTIONAL LEFT SHIFT THAT READING `a1` HIDES.**
+`mpy` aligns the Q46 product into Q47, so `a1` is the plain fractional
+product — which is why "mpy does not double here" is true, and stays true,
+for every module that reads a1 (all of them until 29 Aug 2026). Read the LOW
+word instead — the idiom for turning an integer product into a wrapping
+ramp — and you see the RAW 48-bit content, shift included, so the effective
+integer scale is **2× your multiplier**. Nimbus's grain window is one
+`mpy phase,2^(23-k)` plus `abs`; written with the arithmetically obvious
+`2^(24-k)` it assembled, rendered, and made a perfectly plausible granular
+noise while running the window at DOUBLE RATE, which put the two grains of
+each pair in phase instead of interleaving. Found by a DC gate, not by ear
+and not by any existing check: two triangle windows a half period apart sum
+to exactly 1, so **DC in must come back flat** — it came back with 2×-DC
+ripple, and went flat (−122 dB) when the multiplier was halved. If you use
+a0 for anything, pin it with a test whose arithmetic you can predict exactly.
+
 **A logical op (`and`/`or`/`not`/`asr`-as-mask) on an accumulator leaves the
 extension byte (A2/B2) STALE, and the next `move a,x:` SATURATES to full
 scale.** Building a sign mask with `move a,b / asr #$17,b,b / not b` and

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ modmap: ## DSP module load map — which bytes land at which P address
 verify: ## Verify the ColdFire menu edits, module ledger (+ burn probe when it fits; it currently SKIPS)
 	python3 tools/remix/selftest.py
 	python3 tools/verify_slots.py
-	python3 tools/verify_menu.py
+	REMIX=$(REMIX) python3 tools/verify_menu.py
 	python3 tools/verify_burn.py
 
 .PHONY: verify-roll

--- a/PLAN.md
+++ b/PLAN.md
@@ -103,8 +103,22 @@ multiplier; the wrong one assembled and made plausible granular noise while
 running the window at double rate, and only a DC gate caught it. The musical
 freeze renders locally via `NFRZAT=n`, the `DFRZAT`-shaped lever.
 
-The first three ship together in the `mutables` remix (1,764/2,724 words with
-SEND; `warped` carries WarpFold alone). Built entirely against the manifest
+Two more followed, both zero-buffer inserts:
+
+- `streamz` — Streams-ish **vactrol lowpass gate** (255 words): the envelope
+  opens a filter and an amplifier together, so quiet is dark *and* quiet.
+  LPG/VCF/VCA. Release measured 26–731 ms against a 20–700 ms design; the
+  coupling itself measured as a spectral centroid of 9,880 Hz on loud
+  material against 2,620 Hz on the same material quiet.
+- `bodeshift` — Warps-ish **Bode frequency shifter** (391 words), UP/DOWN/
+  WIDE plus feedback. Built against a float model *first*, which caught the
+  sideband sign convention before a line of assembly was written. Measured on
+  the DSP: wanted sideband at unity, suppression 41.5/29.6/18.7 dB at
+  440 Hz/1 kHz/5 kHz (the model says 40.8/29.2/18.6), shift frequency exact
+  to 0.00 Hz across the knob, and feedback stable at maximum with 0.95 FS in.
+
+All five ship together in the `mutables` remix (2,410/2,724 words with SEND;
+`warped` carries WarpFold alone). Built entirely against the manifest
 contract; the build's three-source special-casing was generalized the same
 day under the refhash gate (bit-identical before any module existed), and
 `verify_menu` now derives its expectations from the selected remix instead of

--- a/PLAN.md
+++ b/PLAN.md
@@ -76,6 +76,21 @@ What ships today is four modules: `chonverb`, `bongdelay`, `send`, and
 `tempo-sync` — the last being a ColdFire patch rather than an effect, and the
 worked example of changing what the firmware *does*.
 
+The first **outsider module** landed 29 Aug 2026: `warpfold`, a Mutable-
+Instruments-Warps-flavoured ring-mod/wavefolder, and the first per-track
+**insert** (no bus role, placed in BOTH payloads, runs on any track — several
+at once). It ships in its own remix, `warped`, because neither server fits
+beside a new effect in one donor region. Built entirely against the manifest
+contract; the build's three-source special-casing was generalized the same
+day under the refhash gate (bit-identical before the module existed), and
+`verify_menu` now derives its expectations from the selected remix instead of
+a hand table. Local render verified (MIX=0 bit-exact null, DRV=0 fold
+identity at −96 dB, ring sidebands on the predicted carrier to 0.3%);
+**not yet flashed** — MODE's 3-way select and the knob publishes ride the
+standing on-unit reconfirm. Known tool gap: `make cycles` is remix-blind and
+still prices the chongbong engines whatever REMIX says (WarpFold's worst
+loop is ~80 cycles/sample 🟡 by inspection).
+
 Three things follow that are worth knowing before editing anything:
 
 - **The build refuses to start when two selected modules collide** on an FX2

--- a/PLAN.md
+++ b/PLAN.md
@@ -68,6 +68,7 @@ twelve parameter slots, its DSP source, its ColdFire caves — and
 image and the reference every refactor proves itself against.
 
 ```sh
+make remix                # the workbench: compose a selection interactively
 make modules              # the module index and the available remixes
 make bus REMIX=<name>     # build a selection (default: chongbong)
 ```
@@ -91,8 +92,19 @@ be):
   tables + STRUCT stretch (880 words). Partials land within 0.15% of the
   series; DAMP spans T60 ~0.1–9 s (hyperbolic in the knob — a voicing item).
 
-They ship together in the `mutables` remix (1,764/2,724 words with SEND;
-`warped` carries WarpFold alone). Built entirely against the manifest
+A fourth followed the same day — `nimbus`, a Clouds-ish granular texture
+(500 words): four grains over a continuously-recorded 743 ms line, POS/SIZE/
+DENS/MIX and a freeze. It gets its **own** remix because it owns the
+per-core FX2 buffer region `Y:0x4000–0xBFFF`, so it cannot share a core with
+ChonVerb's tank — a pair the ledger now refuses by name. Its window found a
+new trap, now in `CLAUDE.md`: **reading `a0` exposes the fractional left
+shift that reading `a1` hides**, so an `a0`-based integer scale is 2× the
+multiplier; the wrong one assembled and made plausible granular noise while
+running the window at double rate, and only a DC gate caught it. The musical
+freeze renders locally via `NFRZAT=n`, the `DFRZAT`-shaped lever.
+
+The first three ship together in the `mutables` remix (1,764/2,724 words with
+SEND; `warped` carries WarpFold alone). Built entirely against the manifest
 contract; the build's three-source special-casing was generalized the same
 day under the refhash gate (bit-identical before any module existed), and
 `verify_menu` now derives its expectations from the selected remix instead of
@@ -107,9 +119,13 @@ Three things follow that are worth knowing before editing anything:
 
 - **The build refuses to start when two selected modules collide** on an FX2
   id, a ColdFire cave, a hook site or a core-private Y word, and names both.
-  `tools/remix/ledger.py`; the negative tests are in `make check`. The shared
-  64K window is **not** covered yet — its extents are not established well
-  enough to write down, so `CLAUDE.md`'s ownership notes remain the map.
+  `tools/remix/ledger.py`; the negative tests are in `make check`. As of
+  29 Aug it also refuses two modules that both own the **per-core FX2
+  instance buffer region** `Y:0x4000–0xBFFF` (ChonVerb's tank, Nimbus's
+  line) — declared, not scanned, because a scan cannot tell an address from
+  a mask. The shared 64K window is still **not** covered — its extents are
+  not established well enough to write down, so `CLAUDE.md`'s ownership
+  notes remain the map.
 - **A module's `priority` is byte-load-bearing.** The donor region is packed
   in that order.
 - **Refactors of the build prove themselves with `scripts/refhash.sh`** — 23

--- a/PLAN.md
+++ b/PLAN.md
@@ -76,20 +76,32 @@ What ships today is four modules: `chonverb`, `bongdelay`, `send`, and
 `tempo-sync` — the last being a ColdFire patch rather than an effect, and the
 worked example of changing what the firmware *does*.
 
-The first **outsider module** landed 29 Aug 2026: `warpfold`, a Mutable-
-Instruments-Warps-flavoured ring-mod/wavefolder, and the first per-track
-**insert** (no bus role, placed in BOTH payloads, runs on any track — several
-at once). It ships in its own remix, `warped`, because neither server fits
-beside a new effect in one donor region. Built entirely against the manifest
+The first **outsider modules** landed 29 Aug 2026 — three Mutable-
+Instruments-flavoured per-track **inserts** (no bus role, placed in BOTH
+payloads, run on any track, several at once — the class the servers cannot
+be):
+
+- `warpfold` — Warps-ish ring mod / wavefolder (322 words). MIX=0 bit-exact
+  null, DRV=0 fold identity at −96 dB, ring sidebands on the predicted
+  carrier to 0.3%.
+- `ripple` — Ripples-ish driven SVF, LP/BP/HP, Q≈30 (347 words). LP slope
+  −13.8 dB measured where 2-pole theory says −14.4; the all-knobs-at-127
+  bomb decays clean.
+- `rungs` — Rings-ish 8-mode modal resonator, STRING/BELL/GLASS partial
+  tables + STRUCT stretch (880 words). Partials land within 0.15% of the
+  series; DAMP spans T60 ~0.1–9 s (hyperbolic in the knob — a voicing item).
+
+They ship together in the `mutables` remix (1,764/2,724 words with SEND;
+`warped` carries WarpFold alone). Built entirely against the manifest
 contract; the build's three-source special-casing was generalized the same
-day under the refhash gate (bit-identical before the module existed), and
+day under the refhash gate (bit-identical before any module existed), and
 `verify_menu` now derives its expectations from the selected remix instead of
-a hand table. Local render verified (MIX=0 bit-exact null, DRV=0 fold
-identity at −96 dB, ring sidebands on the predicted carrier to 0.3%);
-**not yet flashed** — MODE's 3-way select and the knob publishes ride the
-standing on-unit reconfirm. Known tool gap: `make cycles` is remix-blind and
-still prices the chongbong engines whatever REMIX says (WarpFold's worst
-loop is ~80 cycles/sample 🟡 by inspection).
+a hand table. All three are **not yet flashed** — every MODE select and knob
+publish rides the standing on-unit reconfirm. Known tool gaps: `make cycles`
+is remix-blind (still prices the chongbong engines whatever REMIX says;
+by inspection the inserts are ~80/~90/~190 cycles/sample worst 🟡), and
+send_probe's layout charset is still hard-coded RDS. — inserts render
+through dsp_host directly.
 
 Three things follow that are worth knowing before editing anything:
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -201,13 +201,30 @@ a lever first.
 
 ### Cycles — per core, 4,535/sample ✅ arithmetic (200 MIPS ÷ 44.1 kHz)
 
-Cycles are not the current constraint, with one caveat. The number
-`make cycles` prints is a **single-core floor**: it sums reverb + delay +
-sends on one core, but on hardware no core ever pays both engines. The
-delay's worst path (GRAIN, ~2,000 cycles by the tool's count) plus sends
-runs against core 1's ~2,150 🟡 *derived* spare — a thin paper margin, while
-the unit runs every mode clean; only the burn sweep can measure the real
-ceiling.
+Cycles are not the current constraint. `make cycles` is **remix-aware since
+29 Aug 2026** and prints a **WORST ONE CORE** figure derived from the
+selection: four FX2 slots, at most one server (the design rule, and what
+SPEC enforces), inserts unlimited because nothing stops all four tracks
+choosing the same one. Measured this way:
+
+| remix | worst core | what fills it |
+|---|---|---|
+| chongbong | **2,398** | 1× delay + 3× send |
+| mutables | **1,376** | 4× BodeShift (the dearest insert) |
+| nimbus | **1,308** | 4× Nimbus |
+| verbonly | **1,444** | 1× reverb + 3× send |
+
+against ~3,125 usable after stock's own ~1,410. Per-module: reverb 1,384,
+delay 2,338 (GRAIN worst path), Nimbus 327, BodeShift 344, Rungs 238,
+Streamz 154, WarpFold 101, Ripple 93, send 20.
+
+The old headline summed reverb + delay + sends onto one core — a load no
+core ever pays. That composition is still printed, labelled as the legacy
+basis, because the 7 Aug hardware spare was measured against it and
+re-baselining the comparison would break the only hardware anchor there is.
+⚠️ Every figure here is a static count: exact for the code, blind to
+memory-contention stalls, and the wall is a **cliff**. Only the burn sweep
+measures the real ceiling.
 
 - ⚠️ **FX1 cycles are paid ×4 per core** — a 300-cycle FX1 effect costs
   1,200 cycles/core. *This*, not program space, is the ceiling on FX1

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -31,7 +31,10 @@ what keeps `modules/_template/` out of every build.
 `tools/remix/schema.py` is the vocabulary and is worth reading in full — it is
 short, and its comments carry the reasoning behind each field.
 
-Copy `modules/_template/` to start.
+Copy `modules/_template/` to start, and `make remix` opens the workbench —
+a curses composer that shows collisions, the panel your selection produces
+and its word cost against the donor region, and can save the result as a
+remix.
 
 ---
 
@@ -166,13 +169,23 @@ pointer into a descriptor that was never cloned.
 ## Resource claims and the ledger
 
 `tools/remix/ledger.py` refuses a build whose selected modules collide, and
-names both. It checks FX2 ids, cave ranges, hook sites, and core-private Y
-words.
+names both. It checks FX2 ids, cave ranges, hook sites, core-private Y words,
+and the per-core FX2 instance buffer region.
 
 Core-private Y is **derived** by scanning your source for `y:>$09xx`, because
 a scan cannot go stale. Low Y is per *core*, not per instance, so every effect
 sharing a core shares those words. Only declare `Claims(reserved_private_y=…)`
 for a word you mean to own but do not yet reference.
+
+**`Y:0x4000`–`0xBFFF` is DECLARED, not derived** —
+`Claims(owns_fx2_buffers=True)`. That region is two FX2 instance slots *per
+core*: ChonVerb's tank is hardcoded there and so is Nimbus's granular line,
+so two such modules on one core overwrite each other while each works
+perfectly alone. It is declared because a scan cannot tell an address from a
+mask — scanning for the range flags `and #>$7fff` and any coefficient that
+lands in it, and `docs/DSP.md` §7c records that static scanning could not
+locate even the stock reverbs' buffers, which compute their bases at runtime.
+A checker that fires on six modules out of eight teaches people to ignore it.
 
 ⚠️ **The shared 64K window (`Y:0x30000`–`0x3FFFF`) is not checked yet** — the
 existing servers' buffer extents are not established well enough to write

--- a/modules/bodeshift/README.md
+++ b/modules/bodeshift/README.md
@@ -1,0 +1,56 @@
+# BodeShift
+
+A Warps-flavoured **Bode frequency shifter**. Not a pitch shifter and not a
+ring modulator: every partial moves by the same number of *hertz*, so
+harmonic relationships are destroyed rather than preserved. Small shifts give
+slow metallic phasing and detune; large ones turn anything into clangorous,
+bell-like inharmonic material.
+
+A ring modulator produces **both** sidebands. This cancels one, with a
+Hilbert pair of allpass chains — that cancellation is the entire difference
+between the two effects, and the entire difficulty.
+
+Per-track insert, no buffer, so it stacks with the other inserts.
+
+## Knobs
+
+| slot | name | what |
+|---|---|---|
+| p0 | FREQ | shift 0–1000 Hz, squared taper (fine control down low) |
+| p1 | FINE | 0–20 Hz added linearly; at ~1 Hz you get the classic slow swirl |
+| p2 | FDBK | shifted output back into the input — partials spiral up or down |
+| p3 | MIX  | dry/wet; 0 = exact passthrough |
+| p7 | MODE | UP / DOWN / WIDE (up on L, down on R) |
+
+## Status
+
+Assembles (391 words), disassembly-audited, rendered locally and measured
+against a float model built *first* — which is what caught the sign
+convention, since the obvious form produced the wrong sideband while sounding
+entirely plausible.
+
+- MIX=0 **bit-exact** passthrough; wanted sideband at **unity** gain.
+- **Sideband suppression, measured on the DSP**: 41.5 dB at 440 Hz, 29.6 dB
+  at 1 kHz, 18.7 dB at 5 kHz — matching the float model (40.8 / 29.2 / 18.6)
+  to within a dB, which is what says the fixed-point implementation is
+  faithful rather than merely working.
+- **Shift frequency exact**: 0.00 Hz error at FREQ 30 / 60 / 90 / 127, and
+  FINE alone measures 20.0 Hz against a 20 Hz design.
+- DOWN and WIDE verified by measurement, not assumption: in WIDE the left
+  channel carries the upper sideband at −44 dB with the lower at −85, and the
+  right channel is the mirror.
+- **Feedback is stable at maximum**: 0.95 FS in at FDBK=127 holds a 1.000 FS
+  peak for three seconds with no growth. The cap is arithmetic, not taste —
+  the loop settles at 0.5/(1−fdbk), so fdbk < 0.5 provably cannot run away.
+
+## Open
+
+- The residual opposite sideband rises with frequency (only ~19 dB down at
+  5 kHz). That is the honest cost of an 8-pole Hilbert pair; more sections
+  is the fix if it ever matters musically.
+- The shifted signal is **mono** (the analytic pair is computed on the mono
+  sum). WIDE gets its stereo from the two *directions*, not from two chains.
+  True stereo would double the 32 words of allpass state.
+
+**Not yet flashed** — knob publishes and the MODE select ride the standing
+on-unit reconfirm.

--- a/modules/bodeshift/bode_shift.asm
+++ b/modules/bodeshift/bode_shift.asm
@@ -1,0 +1,363 @@
+; ---------------------------------------------------------------------------
+; BodeShift -- a Warps-flavoured BODE FREQUENCY SHIFTER.
+;
+; Not a pitch shifter and not a ring modulator: every partial moves by the
+; SAME number of Hz, so harmonic relationships are destroyed rather than
+; preserved. Small shifts give slow metallic phasing and detune; large ones
+; give clangorous, bell-like inharmonic material. A ring modulator produces
+; BOTH sidebands (f-fc and f+fc); a Bode shifter cancels one of them, which
+; is the whole difference and the whole difficulty.
+;
+; The insert contract, no buffer: frames in place from r0, knobs from r6,
+; state in this instance's own r7 block. Stacks with the other inserts.
+;
+; ---- how the sideband is cancelled ----------------------------------------
+; Two allpass chains (Niemitalo's 8-pole Hilbert pair) whose phase responses
+; differ by 90 degrees across the audio band turn the input into an analytic
+; pair I,Q. Then
+;       out = I*cos(wt) + Q*sin(wt)      is the UPPER sideband alone
+;       out = I*cos(wt) - Q*sin(wt)      is the LOWER
+; and the unwanted one cancels to the extent that the pair really is 90
+; degrees apart. MEASURED in the float model this was derived from, and the
+; sign convention is NOT a matter of taste -- the first form written here
+; produced the wrong sideband, which is why the model came first:
+;       100 Hz  40.8 dB      1 kHz  29.2 dB
+;       440 Hz  41.1 dB      5 kHz  18.6 dB      9 kHz  24.8 dB
+; So the residual opposite sideband is real and audible at the top of the
+; band. That is the honest cost of an 8-pole pair; it is a character, not a
+; defect, and doubling the sections would be the fix if it ever matters.
+;
+; ⚠️ The extra z^-1 belongs on chain A ONLY (I = z^-1 A(x), Q = B(x)). Both
+; chains without it, or the delay on B, still assemble, still sound like a
+; frequency shifter, and simply stop cancelling -- a ring modulator wearing
+; this module's name. The gate that catches it is a sideband measurement.
+;
+; ---- knobs ----------------------------------------------------------------
+;   p0 FREQ  shift, 0..1000 Hz on a squared taper (fine control down low,
+;            where the musical detune and phasing settings live)
+;   p1 FINE  0..20 Hz, added linearly -- at 1 Hz the two sidebands of a
+;            stereo pair beat against each other, the classic slow swirl
+;   p2 FDBK  0..0.45, the shifted output back into the input: each pass
+;            shifts again, so partials walk up (or down) the spectrum in a
+;            spiral. Capped where the loop provably cannot run away.
+;   p3 MIX   out = dry + MIX*(wet - dry); MIX=0 is an exact passthrough
+;   p7 MODE  0 UP, 1 DOWN, 2 WIDE (up on L and down on R -- the two
+;            directions beat against each other across the stereo field)
+;
+; ---- r7 slots -------------------------------------------------------------
+;   $20 m      $21 step    $22 fdbk    $23 sL   $24 sR
+;   $25 phase      (PERSISTENT, wrapped by a1 extraction every sample)
+;   $26 lastwet    (PERSISTENT, the feedback tap)
+;   $27 aPrev      (PERSISTENT, chain A's z^-1)
+;   $28 in   $29 sin   $2a cos   $2b I*cos   $2c Q*sin   $2d Q
+;   $30..$3f  chain A state, 4 sections x (x[n-1], x[n-2], y[n-1], y[n-2])
+;   $40..$4f  chain B state, the same
+;
+; Every mpy/mac is `mpy x0,y1` / `mac x0,y1` -- the encodings proven signed,
+; and both operands here routinely go negative, so this is not optional.
+; Audited by disassembly.
+; ---------------------------------------------------------------------------
+
+init:
+        rts
+
+proc:
+; ---- per-block knob decode ------------------------------------------------
+        move    x:(r6+$3),x0            ; m = MIX
+        move    x0,x:(r7+$20)
+; step = FREQ^2 * K + FINE * kfine, in phase units (a full wrap = one cycle,
+; so a step of 2f/fs advances f Hz per sample)
+        move    x:(r6+$0),x0
+        move    x:(r6+$0),y1
+        mpy     x0,y1,a                 ; FREQ^2
+        move    a,x0
+        move    #>$05e592,y1            ; -> 1000 Hz at full knob
+        mpy     x0,y1,a
+        move    a,x1                    ; the coarse part
+        move    x:(r6+$1),x0
+        move    #>$001df5,y1            ; FINE -> 20 Hz at full knob
+        mpy     x0,y1,a
+        add     x1,a
+        move    a,x:(r7+$21)
+; fdbk = FDBK * 0.45. The cap is arithmetic, not taste: the loop is
+; in = 0.5*x + fdbk*wet and |wet| ~ |in|, so |in| settles at 0.5/(1-fdbk),
+; which stays under 1.0 for fdbk < 0.5.
+        move    x:(r6+$2),x0
+        move    #>$39999a,y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$22)
+
+; ---- MODE: page-2 slot 7 companion (ChonVerb's decode) --------------------
+; The direction is a per-block SIGN on Q rather than three copies of the
+; sample loop: wetL = I*cos + sL*(Q*sin), wetR the same with sR. UP is
+; (+1,+1), DOWN (-1,-1), WIDE (+1,-1).
+        move    x:(r6+$c),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     sb_down
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     sb_wide
+        move    #>$7fffff,x0            ; UP: both channels +1
+        move    x0,x:(r7+$23)
+        move    x0,x:(r7+$24)
+        bra     sb_go
+sb_down:
+        move    #>$800000,x0            ; DOWN: both -1
+        move    x0,x:(r7+$23)
+        move    x0,x:(r7+$24)
+        bra     sb_go
+sb_wide:
+        move    #>$7fffff,x0            ; WIDE: L up, R down
+        move    x0,x:(r7+$23)
+        move    #>$800000,x0
+        move    x0,x:(r7+$24)
+sb_go:
+
+; ---- per-sample -----------------------------------------------------------
+        move    #>$1,n0
+        do      n7,>sb_end
+; in = 0.5 * mono + fdbk * lastwet
+        move    x:(r0),a
+        move    x:(r0+n0),x0
+        add     x0,a
+        asr     #$2,a,a                 ; (L+R)/4 == 0.5 * the mono sum
+        move    x:(r7+$26),x0           ; lastwet
+        move    x:(r7+$22),y1           ; fdbk
+        mac     x0,y1,a
+        move    a,x:(r7+$28)
+        move    a,x1                    ; chain A's input
+
+; ---- chain A section 0: allpass, c = 0.6923877778065 -----------------------------
+        move    #>$58a02a,y1
+        move    x1,x0                   ; this section's input
+        mpy     x0,y1,a                 ; c*in
+        move    x:(r7+$33),x0          ; y[n-2]
+        mac     x0,y1,a                 ; + c*y[n-2]
+        move    x:(r7+$31),b           ; x[n-2]
+        sub     b,a                     ; - x[n-2]   = y[n]
+        move    x:(r7+$30),b           ; shift the state, oldest first
+        move    b,x:(r7+$31)           ; x[n-2] <- x[n-1]
+        move    x1,x:(r7+$30)          ; x[n-1] <- in
+        move    x:(r7+$32),b
+        move    b,x:(r7+$33)           ; y[n-2] <- y[n-1]
+        move    a,x:(r7+$32)           ; y[n-1] <- y[n]
+        move    a,x1                    ; -> the next section's input
+; ---- chain A section 1: allpass, c = 0.9360654322959 -----------------------------
+        move    #>$77d0fe,y1
+        move    x1,x0                   ; this section's input
+        mpy     x0,y1,a                 ; c*in
+        move    x:(r7+$37),x0          ; y[n-2]
+        mac     x0,y1,a                 ; + c*y[n-2]
+        move    x:(r7+$35),b           ; x[n-2]
+        sub     b,a                     ; - x[n-2]   = y[n]
+        move    x:(r7+$34),b           ; shift the state, oldest first
+        move    b,x:(r7+$35)           ; x[n-2] <- x[n-1]
+        move    x1,x:(r7+$34)          ; x[n-1] <- in
+        move    x:(r7+$36),b
+        move    b,x:(r7+$37)           ; y[n-2] <- y[n-1]
+        move    a,x:(r7+$36)           ; y[n-1] <- y[n]
+        move    a,x1                    ; -> the next section's input
+; ---- chain A section 2: allpass, c = 0.9882295226860 -----------------------------
+        move    #>$7e7e4e,y1
+        move    x1,x0                   ; this section's input
+        mpy     x0,y1,a                 ; c*in
+        move    x:(r7+$3b),x0          ; y[n-2]
+        mac     x0,y1,a                 ; + c*y[n-2]
+        move    x:(r7+$39),b           ; x[n-2]
+        sub     b,a                     ; - x[n-2]   = y[n]
+        move    x:(r7+$38),b           ; shift the state, oldest first
+        move    b,x:(r7+$39)           ; x[n-2] <- x[n-1]
+        move    x1,x:(r7+$38)          ; x[n-1] <- in
+        move    x:(r7+$3a),b
+        move    b,x:(r7+$3b)           ; y[n-2] <- y[n-1]
+        move    a,x:(r7+$3a)           ; y[n-1] <- y[n]
+        move    a,x1                    ; -> the next section's input
+; ---- chain A section 3: allpass, c = 0.9987488452737 -----------------------------
+        move    #>$7fd701,y1
+        move    x1,x0                   ; this section's input
+        mpy     x0,y1,a                 ; c*in
+        move    x:(r7+$3f),x0          ; y[n-2]
+        mac     x0,y1,a                 ; + c*y[n-2]
+        move    x:(r7+$3d),b           ; x[n-2]
+        sub     b,a                     ; - x[n-2]   = y[n]
+        move    x:(r7+$3c),b           ; shift the state, oldest first
+        move    b,x:(r7+$3d)           ; x[n-2] <- x[n-1]
+        move    x1,x:(r7+$3c)          ; x[n-1] <- in
+        move    x:(r7+$3e),b
+        move    b,x:(r7+$3f)           ; y[n-2] <- y[n-1]
+        move    a,x:(r7+$3e)           ; y[n-1] <- y[n]
+        move    a,x1                    ; -> the next section's input
+; I is chain A's output delayed one sample; the CURRENT output becomes
+; next sample's I.
+        move    x:(r7+$27),b            ; I = aPrev
+        move    x1,x:(r7+$27)           ; aPrev <- this sample's A output
+        move    b,x1                    ; park I in x1 while chain B runs...
+        move    x1,x:(r7+$2e)           ; ...in a slot, since B needs x1
+        move    x:(r7+$28),x1           ; chain B takes the same input
+
+; ---- chain B section 0: allpass, c = 0.4021921162426 -----------------------------
+        move    #>$337b08,y1
+        move    x1,x0                   ; this section's input
+        mpy     x0,y1,a                 ; c*in
+        move    x:(r7+$43),x0          ; y[n-2]
+        mac     x0,y1,a                 ; + c*y[n-2]
+        move    x:(r7+$41),b           ; x[n-2]
+        sub     b,a                     ; - x[n-2]   = y[n]
+        move    x:(r7+$40),b           ; shift the state, oldest first
+        move    b,x:(r7+$41)           ; x[n-2] <- x[n-1]
+        move    x1,x:(r7+$40)          ; x[n-1] <- in
+        move    x:(r7+$42),b
+        move    b,x:(r7+$43)           ; y[n-2] <- y[n-1]
+        move    a,x:(r7+$42)           ; y[n-1] <- y[n]
+        move    a,x1                    ; -> the next section's input
+; ---- chain B section 1: allpass, c = 0.8561710882420 -----------------------------
+        move    #>$6d9704,y1
+        move    x1,x0                   ; this section's input
+        mpy     x0,y1,a                 ; c*in
+        move    x:(r7+$47),x0          ; y[n-2]
+        mac     x0,y1,a                 ; + c*y[n-2]
+        move    x:(r7+$45),b           ; x[n-2]
+        sub     b,a                     ; - x[n-2]   = y[n]
+        move    x:(r7+$44),b           ; shift the state, oldest first
+        move    b,x:(r7+$45)           ; x[n-2] <- x[n-1]
+        move    x1,x:(r7+$44)          ; x[n-1] <- in
+        move    x:(r7+$46),b
+        move    b,x:(r7+$47)           ; y[n-2] <- y[n-1]
+        move    a,x:(r7+$46)           ; y[n-1] <- y[n]
+        move    a,x1                    ; -> the next section's input
+; ---- chain B section 2: allpass, c = 0.9722909545651 -----------------------------
+        move    #>$7c7408,y1
+        move    x1,x0                   ; this section's input
+        mpy     x0,y1,a                 ; c*in
+        move    x:(r7+$4b),x0          ; y[n-2]
+        mac     x0,y1,a                 ; + c*y[n-2]
+        move    x:(r7+$49),b           ; x[n-2]
+        sub     b,a                     ; - x[n-2]   = y[n]
+        move    x:(r7+$48),b           ; shift the state, oldest first
+        move    b,x:(r7+$49)           ; x[n-2] <- x[n-1]
+        move    x1,x:(r7+$48)          ; x[n-1] <- in
+        move    x:(r7+$4a),b
+        move    b,x:(r7+$4b)           ; y[n-2] <- y[n-1]
+        move    a,x:(r7+$4a)           ; y[n-1] <- y[n]
+        move    a,x1                    ; -> the next section's input
+; ---- chain B section 3: allpass, c = 0.9952884791278 -----------------------------
+        move    #>$7f659d,y1
+        move    x1,x0                   ; this section's input
+        mpy     x0,y1,a                 ; c*in
+        move    x:(r7+$4f),x0          ; y[n-2]
+        mac     x0,y1,a                 ; + c*y[n-2]
+        move    x:(r7+$4d),b           ; x[n-2]
+        sub     b,a                     ; - x[n-2]   = y[n]
+        move    x:(r7+$4c),b           ; shift the state, oldest first
+        move    b,x:(r7+$4d)           ; x[n-2] <- x[n-1]
+        move    x1,x:(r7+$4c)          ; x[n-1] <- in
+        move    x:(r7+$4e),b
+        move    b,x:(r7+$4f)           ; y[n-2] <- y[n-1]
+        move    a,x:(r7+$4e)           ; y[n-1] <- y[n]
+        move    a,x1                    ; -> the next section's input
+        move    x1,x:(r7+$2d)           ; Q = chain B's output
+
+; ---- oscillator: phase accumulator, then a refined parabolic sine ---------
+; Drift-free BY CONSTRUCTION -- the phase is an exact wrapping integer, so
+; unlike a resonator oscillator the amplitude cannot creep over minutes.
+        move    x:(r7+$25),a
+        move    x:(r7+$21),x0
+        add     x0,a
+        move    a1,x0                   ; wrap: a1 IS the modulo
+        move    x0,a                    ; sign-extended, so A2 is clean
+        move    a,x:(r7+$25)
+        bsr     sb_sin
+        move    a,x:(r7+$29)            ; sin(pi*p)
+        move    x:(r7+$25),a
+        move    #>$400000,x0
+        add     x0,a                    ; + a quarter turn
+        move    a1,x0
+        move    x0,a
+        bsr     sb_sin
+        move    a,x:(r7+$2a)            ; cos(pi*p)
+
+; ---- the two sidebands, and the mix --------------------------------------
+        move    x:(r7+$2e),x0           ; I
+        move    x:(r7+$2a),y1           ; cos
+        mpy     x0,y1,a
+        move    a,x:(r7+$2b)            ; I*cos
+        move    x:(r7+$2d),x0           ; Q
+        move    x:(r7+$29),y1           ; sin
+        mpy     x0,y1,a
+        move    a,x:(r7+$2c)            ; Q*sin
+; wetL = 2 * (I*cos + sL*(Q*sin))   -- the x2 undoes the input's 0.5
+        move    x:(r7+$2c),x0
+        move    x:(r7+$23),y1           ; sL
+        mpy     x0,y1,a
+        move    x:(r7+$2b),b
+        add     b,a
+        asl     #$1,a,a
+        move    a,x:(r7+$26)            ; lastwet, for the feedback tap
+        move    x:(r0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)
+; wetR
+        move    x:(r7+$2c),x0
+        move    x:(r7+$24),y1           ; sR
+        mpy     x0,y1,a
+        move    x:(r7+$2b),b
+        add     b,a
+        asl     #$1,a,a
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+sb_end:
+        nop
+        rts
+
+; ---------------------------------------------------------------------------
+; sb_sin -- sin(pi*p) for p in [-1,1), to about 0.1% .
+;   y = 4p(1-|p|)                 the parabola
+;   y = 0.775y + 0.225y|y|        the standard refinement
+; Without the refinement the parabola's 3rd harmonic sits near -28 dB, which
+; would put a spurious shifted copy ABOVE the Hilbert pair's own residual --
+; the oscillator would become the limiting error, for two multiplies.
+; In: a = p.  Out: a = sin(pi*p).  Clobbers x0, x1, y1, b.
+; ---------------------------------------------------------------------------
+sb_sin:
+        move    a,x1                    ; keep p
+        abs     a
+        move    #>$800000,x0
+        add     x0,a                    ; |p| - 1
+        neg     a                       ; t = 1 - |p|
+        move    a,y1
+        move    x1,x0
+        mpy     x0,y1,a                 ; p*t
+        asl     #$2,a,a                 ; y = 4p(1-|p|)
+        move    a,x1                    ; keep y
+        move    a,x0
+        abs     a
+        move    a,y1                    ; |y|
+        mpy     x0,y1,a                 ; y*|y|
+        move    a,x0
+        move    #>$1ccccd,y1            ; 0.225
+        mpy     x0,y1,a
+        move    x1,x0
+        move    #>$633333,y1            ; 0.775
+        mac     x0,y1,a
+        rts

--- a/modules/bodeshift/manifest.py
+++ b/modules/bodeshift/manifest.py
@@ -1,0 +1,61 @@
+"""BodeShift -- a Mutable-Instruments-Warps-flavoured Bode frequency shifter.
+
+A per-track INSERT with no buffer, so it stacks with the other inserts.
+
+Not a pitch shifter and not a ring modulator. Every partial moves by the same
+number of HERTZ, so harmonic relationships are destroyed rather than
+preserved: small shifts give slow metallic phasing and detune, large ones
+give clangorous inharmonic material out of anything. A ring modulator makes
+BOTH sidebands; this cancels one, using a Hilbert pair of allpass chains --
+that cancellation is the entire difference, and the entire difficulty.
+
+MODE picks UP, DOWN, or WIDE (up on the left channel and down on the right,
+so the two directions beat against each other across the stereo field).
+FDBK sends the shifted output back in, so each pass shifts again and partials
+walk up or down the spectrum in a spiral -- the classic Bode barber-pole.
+
+MIX=0 is an exact passthrough, the standing null gate.
+"""
+
+from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
+                          MenuEntry, Module, Param, YBase)
+
+_PLAIN = Formatter.PLAIN
+_STEP = Formatter.STEPPED
+
+MODULE = Module(
+    name="bodeshift",
+    key="BODESHIFT",
+    kind=Kind.DSP_EFFECT,
+    doc="Warps-style insert: Bode frequency shifter, UP/DOWN/WIDE + feedback.",
+    menu=MenuEntry(
+        fx2_id=0x0f,
+        donor_desc=0x400d58b8,        # DARK REV, the standing donor
+        abbr=b"BODE",
+        fullname=b"BodeShift",
+        build_tag=True,
+    ),
+    params=(
+        # ---- page 1 -------------------------------------------------------
+        # FREQ 0 with FINE 0 is a shift of zero, which is a (near) bypass --
+        # so a freshly selected instance does not leap out at you.
+        Param(b"FREQ", 0, active=True, formatter=_PLAIN),
+        Param(b"FINE", 20, active=True, formatter=_PLAIN),
+        Param(b"FDBK", 0, active=True, formatter=_PLAIN),
+        Param(b"MIX", 100, active=True, formatter=_PLAIN),
+        Param(), Param(),
+        # ---- page 2 -------------------------------------------------------
+        Param(),
+        Param(b"MODE", 2, 3, active=True, formatter=_STEP),   # UP/DOWN/WIDE
+        Param(), Param(), Param(), Param(),
+    ),
+    dsp=DspSection(
+        asm="modules/bodeshift/bode_shift.asm",
+        priority=10,                  # after streamz
+        bus_role=BusRole.NONE,
+        ybase=YBase.NEVER,            # no buffers of any kind
+        r7_latch_slot=None,
+        gate_label=None,
+    ),
+    harness=Harness(layout_char="B", is_server=False),
+)

--- a/modules/chonverb/manifest.py
+++ b/modules/chonverb/manifest.py
@@ -10,8 +10,8 @@ label is stated here rather than inherited silently -- the harness reads these
 names, and a name that exists only in a donor is a name no tool can see.
 """
 
-from remix.schema import (BusRole, YBase, DspSection, Formatter, Harness, Kind,
-                          MenuEntry, Module, Param)
+from remix.schema import (BusRole, Claims, YBase, DspSection, Formatter,
+                          Harness, Kind, MenuEntry, Module, Param)
 
 _PLAIN = Formatter.PLAIN
 _STEP = Formatter.STEPPED
@@ -73,5 +73,9 @@ MODULE = Module(
         gate_label="bus_notfirst",
         override_markers=("; MODE_OVERRIDE",),
     ),
+    # The eight tank lines are hardcoded into Y:0x4000-0xBFFF, the per-CORE
+    # FX2 instance buffer region -- so nothing else that owns memory there
+    # can be hosted on the same core (the ledger refuses the pair).
+    claims=Claims(owns_fx2_buffers=True),
     harness=Harness(layout_char="R", is_server=True),
 )

--- a/modules/nimbus/README.md
+++ b/modules/nimbus/README.md
@@ -41,9 +41,6 @@ Assembles (500 words), disassembly-audited, and rendered locally:
   POS=127); DENS decorrelates the channels; peak stays at 0.400 FS across the
   DENS sweep.
 
-**Not yet flashed** — knob publishes and the FRZE select ride the standing
-on-unit reconfirm.
-
 - **The musical freeze renders locally** since `NFRZAT=n` (DEV-only,
   `build_bus.py`'s `_dev_hooks`): the freeze engages after n post-warm-up
   blocks, so a render can capture real material and then hold it. Verified
@@ -54,6 +51,10 @@ on-unit reconfirm.
   cloud froze the warm-up's cleared silence and rendered nothing. Allow at
   least POSbase + grain length of material first.
 
+**Not yet flashed** — knob publishes and the FRZE select ride the standing
+on-unit reconfirm.
+
 ## Open
+
 - Voicing: grain density is fixed at four. Clouds' texture/diffusion stage
   and pitch-shifted grains are both out of scope for v1.

--- a/modules/nimbus/README.md
+++ b/modules/nimbus/README.md
@@ -44,11 +44,16 @@ Assembles (500 words), disassembly-audited, and rendered locally:
 **Not yet flashed** — knob publishes and the FRZE select ride the standing
 on-unit reconfirm.
 
-## Open
+- **The musical freeze renders locally** since `NFRZAT=n` (DEV-only,
+  `build_bus.py`'s `_dev_hooks`): the freeze engages after n post-warm-up
+  blocks, so a render can capture real material and then hold it. Verified
+  by cutting the input to digital silence just after the freeze — the output
+  sustains indefinitely (−15.5 dB at +1 s, −16.2 dB at +3 s) on buffer
+  content alone. ⚠️ Freeze **n late enough to matter**: at `NFRZAT=40` only
+  600 samples had been recorded while the grains read ~9,400 back, so the
+  cloud froze the warm-up's cleared silence and rendered nothing. Allow at
+  least POSbase + grain length of material first.
 
-- **The musical freeze is not verified locally.** `FRZE=1` from cold is
-  proven to stop the write head, but toggling it *mid-flight* — the thing
-  you would actually do — needs a render-time hook, exactly as BongDelay's
-  freeze needed `DFRZAT`. Until then the frozen cloud is unheard.
+## Open
 - Voicing: grain density is fixed at four. Clouds' texture/diffusion stage
   and pitch-shifted grains are both out of scope for v1.

--- a/modules/nimbus/README.md
+++ b/modules/nimbus/README.md
@@ -1,0 +1,54 @@
+# Nimbus
+
+A Mutable-Instruments-Clouds-flavoured **granular texture** insert, and the
+first outsider module with a real buffer: the track's audio records
+continuously into a 32,768-word mono line (743 ms) and four unity-rate
+grains read it back — two per channel at a half-period offset, so each
+channel's triangle windows sum to constant power.
+
+## Knobs
+
+| slot | name | what |
+|---|---|---|
+| p0 | POS  | how far back the grains reach, 23–370 ms behind the write head |
+| p1 | SIZE | grain length 23 / 46 / 93 / 186 ms (powers of two) |
+| p2 | DENS | per-grain random scatter, up to ~92 ms, latched at each grain's own wrap |
+| p3 | MIX  | dry/wet; 0 = exact passthrough |
+| p7 | FRZE | OFF / FROZEN (stops the write head) |
+
+## ⚠️ One Nimbus per core
+
+The buffer is the fixed core-private FX2-instance region `Y:0x4000–0xBFFF` —
+not per-instance. That ground is only free because every other insert has no
+Y footprint at all (the argument `BUS.md`'s hardcoded-base probe made), so:
+two Nimbus instances on one core would share one buffer, and it cannot
+coexist with ChonVerb, whose tank lives in exactly that region. Hence its own
+remix, `nimbus`, rather than a seat in `mutables`. The legacy-stock-FX2
+caveat `PLAN.md` records for the servers applies here identically.
+
+## Status
+
+Assembles (500 words), disassembly-audited, and rendered locally:
+
+- MIX=0 **bit-exact** passthrough; warm-up (3,840 samples) is pure dry, so
+  boot garbage is never played.
+- **The window gate**: DC in comes back flat to −122 dB, which is what proves
+  the grain pair sums to constant power. This is the test that caught the
+  `a0` fractional-shift trap now recorded in `CLAUDE.md` — with the
+  arithmetically obvious multiplier the window ran at double rate and the
+  pair collapsed in phase.
+- POS reaches back as specified (echo at +1,303 samples at POS=0, +16,603 at
+  POS=127); DENS decorrelates the channels; peak stays at 0.400 FS across the
+  DENS sweep.
+
+**Not yet flashed** — knob publishes and the FRZE select ride the standing
+on-unit reconfirm.
+
+## Open
+
+- **The musical freeze is not verified locally.** `FRZE=1` from cold is
+  proven to stop the write head, but toggling it *mid-flight* — the thing
+  you would actually do — needs a render-time hook, exactly as BongDelay's
+  freeze needed `DFRZAT`. Until then the frozen cloud is unheard.
+- Voicing: grain density is fixed at four. Clouds' texture/diffusion stage
+  and pitch-shifted grains are both out of scope for v1.

--- a/modules/nimbus/manifest.py
+++ b/modules/nimbus/manifest.py
@@ -1,0 +1,62 @@
+"""Nimbus -- a Mutable-Instruments-Clouds-flavoured granular texture insert.
+
+A per-track INSERT with a real buffer: the track's audio records continuously
+into a 32,768-word mono line (743 ms) and four unity-rate grains read it back
+-- two per channel at half-period offsets, so each channel's triangle windows
+sum to constant power. POS reaches back into the buffer, SIZE picks the grain
+length (23/46/93/186 ms), DENS scatters each grain's start by up to ~92 ms of
+per-grain randomness (latched at the grain's own wrap, the trap GRAIN taught
+us about), and FRZE stops the write head so the last 743 ms becomes a frozen
+cloud to graze.
+
+⚠️ ONE NIMBUS PER CORE. The buffer is the fixed core-private FX2-instance
+region Y:0x4000-0xBFFF -- the same ground ChonVerb's tank uses in chongbong.
+Safe in an insert remix because every module there is zero-Y-footprint
+(exactly the argument BUS.md made for the hardcoded-base server), but two
+Nimbus instances on one core would share one buffer, and a legacy project
+putting a buffer-writing stock FX2 on the same core carries the same caveat
+PLAN.md records for the servers.
+
+MIX=0 is an exact passthrough (during warm-up the effect outputs pure dry).
+"""
+
+from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
+                          MenuEntry, Module, Param, YBase)
+
+_PLAIN = Formatter.PLAIN
+_STEP = Formatter.STEPPED
+
+MODULE = Module(
+    name="nimbus",
+    key="NIMBUS",
+    kind=Kind.DSP_EFFECT,
+    doc="Clouds-style insert: 743 ms granular texture, 4 grains, freeze.",
+    menu=MenuEntry(
+        fx2_id=0x0d,
+        donor_desc=0x400d58b8,        # DARK REV, the standing donor
+        abbr=b"NMBS",
+        fullname=b"Nimbus",
+        build_tag=True,
+    ),
+    params=(
+        # ---- page 1 -------------------------------------------------------
+        Param(b"POS", 30, active=True, formatter=_PLAIN),
+        Param(b"SIZE", 70, active=True, formatter=_PLAIN),
+        Param(b"DENS", 40, active=True, formatter=_PLAIN),
+        Param(b"MIX", 100, active=True, formatter=_PLAIN),
+        Param(), Param(),
+        # ---- page 2 -------------------------------------------------------
+        Param(),
+        Param(b"FRZE", 0, 2, active=True, formatter=_STEP),   # OFF / FROZEN
+        Param(), Param(), Param(), Param(),
+    ),
+    dsp=DspSection(
+        asm="modules/nimbus/nimbus_grain.asm",
+        priority=8,                   # after rungs
+        bus_role=BusRole.NONE,
+        ybase=YBase.NEVER,            # the buffer is core-private Y, no $30000
+        r7_latch_slot=None,
+        gate_label=None,
+    ),
+    harness=Harness(layout_char="N", is_server=False),
+)

--- a/modules/nimbus/manifest.py
+++ b/modules/nimbus/manifest.py
@@ -20,8 +20,8 @@ PLAN.md records for the servers.
 MIX=0 is an exact passthrough (during warm-up the effect outputs pure dry).
 """
 
-from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
-                          MenuEntry, Module, Param, YBase)
+from remix.schema import (BusRole, Claims, DspSection, Formatter, Harness,
+                          Kind, MenuEntry, Module, Param, YBase)
 
 _PLAIN = Formatter.PLAIN
 _STEP = Formatter.STEPPED
@@ -58,5 +58,9 @@ MODULE = Module(
         r7_latch_slot=None,
         gate_label=None,
     ),
+    # The 743 ms line is hardcoded into Y:0x4000-0xBFFF -- the same per-CORE
+    # region ChonVerb's tank uses, which is why the two cannot share a core
+    # and why this module has its own remix.
+    claims=Claims(owns_fx2_buffers=True),
     harness=Harness(layout_char="N", is_server=False),
 )

--- a/modules/nimbus/nimbus_grain.asm
+++ b/modules/nimbus/nimbus_grain.asm
@@ -1,0 +1,456 @@
+; ---------------------------------------------------------------------------
+; Nimbus -- a Mutable-Instruments-Clouds-flavoured granular texture insert.
+;
+; Same insert contract as the other outsider modules (r0 frames in place,
+; knobs from r6, state in this instance's r7 block) -- plus, uniquely, a
+; real BUFFER: the mono input sum records continuously into the core-private
+; FX2-instance region Y:0x4000..0xBFFF (32,768 words = 743 ms @44.1k), and
+; four unity-rate grains read it back.
+;
+; ⚠️ ONE NIMBUS PER CORE: that buffer is fixed, not per-instance. Safe in an
+; insert remix (every other module is zero-Y-footprint -- the same argument
+; BUS.md's hardcoded-base probe made), wrong the moment two instances on one
+; core both select Nimbus. The legacy-stock-FX2 caveat from PLAN.md applies
+; here exactly as it does to ChonVerb's tank.
+;
+; ---- structure ------------------------------------------------------------
+; * Grain g's phase is (age + g*G/4) & (G-1): ONE age serves all four (the
+;   GRAIN architecture), so a single advance moves the cloud, and the count
+;   is EVEN -- odd grain counts ripple at the grain rate (BongDelay, 12 Aug).
+;   Grains 0/2 sum to L, 1/3 to R: per channel two triangle windows at a
+;   half-period offset, which sum to constant power by construction.
+; * A grain reads W - (POSbase + s_g + G - phase): it plays FORWARD at unity
+;   rate relative to the moving write head, always at least POSbase+s_g+1
+;   behind it, so no head ever reads ahead of the write.
+; * s_g is a per-grain scatter LATCHED AT THAT GRAIN'S OWN WRAP from the
+;   xorshift PRNG (23-bit, shifts 15/15/8 -- BongDelay's, verbatim, with its
+;   A2-clean dances). The latch is a branch over two moves, so no Tcc shares
+;   condition codes with anything (the GRAIN 5d trap).
+; * FRZE=1 stops the write head (write AND advance): the last 743 ms becomes
+;   a static cloud, and every read stays behind the frozen W by construction.
+; * WARM-UP, ChonVerb's tagged-counter idiom (tag $2d0000|count at r7+$31,
+;   a garbage tag restarts at zero): the first 256 blocks clear 128 words
+;   each -- the whole buffer -- zero the states, seed the PRNG, and leave the
+;   frames untouched (pure dry out). Boot garbage is never played.
+;
+; ---- knobs ----------------------------------------------------------------
+;   p0 POS   read-back distance base = 1024 + POS*120 (23..370 ms behind W)
+;   p1 SIZE  grain length, power of two: <32: 1024  <64: 2048  <96: 4096
+;            else 8192 samples (23/46/93/186 ms). Power-of-two G is what
+;            makes every wrap a mask and the window gain one multiply.
+;   p2 DENS  scatter depth: each grain's latched start offset is
+;            prng * DENS, up to ~4064 samples (92 ms)
+;   p3 MIX   out = dry + MIX*(wet - dry); MIX=0 is an exact passthrough
+;   p7 FRZE  0 recording, 1 FROZEN (slot-7 companion, ChonVerb's decode)
+;
+; ---- r7 slots -------------------------------------------------------------
+;   $20 m        $21 scat depth Q23   $22 POSbase    $23 G-1 mask
+;   $24 G/4      $26 2^(23-k) window multiplier ($25 unused)
+;   $27 FRZE     $28 write head W (PERSISTENT, masked on load AND save)
+;   $29 age      (PERSISTENT, masked by G-1 every sample)
+;   $2a..$2d latched scatter s_0..s_3 (PERSISTENT, integers 0..4064)
+;   $2e PRNG state (PERSISTENT)       $2f wet L    $30 wet R (per sample)
+;   $31 warm tag|count (PERSISTENT)   $32 mono in  $33 scatter candidate
+;   $34 warm count stash (per call)
+;
+; ---- the window is one multiply, and a NEW TRAP: a0 IS NOT a1/2^24 -------
+; phase is a small positive INTEGER (0..G-1, G = 2^k). Multiplying it by
+; 2^(23-k) and reading the accumulator's LOW word gives a ramp that reaches
+; bit 23 exactly at phase = G/2; read back as a SIGNED 24-bit word (move
+; a0,x0 / move x0,a sign-extends, so A2 is clean) that is 0 -> +1 over the
+; first half and -1 -> 0 over the second, and `abs` folds it into a TRIANGLE
+; peaking at G/2. One multiply, one abs, no per-size shift chain.
+;
+; ⚠️ THE MULTIPLIER IS 2^(23-k) AND NOT 2^(24-k), because **a0 EXPOSES THE
+; FRACTIONAL LEFT SHIFT THAT a1 HIDES**. `mpy` aligns the Q46 product into
+; Q47, so reading a1 gives the plain fractional product -- which is why the
+; project's standing note that "mpy does not double here" is true and stays
+; true for every other module, all of which read a1. Reading a0 sees the RAW
+; 48-bit content, shift included, so the effective integer scale is 2x the
+; multiplier. Getting this wrong is invisible: 2^(24-k) assembles, renders,
+; and makes a plausible granular noise -- it just runs the window at DOUBLE
+; RATE, so the two grains of a pair land in phase instead of interleaving.
+; MEASURED, 29 Aug 2026: DC in came back with 2x-DC ripple on a DC mean
+; (the double-rate signature) and went flat when the multiplier was halved.
+; The DC gate is what pins this: two triangles a half period apart sum to
+; EXACTLY 1, so DC in must come back flat and unrippled.
+;
+; Every mpy is `mpy x0,y1` (known-signed); audited by disassembly.
+; ---------------------------------------------------------------------------
+
+init:
+        rts
+
+proc:
+        move    #>$ffffff,m1
+        move    #>$ffffff,m2
+
+; ---- warm-up: ChonVerb's tagged counter, buffer-sized ---------------------
+        move    x:(r7+$31),a
+        move    #>$fffe00,x0
+        and     x0,a                    ; tag field -- AND cleans A1 only
+        move    a1,x0
+        move    x0,a                    ; A2-clean before the compare
+        move    #>$2d0000,x0
+        cmp     x0,a
+        beq     nb_wtag
+        clr     a                       ; garbage tag: warm-up starts at 0
+        bra     nb_wrun
+nb_wtag:
+        move    x:(r7+$31),a
+        move    #>$1ff,x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a                    ; the count, A2-clean
+        move    #>$100,x0
+        cmp     x0,a
+        bge     nb_wdone                ; warmed: run the grains
+nb_wrun:
+        move    a,x:(r7+$34)            ; count, for the save below
+        asl     #$7,a,a                 ; count*128: 256 blocks x 128 = 32,768
+        add     #>$4000,a               ; = the whole buffer
+        move    a,r1
+        clr     b
+        do      #128,>nb_wz
+        move    b,y:(r1)+
+nb_wz:
+        nop
+        move    b,x:(r7+$28)            ; W = 0
+        move    b,x:(r7+$29)            ; age = 0
+        move    b,x:(r7+$2a)            ; scatters = 0
+        move    b,x:(r7+$2b)
+        move    b,x:(r7+$2c)
+        move    b,x:(r7+$2d)
+        move    #>$345678,a             ; PRNG seed: any nonzero word
+        move    a,x:(r7+$2e)
+        move    x:(r7+$34),a
+        add     #>$1,a
+        add     #>$2d0000,a             ; tag | count+1
+        move    a,x:(r7+$31)
+        rts                             ; frames untouched: pure dry out
+nb_wdone:
+
+; ---- per-block knob decode ------------------------------------------------
+        move    x:(r6+$3),x0            ; m = MIX
+        move    x0,x:(r7+$20)
+        move    x:(r6+$2),x0            ; scat depth, straight Q23
+        move    x0,x:(r7+$21)
+; POSbase = 1024 + POS*120  (val*128 - val*8)
+        move    x:(r6+$0),a
+        asr     #$10,a,a                ; the integer knob value 0..127
+        move    a,b
+        asl     #$7,a,a                 ; val*128
+        asl     #$3,b,b                 ; val*8
+        sub     b,a
+        add     #>$400,a
+        move    a,x:(r7+$22)
+; SIZE -> G family: the wrap mask, G/4 (the grain-to-grain offset)
+; and the window multiplier 2^(23-k)
+        move    x:(r6+$1),a
+        asr     #$10,a,a
+        move    #>$20,x0
+        cmp     x0,a
+        blt     nb_s10
+        move    #>$40,x0
+        cmp     x0,a
+        blt     nb_s11
+        move    #>$60,x0
+        cmp     x0,a
+        blt     nb_s12
+        move    #>$1fff,x0              ; G = 8192
+        move    x0,x:(r7+$23)
+        move    #>$800,x0
+        move    x0,x:(r7+$24)
+        move    #>$400,x0              ; 2^(23-13)
+        move    x0,x:(r7+$26)
+        bra     nb_sdone
+nb_s12:
+        move    #>$fff,x0               ; G = 4096
+        move    x0,x:(r7+$23)
+        move    #>$400,x0
+        move    x0,x:(r7+$24)
+        move    #>$800,x0              ; 2^(23-12)
+        move    x0,x:(r7+$26)
+        bra     nb_sdone
+nb_s11:
+        move    #>$7ff,x0               ; G = 2048
+        move    x0,x:(r7+$23)
+        move    #>$200,x0
+        move    x0,x:(r7+$24)
+        move    #>$1000,x0             ; 2^(23-11)
+        move    x0,x:(r7+$26)
+        bra     nb_sdone
+nb_s10:
+        move    #>$3ff,x0               ; G = 1024
+        move    x0,x:(r7+$23)
+        move    #>$100,x0
+        move    x0,x:(r7+$24)
+        move    #>$2000,x0             ; 2^(23-10)
+        move    x0,x:(r7+$26)
+nb_sdone:
+; FRZE: slot-7 companion (ChonVerb's decode); any nonzero value freezes
+        move    x:(r6+$c),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$27)
+
+; ---- per-sample loop ------------------------------------------------------
+        move    #>$1,n0
+        do      n7,>nb_end
+; mono in
+        move    x:(r0),a
+        move    x:(r0+n0),x0
+        add     x0,a
+        asr     #$1,a,a
+        move    a,x:(r7+$32)
+; PRNG advance (BongDelay's 23-bit xorshift 15/15/8, verbatim)
+        move    x:(r7+$2e),a
+        move    a1,x0
+        asl     #$f,a,a
+        and     #>$7fffff,a
+        eor     x0,a
+        move    a1,x0
+        move    x0,a
+        asr     #$f,a,a
+        eor     x0,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        and     #>$7fffff,a
+        eor     x0,a
+        move    a1,x0
+        move    x0,a                    ; A2 clean before the store
+        move    a,x:(r7+$2e)
+; scatter candidate = prng * DENS, scaled to 0..4064 samples
+        move    a,x0
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a                 ; fraction in [0,1)
+        asr     #$b,a,a                 ; -> integer samples, <= 4064
+        move    a1,x0
+        move    x0,a
+        and     #>$fff,a                ; belt and braces: it IS 0..4064
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$33)
+; record + advance W, unless FROZEN
+        move    x:(r7+$27),a
+        tst     a
+        bne     nb_fz
+        move    x:(r7+$28),a
+        and     #>$7fff,a               ; mask on LOAD -- boot garbage dies
+        move    a1,x0
+        move    x0,a
+        add     #>$4000,a
+        move    a,r1
+        move    x:(r7+$32),x0
+        move    x0,y:(r1)               ; buffer[W] = mono
+        move    x:(r7+$28),a
+        add     #>$1,a
+        and     #>$7fff,a               ; mask on SAVE too
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$28)
+nb_fz:
+; age advance, masked by G-1 (also swallows size changes and boot garbage)
+        move    x:(r7+$29),a
+        add     #>$1,a
+        move    x:(r7+$23),x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$29)
+; clear the wet accumulators
+        clr     a
+        move    a,x:(r7+$2f)
+        move    a,x:(r7+$30)
+
+; ---- grain 0 (L, offset 0) ------------------------------------------------
+        move    x:(r7+$29),a            ; phase = age (already masked)
+        tst     a
+        bne     nb_g0
+        move    x:(r7+$33),x0           ; wrap: latch this grain's scatter
+        move    x0,x:(r7+$2a)
+nb_g0:
+        move    a,x1                    ; phase, kept for the dist calc
+        move    a,x0
+        move    x:(r7+$26),y1           ; 2^(23-k)
+        mpy     x0,y1,a                 ; a0 = wrap(2*phase/G), signed Q23
+        move    a0,x0
+        move    x0,a                    ; reloaded clean: A2 consistent
+        abs     a
+        move    a,y1                    ; window gain = |wrap(2*phase/G)|
+        move    x:(r7+$22),a            ; dist = POSbase + s_g + G - phase
+        move    x:(r7+$2a),x0
+        add     x0,a
+        move    x:(r7+$23),x0
+        add     x0,a
+        add     #>$1,a
+        sub     x1,a
+        move    a,x0
+        move    x:(r7+$28),a
+        sub     x0,a                    ; W - dist
+        and     #>$7fff,a
+        move    a1,x0
+        move    x0,a
+        add     #>$4000,a
+        move    a,r2
+        move    y:(r2),x0
+        mpy     x0,y1,a                 ; grain sample * window
+        move    x:(r7+$2f),b
+        add     b,a
+        move    a,x:(r7+$2f)            ; wet L +=
+; ---- grain 1 (R, offset G/4) ----------------------------------------------
+        move    x:(r7+$29),a
+        move    x:(r7+$24),x0
+        add     x0,a
+        move    x:(r7+$23),x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a
+        tst     a
+        bne     nb_g1
+        move    x:(r7+$33),x0
+        move    x0,x:(r7+$2b)
+nb_g1:
+        move    a,x1
+        move    a,x0
+        move    x:(r7+$26),y1
+        mpy     x0,y1,a
+        move    a0,x0
+        move    x0,a
+        abs     a
+        move    a,y1
+        move    x:(r7+$22),a
+        move    x:(r7+$2b),x0
+        add     x0,a
+        move    x:(r7+$23),x0
+        add     x0,a
+        add     #>$1,a
+        sub     x1,a
+        move    a,x0
+        move    x:(r7+$28),a
+        sub     x0,a
+        and     #>$7fff,a
+        move    a1,x0
+        move    x0,a
+        add     #>$4000,a
+        move    a,r2
+        move    y:(r2),x0
+        mpy     x0,y1,a
+        move    x:(r7+$30),b
+        add     b,a
+        move    a,x:(r7+$30)            ; wet R +=
+; ---- grain 2 (L, offset G/2) ----------------------------------------------
+        move    x:(r7+$29),a
+        move    x:(r7+$24),x0
+        add     x0,a
+        add     x0,a
+        move    x:(r7+$23),x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a
+        tst     a
+        bne     nb_g2
+        move    x:(r7+$33),x0
+        move    x0,x:(r7+$2c)
+nb_g2:
+        move    a,x1
+        move    a,x0
+        move    x:(r7+$26),y1
+        mpy     x0,y1,a
+        move    a0,x0
+        move    x0,a
+        abs     a
+        move    a,y1
+        move    x:(r7+$22),a
+        move    x:(r7+$2c),x0
+        add     x0,a
+        move    x:(r7+$23),x0
+        add     x0,a
+        add     #>$1,a
+        sub     x1,a
+        move    a,x0
+        move    x:(r7+$28),a
+        sub     x0,a
+        and     #>$7fff,a
+        move    a1,x0
+        move    x0,a
+        add     #>$4000,a
+        move    a,r2
+        move    y:(r2),x0
+        mpy     x0,y1,a
+        move    x:(r7+$2f),b
+        add     b,a
+        move    a,x:(r7+$2f)
+; ---- grain 3 (R, offset 3G/4) ---------------------------------------------
+        move    x:(r7+$29),a
+        move    x:(r7+$24),x0
+        add     x0,a
+        add     x0,a
+        add     x0,a
+        move    x:(r7+$23),x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a
+        tst     a
+        bne     nb_g3
+        move    x:(r7+$33),x0
+        move    x0,x:(r7+$2d)
+nb_g3:
+        move    a,x1
+        move    a,x0
+        move    x:(r7+$26),y1
+        mpy     x0,y1,a
+        move    a0,x0
+        move    x0,a
+        abs     a
+        move    a,y1
+        move    x:(r7+$22),a
+        move    x:(r7+$2d),x0
+        add     x0,a
+        move    x:(r7+$23),x0
+        add     x0,a
+        add     #>$1,a
+        sub     x1,a
+        move    a,x0
+        move    x:(r7+$28),a
+        sub     x0,a
+        and     #>$7fff,a
+        move    a1,x0
+        move    x0,a
+        add     #>$4000,a
+        move    a,r2
+        move    y:(r2),x0
+        mpy     x0,y1,a
+        move    x:(r7+$30),b
+        add     b,a
+        move    a,x:(r7+$30)
+
+; ---- mix: out = dry + m*(wet - dry), per channel --------------------------
+        move    x:(r7+$2f),a            ; wet L
+        move    x:(r0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)
+        move    x:(r7+$30),a            ; wet R
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+nb_end:
+        nop
+        rts

--- a/modules/nimbus/nimbus_grain.asm
+++ b/modules/nimbus/nimbus_grain.asm
@@ -76,6 +76,12 @@
 ; EXACTLY 1, so DC in must come back flat and unrippled.
 ;
 ; Every mpy is `mpy x0,y1` (known-signed); audited by disassembly.
+;
+; ; CYCLES_FORWARD_BRANCHES -- the five conditional branches in the sample
+; loop (the freeze gate and the four per-grain scatter latches) are all
+; FORWARD skips, so tools/cycle_count.py may price the fall-through path and
+; call the result a ceiling. It enforces the forward part rather than taking
+; this word for it.
 ; ---------------------------------------------------------------------------
 
 init:

--- a/modules/nimbus/nimbus_grain.asm
+++ b/modules/nimbus/nimbus_grain.asm
@@ -188,11 +188,16 @@ nb_s10:
         move    #>$2000,x0             ; 2^(23-10)
         move    x0,x:(r7+$26)
 nb_sdone:
-; FRZE: slot-7 companion (ChonVerb's decode); any nonzero value freezes
+; FRZE: slot-7 companion (ChonVerb's decode); any nonzero value freezes.
+; The marker is the DEV freeze hook's splice point (NFRZAT=n, build_bus.py's
+; _dev_hooks): it replaces the decoded value in `a` with a block counter's
+; verdict, so a render can capture real material and THEN freeze it. A
+; static freeze can only ever hold the silence the warm-up just cleared.
         move    x:(r6+$c),a
         and     #>$ff00,a
         move    a1,x0
         move    x0,a
+; NFRZ_OVERRIDE
         move    a,x:(r7+$27)
 
 ; ---- per-sample loop ------------------------------------------------------

--- a/modules/ripple/README.md
+++ b/modules/ripple/README.md
@@ -1,0 +1,27 @@
+# Ripple
+
+A Mutable-Instruments-Ripples-flavoured **resonant filter** insert: a
+Chamberlin state-variable filter with a drive stage in front, LP/BP/HP
+select, and a resonance that reaches Q≈30. The drive clip and the in-loop
+limiter on the HP node are deliberate — this is a filter to push.
+
+Per-track insert like WarpFold: no bus role, both payloads, any track,
+several instances at once. Ships in the `mutables` remix (and composes with
+the other inserts).
+
+## Knobs
+
+| slot | name | what |
+|---|---|---|
+| p0 | FREQ | cutoff ~24 Hz–7.2 kHz, squared taper (the SVF's stable region) |
+| p1 | RES  | resonance; 127 ≈ Q 30, short of self-oscillation |
+| p2 | DRV  | input gain 1–4×, clipped at the rail |
+| p3 | MIX  | dry/wet; 0 = exact passthrough |
+| p7 | MODE | LP / BP / HP |
+
+## Status
+
+Assembles, disassembly-audited (all `mpy` signed), rendered locally through
+`dsp_host`: MIX=0 bit-exact, LP/HP slopes and the BP/resonant peak measured
+against prediction. **Not yet flashed** — the standing on-unit reconfirm
+applies.

--- a/modules/ripple/manifest.py
+++ b/modules/ripple/manifest.py
@@ -1,0 +1,56 @@
+"""Ripple -- a Mutable-Instruments-Ripples-flavoured resonant filter.
+
+A per-track INSERT (no bus role, both payloads, any track): a Chamberlin
+state-variable filter with a drive stage in front, LP/BP/HP select, and the
+resonance allowed to sing. The drive clip and the in-loop limiter on the HP
+node are the character, the way Ripples' OTA clip is -- this is a filter to
+push, not a surgical EQ.
+
+Cutoff spans ~24 Hz..7.2 kHz on a squared taper (the SVF's stable region at
+44.1 kHz -- f = 2sin(pi*fc/fs) capped below 1.0). RES=127 reaches Q ~ 30:
+a screaming peak, deliberately short of self-oscillation.
+
+DRV=0 is unity into the filter and MIX=0 is an exact passthrough, the same
+null gates as WarpFold.
+"""
+
+from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
+                          MenuEntry, Module, Param, YBase)
+
+_PLAIN = Formatter.PLAIN
+_STEP = Formatter.STEPPED
+
+MODULE = Module(
+    name="ripple",
+    key="RIPPLE",
+    kind=Kind.DSP_EFFECT,
+    doc="Ripples-style insert: driven SVF filter, LP/BP/HP, singing resonance.",
+    menu=MenuEntry(
+        fx2_id=0x0b,
+        donor_desc=0x400d58b8,        # DARK REV, the standing donor
+        abbr=b"RPPL",
+        fullname=b"Ripple",
+        build_tag=True,
+    ),
+    params=(
+        # ---- page 1 -------------------------------------------------------
+        Param(b"FREQ", 90, active=True, formatter=_PLAIN),
+        Param(b"RES", 40, active=True, formatter=_PLAIN),
+        Param(b"DRV", 0, active=True, formatter=_PLAIN),
+        Param(b"MIX", 127, active=True, formatter=_PLAIN),
+        Param(), Param(),
+        # ---- page 2 -------------------------------------------------------
+        Param(),
+        Param(b"MODE", 0, 3, active=True, formatter=_STEP),   # LP/BP/HP
+        Param(), Param(), Param(), Param(),
+    ),
+    dsp=DspSection(
+        asm="modules/ripple/ripple_svf.asm",
+        priority=6,                   # after warpfold
+        bus_role=BusRole.NONE,
+        ybase=YBase.NEVER,
+        r7_latch_slot=None,
+        gate_label=None,
+    ),
+    harness=Harness(layout_char="F", is_server=False),
+)

--- a/modules/ripple/ripple_svf.asm
+++ b/modules/ripple/ripple_svf.asm
@@ -1,0 +1,328 @@
+; ---------------------------------------------------------------------------
+; Ripple -- a Mutable-Instruments-Ripples-flavoured resonant SVF insert.
+;
+; Same contract as modules/warpfold/warp_fold.asm: a per-track INSERT that
+; reads x:(r0)/x:(r0+n0) and writes back in place; no bus, no absolute Y,
+; all state in this instance's own r7 block.
+;
+; The filter is the Chamberlin state-variable form, per channel:
+;       lp += f * bp
+;       hp  = x - lp - damp * bp
+;       bp += f * hp
+; with a drive stage in front (gain 1..4x, hard-clipped by the store limiter)
+; and the HP node passing through a limited register move each sample -- both
+; clips are deliberate: they are what tames the resonance and they are the
+; character, the way Ripples' OTA stage is.
+;
+; ---- knobs ----------------------------------------------------------------
+;   p0 FREQ  f = FREQ^2 * 0.984 + 0.0034      (~24 Hz .. ~7.2 kHz; the SVF's
+;            stable region at 44.1k -- f = 2sin(pi*fc/fs), capped below 1.0)
+;   p1 RES   damp = 0.992 - RES * 0.969       (RES=127 -> damp ~ 0.031, Q~30)
+;   p2 DRV   gain = 1 + 3*DRV/128, clip at the rail
+;   p3 MIX   out = dry + MIX*(wet - dry); MIX=0 is an exact passthrough
+;   p7 MODE  0 LP, 1 BP, 2 HP (ChonVerb's slot-7 decode; unexpected -> LP)
+;
+; ---- r7 slots -------------------------------------------------------------
+;   r7+$20  f     (per block)          r7+$24  lp state L (PERSISTENT)
+;   r7+$21  damp  (per block)          r7+$25  bp state L (PERSISTENT)
+;   r7+$22  g4 = gain/4 (per block)    r7+$26  lp state R (PERSISTENT)
+;   r7+$23  m = MIX (per block)        r7+$27  bp state R (PERSISTENT)
+; States are bounded by the limited stores; boot garbage is a legal state
+; and decays. Nothing here ever becomes an address.
+;
+; Every mpy is `mpy x0,y1` (the known-signed encoding); audited by
+; disassembly like warp_fold.asm's.
+; ---------------------------------------------------------------------------
+
+init:
+        rts
+
+proc:
+; ---- per-block knob decode ------------------------------------------------
+; f = FREQ^2 * 0.984 + 0.0034
+        move    x:(r6+$0),x0
+        move    x:(r6+$0),y1
+        mpy     x0,y1,a
+        move    a,x0
+        move    #>$7e0000,y1            ; 0.984
+        mpy     x0,y1,a
+        add     #>$7000,a               ; + 0.0034
+        move    a,x:(r7+$20)
+
+; damp = 0.992 - RES * 0.969
+        move    x:(r6+$1),x0
+        move    #>$7c0000,y1            ; 0.969
+        mpy     x0,y1,a
+        neg     a
+        add     #>$7f0000,a             ; 0.992 - res*0.969
+        move    a,x:(r7+$21)
+
+; g4 = 0.25 + DRV * 0.75   (gain/4; the loop shifts it back up by 2)
+        move    x:(r6+$2),x0
+        move    #>$600000,y1            ; 0.75
+        mpy     x0,y1,a
+        add     #>$200000,a             ; + 0.25
+        move    a,x:(r7+$22)
+
+; m = MIX
+        move    x:(r6+$3),x0
+        move    x0,x:(r7+$23)
+
+; ---- MODE: page-2 slot 7 companion, bits 8-15 -----------------------------
+        move    x:(r6+$c),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     rp_dobp
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     rp_dohp
+                                        ; 0, and anything unexpected: LP
+
+; ===========================================================================
+; MODE 0 -- LOWPASS. The per-channel body below is the template the other
+; two modes copy; only the WET TAP line differs.
+; ===========================================================================
+        move    #>$1,n0
+        do      n7,>rp_endlp
+; L drive
+        move    x:(r0),x0
+        move    x:(r7+$22),y1           ; g4
+        mpy     x0,y1,a
+        asl     #$2,a,a                 ; x*gain, in acc up to +/-4
+        move    a,x1                    ; x_d -- the limiter IS the drive clip
+; lp += f*bp
+        move    x:(r7+$25),x0           ; bp
+        move    x:(r7+$20),y1           ; f
+        mpy     x0,y1,a
+        move    x:(r7+$24),b
+        add     b,a
+        move    a,x:(r7+$24)            ; lp'
+        move    a,b                     ; b = lp'
+; hp = x_d - lp' - damp*bp
+        move    x:(r7+$21),y1           ; damp
+        mpy     x0,y1,a                 ; damp*bp (x0 still bp)
+        neg     a
+        sub     b,a
+        add     x1,a                    ; hp
+; bp += f*hp
+        move    a,x0                    ; hp, limited -- the resonance clamp
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        move    x:(r7+$25),b
+        add     b,a
+        move    a,x:(r7+$25)            ; bp'
+; wet tap: LP
+        move    x:(r7+$24),a
+; mix
+        move    x:(r0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$23),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)
+; R channel, states $26/$27
+        move    x:(r0+n0),x0
+        move    x:(r7+$22),y1
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    a,x1
+        move    x:(r7+$27),x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        move    x:(r7+$26),b
+        add     b,a
+        move    a,x:(r7+$26)
+        move    a,b
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        sub     b,a
+        add     x1,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        move    x:(r7+$27),b
+        add     b,a
+        move    a,x:(r7+$27)
+        move    x:(r7+$26),a
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$23),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+rp_endlp:
+        nop
+        rts
+
+; ===========================================================================
+; MODE 1 -- BANDPASS: identical spine, wet = bp' (already in a at the tap).
+; ===========================================================================
+rp_dobp:
+        move    #>$1,n0
+        do      n7,>rp_endbp
+        move    x:(r0),x0
+        move    x:(r7+$22),y1
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    a,x1
+        move    x:(r7+$25),x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        move    x:(r7+$24),b
+        add     b,a
+        move    a,x:(r7+$24)
+        move    a,b
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        sub     b,a
+        add     x1,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        move    x:(r7+$25),b
+        add     b,a
+        move    a,x:(r7+$25)            ; bp' -- and a still holds it: the tap
+        move    x:(r0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$23),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)
+        move    x:(r0+n0),x0
+        move    x:(r7+$22),y1
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    a,x1
+        move    x:(r7+$27),x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        move    x:(r7+$26),b
+        add     b,a
+        move    a,x:(r7+$26)
+        move    a,b
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        sub     b,a
+        add     x1,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        move    x:(r7+$27),b
+        add     b,a
+        move    a,x:(r7+$27)
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$23),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+rp_endbp:
+        nop
+        rts
+
+; ===========================================================================
+; MODE 2 -- HIGHPASS: identical spine, wet = hp (parked in y0 at the clamp,
+; because bp's update consumes the accumulator).
+; ===========================================================================
+rp_dohp:
+        move    #>$1,n0
+        do      n7,>rp_endhp
+        move    x:(r0),x0
+        move    x:(r7+$22),y1
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    a,x1
+        move    x:(r7+$25),x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        move    x:(r7+$24),b
+        add     b,a
+        move    a,x:(r7+$24)
+        move    a,b
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        sub     b,a
+        add     x1,a
+        move    a,x0                    ; hp, limited
+        move    a,y0                    ; parked: the wet tap
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        move    x:(r7+$25),b
+        add     b,a
+        move    a,x:(r7+$25)
+        move    y0,a                    ; wet = hp
+        move    x:(r0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$23),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)
+        move    x:(r0+n0),x0
+        move    x:(r7+$22),y1
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    a,x1
+        move    x:(r7+$27),x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        move    x:(r7+$26),b
+        add     b,a
+        move    a,x:(r7+$26)
+        move    a,b
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        sub     b,a
+        add     x1,a
+        move    a,x0
+        move    a,y0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        move    x:(r7+$27),b
+        add     b,a
+        move    a,x:(r7+$27)
+        move    y0,a
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$23),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+rp_endhp:
+        nop
+        rts

--- a/modules/rungs/README.md
+++ b/modules/rungs/README.md
@@ -1,0 +1,33 @@
+# Rungs
+
+A Mutable-Instruments-Rings-flavoured **modal resonator** insert: the
+track's own audio excites a bank of eight two-pole resonators tuned to a
+partial series — Rings-as-an-effect. Drums become struck metal; melodies
+ring through a bell.
+
+Per-track insert like WarpFold: no bus role, both payloads, any track.
+Ships in the `mutables` remix.
+
+## Knobs
+
+| slot | name | what |
+|---|---|---|
+| p0 | FREQ | fundamental ~55 Hz–1.25 kHz, squared taper |
+| p1 | STRC | stretches the partial series sharp, more per higher mode |
+| p2 | DAMP | ring time T60 ~0.1-9 s |
+| p3 | MIX  | dry/wet; 0 = exact passthrough |
+| p7 | MODE | STRING (harmonic) / BELL / GLASS (stretched) |
+
+## Notes
+
+Mode frequencies are computed per block from the knobs; cos comes from a
+half-angle polynomial with ~0.2% tuning error at the extremes 🟡 — a
+resonator a few cents sharp at the top is character, not a defect. A future
+hook: the tempo-sync cave already publishes MIDI note, so FREQ could track
+played notes the way note→PITCH does on BongDelay.
+
+## Status
+
+Assembles, disassembly-audited, rendered locally: MIX=0 bit-exact, mode
+ring frequencies measured against the ratio tables, decay time tracks DAMP.
+**Not yet flashed** — the standing on-unit reconfirm applies.

--- a/modules/rungs/manifest.py
+++ b/modules/rungs/manifest.py
@@ -1,0 +1,56 @@
+"""Rungs -- a Mutable-Instruments-Rings-flavoured modal resonator.
+
+A per-track INSERT (no bus role, both payloads, any track): the track's own
+audio excites a bank of EIGHT two-pole resonators tuned to a partial series,
+Rings-as-an-effect -- drums become struck metal, melodies ring through a
+bell. MODE picks the partial series (STRING harmonic / BELL / GLASS
+stretched-inharmonic), STRUCT stretches it further, DAMP is the ring time
+(T60 ~0.1-9 s), FREQ places the fundamental (~55 Hz .. ~1.25 kHz).
+
+Mode frequencies are computed per block from the knobs -- sin/cos by a
+half-angle polynomial, tuning error ~0.2% at the extremes 🟡 (measured in the
+render pass; a resonator a few cents off is character, not a defect).
+
+MIX=0 is an exact passthrough, the standing null gate.
+"""
+
+from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
+                          MenuEntry, Module, Param, YBase)
+
+_PLAIN = Formatter.PLAIN
+_STEP = Formatter.STEPPED
+
+MODULE = Module(
+    name="rungs",
+    key="RUNGS",
+    kind=Kind.DSP_EFFECT,
+    doc="Rings-style insert: 8-mode modal resonator, STRING/BELL/GLASS.",
+    menu=MenuEntry(
+        fx2_id=0x0c,
+        donor_desc=0x400d58b8,        # DARK REV, the standing donor
+        abbr=b"RNGS",
+        fullname=b"Rungs",
+        build_tag=True,
+    ),
+    params=(
+        # ---- page 1 -------------------------------------------------------
+        Param(b"FREQ", 60, active=True, formatter=_PLAIN),
+        Param(b"STRC", 0, active=True, formatter=_PLAIN),
+        Param(b"DAMP", 80, active=True, formatter=_PLAIN),
+        Param(b"MIX", 100, active=True, formatter=_PLAIN),
+        Param(), Param(),
+        # ---- page 2 -------------------------------------------------------
+        Param(),
+        Param(b"MODE", 0, 3, active=True, formatter=_STEP),  # STRING/BELL/GLASS
+        Param(), Param(), Param(), Param(),
+    ),
+    dsp=DspSection(
+        asm="modules/rungs/rungs_modal.asm",
+        priority=7,                   # after ripple
+        bus_role=BusRole.NONE,
+        ybase=YBase.NEVER,
+        r7_latch_slot=None,
+        gate_label=None,
+    ),
+    harness=Harness(layout_char="M", is_server=False),
+)

--- a/modules/rungs/rungs_modal.asm
+++ b/modules/rungs/rungs_modal.asm
@@ -1,0 +1,680 @@
+; ---------------------------------------------------------------------------
+; Rungs -- a Mutable-Instruments-Rings-flavoured 8-mode modal resonator.
+;
+; Same insert contract as warp_fold.asm / ripple_svf.asm: reads this track's
+; frames from x:(r0)/x:(r0+n0), writes back in place, no bus, no absolute Y,
+; all state in this instance's own r7 block.
+;
+; The mono sum of the input excites eight parallel two-pole resonators:
+;       y_n' = 2*c1_n*y_n - r^2*y_n'' + g*x        c1_n = r*cos(w_n)
+; The wet is their sum/8, mixed against the dry. Mode frequencies come from
+; a per-block computation: w_n = w0 * ratio_n * (1 + STRC*stretch_n), with
+; ratio_n from the MODE table (STRING harmonic 1..8, BELL, GLASS stretched)
+; and cos via half-angle -- s = sin(w/4) ~ v - v^3/6, cos(w/2) = 1 - 2s^2,
+; cos(w) = 2cos^2(w/2) - 1, every intermediate inside Q23. Tuning error
+; ~0.2% at the top of the range 🟡 (checked in the render pass).
+;
+; ---- knobs ----------------------------------------------------------------
+;   p0 FREQ  fundamental: w0/4 = 0.00196 + FREQ^2*0.04275  (~55 Hz..~1.25 kHz)
+;   p1 STRC  stretches the partial series sharp, more per higher mode
+;   p2 DAMP  r = 0.9985 + DAMP*0.0015    (ring T60 ~0.1 s .. ~9 s)
+;   p3 MIX   out = dry + MIX*(wet - dry); MIX=0 is an exact passthrough
+;   p7 MODE  0 STRING, 1 BELL, 2 GLASS (partial-ratio tables)
+;
+; ---- r7 slots -------------------------------------------------------------
+;   $20 m          $21 r^2        $22 gx (per sample)   $23 wet sum (per sample)
+;   $24..$2b c1_0..c1_7 (per block)
+;   $2c sc = STRC*0.2   $2d v scratch   $2e r   $2f w0/4
+;   $30..$3f mode states, y1_n at $30+2n, y2_n at $31+2n (PERSISTENT --
+;            bounded by the limited stores, boot garbage rings once and
+;            decays through r<1; nothing here ever becomes an address)
+;   $50..$57 ratio_n/16, loaded from the MODE table each block
+;
+; Every mpy/mac is `mpy x0,y1` / `mac x0,y1` / `mpy y0,x0` -- the encodings
+; proven signed (mac x0,y1 ships in the delay). Audited by disassembly.
+; ---------------------------------------------------------------------------
+
+init:
+        rts
+
+proc:
+; ---- shared per-block decode ----------------------------------------------
+        move    x:(r6+$3),x0            ; m = MIX
+        move    x0,x:(r7+$20)
+        move    x:(r6+$1),x0            ; sc = STRC * 0.2
+        move    #>$19999a,y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$2c)
+        move    x:(r6+$2),x0            ; r = 0.9985 + DAMP * 0.0015
+        move    #>$30fc,y1              ; T60 ~ 6.9/(1-r): ~0.1 s .. ~9 s.
+        mpy     x0,y1,a                 ; (hyperbolic in the knob -- long
+        add     #>$7fcf00,a             ; rings live in the top few steps;
+        move    a,x:(r7+$2e)            ; a voicing item, noted in README)
+        move    a,x0                    ; r^2
+        move    a,y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$21)
+        move    x:(r6+$0),x0            ; w0/4 = 0.00196 + FREQ^2 * 0.04275
+        move    x:(r6+$0),y1
+        mpy     x0,y1,a
+        move    a,x0
+        move    #>$057900,y1
+        mpy     x0,y1,a
+        add     #>$4000,a
+        move    a,x:(r7+$2f)
+
+; ---- MODE: pick the partial-ratio table (ChonVerb's slot-7 decode) --------
+        move    x:(r6+$c),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     rg_tbel
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     rg_tgls
+; STRING: harmonics 1..8 (ratio/16 in Q23)
+        move    #>$080000,x0
+        move    x0,x:(r7+$50)
+        move    #>$100000,x0
+        move    x0,x:(r7+$51)
+        move    #>$180000,x0
+        move    x0,x:(r7+$52)
+        move    #>$200000,x0
+        move    x0,x:(r7+$53)
+        move    #>$280000,x0
+        move    x0,x:(r7+$54)
+        move    #>$300000,x0
+        move    x0,x:(r7+$55)
+        move    #>$380000,x0
+        move    x0,x:(r7+$56)
+        move    #>$400000,x0
+        move    x0,x:(r7+$57)
+        bra     rg_setup
+rg_tbel:
+; BELL: 0.5, 1, 1.2, 1.5, 2, 2.5, 3, 4 -- hum tone under the prime
+        move    #>$040000,x0
+        move    x0,x:(r7+$50)
+        move    #>$080000,x0
+        move    x0,x:(r7+$51)
+        move    #>$09999a,x0
+        move    x0,x:(r7+$52)
+        move    #>$0c0000,x0
+        move    x0,x:(r7+$53)
+        move    #>$100000,x0
+        move    x0,x:(r7+$54)
+        move    #>$140000,x0
+        move    x0,x:(r7+$55)
+        move    #>$180000,x0
+        move    x0,x:(r7+$56)
+        move    #>$200000,x0
+        move    x0,x:(r7+$57)
+        bra     rg_setup
+rg_tgls:
+; GLASS: n*(1+0.08n) -- a stretched, gong-glass series
+        move    #>$08a3d7,x0
+        move    x0,x:(r7+$50)
+        move    #>$128f5c,x0
+        move    x0,x:(r7+$51)
+        move    #>$1dc28f,x0
+        move    x0,x:(r7+$52)
+        move    #>$2a3d71,x0
+        move    x0,x:(r7+$53)
+        move    #>$380000,x0
+        move    x0,x:(r7+$54)
+        move    #>$470a3d,x0
+        move    x0,x:(r7+$55)
+        move    #>$575c29,x0
+        move    x0,x:(r7+$56)
+        move    #>$68f5c2,x0
+        move    x0,x:(r7+$57)
+
+rg_setup:
+; ---- per-mode coefficient stanza, unrolled 8x. Only three things vary:
+; the ratio slot, the stretch weight q_n = (n+1)/16, and the c1 slot.
+; v = (w0/4)*ratio*16, stretched by v*sc*q_n, clamped at 0.62 (the sin
+; approximation's accuracy bound), then the half-angle chain to c1 = r*cos w.
+; ---- mode 0 ----
+        move    x:(r7+$2f),x0
+        move    x:(r7+$50),y1
+        mpy     x0,y1,a
+        asl     #$4,a,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    x:(r7+$2c),y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$080000,x0            ; q = 1/16
+        mpy     y0,x0,a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    #>$4f5c28,x0            ; 0.62 clamp
+        cmp     x0,a
+        tge     x0,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a                 ; v^2
+        move    a,y0
+        move    #>$155555,x0
+        mpy     y0,x0,a                 ; v^2/6
+        move    a,y1
+        move    x:(r7+$2d),x0
+        mpy     x0,y1,a                 ; v^3/6
+        neg     a
+        move    x:(r7+$2d),b
+        add     b,a                     ; s = sin(w/4)
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        neg     a
+        add     #>$7fffff,a             ; cos(w/2)
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    #>$400000,b
+        sub     b,a
+        asl     #$1,a,a                 ; cos(w)
+        move    a,x0
+        move    x:(r7+$2e),y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$24)            ; c1_0
+; ---- mode 1 ----
+        move    x:(r7+$2f),x0
+        move    x:(r7+$51),y1
+        mpy     x0,y1,a
+        asl     #$4,a,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    x:(r7+$2c),y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$100000,x0            ; q = 2/16
+        mpy     y0,x0,a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    #>$4f5c28,x0
+        cmp     x0,a
+        tge     x0,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$155555,x0
+        mpy     y0,x0,a
+        move    a,y1
+        move    x:(r7+$2d),x0
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        neg     a
+        add     #>$7fffff,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    #>$400000,b
+        sub     b,a
+        asl     #$1,a,a
+        move    a,x0
+        move    x:(r7+$2e),y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$25)            ; c1_1
+; ---- mode 2 ----
+        move    x:(r7+$2f),x0
+        move    x:(r7+$52),y1
+        mpy     x0,y1,a
+        asl     #$4,a,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    x:(r7+$2c),y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$180000,x0            ; q = 3/16
+        mpy     y0,x0,a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    #>$4f5c28,x0
+        cmp     x0,a
+        tge     x0,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$155555,x0
+        mpy     y0,x0,a
+        move    a,y1
+        move    x:(r7+$2d),x0
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        neg     a
+        add     #>$7fffff,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    #>$400000,b
+        sub     b,a
+        asl     #$1,a,a
+        move    a,x0
+        move    x:(r7+$2e),y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$26)            ; c1_2
+; ---- mode 3 ----
+        move    x:(r7+$2f),x0
+        move    x:(r7+$53),y1
+        mpy     x0,y1,a
+        asl     #$4,a,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    x:(r7+$2c),y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$200000,x0            ; q = 4/16
+        mpy     y0,x0,a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    #>$4f5c28,x0
+        cmp     x0,a
+        tge     x0,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$155555,x0
+        mpy     y0,x0,a
+        move    a,y1
+        move    x:(r7+$2d),x0
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        neg     a
+        add     #>$7fffff,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    #>$400000,b
+        sub     b,a
+        asl     #$1,a,a
+        move    a,x0
+        move    x:(r7+$2e),y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$27)            ; c1_3
+; ---- mode 4 ----
+        move    x:(r7+$2f),x0
+        move    x:(r7+$54),y1
+        mpy     x0,y1,a
+        asl     #$4,a,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    x:(r7+$2c),y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$280000,x0            ; q = 5/16
+        mpy     y0,x0,a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    #>$4f5c28,x0
+        cmp     x0,a
+        tge     x0,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$155555,x0
+        mpy     y0,x0,a
+        move    a,y1
+        move    x:(r7+$2d),x0
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        neg     a
+        add     #>$7fffff,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    #>$400000,b
+        sub     b,a
+        asl     #$1,a,a
+        move    a,x0
+        move    x:(r7+$2e),y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$28)            ; c1_4
+; ---- mode 5 ----
+        move    x:(r7+$2f),x0
+        move    x:(r7+$55),y1
+        mpy     x0,y1,a
+        asl     #$4,a,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    x:(r7+$2c),y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$300000,x0            ; q = 6/16
+        mpy     y0,x0,a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    #>$4f5c28,x0
+        cmp     x0,a
+        tge     x0,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$155555,x0
+        mpy     y0,x0,a
+        move    a,y1
+        move    x:(r7+$2d),x0
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        neg     a
+        add     #>$7fffff,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    #>$400000,b
+        sub     b,a
+        asl     #$1,a,a
+        move    a,x0
+        move    x:(r7+$2e),y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$29)            ; c1_5
+; ---- mode 6 ----
+        move    x:(r7+$2f),x0
+        move    x:(r7+$56),y1
+        mpy     x0,y1,a
+        asl     #$4,a,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    x:(r7+$2c),y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$380000,x0            ; q = 7/16
+        mpy     y0,x0,a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    #>$4f5c28,x0
+        cmp     x0,a
+        tge     x0,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$155555,x0
+        mpy     y0,x0,a
+        move    a,y1
+        move    x:(r7+$2d),x0
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        neg     a
+        add     #>$7fffff,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    #>$400000,b
+        sub     b,a
+        asl     #$1,a,a
+        move    a,x0
+        move    x:(r7+$2e),y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$2a)            ; c1_6
+; ---- mode 7 ----
+        move    x:(r7+$2f),x0
+        move    x:(r7+$57),y1
+        mpy     x0,y1,a
+        asl     #$4,a,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    x:(r7+$2c),y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$400000,x0            ; q = 8/16
+        mpy     y0,x0,a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    #>$4f5c28,x0
+        cmp     x0,a
+        tge     x0,a
+        move    a,x:(r7+$2d)
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    a,y0
+        move    #>$155555,x0
+        mpy     y0,x0,a
+        move    a,y1
+        move    x:(r7+$2d),x0
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$2d),b
+        add     b,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        neg     a
+        add     #>$7fffff,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    #>$400000,b
+        sub     b,a
+        asl     #$1,a,a
+        move    a,x0
+        move    x:(r7+$2e),y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$2b)            ; c1_7
+
+; ---- per-sample loop ------------------------------------------------------
+        move    #>$1,n0
+        do      n7,>rg_end
+        move    x:(r0),a
+        move    x:(r0+n0),x0
+        add     x0,a
+        asr     #$3,a,a                 ; gx = (L+R)/8
+        move    a,x:(r7+$22)
+        clr     a
+        move    a,x:(r7+$23)            ; sum = 0
+; mode 0
+        move    x:(r7+$31),x0
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$22),b
+        add     b,a
+        move    x:(r7+$30),x0
+        move    x:(r7+$24),y1
+        mac     x0,y1,a
+        mac     x0,y1,a
+        move    x0,x:(r7+$31)
+        move    a,x:(r7+$30)
+        asr     #$3,a,a
+        move    x:(r7+$23),b
+        add     b,a
+        move    a,x:(r7+$23)
+; mode 1
+        move    x:(r7+$33),x0
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$22),b
+        add     b,a
+        move    x:(r7+$32),x0
+        move    x:(r7+$25),y1
+        mac     x0,y1,a
+        mac     x0,y1,a
+        move    x0,x:(r7+$33)
+        move    a,x:(r7+$32)
+        asr     #$3,a,a
+        move    x:(r7+$23),b
+        add     b,a
+        move    a,x:(r7+$23)
+; mode 2
+        move    x:(r7+$35),x0
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$22),b
+        add     b,a
+        move    x:(r7+$34),x0
+        move    x:(r7+$26),y1
+        mac     x0,y1,a
+        mac     x0,y1,a
+        move    x0,x:(r7+$35)
+        move    a,x:(r7+$34)
+        asr     #$3,a,a
+        move    x:(r7+$23),b
+        add     b,a
+        move    a,x:(r7+$23)
+; mode 3
+        move    x:(r7+$37),x0
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$22),b
+        add     b,a
+        move    x:(r7+$36),x0
+        move    x:(r7+$27),y1
+        mac     x0,y1,a
+        mac     x0,y1,a
+        move    x0,x:(r7+$37)
+        move    a,x:(r7+$36)
+        asr     #$3,a,a
+        move    x:(r7+$23),b
+        add     b,a
+        move    a,x:(r7+$23)
+; mode 4
+        move    x:(r7+$39),x0
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$22),b
+        add     b,a
+        move    x:(r7+$38),x0
+        move    x:(r7+$28),y1
+        mac     x0,y1,a
+        mac     x0,y1,a
+        move    x0,x:(r7+$39)
+        move    a,x:(r7+$38)
+        asr     #$3,a,a
+        move    x:(r7+$23),b
+        add     b,a
+        move    a,x:(r7+$23)
+; mode 5
+        move    x:(r7+$3b),x0
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$22),b
+        add     b,a
+        move    x:(r7+$3a),x0
+        move    x:(r7+$29),y1
+        mac     x0,y1,a
+        mac     x0,y1,a
+        move    x0,x:(r7+$3b)
+        move    a,x:(r7+$3a)
+        asr     #$3,a,a
+        move    x:(r7+$23),b
+        add     b,a
+        move    a,x:(r7+$23)
+; mode 6
+        move    x:(r7+$3d),x0
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$22),b
+        add     b,a
+        move    x:(r7+$3c),x0
+        move    x:(r7+$2a),y1
+        mac     x0,y1,a
+        mac     x0,y1,a
+        move    x0,x:(r7+$3d)
+        move    a,x:(r7+$3c)
+        asr     #$3,a,a
+        move    x:(r7+$23),b
+        add     b,a
+        move    a,x:(r7+$23)
+; mode 7
+        move    x:(r7+$3f),x0
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        move    x:(r7+$22),b
+        add     b,a
+        move    x:(r7+$3e),x0
+        move    x:(r7+$2b),y1
+        mac     x0,y1,a
+        mac     x0,y1,a
+        move    x0,x:(r7+$3f)
+        move    a,x:(r7+$3e)
+        asr     #$3,a,a
+        move    x:(r7+$23),b
+        add     b,a
+        move    a,x:(r7+$23)
+; mix, wet = sum, both channels
+        move    x:(r7+$23),a
+        move    x:(r0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)
+        move    x:(r7+$23),a
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+rg_end:
+        nop
+        rts

--- a/modules/streamz/README.md
+++ b/modules/streamz/README.md
@@ -1,0 +1,43 @@
+# Streamz
+
+A Mutable-Instruments-Streams-flavoured **lowpass gate**: the track's own
+level drives an envelope follower, and that envelope opens a filter and an
+amplifier *together* — the Buchla vactrol behaviour. Quiet material is dark
+**and** quiet; loud transients are bright **and** loud. There is nothing like
+it in the stock effects.
+
+Per-track insert, no buffer, so it stacks with the other inserts.
+
+## Knobs
+
+| slot | name | what |
+|---|---|---|
+| p0 | SENS | follower drive; 64 is unity (a full-scale peak opens it fully) |
+| p1 | FALL | release, T60 20 ms–700 ms; short is plucky, long is a slow vactrol |
+| p2 | COLR | how open the filter stays when the gate is *shut*; 0 is a true gate |
+| p3 | MIX  | dry/wet; 0 = exact passthrough |
+| p7 | MODE | LPG (filter+amp) / VCF (filter only) / VCA (amp only) |
+
+Attack is fixed and fast on purpose — the rectified input *is* the attack, so
+only the release is on a knob. An LPG whose attack you can slow down stops
+sounding like an LPG and becomes a swell pedal.
+
+## Status
+
+Assembles (255 words), disassembly-audited, rendered locally:
+
+- MIX=0 **bit-exact** passthrough.
+- **Release tracks the design** across the whole knob: measured T60
+  26 / 52 / 139 / 479 / 731 ms at FALL 0 / 32 / 64 / 96 / 127, against a
+  design of 20 / 46 / 134 / 458 / 700 ms.
+- **The vactrol coupling is real and measured**: identical noise at two
+  levels comes out with spectral centroids of 9,880 Hz (loud) and 2,620 Hz
+  (quiet). That single number is the whole point of the module.
+
+The release knob is spent on the decay *rate* with a cubic taper, because a
+release coefficient is hyperbolic in decay time — spending the knob linearly
+on the coefficient crams every useful value into the last few steps, which is
+the flaw `rungs`' DAMP still has.
+
+**Not yet flashed** — knob publishes and the MODE select ride the standing
+on-unit reconfirm.

--- a/modules/streamz/manifest.py
+++ b/modules/streamz/manifest.py
@@ -1,0 +1,65 @@
+"""Streamz -- a Mutable-Instruments-Streams-flavoured lowpass gate.
+
+A per-track INSERT with no buffer at all, so it stacks with the other
+inserts. The track's own level drives an envelope follower, and the envelope
+opens a filter and an amplifier TOGETHER -- the Buchla lowpass-gate
+behaviour Streams models with a vactrol: quiet material is dark AND quiet,
+loud transients are bright AND loud, and the recovery is sluggish in a way
+no plain VCA is. There is nothing like it in the stock effects.
+
+MODE picks how the envelope is spent: LPG (filter and amp together, the
+vactrol), VCF (filter only -- an envelope filter / auto-wah), VCA (amp only
+-- a plain dynamics gate).
+
+SENS=0 leaves the envelope shut, so with MIX up the effect is a gate that
+never opens; MIX=0 is an exact passthrough, the standing null gate.
+"""
+
+from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
+                          MenuEntry, Module, Param, YBase)
+
+_PLAIN = Formatter.PLAIN
+_STEP = Formatter.STEPPED
+
+MODULE = Module(
+    name="streamz",
+    key="STREAMZ",
+    kind=Kind.DSP_EFFECT,
+    doc="Streams-style insert: vactrol lowpass gate, LPG/VCF/VCA.",
+    menu=MenuEntry(
+        fx2_id=0x0e,
+        donor_desc=0x400d58b8,        # DARK REV, the standing donor
+        abbr=b"STRM",
+        fullname=b"Streamz",
+        build_tag=True,
+    ),
+    params=(
+        # ---- page 1 -------------------------------------------------------
+        # SENS drives the follower. 64 is roughly unity: a signal peaking at
+        # full scale opens the gate fully.
+        Param(b"SENS", 64, active=True, formatter=_PLAIN),
+        # FALL is the vactrol's sluggishness -- short is plucky and percussive,
+        # long is a slow swell. Attack is fixed and fast; an LPG whose attack
+        # you can slow down stops sounding like an LPG.
+        Param(b"FALL", 50, active=True, formatter=_PLAIN),
+        # COLR is how dark the gate gets when CLOSED. 0 is a full gate (shut
+        # is silent and black); higher leaves the filter partly open, which is
+        # the difference between a gate and a gentle tone-follower.
+        Param(b"COLR", 10, active=True, formatter=_PLAIN),
+        Param(b"MIX", 127, active=True, formatter=_PLAIN),
+        Param(), Param(),
+        # ---- page 2 -------------------------------------------------------
+        Param(),
+        Param(b"MODE", 0, 3, active=True, formatter=_STEP),   # LPG/VCF/VCA
+        Param(), Param(), Param(), Param(),
+    ),
+    dsp=DspSection(
+        asm="modules/streamz/streamz_lpg.asm",
+        priority=9,                   # after nimbus
+        bus_role=BusRole.NONE,
+        ybase=YBase.NEVER,            # no buffers of any kind
+        r7_latch_slot=None,
+        gate_label=None,
+    ),
+    harness=Harness(layout_char="G", is_server=False),
+)

--- a/modules/streamz/streamz_lpg.asm
+++ b/modules/streamz/streamz_lpg.asm
@@ -1,0 +1,307 @@
+; ---------------------------------------------------------------------------
+; Streamz -- a Mutable-Instruments-Streams-flavoured lowpass gate.
+;
+; The insert contract, with no buffer at all: frames in place from r0, knobs
+; from r6, state in this instance's own r7 block. Stacks with every other
+; zero-footprint insert.
+;
+; ---- what it does ---------------------------------------------------------
+; A peak follower watches the mono sum. Its envelope then opens a filter and
+; an amplifier TOGETHER -- the vactrol coupling that makes a lowpass gate
+; sound unlike a VCA: quiet is dark AND quiet, loud is bright AND loud.
+;
+;   env  = max(|x| * SENS, env * fall)      fast attack, knob-set release
+;   c    = COLR + (1-COLR) * env            filter opening, 0..1
+;   y    = two cascaded one-poles at c      12 dB/oct, no resonance
+;   out  = y * env                          (LPG; VCF skips this, VCA skips
+;                                            the filter)
+;
+; Two cascaded one-poles rather than an SVF: a lowpass gate wants a gentle,
+; unresonant slope, and this costs 6 instructions a pole with no stability
+; question at any coefficient the knobs can reach.
+;
+; ⚠️ ATTACK IS FIXED AND FAST, deliberately. `max` against the rectified
+; input IS the attack, so it is instantaneous, and the release is the only
+; time constant on a knob. An LPG whose attack you can slow down stops
+; sounding like one -- it becomes a swell pedal.
+;
+; ---- knobs ----------------------------------------------------------------
+;   p0 SENS  follower drive; gain = SENS/64, so 64 is unity (a full-scale
+;            peak opens the gate fully) and 127 is ~2x for quiet material
+;   p1 FALL  release, T60 20 ms .. 700 ms on a cubic-in-rate taper.
+;            Short is plucky; long is a slow vactrol.
+;   p2 COLR  how open the filter is when the gate is SHUT, 0 .. ~0.35.
+;            0 is a true gate (shut is silent and black)
+;   p3 MIX   out = dry + MIX*(wet - dry); MIX=0 is an exact passthrough
+;   p7 MODE  0 LPG (filter+amp), 1 VCF (filter only), 2 VCA (amp only)
+;
+; ---- r7 slots -------------------------------------------------------------
+;   $20 m (MIX)      $21 sens        $22 fall        $23 colr
+;   $24 env          (PERSISTENT; bounded by construction -- it is a max of
+;                     two things that are each <= full scale, and it decays)
+;   $25 c            (per sample, the shared filter coefficient)
+;   $26/$27 pole 1/2 state L   $28/$29 pole 1/2 state R   (PERSISTENT)
+;
+; Every mpy is `mpy x0,y1` (the known-signed encoding), and every value fed
+; to one is non-negative except the audio itself, which is the FIRST operand
+; throughout. Audited by disassembly.
+; ---------------------------------------------------------------------------
+
+init:
+        rts
+
+proc:
+; ---- per-block knob decode ------------------------------------------------
+        move    x:(r6+$3),x0            ; m = MIX
+        move    x0,x:(r7+$20)
+; sens: the knob STRAIGHT THROUGH (0..0.992), doubled later in the
+; accumulator where there are guard bits.
+; ⚠️ NOT `asl #$1` here: 127<<16 doubled is 0xfe0000, which exceeds the
+; 24-bit signed range, so the STORE's limiter would clamp it to 1.0 and
+; every SENS above 64 would behave identically. Legal, silent, and half the
+; knob dead -- the store-limiter family from CLAUDE.md, in its quietest form.
+        move    x:(r6+$0),x0
+        move    x0,x:(r7+$21)
+; fall: a release COEFFICIENT is hyperbolic in decay time (T60 ~ 6.9/(1-r)),
+; so spending the knob linearly on r crams every useful value into the last
+; few steps -- Rungs' DAMP has exactly that flaw, noted there as a voicing
+; item. Here the knob is spent on the decay RATE with a cubic taper:
+;   d = d1 + (d0-d1)*(1-knob)^3,  r = 1 - d
+; which gives T60 20 / 46 / 134 / 458 / 700 ms at FALL 0 / 32 / 64 / 96 /
+; 127 -- fine control where a lowpass gate lives and a real 700 ms at the
+; top. Two multiplies for the cube.
+        move    x:(r6+$1),a
+        neg     a
+        add     #>$7fffff,a             ; u = 1 - knob
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a                 ; u^2
+        move    a,x0
+        move    x:(r6+$1),a
+        neg     a
+        add     #>$7fffff,a
+        move    a,y1                    ; u again
+        mpy     x0,y1,a                 ; u^3
+        move    a,x0
+        move    #>$f84e,y1              ; d0 - d1
+        mpy     x0,y1,a
+        add     #>$755,a                ; + d1  = the decay rate
+        neg     a
+        add     #>$7fffff,a             ; r = 1 - d
+        move    a,x:(r7+$22)
+; colr = COLR * 0.35  (the filter's floor when the gate is shut)
+        move    x:(r6+$2),x0
+        move    #>$2ccccd,y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$23)
+
+; ---- MODE: page-2 slot 7 companion (ChonVerb's decode) --------------------
+        move    x:(r6+$c),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     sz_vcf
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     sz_vca
+                                        ; 0, and anything unexpected: LPG
+
+; ===========================================================================
+; MODE 0 -- LPG: the envelope opens the filter AND the amplifier.
+; ===========================================================================
+        move    #>$1,n0
+        do      n7,>sz_endlpg
+        bsr     sz_env                  ; env -> x:(r7+$24), c -> x:(r7+$25)
+; ---- L: two poles, then the VCA -------------------------------------------
+        move    x:(r0),x0
+        bsr     sz_polel                ; filtered L in a
+        move    a,x0
+        move    x:(r7+$24),y1           ; env
+        mpy     x0,y1,a                 ; the coupled amplifier
+        bsr     sz_mixl
+; ---- R --------------------------------------------------------------------
+        move    x:(r0+n0),x0
+        bsr     sz_poler
+        move    a,x0
+        move    x:(r7+$24),y1
+        mpy     x0,y1,a
+        bsr     sz_mixr
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+sz_endlpg:
+        nop
+        rts
+
+; ===========================================================================
+; MODE 1 -- VCF: the filter follows the envelope, the level is untouched.
+; An envelope filter rather than a gate.
+; ===========================================================================
+sz_vcf:
+        move    #>$1,n0
+        do      n7,>sz_endvcf
+        bsr     sz_env
+        move    x:(r0),x0
+        bsr     sz_polel
+        bsr     sz_mixl
+        move    x:(r0+n0),x0
+        bsr     sz_poler
+        bsr     sz_mixr
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+sz_endvcf:
+        nop
+        rts
+
+; ===========================================================================
+; MODE 2 -- VCA: the envelope drives the amplifier only. A dynamics gate,
+; and the control for hearing what the filter coupling actually adds.
+; ===========================================================================
+sz_vca:
+        move    #>$1,n0
+        do      n7,>sz_endvca
+        bsr     sz_env
+        move    x:(r0),x0
+        move    x:(r7+$24),y1
+        mpy     x0,y1,a
+        bsr     sz_mixl
+        move    x:(r0+n0),x0
+        move    x:(r7+$24),y1
+        mpy     x0,y1,a
+        bsr     sz_mixr
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+sz_endvca:
+        nop
+        rts
+
+; ---------------------------------------------------------------------------
+; sz_env -- advance the follower and derive this sample's filter coefficient.
+;
+; env = max(|mono| * sens, env * fall);  c = colr + (1-colr)*env
+;
+; The max is a cmp and ONE Tcc with nothing between them (the flag-clobber
+; trap: `clr`, `and`, `abs` and every arithmetic op set the condition codes,
+; and a Tcc that reads a stale flag is the GRAIN 5d noise wash). Tcc takes a
+; REGISTER source, never an accumulator, so the candidate travels via x1.
+; ---------------------------------------------------------------------------
+sz_env:
+        move    x:(r0),a                ; mono sum of this frame
+        move    x:(r0+n0),x0
+        add     x0,a
+        asr     #$1,a,a
+        abs     a                       ; |x|, and A2 stays consistent
+        move    a,x0
+        move    x:(r7+$21),y1           ; sens
+        mpy     x0,y1,a                 ; the attack candidate
+        asl     #$1,a,a                 ; x2 HERE, in the accumulator's guard
+                                        ; bits, so SENS 64 is unity and 127 is
+                                        ; ~2x -- see the decode's note on why
+                                        ; this cannot be done at the store
+        move    #>$7fffff,x0            ; and clamp: env > 1 would make the
+        cmp     x0,a                    ; filter coefficient exceed 1 and the
+        tgt     x0,a                    ; pole unstable
+        move    a,x1                    ; -- into a REGISTER for the Tcc
+        move    x:(r7+$24),x0           ; env
+        move    x:(r7+$22),y1           ; fall
+        mpy     x0,y1,a                 ; the release path
+        cmp     x1,a                    ; nothing between this and the Tcc
+        tlt     x1,a                    ; env = max(attack, release)
+        move    a,x:(r7+$24)
+; c = colr + (1-colr)*env  ==  colr + env - colr*env
+        move    a,x0
+        move    x:(r7+$23),y1           ; colr
+        mpy     x0,y1,a                 ; colr*env
+        neg     a
+        move    x:(r7+$24),x0
+        add     x0,a                    ; env - colr*env
+        move    x:(r7+$23),x0
+        add     x0,a                    ; + colr
+        move    a,x:(r7+$25)
+        rts
+
+; ---------------------------------------------------------------------------
+; sz_polel / sz_poler -- two cascaded one-poles at this sample's coefficient.
+; In:  x0 = the sample.   Out: a = filtered.
+; Each pole is y += c*(x-y); the difference spans (-2,2), so it is halved
+; before the multiply and doubled after -- the same headroom idiom the other
+; inserts use.
+; ---------------------------------------------------------------------------
+sz_polel:
+        move    x:(r7+$26),b            ; pole 1 state
+        move    x0,a
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$25),y1           ; c
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$26)
+        move    x:(r7+$27),b            ; pole 2 state
+        move    a,x0
+        move    x0,a
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$25),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$27)
+        rts
+sz_poler:
+        move    x:(r7+$28),b
+        move    x0,a
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$25),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$28)
+        move    x:(r7+$29),b
+        move    a,x0
+        move    x0,a
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$25),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$29)
+        rts
+
+; ---------------------------------------------------------------------------
+; sz_mixl / sz_mixr -- out = dry + m*(wet - dry), written back in place.
+; In: a = wet.
+; ---------------------------------------------------------------------------
+sz_mixl:
+        move    x:(r0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)
+        rts
+sz_mixr:
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+        rts

--- a/modules/warpfold/README.md
+++ b/modules/warpfold/README.md
@@ -1,0 +1,38 @@
+# WarpFold
+
+A Mutable-Instruments-Warps-flavoured **ring modulator / wavefolder**, and the
+first module built entirely against the manifest contract (`docs/MODULES.md`)
+with no build knowledge of its own.
+
+Unlike ChonVerb and BongDelay it is a plain **per-track insert**: no bus role,
+no shared-window buffers, placed in **both payloads**, so it runs on any of
+the eight tracks and several tracks can host their own instance at once. All
+state lives in the instance's own r7 block.
+
+## Knobs
+
+| slot | name | what |
+|---|---|---|
+| p0 | DRV  | fold drive, 1–7.9×. 0 = the folder is an identity (±1 LSB) |
+| p1 | FREQ | ring carrier ~5 Hz–2.95 kHz, squared taper |
+| p2 | TONE | one-pole lowpass on the wet; 127 ≈ transparent |
+| p3 | MIX  | dry/wet; 0 = exact passthrough |
+| p7 | MODE | FOLD / RING / BOTH (fold, then ring the folded signal) |
+
+## Status
+
+- Assembles, places in both payloads (`make bus REMIX=warped`), disassembly
+  audited: every `mpy` encodes signed, no label-prefix hazards.
+- Rendered locally through `dsp_host` (payload A): MIX=0 null, DRV=0 FOLD
+  null, RING sideband placement, fold harmonics — see the build/verify notes
+  in the repo history for the measurements.
+- **Not yet flashed.** Descriptor behaviour (MODE select drawing as a 3-way,
+  knob publishes) needs the standing on-unit reconfirm any new parameter
+  rides (`docs/PARAM_PAGES.md`).
+
+## Open
+
+- Voicing pass by ear (fold curve steepness, carrier shape) once it has been
+  heard on hardware.
+- Warps' full crossfade/algorithm sweep (XFADE, analog drive model) is out of
+  scope for v1 — this is the two characters that earn the insert its slot.

--- a/modules/warpfold/manifest.py
+++ b/modules/warpfold/manifest.py
@@ -1,0 +1,69 @@
+"""WarpFold -- a Mutable-Instruments-Warps-flavoured ring modulator / wavefolder.
+
+The first OUTSIDER module: an effect built entirely against the manifest
+contract, with no build_bus.py knowledge of its own. Unlike the two servers it
+is a plain per-track INSERT -- no bus role, no shared-window buffers, placed in
+BOTH payloads -- so it runs on any of the eight tracks, and several tracks can
+run their own instance at once.
+
+Algorithm (modules/warpfold/warp_fold.asm):
+  FOLD  -- drive the input 1..8x and reflect it back through +/-1 with the
+           wrap-and-reflect identity fold(v) = 2*|wrap((v+1)/2)| - 1, computed
+           from an A1 extraction so no logical op ever leaves A2 stale.
+  RING  -- multiply by an internal carrier (triangle phase accumulator shaped
+           to a parabolic sine), ~20 Hz..3 kHz on a squared taper.
+  BOTH  -- fold first, then ring the folded signal.
+All state lives in the instance's own r7 block; persistent words are masked on
+load AND save per the two-track-freeze discipline.
+
+DRV=0 makes FOLD an exact identity and MIX=0 is an exact passthrough, so the
+effect nulls against its input at either extreme -- the render harness uses
+both as correctness gates.
+"""
+
+from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
+                          MenuEntry, Module, Param, YBase)
+
+_PLAIN = Formatter.PLAIN
+_STEP = Formatter.STEPPED
+
+MODULE = Module(
+    name="warpfold",
+    key="WARPFOLD",
+    kind=Kind.DSP_EFFECT,
+    doc="Warps-style insert: wavefolder + ring mod, FOLD/RING/BOTH.",
+    menu=MenuEntry(
+        fx2_id=0x0a,
+        donor_desc=0x400d58b8,        # DARK REV, same donor as ChonVerb
+        abbr=b"WFLD",
+        fullname=b"WarpFold",
+        build_tag=True,
+    ),
+    params=(
+        # ---- page 1 -------------------------------------------------------
+        # DRV 0 is an exact identity through the folder (gain 1x never
+        # reaches the reflection), so a fresh instance in FOLD mode passes
+        # audio untouched until the knob moves -- deliberate, after SHMR's
+        # lesson about defaults that were never revisited.
+        Param(b"DRV", 0, active=True, formatter=_PLAIN),
+        Param(b"FREQ", 48, active=True, formatter=_PLAIN),
+        # TONE 127 is the filter nearly wide open (one-pole coefficient
+        # ~0.98); it exists to tame fold harshness, not to be a filter.
+        Param(b"TONE", 127, active=True, formatter=_PLAIN),
+        Param(b"MIX", 127, active=True, formatter=_PLAIN),
+        Param(), Param(),
+        # ---- page 2: knob, select, knob, select, knob, select -------------
+        Param(),
+        Param(b"MODE", 0, 3, active=True, formatter=_STEP),   # FOLD/RING/BOTH
+        Param(), Param(), Param(), Param(),
+    ),
+    dsp=DspSection(
+        asm="modules/warpfold/warp_fold.asm",
+        priority=5,                   # after every shipping module
+        bus_role=BusRole.NONE,
+        ybase=YBase.NEVER,            # no shared-window buffers at all
+        r7_latch_slot=None,
+        gate_label=None,
+    ),
+    harness=Harness(layout_char="W", is_server=False),
+)

--- a/modules/warpfold/warp_fold.asm
+++ b/modules/warpfold/warp_fold.asm
@@ -1,0 +1,346 @@
+; ---------------------------------------------------------------------------
+; WarpFold -- a Mutable-Instruments-Warps-flavoured ring mod / wavefolder.
+;
+; A per-track INSERT, not a bus effect: it reads this track's stereo frames
+; from x:(r0)/x:(r0+n0) and writes the processed frames back in place, the
+; way the stock FX2 inserts do and the way ChonVerb writes its dry+wet. It
+; touches no bus scratch, no shared window and no absolute Y at all -- every
+; word of state lives in this instance's own r7 block, which is per instance
+; by construction (X:0x20a allocator, DSP.md section 10), so eight tracks can
+; each run their own WarpFold.
+;
+; ---- knobs (page 1 val<<16; MODE is the page-2 slot-7 companion) ----------
+;   p0 DRV   x:(r6+$0)  fold drive. gain = 1 + 7*DRV/128 (1x..7.9x). DRV=0
+;            leaves the folder an identity to within 1 LSB -- the reflection
+;            is never reached, so the only error is the wrap extraction's
+;            truncation. The render harness nulls this against the input.
+;   p1 FREQ  x:(r6+$1)  ring carrier, ~5 Hz..2.95 kHz on a squared taper:
+;            step = FREQ^2 * 0.136 + 2^-12, carrier freq = SR*step/2.
+;   p2 TONE  x:(r6+$2)  one-pole lowpass on the wet, c = 0.0078 + TONE*0.969.
+;            127 is near-transparent (c ~ 0.98); it tames fold hash, it is
+;            not meant to be a filter.
+;   p3 MIX   x:(r6+$3)  dry/wet: out = dry + MIX*(wet - dry). MIX=0 is an
+;            EXACT passthrough (the dry word is stored back untouched by
+;            arithmetic that adds exactly zero).
+;   p7 MODE  x:(r6+$c) bits 8-15 (ChonVerb's exact decode): 0 FOLD, 1 RING,
+;            2 BOTH (fold, then ring the folded signal). Anything unexpected
+;            runs FOLD.
+;
+; ---- r7 slots (this instance's own block; nothing else runs on it) --------
+;   r7+$20  carrier phase, 24-bit wrap (PERSISTENT; a garbage boot value is
+;           a legal phase, and it never becomes an address, so no mask is
+;           needed -- the two-track-freeze discipline is about AGU words)
+;   r7+$21  TONE lowpass state L (PERSISTENT; bounded (-1,1) by construction
+;           after the first block, boot garbage decays through the filter)
+;   r7+$22  TONE lowpass state R (PERSISTENT, same)
+;   r7+$23  gq   = gain/8, Q23        (per block, from DRV)
+;   r7+$24  step = carrier phase inc  (per block, from FREQ)
+;   r7+$25  c    = TONE coefficient   (per block)
+;   r7+$26  m    = MIX, Q23           (per block)
+;
+; ---- arithmetic notes (the traps this file is written around) -------------
+; * EVERY mpy is `mpy x0,y1` or `mpy y0,x0` -- the only two operand orders
+;   dsp_asm is known to encode SIGNED (CLAUDE.md: anything it does not know
+;   becomes mpysu, silently, and both operands here go negative). Audited by
+;   disassembly, not by reading this source.
+; * The fold is the wrap-and-reflect identity fold(v) = 2*|wrap((v+1)/2)|-1,
+;   with wrap done by extracting A1 -- a plain register move, so no logical
+;   op ever touches an accumulator whose extension byte then goes stale.
+;   The one `and` in the file (the MODE field mask) is followed by ChonVerb's
+;   exact A1-clean dance before the value is compared.
+; * 2|s|-1 is computed as (|s| - 0.5) << 1 so no intermediate needs +1.0,
+;   which Q23 cannot represent.
+; * mpy here is the emulator's PLAIN product (no <<1), confirmed on silicon
+;   within 13% by the decay-vs-TIME capture (docs/CAPTURE.md).
+; ---------------------------------------------------------------------------
+
+init:
+; Nothing to seed: r7 is NOT reliably set at init on hardware (the rotation
+; seeding note in modules/send/send_client.asm), and every persistent word
+; above is harmless as boot garbage.
+        rts
+
+proc:
+; ---- per-block: decode the four knobs into r7 scratch ---------------------
+; gq = 0.125 + DRV*0.875  (gain/8, so the fold stage's mpy cannot overflow)
+        move    x:(r6+$0),x0            ; DRV, val<<16, positive
+        move    #>$700000,y1            ; 0.875
+        mpy     x0,y1,a
+        add     #>$100000,a             ; + 0.125
+        move    a,x:(r7+$23)
+
+; step = FREQ^2 * 0.136 + 2^-12  (squared taper, ~5 Hz floor)
+        move    x:(r6+$1),x0
+        move    x:(r6+$1),y1
+        mpy     x0,y1,a                 ; FREQ^2
+        move    a,x0
+        move    #>$116a00,y1            ; 0.136 -> ~2.95 kHz at full knob
+        mpy     x0,y1,a
+        add     #>$800,a                ; floor: never a frozen carrier
+        move    a,x:(r7+$24)
+
+; c = 0.0078 + TONE*0.969  (one-pole coefficient; 0 would freeze the wet)
+        move    x:(r6+$2),x0
+        move    #>$7c0000,y1            ; 0.969
+        mpy     x0,y1,a
+        add     #>$10000,a              ; + 0.0078
+        move    a,x:(r7+$25)
+
+; m = MIX, straight through
+        move    x:(r6+$3),x0
+        move    x0,x:(r7+$26)
+
+; ---- MODE: page-2 slot 7 companion, bits 8-15 -- ChonVerb's exact decode --
+        move    x:(r6+$c),a
+        and     #>$ff00,a               ; slot 7's field, NOT the knob field
+        move    a1,x0                   ; AND cleans A1 only
+        move    x0,a
+        asl     #$8,a,a                 ; -> 0..2, MSB-ALIGNED ($010000 per
+                                        ; step) to match the compares below
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     wf_doring
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     wf_doboth
+                                        ; 0, and anything unexpected: FOLD
+
+; ===========================================================================
+; MODE 0 -- FOLD: wet = fold(dry * gain), tone, mix. No carrier.
+; ===========================================================================
+        move    #>$1,n0
+        do      n7,>wf_endf
+        move    x:(r0),x0               ; dry L
+        move    x:(r7+$23),y1           ; gq
+        mpy     x0,y1,a                 ; v/8       (signed encoding)
+        asl     #$2,a,a                 ; v/2
+        move    #>$400000,x1
+        add     x1,a                    ; (v+1)/2, |.| <= 4.5 -- guard bits
+        move    a1,x1                   ; s = wrap((v+1)/2), raw A1, no limiter
+        move    x1,a                    ; clean re-load: A2 consistent again
+        abs     a                       ; |s| in [0,1)
+        move    #>$400000,b
+        sub     b,a                     ; |s| - 0.5
+        asl     #$1,a,a                 ; fold in [-1,1)
+; tone L: y' = y + c*(x - y), the difference halved through the multiply
+        move    x:(r7+$21),b            ; lp state L
+        sub     b,a                     ; x - y, range (-2,2) -- stays in acc
+        asr     #$1,a,a
+        move    a,x0                    ; (x-y)/2, within +/-1
+        move    x:(r7+$25),y1           ; c
+        mpy     x0,y1,a
+        asl     #$1,a,a                 ; c*(x-y)
+        add     b,a                     ; y'
+        move    a,x:(r7+$21)
+; mix L: out = dry + m*(wet - dry)
+        move    x:(r0),b                ; dry L, still in place
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$26),y1           ; m
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)                ; L in place
+; R channel, identical, lp state $22
+        move    x:(r0+n0),x0
+        move    x:(r7+$23),y1
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    #>$400000,x1
+        add     x1,a
+        move    a1,x1
+        move    x1,a
+        abs     a
+        move    #>$400000,b
+        sub     b,a
+        asl     #$1,a,a
+        move    x:(r7+$22),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$25),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$22)
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$26),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+        move    #>$2,n0
+        move    (r0)+n0                 ; next stereo frame
+        move    #>$1,n0
+wf_endf:
+        nop
+        rts
+
+; ===========================================================================
+; MODE 1 -- RING: wet = dry * carrier, tone, mix. No fold.
+; carrier: triangle phase wrapped in A1, shaped to a parabolic sine
+;          4*p*(1-|p|) -- continuous at the wrap, exact +/-1 peaks (the
+;          store's limiter turns the exact 1.0 into $7fffff, one LSB shy).
+; ===========================================================================
+wf_doring:
+        move    #>$1,n0
+        do      n7,>wf_endr
+        move    x:(r7+$24),y0           ; step
+        move    x:(r7+$20),a            ; phase
+        add     y0,a
+        move    a1,x0                   ; p = wrapped phase
+        move    x0,x:(r7+$20)
+        move    x0,a                    ; clean
+        abs     a
+        move    #>$800000,y1            ; -1.0
+        add     y1,a                    ; |p| - 1, in [-1,0)
+        neg     a                       ; t = 1 - |p|, in (0,1]
+        move    a,y1                    ; (limiter: 1.0 -> $7fffff)
+        mpy     x0,y1,a                 ; p*t      (signed encoding)
+        asl     #$2,a,a                 ; carrier = 4*p*t
+        move    a,y0                    ; carrier, held for both channels
+; L
+        move    x:(r0),x0
+        mpy     y0,x0,a                 ; dry * carrier  (signed encoding)
+        move    x:(r7+$21),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$25),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$21)
+        move    x:(r0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$26),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)
+; R
+        move    x:(r0+n0),x0
+        mpy     y0,x0,a
+        move    x:(r7+$22),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$25),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$22)
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$26),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+wf_endr:
+        nop
+        rts
+
+; ===========================================================================
+; MODE 2 -- BOTH: wet = fold(dry * gain) * carrier, tone, mix.
+; ===========================================================================
+wf_doboth:
+        move    #>$1,n0
+        do      n7,>wf_endb
+        move    x:(r7+$24),y0           ; ---- carrier, as in RING ----
+        move    x:(r7+$20),a
+        add     y0,a
+        move    a1,x0
+        move    x0,x:(r7+$20)
+        move    x0,a
+        abs     a
+        move    #>$800000,y1
+        add     y1,a
+        neg     a
+        move    a,y1
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    a,y0                    ; carrier
+; L: fold, then ring
+        move    x:(r0),x0
+        move    x:(r7+$23),y1           ; gq
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    #>$400000,x1
+        add     x1,a
+        move    a1,x1
+        move    x1,a
+        abs     a
+        move    #>$400000,b
+        sub     b,a
+        asl     #$1,a,a                 ; fold
+        move    a,x0
+        mpy     y0,x0,a                 ; fold * carrier  (signed encoding)
+        move    x:(r7+$21),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$25),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$21)
+        move    x:(r0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$26),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)
+; R
+        move    x:(r0+n0),x0
+        move    x:(r7+$23),y1
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    #>$400000,x1
+        add     x1,a
+        move    a1,x1
+        move    x1,a
+        abs     a
+        move    #>$400000,b
+        sub     b,a
+        asl     #$1,a,a
+        move    a,x0
+        mpy     y0,x0,a
+        move    x:(r7+$22),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$25),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$22)
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$26),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+wf_endb:
+        nop
+        rts

--- a/remixes/_probe_collide.py
+++ b/remixes/_probe_collide.py
@@ -1,0 +1,4 @@
+"""_probe_collide -- deliberate collision, to watch the ledger refuse it."""
+from remix.schema import Remix
+REMIX = Remix(name="_probe_collide", doc="deliberate collision",
+              modules=("REVERB SERVER", "NIMBUS", "SEND"), fallback="SEND")

--- a/remixes/_probe_collide.py
+++ b/remixes/_probe_collide.py
@@ -1,4 +1,0 @@
-"""_probe_collide -- deliberate collision, to watch the ledger refuse it."""
-from remix.schema import Remix
-REMIX = Remix(name="_probe_collide", doc="deliberate collision",
-              modules=("REVERB SERVER", "NIMBUS", "SEND"), fallback="SEND")

--- a/remixes/mutables.py
+++ b/remixes/mutables.py
@@ -1,7 +1,8 @@
 """mutables -- the Mutable-Instruments-flavoured insert collection.
 
-Three inserts on one card: WarpFold (ring mod / wavefolder), Ripple (driven
-SVF filter) and Rungs (8-mode modal resonator). Inserts stack, unlike the
+Five inserts on one card: WarpFold (ring mod / wavefolder), Ripple (driven
+SVF filter), Rungs (8-mode modal resonator), Streamz (a vactrol lowpass
+gate) and BodeShift (a frequency shifter). Inserts stack, unlike the
 servers -- each is in both payloads, any track can host any of them, several
 at once -- so this remix carries the whole set where `warped` carries one.
 
@@ -13,7 +14,7 @@ from remix.schema import Remix
 
 REMIX = Remix(
     name="mutables",
-    doc="Three MI-flavoured inserts: WarpFold + Ripple + Rungs, + send bus.",
-    modules=("WARPFOLD", "RIPPLE", "RUNGS", "SEND"),
+    doc="Five MI-flavoured inserts: WarpFold, Ripple, Rungs, Streamz, BodeShift.",
+    modules=("WARPFOLD", "RIPPLE", "RUNGS", "STREAMZ", "BODESHIFT", "SEND"),
     fallback="SEND",
 )

--- a/remixes/mutables.py
+++ b/remixes/mutables.py
@@ -1,0 +1,19 @@
+"""mutables -- the Mutable-Instruments-flavoured insert collection.
+
+Three inserts on one card: WarpFold (ring mod / wavefolder), Ripple (driven
+SVF filter) and Rungs (8-mode modal resonator). Inserts stack, unlike the
+servers -- each is in both payloads, any track can host any of them, several
+at once -- so this remix carries the whole set where `warped` carries one.
+
+SEND is the fallback and the housekeeper, as everywhere; both servers' ids
+degrade to it. No ColdFire caves.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="mutables",
+    doc="Three MI-flavoured inserts: WarpFold + Ripple + Rungs, + send bus.",
+    modules=("WARPFOLD", "RIPPLE", "RUNGS", "SEND"),
+    fallback="SEND",
+)

--- a/remixes/nimbus.py
+++ b/remixes/nimbus.py
@@ -1,0 +1,20 @@
+"""nimbus -- the granular texture card: Nimbus alone, plus the send bus.
+
+Nimbus owns the core-private FX2 buffer region Y:0x4000-0xBFFF, which is
+only free because every other module in an insert remix has no Y footprint
+at all. That makes it a deliberately narrow selection: ONE Nimbus per core
+(two instances would share one buffer), and no server, since ChonVerb's tank
+lives in exactly that region.
+
+`mutables` carries the three zero-footprint inserts together; this remix is
+the one that needs a buffer, so it stands alone.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="nimbus",
+    doc="Nimbus granular texture + send bus. One instance per core.",
+    modules=("NIMBUS", "SEND"),
+    fallback="SEND",
+)

--- a/remixes/warped.py
+++ b/remixes/warped.py
@@ -1,0 +1,21 @@
+"""warped -- WarpFold on every track, the send bus idle underneath.
+
+The first remix built around an OUTSIDER module: WarpFold is an insert with
+no bus role, placed in BOTH payloads, so any of the eight tracks can host
+one. SEND is here as the fallback (a saved project's stale id degrades to a
+send, per the standing rule) and because a remix without it would leave
+nothing to housekeep the bus scratch; nothing consumes its accumulators in
+this selection, which is harmless -- the housekeeper clears them each block.
+
+Neither server fits beside a new effect in one donor region, so this remix
+carries neither; their ids fall back to SEND like every other absent id.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="warped",
+    doc="WarpFold insert + send bus only. No servers, no ColdFire caves.",
+    modules=("WARPFOLD", "SEND"),
+    fallback="SEND",
+)

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -606,7 +606,12 @@ if SPEC:
            # renders two engines in one script and compares byte-for-byte.
            # It only means anything where the real delay is placed (DEV/SPEC/
            # plain); the XBUS stub and BURN probe arms ignore it.
-ASM_SRC = {k: v for k, v in {"DELAY SERVER": ((os.environ.get("DLSRC") or _DEF_ASM.get("DELAY SERVER"))
+           # Any module the three special cases below do not name (a remix
+           # contribution like a new insert) builds from its manifest's
+           # declared source, unconditionally -- the probe/override arms are
+           # all reverb- or delay-shaped and do not apply to it.
+ASM_SRC = {k: v for k, v in {**_DEF_ASM,
+           "DELAY SERVER": ((os.environ.get("DLSRC") or _DEF_ASM.get("DELAY SERVER"))
                             if DEV or SPEC
                             else "dsp/silence_stub.asm" if os.environ.get("XBUS") == "1"
                             else "dsp/alias_probe.asm" if os.environ.get("BURN") == "1"
@@ -975,10 +980,22 @@ def main():
         if _dset:
             sys.exit(f"{'/'.join(_dset)} set, but remix {REMIX.name!r} "
                      f"carries no DELAY SERVER")
-    reverb_src = pathlib.Path(ASM_SRC["REVERB SERVER"]).read_text()
+    reverb_src = (pathlib.Path(ASM_SRC["REVERB SERVER"]).read_text()
+                  if "REVERB SERVER" in ASM_SRC else None)
+    if reverb_src is None:
+        # Same courtesy as the delay's guard above: every one of these arms
+        # splices into or substitutes the reverb's source, so asking for one
+        # in a remix that has no reverb is a mistake worth naming.
+        _rset = [v for v in ("NOSHIM", "MARKER", "BURN", "MODE", "PROBE",
+                             "XPROBE", "TPROBE", "RVSRC")
+                 if os.environ.get(v) is not None]
+        if _rset:
+            sys.exit(f"{'/'.join(_rset)} set, but remix {REMIX.name!r} "
+                     f"carries no REVERB SERVER")
     if os.environ.get("PROBE") == "1":
         print("  *** PROBE BUILD: ChongVerb replaced by dsp/page2_probe.asm ***")
-    send_src = pathlib.Path(ASM_SRC["SEND"]).read_text()
+    send_src = (pathlib.Path(ASM_SRC["SEND"]).read_text()
+                if "SEND" in ASM_SRC else None)
     # MODE=n substitutes a literal for the page-2 MODE read, so each character
     # can be auditioned locally. (dsp_host HAS driven companion fields via
     # -params indices 7/9/11 since 17 Aug 2026; these overrides predate that
@@ -999,7 +1016,7 @@ def main():
         cut = reverb_src[i:j].count("\n")
         reverb_src = reverb_src[:i] + "; SHIMMER REMOVED (NOSHIM=1)" + reverb_src[j:]
         print(f"  shimmer excised ({cut} lines) -- NOSHIM=1 set")
-    else:
+    elif reverb_src is not None:
         print("  shimmer IN (default) -- NOSHIM=1 to excise")
 
     # ---- MARKER=1: inject the staged audible execution marks ---------------
@@ -1367,7 +1384,8 @@ mkgo:""",
         # draft and the architecture question needs only a SERVER and a SENDER.
         # Its words are what pays for the gates (historical sizing: 507 words
         # against a region that then had 11 free).
-        send_src = xbus(send_src, "SEND", "notfirst")
+        if send_src is not None:
+            send_src = xbus(send_src, "SEND", "notfirst")
         # A PROBE build replaces the reverb's engine with a diagnostic that is
         # not a bus client at all: it has no scratch literals to relocate and
         # no housekeeping to gate, so xbus() would refuse it for lacking the
@@ -1378,7 +1396,9 @@ mkgo:""",
         # The guard stays exactly as strict for every real engine: this skips
         # the treatment for a substituted probe source, it does not weaken the
         # check for anything that is actually on the bus.
-        if not _REVERB_IS_PROBE:
+        if reverb_src is None:
+            pass                    # this remix carries no reverb at all
+        elif not _REVERB_IS_PROBE:
             reverb_src = xbus(reverb_src, "REVERB SERVER", "bus_notfirst")
         else:
             print("  XBUS: REVERB SERVER is a PROBE -- no bus scratch to move, "
@@ -1663,9 +1683,20 @@ mkgo:""",
         # region is packed in this order, so SEND first (the fallback alias
         # needs its entry points to exist) and the delay last, so the region's
         # trailing free words belong to the algorithm still being designed.
-        _texts = {"SEND": send_src, "REVERB SERVER": reverb_src}
+        _texts = {}
+        if send_src is not None:
+            _texts["SEND"] = send_src
+        if reverb_src is not None:
+            _texts["REVERB SERVER"] = reverb_src
         if delay_src is not None:
             _texts["DELAY SERVER"] = delay_src
+        # Any other selected module with DSP code loads straight from its
+        # manifest's source -- no probe arms, no override splices, no bus
+        # treatment. A module that needs any of those is one of the three
+        # named above by definition, because that is where those hooks live.
+        for _k in ORDER:
+            if _k not in _texts and _k in ASM_SRC:
+                _texts[_k] = pathlib.Path(ASM_SRC[_k]).read_text()
 
         def _ybase(m, src):
             if DEV and m.dsp.dev_pin_ybase is not None:
@@ -1913,11 +1944,16 @@ mkgo:""",
                 fh.write(term)
             print(f"  + DELAY SERVER record appended to the dump: "
                   f"P:0x{DEV_DELAY_P:05x} ({len(dev_delay)} words)")
-        print(f"\nDEV hatch ready. All three servers are real in payload A:\n"
-              f"  python3 tools/send_probe.py --mem {mem}\n"
-              f"  python3 tools/render_reverb.py loop.wav --mem {mem}\n"
-              f"DELAY SERVER is id 0x{NEW_IDS['DELAY SERVER']:02x}; "
-              f"send_probe's entry_points() resolves it from the dump.")
+        if "DELAY SERVER" in NEW_IDS:
+            print(f"\nDEV hatch ready. All three servers are real in payload A:\n"
+                  f"  python3 tools/send_probe.py --mem {mem}\n"
+                  f"  python3 tools/render_reverb.py loop.wav --mem {mem}\n"
+                  f"DELAY SERVER is id 0x{NEW_IDS['DELAY SERVER']:02x}; "
+                  f"send_probe's entry_points() resolves it from the dump.")
+        else:
+            print(f"\nDEV dump ready ({REMIX.name} carries no DELAY SERVER):\n"
+                  f"  drive dsp_host against {mem} directly, or through "
+                  f"send_probe for the modules it knows.")
 
 
 if __name__ == "__main__":

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -668,6 +668,52 @@ STOCK_DELAY_ID = 0x08
 STOCK_DELAY_P = 0x400d4ace          # DELAY's E (0x400d4a96) + 0x38
 
 
+# ---- DEV repro hooks for outsider modules ----------------------------------
+# The three core sources have their override arms written out at the top of
+# main() (MODE, DMODE, DFRZAT and the rest). A module that arrives later needs
+# the same kind of lever without another special case in the placement loop,
+# so it declares a marker in its source and a rule here.
+#
+# ⚠️ EVERY HOOK HERE IS DEV-ONLY, for the reason DFRZAT is: the counter word
+# lives at Y:0x37FFE in payload A's owned half of the shared window (init-
+# zeroed, above the bus scratch at 0x360d2), which is free ground in a DEV
+# layout and is NOT a promise about any shipping one.
+def _dev_hooks(key, src):
+    if key != "NIMBUS":
+        return src
+    at = os.environ.get("NFRZAT")
+    if at is None:
+        return src
+    # NFRZAT=n engages Nimbus's FREEZE after n post-warm-up BLOCKS instead of
+    # from sample 0. Without it the frozen cloud cannot be heard locally at
+    # all: a static FRZE=1 holds the silence the warm-up just cleared, so the
+    # only thing a render proves is that the write head stopped. Exactly the
+    # gap DFRZAT was built to close for BongDelay, and the same shape of fix.
+    if os.environ.get("DEV") is None:
+        sys.exit("NFRZAT=n is a DEV-only repro hook (its counter word lives "
+                 "in payload A's shared-window half) -- set DEV=1")
+    if src.count("; NFRZ_OVERRIDE") != 1:
+        sys.exit("NFRZAT=n set but the NIMBUS source has no single "
+                 "; NFRZ_OVERRIDE marker")
+    # Branchless, and the same shared-flag idiom as everywhere else: `sub`
+    # sets N once, the two Tcc read it, and the interleaved immediate moves
+    # do not disturb the condition codes.
+    src = src.replace(
+        "; NFRZ_OVERRIDE",
+        "        move    y:>$37ffe,a\n"
+        "        add     #>1,a\n"
+        "        move    a,y:>$37ffe\n"
+        "        move    #>%d,x0\n"
+        "        sub     x0,a\n"
+        "        move    #>0,x0\n"
+        "        tmi     x0,a\n"
+        "        move    #>1,x0\n"
+        "        tpl     x0,a" % int(at))
+    print(f"  *** NFRZAT OVERRIDE: Nimbus freezes after {int(at)} "
+          f"post-warm blocks ***")
+    return src
+
+
 def assemble(src_text, org):
     tmp = pathlib.Path("/tmp/build_bus_src.asm")
     tmp.write_text(src_text)
@@ -1691,12 +1737,12 @@ mkgo:""",
         if delay_src is not None:
             _texts["DELAY SERVER"] = delay_src
         # Any other selected module with DSP code loads straight from its
-        # manifest's source -- no probe arms, no override splices, no bus
-        # treatment. A module that needs any of those is one of the three
-        # named above by definition, because that is where those hooks live.
+        # manifest's source and gets no bus treatment, but MAY declare its own
+        # DEV repro hooks below -- the generic version of the arms the three
+        # core sources have at the top of main().
         for _k in ORDER:
             if _k not in _texts and _k in ASM_SRC:
-                _texts[_k] = pathlib.Path(ASM_SRC[_k]).read_text()
+                _texts[_k] = _dev_hooks(_k, pathlib.Path(ASM_SRC[_k]).read_text())
 
         def _ybase(m, src):
             if DEV and m.dsp.dev_pin_ybase is not None:

--- a/tools/cycle_count.py
+++ b/tools/cycle_count.py
@@ -89,8 +89,52 @@ def room_for_new_work(bank):
 # so a module moving its own source cannot leave this pointing at nothing.
 _ASM = registry.asm_by_stem()
 
-# A full bank's four FX2 slots: one reverb, one delay, two sends.
+# The LEGACY bank composition -- one reverb, one delay, two sends. This is
+# the shape BANK_AT_MEASURE was measured with on 7 Aug 2026, so the headroom
+# arithmetic below is only comparable to that measurement while the bank is
+# counted the same way. It is NOT what a core actually runs (see bank_worst).
 BANK = {"reverb_server": 1, "delay_server": 1, "send_client": 2}
+
+FX2_SLOTS = 4           # per core: four tracks, one FX2 each
+
+
+def bank_worst(rows, mods):
+    """The worst per-core load the SELECTED remix can actually be asked for.
+
+    Four FX2 slots on a core, and the modules that can occupy them are the
+    remix's own. Two rules shape the answer:
+
+      * AT MOST ONE SERVER per core. That is the standing design rule and
+        what SPEC enforces by placing only one engine per payload -- so the
+        legacy `reverb + delay + 2 sends` figure prices a core for two
+        engines no core ever pays, which PLAN.md already flags as a
+        single-core floor rather than a real configuration.
+      * INSERTS ARE UNLIMITED. Nothing stops all four tracks selecting the
+        same insert, so the worst case is four copies of the dearest one --
+        the number that matters for a card of inserts, and the one no
+        previous version of this tool could produce.
+
+    Returns (total, [(name, count), ...]).
+    """
+    cyc = {r["name"]: r["cycles"] for r in rows}
+    servers = sorted((m for m in mods if m["server"] and m["stem"] in cyc),
+                     key=lambda m: -cyc[m["stem"]])
+    others = sorted((m for m in mods if not m["server"] and m["stem"] in cyc),
+                    key=lambda m: -cyc[m["stem"]])
+    picks = []
+    if servers:
+        picks.append(servers[0]["stem"])
+    if others:
+        picks += [others[0]["stem"]] * (FX2_SLOTS - len(picks))
+    elif servers:
+        # A remix of nothing but servers cannot fill the other slots with
+        # anything of ours; those tracks run stock, which this tool does not
+        # price. Say so rather than inventing a number for them.
+        pass
+    counts = {}
+    for n in picks:
+        counts[n] = counts.get(n, 0) + 1
+    return sum(cyc[n] * c for n, c in counts.items()), sorted(counts.items())
 
 # Kept in step with build_bus.py's BURN block -- same include files, same
 # anchors. Duplicated rather than imported because build_bus.py runs a whole
@@ -168,14 +212,37 @@ def assemble(src, tag):
 
 
 def measure(name):
+    """Cycles for one module's per-sample work.
+
+    A module may carry SEVERAL `do n7` loops -- the insert modules dispatch
+    their MODE before the loop and give each mode its own, which is cheaper
+    than testing the mode per sample. Those loops are mutually exclusive by
+    construction (the dispatch branches to exactly one), so the module's
+    per-sample cost is the WORST of them, not their sum. That is the same
+    reasoning MODEFORK applies to alternatives INSIDE one loop; this is the
+    case where the fork sits outside it.
+
+    ⚠️ Summing them instead would price every mode at once -- charging a
+    five-mode module five engines and making it look unaffordable.
+    """
     src = prep(name)
     lines = src.split("\n")
 
     hits = [i for i, l in enumerate(lines) if SAMPLE_LOOP.match(l)]
-    if len(hits) != 1:
-        sys.exit(f"{name}: expected exactly one `do n7,>...` sample loop, "
-                 f"found {len(hits)}")
-    i = hits[0]
+    if not hits:
+        sys.exit(f"{name}: no `do n7,>...` sample loop found")
+    if len(hits) > 1:
+        alts = [_measure_loop(name, src, lines, i) for i in hits]
+        worst = max(alts, key=lambda m: m["cycles"])
+        others = "/".join(str(a["cycles"]) for a in alts)
+        worst = dict(worst)
+        worst["inner"] = ((worst["inner"] + ", ") if worst["inner"] else "") + \
+            f"worst of {len(alts)} mode loops ({others})"
+        return worst
+    return _measure_loop(name, src, lines, hits[0])
+
+
+def _measure_loop(name, src, lines, i):
     end_label = SAMPLE_LOOP.match(lines[i]).group(1)
 
     # The body is everything between the `do` and its end label. Refuse to
@@ -249,8 +316,33 @@ def measure(name):
             if inner_bad:
                 sys.exit(f"{name}: bsr callee {lbl} is not straight-line")
             bsr_lines[j] = (lbl, k0, k1)
+    # ---- forward skips, opted into per module -----------------------------
+    # A module may declare `; CYCLES_FORWARD_BRANCHES` in its header. Then a
+    # CONDITIONAL branch whose target label sits LATER in the same loop body
+    # is allowed, because such a branch can only SKIP code: the word span
+    # already counts what it skips, so the figure stays a ceiling for that
+    # path rather than becoming wrong. Nimbus needs this -- its per-grain
+    # scatter latches and its freeze gate are all two-instruction skips.
+    #
+    # The FORWARD test is the whole safety of it and is enforced, not
+    # trusted: a BACKWARD conditional branch is a loop, the span would count
+    # its body once, and the count would understate by however many times it
+    # went round. That is the shape this tool exists to refuse.
+    fwd_ok = set()
+    if "; CYCLES_FORWARD_BRANCHES" in src:
+        COND = re.compile(r"^\s*b(?:cc|cs|eq|ne|ge|lt|gt|le|mi|pl)\s+(\w+)", re.I)
+        for j in range(i + 1, end_line):
+            m = COND.match(lines[j])
+            if not m:
+                continue
+            tgt = m.group(1)
+            at = next((k for k, l in enumerate(lines)
+                       if l.strip().startswith(tgt + ":")), None)
+            if at is not None and j < at <= end_line:
+                fwd_ok.add(j)
     bad = [(j + 1, lines[j].strip()) for j in range(i + 1, end_line)
            if j not in shim_lines and j not in fork_lines and j not in bsr_lines
+           and j not in fwd_ok
            and CONTROL_FLOW.match(lines[j]) and not INNER_LOOP.match(lines[j])]
     if bad:
         print(f"{name}: loop body is not straight-line -- words != cycles here.",
@@ -356,7 +448,17 @@ def main():
         sys.exit(f"missing {ASM} -- run 'make setup'")
     args = sys.argv[1:]
 
-    rows = [measure(n) for n in BANK]
+    # The modules to price come from the SELECTED REMIX, not a hard-coded
+    # list -- a card of inserts and the shipping image are different loads,
+    # and until 29 Aug this tool priced chongbong's engines whatever REMIX
+    # said, which made every insert's cost an inspection guess.
+    import os
+    from remix.schema import BusRole
+    remix = registry.remix(os.environ.get("REMIX") or registry.DEFAULT_REMIX)
+    mods = [dict(stem=pathlib.Path(m.dsp.asm).stem, key=m.key,
+                 server=(m.dsp.bus_role is BusRole.SERVER))
+            for m in registry.selected(remix) if m.dsp is not None]
+    rows = [measure(m["stem"]) for m in mods]
 
     if "--verify" in args:
         for m in rows:
@@ -366,32 +468,55 @@ def main():
             if not ok:
                 sys.exit("marker changed codegen -- the count is not trustworthy")
 
-    bank = sum(m["cycles"] * BANK[m["name"]] for m in rows)
-
-    room = room_for_new_work(bank)
+    worst, picks = bank_worst(rows, mods)
+    # The legacy composition, and ONLY when the remix still carries the
+    # modules it was measured with -- otherwise the comparison to the 7 Aug
+    # hardware sweep is against a bank that shares nothing with it.
+    legacy = ({m["name"]: m["cycles"] for m in rows}
+              if all(k in {r["name"] for r in rows} for k in BANK) else None)
+    bank = sum(legacy[k] * n for k, n in BANK.items()) if legacy else None
+    room = room_for_new_work(bank) if bank is not None else None
 
     if "--json" in args:
-        print(json.dumps(dict(per_effect={m["name"]: m["cycles"] for m in rows},
+        print(json.dumps(dict(remix=remix.name,
+                              per_effect={m["name"]: m["cycles"] for m in rows},
+                              worst_core=worst,
+                              worst_core_mix=dict(picks),
                               bank=bank, headroom=room,
                               burn_spare_measured=BURN_SPARE,
                               bank_at_measure=BANK_AT_MEASURE,
                               core_total=CORE_TOTAL), indent=2))
         return
 
-    w = max(len(m["name"]) for m in rows)
-    print(f"{'':{w}}  cycles/sample   in a bank")
+    w = max(max(len(m["name"]) for m in rows), 17)
+    print(f"remix {remix.name!r}\n")
+    print(f"{'':{w}}  cycles/sample")
     for m in rows:
-        n = BANK[m["name"]]
-        extra = f"   [rolled: {m['inner']}]" if m["inner"] else ""
-        print(f"{m['name']:{w}}  {m['cycles']:>13}   x{n} = {m['cycles'] * n}{extra}")
-    print(f"{'full bank':{w}}  {'':>13}   {bank}")
+        extra = f"   [{m['inner']}]" if m["inner"] else ""
+        print(f"{m['name']:{w}}  {m['cycles']:>13}{extra}")
+    print()
+    mix = " + ".join(f"{n}x {k}" for k, n in picks) or "(nothing of ours)"
+    print(f"{'WORST ONE CORE':{w}}  {worst:>13}   {mix}")
+    print(f"{'':{w}}  {'':>13}   4 FX2 slots, at most one server (the design rule)")
+    if worst > CORE_TOTAL:
+        print(f"{'':{w}}  {'':>13}   *** OVER the arithmetic ceiling ***")
     # The measured spare is what was left ON TOP of a full bank plus four FX1
     # FILTERs, so it is headroom for NEW work, not a number the bank is scored
     # against. Printing "% used" against a fixed budget is exactly what made
     # 1080 dangerous -- it turned an unknown into a pass/fail.
     print(f"{'budget/core':{w}}  {CORE_TOTAL:>13}   (200 MIPS / 44.1 kHz)")
+    if bank is None:
+        print()
+        print("  This remix carries none of the modules the 7 Aug hardware sweep")
+        print("  was measured with, so the headroom arithmetic below does not")
+        print(f"  apply to it. What can be said: the worst core costs {worst},")
+        print(f"  against ~{CORE_TOTAL - 1410} usable after stock's own ~1410 -- and")
+        print("  the wall is a CLIFF, not a slope. Only a burn sweep measures it.")
+        return
     print(f"{'MEASURED spare':{w}}  {BURN_SPARE:>13}   on a {BANK_AT_MEASURE}-cycle bank "
           f"+ 4x FX1 FILTER (hardware, 7 Aug 2026)")
+    print(f"{'legacy bank':{w}}  {bank:>13}   reverb + delay + 2 sends, the composition"
+          f"\n{'':{w}}  {'':>13}   that measurement was made against (NOT a real core)")
     grown = bank - BANK_AT_MEASURE
     print(f"{'bank has grown by':{w}}  {grown:>13}   since that measurement")
     print(f"{'room for new work':{w}}  {room:>13}   cycles/sample"

--- a/tools/remix/ledger.py
+++ b/tools/remix/ledger.py
@@ -97,6 +97,22 @@ def check(selected) -> list[str]:
                           f"the first, so the first module never runs")
                 hooks[c.hook_addr] = m.name
 
+    # ---- the per-core FX2 instance buffer region --------------------------
+    # Y:0x4000-0xBFFF is TWO FX2 instance slots of 16,384 words, per core and
+    # not per instance in any sense a module can rely on: ChonVerb hardcodes
+    # its tank there and Nimbus hardcodes its granular line there, so two of
+    # them on one core write over each other. Each works perfectly alone.
+    # Declared rather than scanned -- see Claims.owns_fx2_buffers for why a
+    # scan cannot tell an address from a mask.
+    buf = [m for m in selected
+           if getattr(m, "claims", None) is not None
+           and m.claims.owns_fx2_buffers]
+    for i, a in enumerate(buf):
+        for b in buf[i + 1:]:
+            clash("FX2 instance buffers", a.name, b.name,
+                  "Y:0x4000-0xBFFF -- that region is per CORE, so only one "
+                  "of them can be hosted on a given core; each works alone")
+
     # ---- core-private Y ---------------------------------------------------
     # Low Y is per CORE. Two effects that can share a core share these words,
     # so this is checked across every selected module, not per payload.

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -223,6 +223,26 @@ class Claims:
     """
 
     reserved_private_y: tuple[int, ...] = ()
+    # Does this module hold memory in the per-core FX2 INSTANCE BUFFER region
+    # Y:0x4000-0xBFFF? ChonVerb's eight tank lines live there and so does
+    # Nimbus's granular line, and two such modules on one core silently
+    # corrupt each other -- each works perfectly alone, which is the worst
+    # shape a defect can have.
+    #
+    # DECLARED, where private-Y is derived, and the difference is not
+    # laziness. A source scan cannot tell an address from a mask or a
+    # constant: scanning for this range flags `and #>$7fff` and every
+    # coefficient that happens to land in it, and docs/DSP.md 7c records
+    # that static scanning could not find even the STOCK reverbs' buffers,
+    # because they compute their bases at runtime. A checker that fires on
+    # six modules out of eight teaches people to ignore it.
+    #
+    # ⚠️ This is narrower than "the shared 64K window", which PLAN.md still
+    # lists as unledgered: this region's extents are established (DSP.md's
+    # load map -- 2 FX2 instances of 16,384 words), so it can be written
+    # down honestly. The shared window's are not, and a plausible claim
+    # there would read as a guarantee.
+    owns_fx2_buffers: bool = False
 
 
 @dataclass(frozen=True)

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -20,7 +20,7 @@ from remix.schema import (CavePatch, Claims, DspSection, Kind, MenuEntry,  # noq
                           Module, Param)
 
 
-def _effect(name, fx2_id, priority=0, reserved=()):
+def _effect(name, fx2_id, priority=0, reserved=(), buffers=False):
     return Module(
         name=name, key=name.upper(), kind=Kind.DSP_EFFECT,
         doc="fixture",
@@ -31,7 +31,8 @@ def _effect(name, fx2_id, priority=0, reserved=()):
         # the reserved words below are claimed -- which is what lets these
         # fixtures test the claim path in isolation.
         dsp=DspSection(asm="does/not/exist.asm", priority=priority),
-        claims=Claims(reserved_private_y=reserved),
+        claims=Claims(reserved_private_y=reserved,
+                      owns_fx2_buffers=buffers),
     )
 
 
@@ -57,6 +58,12 @@ CASES = [
     ("two effects claiming one core-private Y word",
      [_effect("alpha", 0x07, reserved=(0x0905,)),
       _effect("beta", 0x08, reserved=(0x0905,))], "core-private Y"),
+    # The shape this one guards is a module that works perfectly in every
+    # test done alone: ChonVerb's tank and Nimbus's granular line are both
+    # hardcoded into Y:0x4000-0xBFFF, which is per CORE.
+    ("two effects owning the FX2 instance buffer region",
+     [_effect("alpha", 0x07, buffers=True),
+      _effect("beta", 0x08, buffers=True)], "FX2 instance buffers"),
 ]
 
 CLEAN = [_effect("alpha", 0x07, reserved=(0x0905,)),

--- a/tools/remix/tui.py
+++ b/tools/remix/tui.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""The remix workbench: compose a selection, see what it costs, build it.
+
+    make remix          (or: python3 tools/remix/tui.py)
+
+WHY THIS EXISTS. `make modules` prints the index and `make bus REMIX=<name>`
+builds one, which is enough while there are two remixes and one author. It
+stops being enough the moment a selection is a real choice: the things you
+want to know before building -- do these modules collide, does the set fit
+the donor region, what does the panel end up looking like -- are spread
+across the ledger, the build report and the manifests, and the only way to
+see them together was to run a build and read 200 lines of output.
+
+So this is a composer, not a launcher. Toggle modules, and the panel on the
+right answers those three questions continuously, from the same statements
+the build reads (`registry`, `ledger`, and each module's manifest). Nothing
+here re-derives a fact the build derives -- a second copy of the knob map or
+the id table is precisely the defect the manifest was introduced to end.
+The word counts are the one thing it cannot know without assembling, so it
+assembles them: `w` runs a real build and keeps the reported figures.
+
+CURSES, not a framework, because the repo has no runtime dependencies and
+this is not worth acquiring one for.
+
+KEYS
+    up/down k j    move          space  toggle the module under the cursor
+    a / n          all / none    f      make it the fallback
+    l              load a remix  s      save the selection as a remix
+    w              assemble and report words (a real build)
+    b              build the image        c   make check
+    q              quit
+"""
+
+from __future__ import annotations
+
+import curses
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import textwrap
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from remix import ledger, registry  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+DONOR_WORDS = 2724          # per payload; build_bus.py prints the live figure
+
+
+class State:
+    def __init__(self):
+        self.mods = registry.modules()
+        self.keys = sorted(self.mods)
+        self.sel: set[str] = set()
+        self.fallback: str | None = None
+        self.cursor = 0
+        self.words: dict[str, int] = {}      # key -> words, from a real build
+        self.words_from = ""                 # which remix produced them
+        self.msg = "space toggles; w assembles for word counts; ? for keys"
+        self.load("chongbong" if "chongbong" in registry.remix_names()
+                  else (registry.remix_names() or [None])[0])
+
+    # ---- selection ----------------------------------------------------
+    def load(self, name):
+        if not name:
+            return
+        r = registry.remix(name)
+        self.sel = set(r.modules)
+        self.fallback = r.fallback
+        self.msg = f"loaded remix {name!r}"
+
+    def toggle(self, key):
+        if key in self.sel:
+            self.sel.discard(key)
+            if self.fallback == key:
+                self.fallback = None
+        else:
+            self.sel.add(key)
+
+    @property
+    def selected(self):
+        return [self.mods[k] for k in self.keys if k in self.sel]
+
+    @property
+    def menu_modules(self):
+        """Selected modules that appear in the FX2 chooser, in panel order."""
+        return [m for m in self.selected if m.menu is not None]
+
+    # ---- what the selection costs and whether it is legal ---------------
+    def problems(self):
+        """Everything that would stop this selection building, in one list.
+
+        The collisions come from the ledger -- the same call the build makes,
+        not a reimplementation. The rest are the two rules a remix has to
+        satisfy that the ledger does not speak to.
+        """
+        out = list(ledger.check(self.selected))
+        if not self.menu_modules:
+            out.append("no module with a menu entry: nothing would be "
+                       "selectable on the panel")
+        if self.fallback is None:
+            out.append("no fallback: an id this image does not implement "
+                       "would dispatch into whatever occupies its slot")
+        elif self.fallback not in self.sel:
+            out.append(f"fallback {self.fallback!r} is not in the selection")
+        elif self.mods[self.fallback].menu is None:
+            out.append(f"fallback {self.fallback!r} has no menu entry, so "
+                       f"ids aliased to it would dispatch nowhere")
+        # A module whose words we know, summed against the region it must fit.
+        known = [k for k in self.sel if k in self.words]
+        if known and len(known) == len([k for k in self.sel
+                                        if self.mods[k].dsp is not None]):
+            total = sum(self.words[k] for k in known)
+            if total > DONOR_WORDS:
+                out.append(f"{total} words exceeds the {DONOR_WORDS}-word "
+                           f"donor region by {total - DONOR_WORDS}")
+        return out
+
+    # ---- the one thing that needs a real build --------------------------
+    def measure(self, note):
+        """Assemble this selection and keep the words the build reports.
+
+        Writes a scratch remix rather than guessing: the placement order,
+        the payload gating and the per-module substitutions all affect the
+        count, and only the build knows them. The build report is API
+        (verify_delay and friends parse it), which is why this can parse it.
+        """
+        tmp = ROOT / "remixes/_tui_scratch.py"
+        tmp.write_text(self.as_remix("_tui_scratch",
+                                     "scratch selection from the remix TUI"))
+        try:
+            env = {**os.environ, "REMIX": "_tui_scratch",
+                   "XBUS": "1", "SPEC": "1"}
+            r = subprocess.run([sys.executable, "tools/build_bus.py"],
+                               cwd=ROOT, env=env, capture_output=True,
+                               text=True)
+            if r.returncode != 0:
+                tail = (r.stdout + r.stderr).strip().splitlines()
+                return False, (tail[-1] if tail else "build failed")
+            words, free = {}, None
+            for line in r.stdout.splitlines():
+                m = re.match(r"\s{2}(\S.*?)\s+P:0x[0-9a-f]+\.\.0x[0-9a-f]+"
+                             r"\s+\(\s*(\d+) words\)", line)
+                if m and m.group(1).strip() in self.mods:
+                    words[m.group(1).strip()] = int(m.group(2))
+                m = re.search(r"used (\d+)\s+FREE (\d+)", line)
+                if m:
+                    free = (int(m.group(1)), int(m.group(2)))
+            self.words.update(words)
+            self.words_from = note
+            if free:
+                return True, (f"assembled: {free[0]} words used, "
+                              f"{free[1]} free in the donor region")
+            return True, "assembled"
+        finally:
+            tmp.unlink(missing_ok=True)
+            for junk in (ROOT / "remixes/__pycache__").glob("_tui_scratch*"):
+                junk.unlink(missing_ok=True)
+
+    # ---- saving ---------------------------------------------------------
+    def as_remix(self, name, doc):
+        mods = ", ".join(f'"{k}"' for k in self.keys if k in self.sel)
+        return (f'"""{name} -- {doc}\n\n'
+                f'Written by tools/remix/tui.py. Edit freely: the docstring\n'
+                f'is the only thing here a human is expected to improve.\n'
+                f'"""\n\n'
+                f'from remix.schema import Remix\n\n'
+                f'REMIX = Remix(\n'
+                f'    name="{name}",\n'
+                f'    doc="{doc}",\n'
+                f'    modules=({mods},),\n'
+                f'    fallback="{self.fallback}",\n'
+                f')\n')
+
+
+# ---- drawing ---------------------------------------------------------------
+def draw(scr, st):
+    scr.erase()
+    h, w = scr.getmaxyx()
+    if h < 12 or w < 76:
+        scr.addstr(0, 0, "window too small (needs 76x12)"[:max(w - 1, 0)])
+        scr.refresh()
+        return
+    left = min(46, w // 2)
+
+    def put(y, x, s, attr=0, width=None):
+        limit = (width if width is not None else w - x) - 1
+        if 0 <= y < h and limit > 0:
+            scr.addstr(y, x, s[:limit], attr)
+
+    put(0, 0, " remix workbench ".ljust(w - 1), curses.A_REVERSE)
+
+    # ---- module list --------------------------------------------------
+    put(2, 0, "MODULES", curses.A_BOLD)
+    y = 3
+    for i, k in enumerate(st.keys):
+        m = st.mods[k]
+        on = k in st.sel
+        mark = "x" if on else " "
+        fb = "*" if st.fallback == k else " "
+        wd = f"{st.words[k]:>5}w" if k in st.words else "     -"
+        idtxt = f"0x{m.menu.fx2_id:02x}" if m.menu else " -- "
+        line = f" [{mark}]{fb} {m.name:<11} {idtxt} {wd}"
+        attr = curses.A_REVERSE if i == st.cursor else (
+            curses.A_BOLD if on else curses.A_DIM)
+        put(y, 0, line.ljust(left - 1), attr, left)
+        y += 1
+
+    y += 1
+    put(y, 0, "REMIXES", curses.A_BOLD); y += 1
+    names = registry.remix_names()
+    put(y, 1, textwrap.shorten(" ".join(n for n in names
+                                        if not n.startswith("_")),
+                               left - 3, placeholder=" ..."), 0, left)
+
+    # ---- the panel: what this selection IS ----------------------------
+    x = left + 1
+    for row in range(2, h - 3):
+        put(row, left, "|", curses.A_DIM)
+    ry = 2
+    put(ry, x, "THIS SELECTION", curses.A_BOLD); ry += 2
+
+    menu = st.menu_modules
+    put(ry, x, f"panel: {len(menu)} entries" + (
+        "" if menu else "  (nothing selectable!)")); ry += 1
+    for i, m in enumerate(menu):
+        star = " <- fallback" if m.key == st.fallback else ""
+        put(ry, x + 2, f"{i}. {m.menu.fullname.decode('latin1'):<13}"
+                       f"0x{m.menu.fx2_id:02x}{star}")
+        ry += 1
+    absent = [m for m in st.mods.values()
+              if m.menu is not None and m.key not in st.sel]
+    if absent and st.fallback:
+        ry += 1
+        put(ry, x, f"{len(absent)} absent id(s) alias to "
+                   f"{st.mods[st.fallback].name}", curses.A_DIM); ry += 1
+
+    # words
+    ry += 1
+    dsp = [m for m in st.selected if m.dsp is not None]
+    known = [m for m in dsp if m.key in st.words]
+    if known:
+        total = sum(st.words[m.key] for m in known)
+        partial = "" if len(known) == len(dsp) else \
+                  f" ({len(known)}/{len(dsp)} measured)"
+        put(ry, x, f"program: {total} of {DONOR_WORDS} words{partial}",
+            curses.A_BOLD if total > DONOR_WORDS else 0); ry += 1
+        bar_w = max(10, min(w - x - 2, 40))
+        fill = min(bar_w, round(bar_w * total / DONOR_WORDS))
+        put(ry, x, "[" + "#" * fill + "." * (bar_w - fill) + "]",
+            curses.A_REVERSE if total > DONOR_WORDS else 0); ry += 1
+        if st.words_from:
+            put(ry, x, f"measured from: {st.words_from}", curses.A_DIM); ry += 1
+    else:
+        put(ry, x, "program: press w to assemble and measure",
+            curses.A_DIM); ry += 1
+
+    # problems -- the whole point
+    ry += 1
+    probs = st.problems()
+    if probs:
+        put(ry, x, f"WILL NOT BUILD ({len(probs)})", curses.A_BOLD); ry += 1
+        for p in probs:
+            for chunk in textwrap.wrap(p, max(20, w - x - 3))[:3]:
+                put(ry, x + 1, chunk); ry += 1
+    else:
+        put(ry, x, "no LEDGER collisions -- this selection builds",
+            curses.A_BOLD); ry += 1
+        # ⚠️ NEVER let that read as "this selection is safe". The ledger does
+        # not check the shared 64K window or the FX2 instance buffers, and
+        # those are where the expensive overlaps have actually happened --
+        # a delay based on the reverb's buffers, a bus scratch swept every
+        # 16,384 samples. Modules that own memory say so in prose, so the
+        # panel says which ones and lets the reader do the arithmetic the
+        # tool cannot. Naming the specific claimants beats a generic
+        # disclaimer, which is the kind of warning people learn to skip.
+        put(ry, x, "not checked: the shared 64K window", curses.A_DIM)
+        ry += 1
+        put(ry, x, "(PLAN.md) -- see CLAUDE.md for who owns what",
+            curses.A_DIM); ry += 1
+        buffered = [m for m in st.selected
+                    if getattr(m, "claims", None) is not None
+                    and m.claims.owns_fx2_buffers]
+        if buffered:
+            ry += 1
+            put(ry, x, f"{buffered[0].name} owns Y:0x4000-0xBFFF, so it "
+                       f"must be", curses.A_DIM); ry += 1
+            put(ry, x, "the only such module on its core", curses.A_DIM)
+            ry += 1
+
+    put(h - 2, 0, st.msg[:w - 1], curses.A_DIM)
+    put(h - 1, 0, (" space toggle  f fallback  w words  b build  c check  "
+                   "l load  s save  q quit").ljust(w - 1), curses.A_REVERSE)
+    scr.refresh()
+
+
+def prompt(scr, question):
+    h, w = scr.getmaxyx()
+    curses.echo()
+    scr.addstr(h - 2, 0, (question + " ").ljust(w - 1), curses.A_REVERSE)
+    scr.clrtoeol()
+    try:
+        s = scr.getstr(h - 2, len(question) + 1, 40).decode().strip()
+    except Exception:
+        s = ""
+    curses.noecho()
+    return s
+
+
+def shell_out(scr, argv, env=None):
+    """Drop out of curses to run a build, so its output is the real thing."""
+    curses.endwin()
+    print("\n$ " + " ".join(argv) + "\n")
+    r = subprocess.run(argv, cwd=ROOT, env={**os.environ, **(env or {})})
+    input("\n[enter] to return to the workbench ")
+    scr.clear()
+    curses.doupdate()
+    return r.returncode
+
+
+def main(scr):
+    curses.curs_set(0)
+    st = State()
+    while True:
+        draw(scr, st)
+        try:
+            c = scr.getch()
+        except KeyboardInterrupt:
+            return
+        k = st.keys[st.cursor] if st.keys else None
+        if c in (ord("q"), 27):
+            return
+        elif c in (curses.KEY_DOWN, ord("j")):
+            st.cursor = min(len(st.keys) - 1, st.cursor + 1)
+        elif c in (curses.KEY_UP, ord("k")):
+            st.cursor = max(0, st.cursor - 1)
+        elif c == ord(" ") and k:
+            st.toggle(k)
+        elif c == ord("a"):
+            st.sel = set(st.keys)
+        elif c == ord("n"):
+            st.sel, st.fallback = set(), None
+        elif c == ord("f") and k:
+            if k in st.sel and st.mods[k].menu is not None:
+                st.fallback = k
+                st.msg = f"fallback: {st.mods[k].name}"
+            else:
+                st.msg = "the fallback must be selected and have a menu entry"
+        elif c == ord("l"):
+            name = prompt(scr, "load remix:")
+            if name:
+                try:
+                    st.load(name)
+                except SystemExit as e:
+                    st.msg = str(e)
+        elif c == ord("s"):
+            probs = st.problems()
+            if probs:
+                st.msg = f"refusing to save: {probs[0]}"
+            else:
+                name = prompt(scr, "save as remix:")
+                if name:
+                    if not re.fullmatch(r"[a-z][a-z0-9_]*", name):
+                        st.msg = "name must be lowercase [a-z][a-z0-9_]*"
+                    else:
+                        doc = prompt(scr, "one-line description:") or \
+                              "a selection composed in the remix TUI"
+                        p = ROOT / f"remixes/{name}.py"
+                        if p.exists() and prompt(
+                                scr, f"{name}.py exists -- overwrite? [y/N]"
+                        ).lower() != "y":
+                            st.msg = "not saved"
+                        else:
+                            p.write_text(st.as_remix(name, doc))
+                            st.msg = f"wrote remixes/{name}.py"
+        elif c == ord("w"):
+            st.msg = "assembling..."
+            draw(scr, st)
+            ok, msg = st.measure("this selection")
+            st.msg = msg
+        elif c in (ord("b"), ord("c")):
+            probs = st.problems()
+            if probs:
+                st.msg = f"refusing: {probs[0]}"
+                continue
+            name = prompt(scr, "build which saved remix? [name]:")
+            if not name:
+                st.msg = ("build runs a SAVED remix -- press s to save this "
+                          "selection first")
+                continue
+            target = "bus" if c == ord("b") else "check"
+            shell_out(scr, ["make", target, f"REMIX={name}"])
+            st.msg = f"make {target} REMIX={name} finished"
+
+
+if __name__ == "__main__":
+    if not sys.stdout.isatty():
+        sys.exit("the remix workbench needs a terminal (try: make remix)")
+    curses.wrapper(main)

--- a/tools/verify_menu.py
+++ b/tools/verify_menu.py
@@ -33,10 +33,11 @@ to what task 11 needs to prove (the five tables agree with each other and
 with what the two real functions read). This is "measure, don't guess" in the
 form the ColdFire side allows without a full UI emulation harness.
 """
-import pathlib, sys
+import os, pathlib, sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
 from dsp_modmap import BASE  # noqa: E402
+from remix import registry as _reg  # noqa: E402
 
 STOCK = pathlib.Path("out/raw/section_3_MAIN_OS.bin")
 BUILT = pathlib.Path("out/mainos_bus.bin")
@@ -48,9 +49,18 @@ LIST_REFS = [0x400375f4, 0x40052496, 0x40059a42]
 FX1_ID_LOOKUP = 0x400d5f58
 FX1_CHOOSER = 0x400d6060
 
-# name -> (effect id, chooser position). NONE occupies position 0.
-EXPECT = {"REVERB SERVER": (0x07, 0), "DELAY SERVER": (0x06, 1), "SEND": (0x09, 2)}
+# name -> (effect id, chooser position), derived from the SELECTED REMIX
+# (REMIX=<name> env, same default as the build) -- the image being verified
+# is whatever remix was built last, so the expectations must come from the
+# same selection or every check below compares against the wrong menu. This
+# table was hand-written for the shipping trio until the first outsider
+# module made a per-remix hand copy impossible (29 Aug 2026).
+REMIX = _reg.remix(os.environ.get("REMIX") or _reg.DEFAULT_REMIX)
+_MODS = _reg.modules()
+_ORDER = [k for k in REMIX.modules if _MODS[k].menu is not None]
+EXPECT = {k: (_MODS[k].menu.fx2_id, i) for i, k in enumerate(_ORDER)}
 N_REAL = len(EXPECT)                    # no NONE entry any more
+FALLBACK = REMIX.fallback               # id 0 and every absent id alias here
 ROWCOUNT_AT = 0x40059a56
 NONE_ID = 0x00                          # aliased to SEND
 
@@ -58,23 +68,17 @@ NONE_ID = 0x00                          # aliased to SEND
 P_PARAM_NAMES = 0x16
 P_PENABLE_LO = 0x18e                    # params 0..7, one nibble each
 P_PENABLE_HI = 0x18a                    # params 8..11
-# which knobs each effect's DSP code actually reads (mirrors build_menu.py)
-ACTIVE_PARAMS = {
-    # v2 stage 5 fills page 2: WOW(6) MODE(7) VRBD(8) PTCH(9) SPRA(10) FRZE(11)
-    # -- three knobs and three selects, which is the hardware budget exactly.
-    # ⚠️ 6 and 11 were implemented, named, defaulted and counted by stages 3/4
-    # and never enabled, so they shipped undrawable; this check is an
-    # INDEPENDENT copy of build_bus.py's list on purpose (it reads the built
-    # image, not the source of truth that built it), so it could not catch
-    # that -- both lists were simply missing the same slots.
-    # v3 stage 1 retired 5 (VRBW) and 8 (VRBD): ->VERB is hardwired and its
-    # DRY half is gone. Independent copy, as above -- kept in step by hand.
-    "DELAY SERVER": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],  # + p8 RATE (18 Aug 2026)
-    # v92 page-2 rejig: all twelve. Even page-2 slots are knob fields, odd ones
-    # are companion fields of the same word (DSP.md section 9).
-    "REVERB SERVER": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],  # p11 = RATE (18 Aug 2026)
-    "SEND": [0, 1],
-}
+# Which knobs each effect draws -- from the manifests, the same statement the
+# build reads. This USED to be a deliberately independent hand copy of
+# build_bus.py's list (its old comment told the story of slots 6/11 shipping
+# undrawable because both hand copies were missing the same entries). Remixes
+# ended that arrangement: a per-remix hand table cannot be kept, and the
+# manifest is now the single declaration both sides read. What this check
+# still proves byte-for-byte is that the BUILD PASS wrote what the manifest
+# declares -- the R19 formatter-gate class of bug. What no static check can
+# see is a manifest that under-declares its own effect; that class rides the
+# standing on-unit reconfirm rule (docs/PARAM_PAGES.md).
+ACTIVE_PARAMS = {k: _MODS[k].active_params for k in _ORDER}
 
 
 # P-relative: the per-parameter value-COUNT array and the defaults array.
@@ -135,13 +139,13 @@ def main():
     rows = int.from_bytes(img[ROWCOUNT_AT - BASE:ROWCOUNT_AT - BASE + 2], "big")
     check(rows == N_REAL, f"viewport row count == {N_REAL} (got {rows})")
 
-    print("\n=== id 0 (a fresh/unassigned track) is aliased to SEND, so every "
-          "track sends by default and always does the bus housekeeping ===")
-    send_p = rd32(img, FX2_IDS + EXPECT["SEND"][0] * 4)
-    check(rd32(img, FX2_IDS + NONE_ID * 4) == send_p,
-          f"FX2_IDS[0x00] == SEND's descriptor (0x{send_p:08x})")
-    check(rd32(img, ID2POS + NONE_ID * 4) == EXPECT["SEND"][1],
-          f"ID2POS[0x00] == SEND's position ({EXPECT['SEND'][1]})")
+    print(f"\n=== id 0 (a fresh/unassigned track) is aliased to the remix's "
+          f"fallback ({FALLBACK}), so every track degrades to it by default ===")
+    fb_p = rd32(img, FX2_IDS + EXPECT[FALLBACK][0] * 4)
+    check(rd32(img, FX2_IDS + NONE_ID * 4) == fb_p,
+          f"FX2_IDS[0x00] == {FALLBACK}'s descriptor (0x{fb_p:08x})")
+    check(rd32(img, ID2POS + NONE_ID * 4) == EXPECT[FALLBACK][1],
+          f"ID2POS[0x00] == {FALLBACK}'s position ({EXPECT[FALLBACK][1]})")
 
     print("\n=== FUN_40052474: list[cursor] and FUN_4005996c/FUN_400326d4's "
           "independent FX2_IDS[id] lookup must resolve to the SAME "


### PR DESCRIPTION
Six new effect modules, all built against the manifest contract in `docs/MODULES.md` with no build knowledge of their own — the first real test of the remix platform by contribution rather than refactor.

## The modules

All six are per-track **inserts**: no bus role, placed in *both* payloads, runnable on any of the eight tracks with several at once. That is a class the servers cannot be, and it is why they stack onto one card.

| module | what | words | cycles/sample |
|---|---|---|---|
| `warpfold` | Warps-ish ring mod + wavefolder, FOLD/RING/BOTH | 322 | 101 |
| `ripple` | Ripples-ish driven SVF, LP/BP/HP, Q≈30 | 347 | 93 |
| `rungs` | Rings-ish 8-mode modal resonator, STRING/BELL/GLASS | 880 | 238 |
| `streamz` | Streams-ish vactrol lowpass gate, LPG/VCF/VCA | 255 | 154 |
| `bodeshift` | Warps-ish Bode frequency shifter, UP/DOWN/WIDE + feedback | 391 | 344 |
| `nimbus` | Clouds-ish granular texture over a 743 ms line, + freeze | 500 | 327 |

New remixes: `mutables` (five zero-buffer inserts + send, 2,410/2,724 words), `warped`, `nimbus` (its own, see below).

## Evidence, not assertion

Every module has a bit-exact `MIX=0` null and was disassembly-audited — every `mpy`/`mac` confirmed to encode signed, which is not optional when both operands go negative. Beyond that, each was measured against a prediction:

- **`bodeshift`** was derived against a float model *first*, which caught the sideband sign convention before a line of assembly existed — the obvious form produced the wrong sideband while sounding entirely plausible. On the DSP: wanted sideband at unity, suppression 41.5/29.6/18.7 dB at 440 Hz/1 kHz/5 kHz (model: 40.8/29.2/18.6), shift frequency exact to **0.00 Hz** across the knob, feedback stable at maximum.
- **`nimbus`**: DC in comes back flat to −122 dB, which is what proves the grain pair sums to constant power.
- **`streamz`**: release T60 26/52/139/479/731 ms against a 20/46/134/458/700 ms design; the vactrol coupling measured as a spectral centroid of 9,880 Hz on loud material vs 2,620 Hz on the same material quiet.
- **`rungs`**: partials land within 0.15% of their ratio tables.
- **`ripple`**: LP slope −13.8 dB where 2-pole theory says −14.4; all-knobs-at-127 decays clean.

## A new trap for CLAUDE.md

Nimbus's grain window found one: **reading `a0` exposes the fractional left shift that reading `a1` hides**, so an `a0`-based integer scale is 2× the multiplier. The arithmetically obvious constant assembled, rendered, and made perfectly plausible granular noise while running the window at double rate — the two grains of each pair landing in phase instead of interleaving. Only a DC gate caught it. The project's standing "mpy does not double here" note remains true, and this says why: every other module reads `a1`.

## Platform work this forced

- **`build_bus.py` generalized**: it hard-required the reverb and send sources and only ever placed three named modules. Proven inert under `scripts/refhash.sh` — all 26 cases bit-identical before any new module existed.
- **`verify_menu` is remix-derived** rather than carrying a hand-written chongbong table.
- **`make remix`** — a stdlib-curses workbench that composes a selection, shows ledger collisions and the panel it produces live, measures word cost via a real scratch build, and saves remixes. Stdlib because the repo has no runtime dependencies.
- **A new ledger rule**: building the TUI exposed that it cheerfully blessed ChonVerb + Nimbus, which *corrupts* — both hardcode buffers into the per-core `Y:0x4000–0xBFFF`, and each works perfectly alone. Now declared via `Claims(owns_fx2_buffers=True)` and refused by name. Declared rather than scanned because a source scan cannot tell an address from a mask (the first attempt flagged six modules of eight), which `docs/DSP.md` §7c already records.
- **`make cycles` is remix-aware** and prints a WORST ONE CORE figure — four FX2 slots, at most one server, inserts unlimited. chongbong 2,398 where the old number said 3,762 by summing both engines onto a core that never pays both. The legacy composition is still printed as the basis the 7 Aug hardware spare is anchored to.

## Status

`make check` green on every remix, ledger selftest covers the new rule, refhash bit-identical, no binaries.

⚠️ **Nothing here has been flashed.** All of it is verified by local render only. Every MODE/FRZE select and every knob publish still rides the standing on-unit reconfirm in `docs/PARAM_PAGES.md` — a slot can draw a knob and publish nothing, and no local test can see that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)