### PR TITLE
docs: reframe from "two effects" to a platform of modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,15 +5,23 @@ work order. `docs/XBUS.md` is the architecture record, not the plan.
 
 The repo is organised as **modules** (`modules/<name>/manifest.py` declares one
 contribution) composed into **remixes** (`remixes/<name>.py` selects a set).
-`make modules` lists them; `docs/MODULES.md` is the contributor guide. Two
-consequences for working here: a module's declared `priority` is
-byte-load-bearing, and the build refuses to start when two selected modules
-claim the same FX2 id, cave, hook site or core-private Y word.
+`make modules` lists them, `make remix` composes one. `docs/MODULES.md` is the
+contributor guide. Two consequences for working here: a module's declared
+`priority` is byte-load-bearing, and the build refuses to start when two
+selected modules claim the same FX2 id, cave, hook site, core-private Y word,
+or the per-core FX2 buffer region.
+
+**Modules come in kinds, and most of the traps below are a SERVER's.** An
+insert (six of the ten) has no bus role, no shared-window claim, sits in both
+payloads and runs on any track; it never touches the rotation, the
+housekeeping election, the auto-gain, or the payload asymmetry. A server pays
+all of that. Read a warning below asking which kind it applies to.
 
 **If you change the BUILD rather than a module, prove it changed nothing:**
 `scripts/refhash.sh save` on a tree you trust, then `scripts/refhash.sh check`
-— 23 configurations, artifacts and build reports, bit-identical. The whole
-remix refactor was done under that gate.
+— 26 configurations, artifacts and build reports, bit-identical. The whole
+remix refactor was done under that gate, and every module added since has
+been proven not to change it.
 
 This is a DSP effects project. The firmware reverse engineering in `docs/` is
 infrastructure that makes the effects possible — it is not the deliverable.
@@ -204,7 +212,9 @@ DELAY entry equals SEND's. The general rule: before believing a *negative*
 result, check which code the dispatch entry actually points at — same
 family as "disassemble what you assemble".
 
-**Payload A's half of the shared window is FULLY OWNED**: ChonVerb's
+**IN THE SHIPPING REMIX, payload A's half of the shared window is FULLY
+OWNED** (a remix without the reverb frees it, which is how the insert
+collection has room to stack): ChonVerb's
 relocated buffers at `0x30000`/`0x34000`, bus scratch at `0x36000-0x360d2`
 (grew 12 Aug for the DELAY send counts + reciprocal table, and again 17 Aug
 when the accumulators went to FOUR buffers for the cross-core race fix).

--- a/README.md
+++ b/README.md
@@ -12,19 +12,43 @@ selection of modules. `make modules` lists what exists, `make bus REMIX=<name>`
 builds a selection, and adding a module is adding a directory. See
 **[docs/MODULES.md](docs/MODULES.md)** to write one.
 
-What ships today:
+**Ten modules ship today.** Two are bus *servers*, six are per-track
+*inserts*, one is the bus client they all lean on, and one patches the
+ColdFire rather than the audio at all.
+
+### Effects that serve a bus
 
 | | |
 |---|---|
-| **ChonVerb** | An eight-line FDN reverb with ROOM/PLATE/BIG modes, modulated taps, shimmer, a gate, and mid/side width. Voiced by ear, confirmed on hardware. It takes over the three stock FX2 reverb slots, which is where the program space for it came from. |
-| **BongDelay** | A multi-mode delay — CLEAN, PITCH (a once-per-repeat harmoniser), GRAIN (a granular cloud) and REVERSE — with tape-style wow/flutter (DPTH/RATE), drive (DRV) and a FREEZE hold available in **every** mode, routable *into* the reverb over the bus (`-VRB`, default 0). Its program space is the **other core's copy of the same three donor slots** — the stock FX2 delay itself has no DSP code to take. Confirmed on hardware, every knob live and audible. |
-| **The send bus** | All eight tracks feed one shared reverb and one shared delay, across both DSP cores. Both effects are **returns**: a track running one outputs its own dry at unity plus the wet, fed by the other tracks' SEND knobs. This is the part the hardware was not designed to do. |
-| **Tempo sync** | A ColdFire module rather than an effect: two code caves, one publishing the project tempo, crossfader and held MIDI note where the DSP can read them, one drawing BongDelay's TIME knob as a tempo division. It is the worked example of patching what the firmware *does*. |
+| **ChonVerb** | An eight-line FDN reverb with ROOM/PLATE/BIG modes, modulated taps, shimmer, a gate, and mid/side width. Voiced by ear. |
+| **BongDelay** | A multi-mode delay — CLEAN, PITCH (a once-per-repeat harmoniser), GRAIN (a granular cloud) and REVERSE — with tape-style wow/flutter, drive, and a FREEZE hold available in **every** mode. Its wet can be sent on into the reverb, across cores. |
+| **Send** | The bus client: any track can select it and feed `-DEL` / `-VRB`. It is also the fallback an unimplemented id degrades to. |
 
-Those four are **confirmed on hardware**. There is also a set of six
-Mutable-Instruments-flavoured **inserts** — see below — which are verified by
-local render and measurement but have **never been flashed**. If you build
-and flash them you are the first person to run them on real hardware.
+### Effects that run on one track
+
+Six inserts, Mutable-Instruments-flavoured. They need no bus, sit in both
+payloads, run on any track, and **stack** — `make bus REMIX=mutables` puts
+five of them on one card.
+
+| | |
+|---|---|
+| **WarpFold** | A wavefolder into a ring modulator. FOLD / RING / BOTH. |
+| **Ripple** | A driven state-variable filter, LP / BP / HP, resonance to Q≈30. The drive clip is the character. |
+| **Rungs** | Eight tuned resonators struck by the audio itself. STRING / BELL / GLASS, plus a stretch control. |
+| **Streamz** | A vactrol lowpass gate: the envelope opens a filter and an amplifier *together*, so quiet is dark as well as quiet. LPG / VCF / VCA. |
+| **BodeShift** | A Bode frequency shifter — every partial moves by the same number of *hertz*, so it is not a pitch shifter. UP / DOWN / WIDE, plus a feedback spiral. |
+| **Nimbus** | Four grains reading back out of a continuously-recorded 743 ms buffer, with a freeze. |
+
+### Firmware behaviour, not audio
+
+| | |
+|---|---|
+| **Tempo sync** | Two ColdFire code caves: one publishes the project tempo, crossfader and held MIDI note where the DSP can read them; the other draws a TIME knob as a tempo division. The worked example of patching what the firmware *does*. |
+
+⚠️ **ChonVerb, BongDelay, Send and Tempo sync are confirmed on hardware. The
+six inserts are not** — they are verified by local render and measurement and
+have never been flashed. Whoever flashes them is the first to run them on a
+real machine.
 
 The reverse-engineering in `docs/` is infrastructure, not the product. It
 exists because you cannot write an effect for a machine whose memory map,
@@ -32,57 +56,47 @@ cycle budget and parameter plumbing you do not know.
 
 ---
 
-## Why the send bus is the interesting part
+## Two kinds of effect
 
-Stock, an effect is an *insert*: it lives on one track and hears only that
+This is the distinction to understand before writing anything, because it
+decides how hard your module is to build.
+
+An **insert** processes its own track's frames in place. It has no bus role,
+claims no shared memory, is placed in *both* payloads, and therefore runs on
+any of the eight tracks — several at once, all different, or four copies of
+the same one. Nothing negotiates with anything, so inserts **stack**: one
+image can carry a whole set of them. This is far the easier thing to
+contribute, and the six above are all of this kind.
+
+A **server** owns a bus accumulator and is *bank-bound*. ChonVerb exists only
+on core 0 and BongDelay only on core 1, one per core by design rule. That
+asymmetry is what bought each of them a whole donor region's worth of program
+space, and it is why they can be big.
+
+## What a server buys: the send bus
+
+Stock, every effect is an insert — it lives on one track and hears only that
 track. A reverb used that way is one reverb per track, each with its own
-memory and its own cycles, and you cannot feed several tracks into a single
-space.
+memory and cycles, and you cannot feed several tracks into a single space.
 
 octabam turns the FX2 slot into a **bus server**. One track hosts the reverb;
 the others select SEND and contribute to it. Because the two payloads run on
-separate cores, and each carries a different server, the delay's output can
+separate cores and each carries a different server, the delay's output can
 cross into the reverb — a route the stock firmware has no path for at all.
+
+Both servers are **returns**: a track hosting one outputs its own dry at
+unity plus the wet, fed by the other tracks' sends.
 
 The costs are all measured, not estimated:
 
-| resource | per core | state (Aug 2026 build) |
+| resource | per core | state |
 |---|---|---|
-| Cycles | 4,535/sample | derived budget (200 MIPS ÷ 44.1 kHz); every mode runs clean on hardware, true per-core ceiling unmeasured |
-| Program space | 8,192 words | donor region 2,724 words/payload: A 74 free, B 30 free (29 Aug 2026; `make bus` prints the live ledger, and this line goes stale — believe the build) |
+| Cycles | 4,535/sample | derived (200 MIPS ÷ 44.1 kHz). `make cycles` prints the worst load the selected remix can be asked for; the real ceiling is a cliff and only a hardware burn sweep measures it |
+| Program space | 8,192 words | donor region **2,724 words per payload**, shared by every module in the remix. `make bus` prints the live ledger |
 | FX2 memory | 65,536 words/server | 1.49 s, pooled from private slots + the shared window |
 
 `docs/CHIP.md` carries every one of these numbers with a confidence marker —
 measured or inferred, and what would falsify it.
-
-### Servers and inserts, and why the difference matters
-
-A **server** owns a bus accumulator and is *bank-bound*: ChonVerb exists only
-on core 0, BongDelay only on core 1, and one of each per core is the design
-rule. That asymmetry is what bought them their program space.
-
-An **insert** has no bus role at all. It processes its own track's frames in
-place, is placed in *both* payloads, and can therefore run on any of the
-eight tracks — several at once, all different, or four copies of the same
-one. Inserts also **stack**: because none of them negotiates for the bus or
-the shared window, a single image can carry a whole set.
-
-That makes an insert far the easier thing to contribute, and it is what the
-six modules below are:
-
-| | |
-|---|---|
-| **WarpFold** | Warps-ish: a wavefolder into a ring modulator. FOLD / RING / BOTH. |
-| **Ripple** | Ripples-ish: a driven state-variable filter, LP / BP / HP, resonance to Q≈30. The drive clip is the character. |
-| **Rungs** | Rings-ish: eight tuned resonators struck by the audio itself. STRING / BELL / GLASS, plus a stretch control. |
-| **Streamz** | Streams-ish: a vactrol lowpass gate. The envelope opens a filter and an amplifier *together*, so quiet is dark as well as quiet. LPG / VCF / VCA. |
-| **BodeShift** | Warps-ish: a Bode frequency shifter — every partial moves by the same number of *hertz*, so it is not a pitch shifter. UP / DOWN / WIDE, plus a feedback spiral. |
-| **Nimbus** | Clouds-ish: four grains reading back out of a continuously-recorded 743 ms buffer, with a freeze. |
-
-`make bus REMIX=mutables` builds five of them onto one card (2,410 of the
-2,724 available words). Nimbus gets its own remix, because it owns the
-per-core FX2 buffer region and so cannot share a core with ChonVerb's tank —
-a pair the build refuses by name rather than letting you discover it by ear.
 
 ### The machine, on one page
 
@@ -101,21 +115,33 @@ P  8,192 words                          8,192 words
    ├─ stock: dispatch, FX1, mixing…     ├─ stock: dispatch, FX1, mixing…
    └─ donor region, 2,724 words         └─ donor region, 2,724 words
       (was PLATE+SPRING+DARK)              (this core's copy of the same
-      now SEND + CHONVERB                   three slots)
-      used 2,669 · free 55                 now SEND + BONGDELAY
-                                           used 2,723 · free 1
+      the remix's modules go here           three slots)
+      -- `make bus` prints who got          same, for this core's half of
+      what and how much is left             the selection
 
 Y  private 0x4000–0xBFFF (32 K)         private 0x4000–0xBFFF (32 K)
-   └─ the tank: 8 lines × 4,096         └─ pooled, unclaimed by the delay
+   └─ two FX2 instance slots -- where a └─ same. At most ONE module per
+      module that needs a big buffer       core may claim this, and the
+      puts it. Only one per core.         build refuses a remix where two do
 
    shared half 0x30000–0x37FFF (32 K)   shared half 0x38000–0x3FFFF (32 K)
-   ├─ 4 input + 2 in-loop allpasses     └─ LineL + LineR, 16,384 each
-   ├─ shimmer pitch-shift line (2 K)       (ping-pong, ~371 ms per line)
-   ├─ dead pre-delay buffer (4 K —
+   └─ this payload's half of the 64 K   └─ the other half, likewise
+      window, plus the BUS SCRATCH at
+      0x36000 -- the one region BOTH
+      cores touch
+```
+
+Below, what the *shipping* remix does with that space — one arrangement of
+many, not a property of the machine:
+
+```
+   payload A (ChonVerb)                 payload B (BongDelay)
+   ├─ the tank: 8 lines x 4,096         └─ LineL + LineR, 16,384 each
+   ├─ 4 input + 2 in-loop allpasses        (ping-pong, ~371 ms per line)
+   ├─ shimmer pitch-shift line (2 K)
+   ├─ dead pre-delay buffer (4 K --
    │  PRE became GATE; still mapped)
-   ├─ tank state tables
-   └─ BUS SCRATCH at 0x36000 — the
-      one region both cores touch
+   └─ tank state tables
 ```
 
 The shared window `0x30000–0x3FFFF` is 64 K that both cores address (P, X
@@ -193,13 +219,21 @@ This matters more than it sounds. A flash cycle is slow and manual, so the
 project is built around **not needing one** to make a judgement:
 
 ```bash
-make render                      # render the whole bus locally
+make render                      # the send bus: SEND -> ChonVerb
+make render-delay                # the delay hatch, all servers real
 make reverb IN=loop.wav          # push audio through ChonVerb
 make reverb IN=loop.wav ARGS='--sweep SIZE=0,64,127 --wet'
 ```
 
-These run the *real assembled instruction stream* on a DSP56300 emulator, at
-roughly 6× real time. What you hear is what the chip will do, which is why
+Those wrappers drive the two servers. **An insert has no bus accumulator to
+measure**, so it is rendered on its own track instead — `send_probe.py
+--direct` with the module's layout letter, or `dsp_host` directly. The layout
+alphabet comes from the manifests, so your module joins it by declaring a
+`harness.layout_char`; ask for a layout the tool cannot analyse and it says
+so, with the alternative. `docs/HARNESS.md` has the recipes.
+
+All of it runs the *real assembled instruction stream* on a DSP56300
+emulator, at roughly 6× real time. What you hear is what the chip will do, which is why
 voicing decisions in `docs/VOICING.md` are recorded as listening results
 rather than as guesses about coefficients.
 
@@ -217,8 +251,10 @@ make check     # build + cycle budget + ledger selftest + menu verification
 ```bash
 make remix                # compose one interactively
 make modules              # the module index and the available remixes
+make bus REMIX=chongbong  # the shipping image (the default)
 make bus REMIX=verbonly   # ChonVerb and the send bus, no delay, no caves
 make bus REMIX=mutables   # five stacking inserts, no servers
+make bus REMIX=nimbus     # the granular insert, which owns a buffer region
 ```
 
 A module left out of a remix is not built, not placed and not listed — and
@@ -248,9 +284,11 @@ The documents that stay current:
 |---|---|
 | `PLAN.md` | The cold-start document — what is being built and in what order |
 | `docs/MODULES.md` | **Writing a module** — the schema, the traps, the gates |
+| `docs/HARNESS.md` | Rendering and measuring a module without hardware |
 | `docs/XBUS.md` | How the cross-core bus works, and why |
 | `docs/CHIP.md` | Cycles and memory, every number with a confidence marker |
 | `docs/REVERB.md` | ChonVerb: structure, parameters, memory layout |
+| `modules/*/README.md` | Each module's own notes: what it is, what was measured, what is open |
 | `docs/VOICING.md` | What was decided by listening, and why |
 | `docs/FLASHING.md` | Getting an image onto hardware, and back off it |
 | `docs/CAPTURE.md` | Hardware capture protocol — predictions committed before measuring |

--- a/docs/FLASHING.md
+++ b/docs/FLASHING.md
@@ -113,9 +113,10 @@ at 31250 baud, so it takes seconds rather than minutes.
    twice, cleared by a reboot both times.
 
    🟡 The mechanism, inferred from the code and matching the symptom exactly
-   (not yet measured on hardware): both engines skip warm-up when their
-   tagged counter at `r7+$82` holds a valid tag at full count — ChonVerb
-   `$2c0000`, BongDelay `$2e0000`. **An OS upgrade rewrites program memory
+   (not yet measured on hardware): an engine skips warm-up when its tagged
+   counter holds a valid tag at full count — ChonVerb `$2c0000` at `r7+$82`,
+   BongDelay `$2e0000`, Nimbus `$2d0000` at `r7+$31`. **Any module that
+   tags warm-up state in r7 inherits this**, so if yours does, expect it. **An OS upgrade rewrites program memory
    but does not clear DSP state RAM.** If that word survives with a valid
    tag, the engine concludes it is already warmed up and runs on whatever is
    in its buffers — the previous firmware's contents, or boot garbage. The
@@ -165,23 +166,36 @@ container before it will produce a modified one.
 1. **Version string.** The boot screen and **SYSTEM STATUS → OS VERSION**
    should read **`OCTABAM<NNN>`** — the `-V` stamp from `make image`. If it
    still says `1.40C`, the official OS is running, not your build.
-2. **The reverb, on track 5.** Assign ChonVerb to an FX2 slot on one of
-   **tracks 5–8** (payload A runs the high tracks — measured, and inverted
-   from what you'd guess; on tracks 1–4 the pick falls back to a SEND).
-   Feed it audio via `IN` and step **MODE**: you
-   should hear distinct ROOM → PLATE → BIG spaces. Both effects are
-   **returns with a unity dry passthrough** (v5, 23 Aug 2026): the host
-   track's own audio passes untouched, `IN` adds it into the engine on top.
-   `IN` at 0 is an exact passthrough — the R41-and-earlier behaviour of a
-   silent host track is retired.
-3. **The delay, on tracks 1–4.** BongDelay lives on the low tracks (payload
-   B). Same deal: it is a return, fed over the bus.
+**Which of the steps below apply depends on what your remix contains.** An
+insert-only image (`mutables`, `warped`, `nimbus`) has no reverb, no delay
+and no bus to check — steps 2–4 simply do not apply to it, and step 5 is the
+whole test.
+
+2. **A bank-bound server is restricted to its payload's tracks.** ChonVerb
+   runs on **tracks 5–8** (payload A runs the high tracks — measured, and
+   inverted from what you'd guess); BongDelay on **tracks 1–4**. Picking one
+   on the wrong bank falls back to a SEND, deliberately, so a wrong guess
+   makes a send rather than silence. Assign ChonVerb on track 5, feed it via
+   `IN`, step **MODE**: distinct ROOM → PLATE → BIG spaces.
+3. **The two servers are returns with a unity dry passthrough** (v5, 23 Aug
+   2026): the host track's own audio passes untouched and `IN` adds it into
+   the engine on top, so `IN` at 0 is an exact passthrough. This is a
+   property of the SERVERS, not of every module — an insert processes the
+   host track's audio directly and has its own MIX.
 4. **The bus.** Put SEND on any other track and drive `→REVERB` /
    `→DELAY` — those are two separate knobs, and driving the wrong one
    renders silence that reads as a broken algorithm.
+5. **An insert: select it on any track.** Inserts are placed in both
+   payloads, so any of the eight tracks will do, and several tracks may run
+   the same one or different ones. Expect it to process that track's own
+   audio. Then check the two things **no local test can see**: that each
+   page-2 select draws as a select (not a dial, not nothing — a formatter
+   outranks the value count beside it), and that every knob actually reaches
+   the DSP. A slot can draw a knob and publish nothing; `dsp_host` pokes
+   `r6` directly, so both faults are invisible until this moment.
 
 `docs/BUS.md` has the menu layout; `docs/PARAM_PAGES.md` explains how a knob
-reaches the DSP.
+reaches the DSP; `docs/MODULES.md` is what to read before writing one.
 
 ---
 
@@ -198,8 +212,10 @@ from Elektron's zip (card). Your CF card and projects are not affected.
 - This firmware is **modified by you, for your own unit, for study
   purposes.** It is not official Elektron firmware and has no support from
   anyone — Elektron least of all.
-- Everything checkable without hardware is checked (`make check`,
-  `make render`, the verify gates) — but the emulator is **single-core**, so
+- Everything checkable without hardware is checked — `make check`, the
+  verify gates, and whatever local render your modules support (`make render`
+  for the bus, `send_probe --direct` for an insert) — but the emulator is
+  **single-core**, so
   no local test can reproduce a cross-core bus timing defect, and its mpy
   semantics and truncation are its own. Treat emulator green as necessary,
   not sufficient, and go in with the recovery net ready.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -8,7 +8,7 @@ is as important as the rest of this page).
 
 The one-line claim, and why it is trustworthy: **the harness runs the real
 assembled instruction stream on a cycle-exact DSP56300 emulator.** It is not
-a model of the reverb; it is the reverb, executed by
+a model of your module; it is your module, executed by
 [dsp56300](https://github.com/dsp56300/dsp56300)'s emulator core at roughly
 6× real time. When a render sounds wrong, the code is wrong — modulo the
 blind spots listed at the end.
@@ -34,13 +34,30 @@ modules/*/*.asm (+ dsp/ probes)
         (make reverb IN=..)                        (make render / render-delay)
 ```
 
-Three commands cover most days:
+Three commands cover most days **if you are working on a bus server**:
 
 ```bash
 make reverb IN=loop.wav ARGS='--wet --mode all'   # hear ChonVerb
 make render                                       # the full bus, SEND → REVERB
 make render-delay                                 # BongDelay via the DEV hatch
 ```
+
+**An INSERT is rendered differently, and none of those three do it.** An
+insert has no bus accumulator, so there is nothing for `send_probe`'s bus
+analysis to read — it will refuse a layout of nothing but inserts, and say
+so. Render one on its own track instead:
+
+```bash
+# the tone (or a wav) straight into the module on its own track
+python3 tools/send_probe.py --mem out/dsp/mem_dev_A.mem --direct --pick W
+
+# or drive the emulator yourself, which is what the module authors did:
+#   -inst 1 -r7 2 -alloc 1 -inmask 1, entry points from the dump
+```
+
+The letter (`W` above) is the module's `harness.layout_char`. Build the DEV
+image for a remix that contains it first — `REMIX=<name> DEV=1 XBUS=1 SPEC=1
+python3 tools/build_bus.py`.
 
 ## dsp_host — the emulator harness
 
@@ -141,11 +158,24 @@ Two design points worth knowing, both scars:
 → shared bus accumulator → REVERB server — with the tone fed *only* to the
 SEND instance, so everything in the server's output crossed the bus. That is
 what makes the measurement unambiguous. `--layout` is a string of dispatch
-slots in hardware order — `R`=reverb, `D`=delay, `S`=send, `.`=neither, slot
-0 being position 0, the housekeeper — so `RS`, `.RS` and `SSR` are different
-machines, not different spellings; entry points are
-read from the dump's own dispatch tables, never hardcoded, and a `--direct`
-control run bypasses the bus for comparison.
+slots in hardware order, one character per dispatch slot, slot 0 being
+position 0 (the housekeeper) — so `RS`, `.RS` and `SSR` are different
+machines, not different spellings.
+
+**The alphabet is DERIVED from the manifests**, not a fixed list: every
+module that declares a `harness.layout_char` gets its letter, and `.` means a
+track running neither (NONE, or a stock effect). Today that is `R` reverb,
+`D` delay, `S` send, and `W F M G B N` for the six inserts — but read
+`harness.layout_char` in the manifests rather than trusting this sentence,
+which is exactly the kind that goes stale. It did: the alphabet was a
+hard-coded `"RDS."` until 29 Aug 2026, which silently dropped every module
+outside it from every layout string.
+
+`send_probe` ANALYSES a bus accumulator, so only modules whose harness says
+`is_server` can be the target of a measurement; ask for a layout without one
+and it refuses with the reason. Entry points are read from the dump's own
+dispatch tables, never hardcoded, and `--direct` bypasses the bus — a control
+run for a server, and the ordinary way to render an insert.
 
 The metric: a bin-centred 438.75 Hz sine through a linear system should come
 back as one FFT bin. Total non-fundamental energy relative to the

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -11,6 +11,25 @@ and `CLAUDE.md` for the traps that have already cost real work — several of
 them are traps a new module can walk straight into, and they are repeated
 here where they apply.
 
+**Decide first which kind you are writing, because it decides most of what
+follows.**
+
+An **insert** processes its own track's frames in place: no bus role, no
+shared-window claim, placed in both payloads, runnable on any track and
+several at once. Nothing negotiates with anything. `bus_role=BusRole.NONE`,
+`ybase=YBase.NEVER`, and most of the hazards below simply do not apply.
+**Start here** — six of the ten shipping modules are inserts, and each was
+built against this document alone.
+
+A **server** owns a bus accumulator, is bank-bound to one core, and has to
+take part in the rotation, the housekeeping election and the auto-gain. It
+buys a whole donor region's worth of program space with that complexity.
+There are two, they are documented in `docs/XBUS.md`, and you should have a
+reason before writing a third.
+
+A module can also be neither: a **bus client** (`send`) or a **ColdFire
+patch** (`tempo-sync`) that changes firmware behaviour and touches no audio.
+
 ---
 
 ## The shape of a module
@@ -232,9 +251,13 @@ full list. All of them assemble clean and do the wrong thing.
 ## Two things that will surprise you
 
 **`dsp_host` cannot boot payload B.** Local testability therefore depends on
-which payload a module lands on. BongDelay ships on payload B and can only be
-rendered locally through the DEV hatch, which places it out of region in
-payload A. A module on core 1 inherits that constraint.
+which payload a module lands on — and that is a SERVER's problem, because
+specialization is what puts a server on one core. BongDelay ships on payload
+B and can only be rendered locally through the DEV hatch, which places it out
+of region in payload A; a server on core 1 inherits that constraint.
+
+An insert is in BOTH payloads, so it is always reachable in payload A and
+renders with no hatch at all.
 
 **No local test can reproduce a cross-core timing defect**, because
 `dsp_host` is single-core. When local says clean and hardware says broken,

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -547,6 +547,13 @@ effect will still appear unselectable.
 COMPANION field at BITS 8–15.** Not the low byte. The low byte is never
 published.
 
+**The rule is slot -> word -> bit field, whatever a module calls its knobs.**
+The examples below are named `<ChonVerb> / <BongDelay>` because those were the
+only two effects when this was measured; a module names its own twelve slots
+in its manifest and the mapping is unchanged. Note the consequence: because
+the companion fields ARE slots 7, 9 and 11, a stepped control can only live
+there — `schema.py` enforces it.
+
 | slot | word | field | example |
 |---|---|---|---|
 | 6 | `$c` | knob, bits 16–23 | SHMR / DPTH |
@@ -564,12 +571,12 @@ documented anywhere:
   positions, repeatedly.
 - **SHMR independently needed `$c`'s knob field, not `$b`'s** — the
   same off-by-one word.
-- **Slot 11 confirmed dead for BOTH effects** (ChonVerb's →DEL and BongDelay's
+- **Slot 11 confirmed dead for both effects TESTED** (ChonVerb's →DEL and BongDelay's
   FRZE), which rules out a per-effect descriptor fault and leaves the
   slot itself.
 
 Everything that read bits 0–7 had never worked on hardware: slot 9 and slot 11,
-in both effects, until this map was applied (fixed in `7a4f96b`).
+in both effects then existing, until this map was applied (fixed in `7a4f96b`).
 
 ⚠️ **The trap this map explains**: dsp_host used to write only KNOB fields
 (`(pv[i] & 0x7f) << 16`) and mapped slots 6–11 onto `$b,$c,$d,$e` cyclically —

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -77,7 +77,8 @@ Two instruction sets, two toolchains:
 
 **`tools/build_bus.py` is THE builder** (`make bus` = `XBUS=1 SPEC=1`). What
 it builds is a **remix**: a named selection of modules (`make bus
-REMIX=<name>`, default `chongbong`; `make modules` lists both). Each
+REMIX=<name>`, default `chongbong`; `make modules` lists the modules and the
+remixes, `make remix` composes one interactively). Each
 `modules/<name>/manifest.py` declares one contribution — menu entry,
 parameters, DSP source, ColdFire caves — against the schema in
 `tools/remix/schema.py`, and `tools/remix/ledger.py` refuses a selection
@@ -111,8 +112,8 @@ version:
 | tool | what it does |
 |---|---|
 | `tools/dsp_host` | the emulator harness itself — boots a payload dump, calls effects through the recovered ABI, captures audio, polices memory |
-| `tools/render_reverb.py` (`make reverb IN=..`) | wav → ChonVerb → wav, knobs by name, sweeps, wet-only — the voicing instrument |
-| `tools/send_probe.py` (`make render`, `make render-delay`) | renders a real SEND→bus→server path and measures it numerically |
+| `tools/render_reverb.py` (`make reverb IN=..`) | wav → ChonVerb → wav, knobs by name, sweeps, wet-only — the voicing instrument **for the reverb specifically** |
+| `tools/send_probe.py` (`make render`, `make render-delay`) | renders a real SEND→bus→server path and measures it numerically. `--direct` puts audio through one module on its own track instead — **the way an insert is rendered**, since an insert has no bus accumulator to analyse |
 | `scripts/make_test_audio.py` | synthesises the standard audition material into `out/test_audio/` |
 
 ## 6. Verifying
@@ -121,7 +122,7 @@ version:
 
 | tool | proves |
 |---|---|
-| `tools/cycle_count.py` (`make cycles`) | static per-sample cycle count of each server against the measured budget — static because the emulator's instruction counter cannot measure this |
+| `tools/cycle_count.py` (`make cycles`) | static per-sample cycle count of **every module in the selected remix**, plus the worst load one core can be asked for — static because the emulator's instruction counter cannot measure this |
 | `tools/verify_roll.py` / `verify_delay.py` | an alternate reverb / delay engine is **bit-identical** to the shipping one — the gate every refactor passes before landing |
 | `tools/verify_bus.py` (`make verify-bus`) | a bus-layout change is behaviour-preserving: 17 layouts, stamp-edit-compare (`docs/XBUS.md`) |
 | `tools/verify_menu.py` | the ColdFire menu edits against the real chooser mechanism, decompiled from the firmware — including the descriptor traps (formatter vs count) |


### PR DESCRIPTION
The repo has ten modules and six remixes; the docs still described a project with a reverb and a delay. In three places that had crossed from parochial into **wrong**:

| where | said | actually |
|---|---|---|
| `docs/HARNESS.md` | the layout alphabet is `R`=reverb, `D`=delay, `S`=send | it is *derived from the manifests* and today also carries `W F M G B N` |
| `docs/TOOLING.md` | `make cycles` counts "each server" | it walks every module in the selected remix |
| `docs/FLASHING.md` | "Both effects are returns with a unity dry passthrough" | that is a property of the two **servers**; the six inserts are not returns and have no `IN` |

The HARNESS one is worth dwelling on: the alphabet had been a hard-coded `"RDS."` in the tool as well, which silently dropped every other module from every layout string. The tool was fixed in #12; the doc now says the alphabet is derived, names today's letters *as* today's, and flags itself as the kind of sentence that goes stale.

## The reframing

**README** leads with the ten modules grouped by *kind* — servers, inserts, ColdFire — rather than a two-effect table with everything else appended. The **server/insert distinction is promoted to its own section**, because it is what decides how hard a module is to write. The send bus becomes "what a server buys" instead of the headline. The memory diagram no longer hard-codes `CHONVERB`/`BONGDELAY` or carries free-word counts that go stale; the shipping remix's arrangement is shown separately and labelled as one arrangement of many.

**docs/MODULES.md** opens by telling a contributor to decide which kind they are writing, says an insert is where to start, and that most of the hazards below are a server's.

**docs/HARNESS.md and TOOLING.md** gain the insert render route. Neither previously named it, so an insert author following either had no command that worked — which is exactly what happened for all six.

**docs/FLASHING.md**'s post-flash checklist assumed every build contains a reverb, a delay and a bus. Three shipping remixes contain none of them. It now says which steps apply to what, and adds an insert step covering the two faults only a flash can reveal: a select that draws as something else, and a knob that publishes nothing.

**docs/PARAM_PAGES.md** states the slot → word → field rule generally and labels its reverb/delay column as examples. "BOTH effects" → "both effects tested", which keeps the evidence and drops the closed-world claim.

**CLAUDE.md** notes that most of its trap list is a server's problem, and corrects the refhash count and the ledger's scope. Its effect-specific *provenance* is deliberately untouched — those names record how each lesson was learned, and the file says elsewhere not to erase that.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)