### PR TITLE
Make the repo shareable: current README, and a harness that does not drop new modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ What ships today:
 | **The send bus** | All eight tracks feed one shared reverb and one shared delay, across both DSP cores. Both effects are **returns**: a track running one outputs its own dry at unity plus the wet, fed by the other tracks' SEND knobs. This is the part the hardware was not designed to do. |
 | **Tempo sync** | A ColdFire module rather than an effect: two code caves, one publishing the project tempo, crossfader and held MIDI note where the DSP can read them, one drawing BongDelay's TIME knob as a tempo division. It is the worked example of patching what the firmware *does*. |
 
+Those four are **confirmed on hardware**. There is also a set of six
+Mutable-Instruments-flavoured **inserts** — see below — which are verified by
+local render and measurement but have **never been flashed**. If you build
+and flash them you are the first person to run them on real hardware.
+
 The reverse-engineering in `docs/` is infrastructure, not the product. It
 exists because you cannot write an effect for a machine whose memory map,
 cycle budget and parameter plumbing you do not know.
@@ -49,6 +54,35 @@ The costs are all measured, not estimated:
 
 `docs/CHIP.md` carries every one of these numbers with a confidence marker —
 measured or inferred, and what would falsify it.
+
+### Servers and inserts, and why the difference matters
+
+A **server** owns a bus accumulator and is *bank-bound*: ChonVerb exists only
+on core 0, BongDelay only on core 1, and one of each per core is the design
+rule. That asymmetry is what bought them their program space.
+
+An **insert** has no bus role at all. It processes its own track's frames in
+place, is placed in *both* payloads, and can therefore run on any of the
+eight tracks — several at once, all different, or four copies of the same
+one. Inserts also **stack**: because none of them negotiates for the bus or
+the shared window, a single image can carry a whole set.
+
+That makes an insert far the easier thing to contribute, and it is what the
+six modules below are:
+
+| | |
+|---|---|
+| **WarpFold** | Warps-ish: a wavefolder into a ring modulator. FOLD / RING / BOTH. |
+| **Ripple** | Ripples-ish: a driven state-variable filter, LP / BP / HP, resonance to Q≈30. The drive clip is the character. |
+| **Rungs** | Rings-ish: eight tuned resonators struck by the audio itself. STRING / BELL / GLASS, plus a stretch control. |
+| **Streamz** | Streams-ish: a vactrol lowpass gate. The envelope opens a filter and an amplifier *together*, so quiet is dark as well as quiet. LPG / VCF / VCA. |
+| **BodeShift** | Warps-ish: a Bode frequency shifter — every partial moves by the same number of *hertz*, so it is not a pitch shifter. UP / DOWN / WIDE, plus a feedback spiral. |
+| **Nimbus** | Clouds-ish: four grains reading back out of a continuously-recorded 743 ms buffer, with a freeze. |
+
+`make bus REMIX=mutables` builds five of them onto one card (2,410 of the
+2,724 available words). Nimbus gets its own remix, because it owns the
+per-core FX2 buffer region and so cannot share a core with ChonVerb's tank —
+a pair the build refuses by name rather than letting you discover it by ear.
 
 ### The machine, on one page
 
@@ -145,6 +179,10 @@ make bus       # build the effects into it
 make image     # repack as a card-flashable .bin
 ```
 
+`make remix` opens a workbench for composing a selection: toggle modules and
+it shows collisions, the panel your choice produces, and its word cost
+against the donor region, then builds or saves it.
+
 `make help` lists everything. The setup script assumes **macOS + Homebrew**;
 on Linux the substitutions are the obvious ones (the DSP toolchain itself is
 plain CMake — see `scripts/setup.sh`).
@@ -177,8 +215,10 @@ make check     # build + cycle budget + ledger selftest + menu verification
 ### Building a different selection
 
 ```bash
+make remix                # compose one interactively
 make modules              # the module index and the available remixes
 make bus REMIX=verbonly   # ChonVerb and the send bus, no delay, no caves
+make bus REMIX=mutables   # five stacking inserts, no servers
 ```
 
 A module left out of a remix is not built, not placed and not listed — and
@@ -248,12 +288,17 @@ Issues, listening reports and findings are welcome, and so are modules.
 **To add one**, copy `modules/_template/` and read
 **[docs/MODULES.md](docs/MODULES.md)**. Your module declares what it is and
 what it claims; the build refuses to start if two selected modules claim the
-same FX2 id, cave, hook site or core-private word, and names both.
+same FX2 id, cave, hook site, core-private word, or the per-core FX2 buffer
+region, and names both.
+
+**An insert is the easiest first module** — no bus role, no shared window, no
+payload asymmetry to reason about. The six above were each built against
+`docs/MODULES.md` alone.
 
 If you open a PR: `make check` is the floor, and read the traps in
 `CLAUDE.md` first — several are the kind that assemble clean and do the wrong
 thing. If you changed the *build* rather than adding a module, prove it
-changed nothing with `scripts/refhash.sh` (23 configurations, artifacts and
+changed nothing with `scripts/refhash.sh` (26 configurations, artifacts and
 build reports, bit-identical).
 
 **Never attach a built image, an OS file, or any Elektron-derived binary to

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -213,6 +213,13 @@ the remix work proved itself, and it caught things reading the diff did not.
 `docs/VOICING.md`. Render locally rather than flashing: every hardware test
 costs a manual firmware write.
 
+**A `layout_char` makes your module placeable by `send_probe`**, whose
+alphabet is derived from the manifests. But `send_probe` measures a BUS
+ACCUMULATOR, so it only analyses modules whose harness says `is_server`. An
+insert has no accumulator to read: render it with `--direct`, which puts the
+audio through the effect's own track, or drive `dsp_host` yourself. The tool
+says so if you ask for a layout it cannot measure.
+
 **Disassemble what you assemble.** `dsp_asm` mis-encodes several instructions
 silently — `tfr a,b` as `rnd b`, and any `mpy` operand order it does not know
 as `mpysu`, which treats its second operand as unsigned. `CLAUDE.md` has the

--- a/tools/send_probe.py
+++ b/tools/send_probe.py
@@ -86,6 +86,26 @@ SERVER_ID = {m.harness.layout_char: m.menu.fx2_id
              for m in registry.modules().values()
              if m.harness is not None and m.harness.layout_char
              and m.menu is not None}
+# The layout ALPHABET, derived. It used to be the literal "RDS." in two
+# places, so a module could declare a layout_char, have it resolved into
+# SERVER_ID above, and still be silently dropped from every layout string --
+# which is what happened to all six inserts: they had to be driven through
+# dsp_host by hand. `.` means a track running neither (NONE, or a stock
+# effect): our code never runs there, so the slot is simply skipped.
+LAYOUT_CHARS = set(SERVER_ID) | {"."}
+# Which of them own a bus accumulator and can therefore be MEASURED as the
+# target of a send. An insert has no bus role, so a layout of nothing but
+# inserts has nothing to analyse -- that is what the check below is for.
+SERVER_CHARS = {m.harness.layout_char for m in registry.modules().values()
+                if m.harness is not None and m.harness.layout_char
+                and m.harness.is_server}
+# Every module's own declared defaults, as a -params list. A module the CLI
+# has no flags for still needs SOMETHING sensible on its knobs, and the
+# manifest is where that is already written down.
+MODULE_DEFAULTS = {m.harness.layout_char: [(p.default or 0) for p in m.params]
+                   for m in registry.modules().values()
+                   if m.harness is not None and m.harness.layout_char
+                   and m.params}
 REVERB_ID = SERVER_ID.get("R")
 SEND_ID = SERVER_ID.get("S")
 DELAY_ID = SERVER_ID.get("D")
@@ -235,7 +255,10 @@ def run(mem, dur, tail, rev_params, send_params, verbose=False, amp=0.5,
     # control is precisely the class of mislabel this project has lost sessions
     # to, and here it would silently compare two different effects.
     dpar = delay_params if delay_params is not None else DELAY_PARAMS
-    tgt = pick or ("R" if "R" in layout.upper() else "D")
+    _present = [c for c in layout.upper() if c in SERVER_CHARS]
+    tgt = pick or ("R" if "R" in layout.upper() else
+                   "D" if "D" in layout.upper() else
+                   (_present[0] if _present else "R"))
     live = [(0, tgt)]
     if direct:
         ri, rp = entry(tgt)
@@ -262,11 +285,16 @@ def run(mem, dur, tail, rev_params, send_params, verbose=False, amp=0.5,
         # dsp_host cannot boot. Against either of those `--layout DS` renders
         # silence from a 10-word stub rather than failing, which is why the
         # silence check below is a FAILED measurement and not a clean one.
-        slots = [c for c in layout.upper() if c in "RDS."]
+        slots = [c for c in layout.upper() if c in LAYOUT_CHARS]
         live = [(k, c) for k, c in enumerate(slots) if c != "."]
         n = len(live)
-        if not any(c in "RD" for _, c in live):
-            die(f"layout {layout!r} has no server -- needs an R or a D")
+        if not any(c in SERVER_CHARS for _, c in live):
+            die(f"layout {layout!r} has no bus server to measure -- needs one "
+                f"of {''.join(sorted(SERVER_CHARS))}. The others "
+                f"({''.join(sorted(set(SERVER_ID) - SERVER_CHARS))}) either "
+                f"feed a bus (SEND) or are inserts that process their own "
+                f"track's frames, so there is no accumulator to analyse; "
+                f"render an insert with --direct instead")
         r7s = ",".join(str(2 + 2 * k) for k, _ in live)
         als = ",".join(str(1 + 2 * k) for k, _ in live)
         # The tone normally reaches the SENDs only, so a SERVER's own track
@@ -278,7 +306,10 @@ def run(mem, dur, tail, rev_params, send_params, verbose=False, amp=0.5,
         # measured for what it does on the unit.
         inmask = sum(1 << i for i, (_, c) in enumerate(live)
                      if c == "S" or inall)
-        par = {"R": rev_params, "S": send_params, "D": dpar}
+        # The three the CLI has flags for keep their flag-driven values;
+        # anything else falls back to what its own manifest declares.
+        par = dict(MODULE_DEFAULTS)
+        par.update({"R": rev_params, "S": send_params, "D": dpar})
         cmd = [str(HOST), "-mem", str(mem),
                "-init", ",".join(f"{entry(c)[0]:x}" for _, c in live),
                "-proc", ",".join(f"{entry(c)[1]:x}" for _, c in live),


### PR DESCRIPTION
Groundwork so the remix platform can be shared. Both items were found by walking the path a newcomer actually takes, rather than assuming it worked.

## `send_probe` was silently dropping every new module

The layout alphabet was the literal `"RDS."` in two places. A module could declare a `layout_char`, have it correctly resolved into `SERVER_ID`, and still be dropped from every layout string without a word — which is what happened to all six inserts, and why they had to be driven through `dsp_host` by hand all session. A contributor following `docs/MODULES.md` would have hit the same wall with no explanation.

Now derived from the manifests: the alphabet, the "is there anything here to measure" test, and each module's default knob values (from its own declared defaults). A layout it genuinely cannot measure is refused with the reason and the alternative:

```
layout 'WS' has no bus server to measure -- needs one of DR. The others
(BFGMNSW) either feed a bus (SEND) or are inserts that process their own
track's frames, so there is no accumulator to analyse; render an insert
with --direct instead
```

The existing `--layout RS` path renders byte-for-byte as before.

## The README described a three-module world

It predated the six inserts entirely — no mention of them, no `make remix`, and its "confirmed on hardware" table implied a status the new modules do not have. It now:

- names the six inserts and what each one is;
- explains **servers vs inserts**, which is the distinction that matters to anyone thinking of contributing — a server owns a bus accumulator and is bank-bound, an insert has no bus role, sits in both payloads, runs on any track, and *stacks*, which makes it far the easier first module;
- states plainly that the inserts are verified by local render only and have **never been flashed**, so whoever flashes them is the first;
- corrects the refhash count (23 → 26) and adds the FX2 buffer region to the ledger's advertised scope.

`docs/MODULES.md` gains the matching note about `--direct`.

## Gates

`make check` green on chongbong and mutables; all 26 refhash cases bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)