### PR TITLE
docs: ingest external findings — the delay mystery is solved, and our ESAI claim is retracted

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ The documents that stay current:
 | `docs/DSP.md` | The DSP56300 module load map — which bytes land where |
 | `docs/PARAM_PAGES.md` | Parameter-page descriptors: how a knob reaches the DSP |
 | `docs/ARCHITECTURE.md` | The firmware as a whole |
+| `docs/EXTERNAL.md` | Findings from outside this project, and what they retract |
 | `docs/BUS.md` | The FX2 menu and descriptor work behind the bus |
 
 ---

--- a/docs/CHIP.md
+++ b/docs/CHIP.md
@@ -407,6 +407,7 @@ same address are the same memory.
 |---|---|---|
 | `0x30000-0x30047` (**72 words**) | **stock's per-frame PARAMETER STAGING.** Copied X→`Y:0x1b8` and written back every frame | disassembled: `do #<$48` loops at `P:0x0a4` (read) and `P:0x366` (write) |
 | `0x30000-0x300AA` (171 words) | DSP **host-port loader + ESAI setup**, payload A, boot-time | module dump |
+| | ⚠️ That "ESAI setup" is real and the ESAIs really do carry audio — 8-slot network mode, verified 30 Aug 2026. `DSP.md` asserted the opposite for weeks while this line sat here; see `docs/EXTERNAL.md` §2. | |
 | `0x31000-0x31031` (50 words) | **bootstrap A** | `DSP.md:22` |
 | `0x32000-0x32039` (58 words) | **bootstrap B** | `DSP.md:27` |
 | `0x38000-0x38012` (19 words) | payload **B's entry stub** — `jsr`s into `0x30082`/`0x3008a` | module dump |

--- a/docs/DSP.md
+++ b/docs/DSP.md
@@ -218,7 +218,28 @@ The null stub is not silence, it is a **passthrough**:
 Which is exactly the observed behaviour: the parameter page works, the audio is
 untouched. `0x08` has no implementation in *either* payload.
 
-### Where DELAY actually is — OPEN, and the DSP is ruled out
+### Where DELAY actually is — ✅ ANSWERED 30 Aug 2026, externally
+
+**It is on the ColdFire: per-frame DMA descriptor arithmetic over per-track
+circular buffers in SDRAM based at `0x4F502C10`, with an EMAC loop doing the
+gain and mix work.** The frame routine is `0x400031a0`. Full summary and
+provenance in **`docs/EXTERNAL.md`** — this is other people's work, adopted
+on their evidence and not re-verified by us (🟡).
+
+Everything below stands: every negative in this section was correct, and the
+DSP genuinely is ruled out. What the section lacked was the positive answer,
+and the reason it stayed missing is worth keeping — the searches keyed on
+parameter-storage addresses (the routine reads a *derived* time word), on the
+FX2-id field offset (the gate is a `moveq #8` against a copied byte), and on
+the `0x46xxxxxx` globals region (the rings are nowhere near it). What cracked
+it was searching for the **physics** — the literals 176400 and 1,411,200 —
+rather than the plumbing.
+
+One claim of ours does not survive it: *"the ColdFire does no per-sample audio
+arithmetic"* was verified only for the audio ISR at `0x4000aad0`, and the
+delay's EMAC loops are per-sample arithmetic outside it. ❌
+
+The old framing follows, still accurate as a record of what was ruled out:
 
 A tempting explanation — "a dedicated stage in the audio graph that the FX2
 slot enables" — **is an inference that a full search failed to support**; do not
@@ -243,9 +264,15 @@ a documented per-track insert whose id resolves to a passthrough.
   instructions and **98.5%** of payload B's. Every unreached run is small
   (≤112 instructions) and sits inside a module that is otherwise reached.
   There is no delay-sized body of unreferenced code.
-* **No delay buffer.** Every non-effect module characterised: `0x2bf` is a
-  MAC/pointer-walk resampler, `0x3a1` parameter unpacking, `0x5cb` flag
-  handling off `r6+$1e`, `0x6f4` a small MAC helper. **The largest modulo
+* **No delay buffer.** Every non-effect module characterised: `0x2bf`, `0x3a1`,
+  `0x5cb` flag handling off `r6+$1e`, `0x6f4` a small MAC helper.
+  🟡 **Two of those labels are corrected by external work** (`docs/EXTERNAL.md`,
+  30 Aug 2026, not re-verified by us): `0x3a1` is the **voice playback
+  engine** — a 2-tap linear interpolator over the 128-word ring — not
+  "parameter unpacking"; `0x2bf` is the **summing mixdown**, not a resampler.
+  `func_00055a` (below) is the 24-bit ↔ dual-16-bit host packer rather than a
+  gain routine. The *conclusion* of this bullet is untouched: none of them is
+  a delay. **The largest modulo
   buffer anywhere in the program is 128 words** (`m6=$7f`). A delay needs
   thousands.
 * **No third program.** Payloads A and B are back-to-back and the image tail
@@ -429,7 +456,9 @@ for.
 program uses a modulo bigger than `m6=$7f` (128 words), but it does not follow
 that no delay line exists: a delay line needs no modulo at all. Module `0x2bf`
 walks the shared window with `m0` linear, which is exactly how a long buffer
-would be read. (There is no external memory on this board; the shared window
+would be read. (🟡 `0x2bf` is now externally identified as the summing
+mixdown — `docs/EXTERNAL.md`. The caution in this paragraph stands on its own
+reasoning regardless.) (There is no external memory on this board; the shared window
 runs at the same speed as internal memory — see `CHIP.md`.) The reachability
 sweep and the module-by-module characterisation are what carry the conclusion,
 not the modulo scan.
@@ -650,8 +679,27 @@ renders the full bus — `docs/HARNESS.md`.)*
 
 ### Why address-guessing kept failing: the audio is DMA'd in
 
+❌ **RETRACTED 30 Aug 2026 — "audio does not arrive over the ESAI" was
+WRONG, and the reasoning below is the trap.** The vector reading is accurate;
+the inference from it is not. **A DMA-serviced peripheral needs no interrupt
+vectors at all**, so dead ESAI vectors say nothing about whether the ESAI
+carries audio. It does: both DSPs fully configure their ESAIs at boot
+(payload A `P:0x30026`, and a second port right after it) —
+`M_TMOD=1` network mode, `M_TDC=$7` (8 slots), `M_TSMA=$ff` enabling all
+eight, transmit and receive both enabled, and a live `movep a,x:<<M_TX0`.
+✅ **Verified in our own `payload_A.asm`**, prompted by an external finding
+(`docs/EXTERNAL.md`). Note the standing internal contradiction this leaves
+in the record: `CHIP.md` has labelled that very module "host-port loader +
+**ESAI setup**" the whole time, and nobody noticed the two documents
+disagreeing.
+
+The host-port/DMA path described below is real and still stands — it is how
+the *frame blocks* move. What is retracted is the exclusivity: the DMA path
+is not the only audio path, and the ESAI is not idle.
+
 The interrupt vector table at `P:0x00000` decodes cleanly. The ESAI vectors
-(`0x30`–`0x3e`) are all `jmp` to themselves — the unused-vector idiom — so audio
+(`0x30`–`0x3e`) are all `jmp` to themselves — the unused-vector idiom — which
+was read (wrongly, see above) as meaning audio
 does **not** arrive over the serial audio interface. The live vectors are
 `0x10`–`0x1c`, and they are host-port handlers that program the DMA controller:
 

--- a/docs/EXTERNAL.md
+++ b/docs/EXTERNAL.md
@@ -1,0 +1,199 @@
+# External findings
+
+Reverse-engineering results **from outside this project**, recorded here so
+that what we adopted, what we verified, and what we merely repeated are three
+distinguishable things.
+
+⚠️ **ATTRIBUTION IS INCOMPLETE.** These arrived as three documents with no
+author line. Whoever did this work deserves the credit, and this file should
+name them — if you know, fix it. Until then nothing here should be presented
+as octabam's own finding.
+
+Received 30 Aug 2026: `octatrack-delay-architecture.md`, `TABLE_ATLAS.md`,
+`timestretch.md`. All three are careful work: they mark their own claims
+`[measured]` / `[inferred]` / `[open]`, state their method, and are explicit
+about what would falsify them — the same discipline `CLAUDE.md` asks for here.
+Each was derived from the officially distributed OS 1.40C, hash-verified
+against stock, and the hash they quote matches our own canonical
+`section_3_MAIN_OS.bin`.
+
+**Status key:** ✅ we re-verified it ourselves · 🟡 adopted on their evidence,
+not re-verified · ❌ it retracts something we had written.
+
+---
+
+## 1. The Echo Freeze Delay: solved, and it was never on the DSP
+
+**This closes the project's oldest open question.** We had established a wall
+of negatives — no DSP code, no parameter reads, no id-8 gate, no delay-sized
+buffer — and concluded correctly that it was not on the DSP, without ever
+finding where it *was*.
+
+🟡 **It is on the ColdFire, as per-frame DMA descriptor arithmetic over
+per-track circular buffers in SDRAM**, with an EMAC loop for the gain and mix
+work. The "algorithm" is mostly address computation: once per frame the CPU
+works out where "delay-time ago" lives in each track's ring and points the DMA
+engine at it. The audio itself is moved by hardware, which is why no
+per-sample delay code exists anywhere the obvious searches looked.
+
+Load-bearing specifics, all marked `[measured]` by the source:
+
+| | |
+|---|---|
+| frame routine | `0x400031a0` (body to ~`0x40003900`) |
+| ring base | SDRAM `0x4F502C10` — outside the `0x46xxxxxx` globals region every address sweep covered |
+| ring size | 1,411,200 bytes per track = 176,400 × 8 = 4 s × stereo × 4 bytes |
+| the 4-second cap | `if (samples > 176400) samples = 176400`, as a literal |
+| read head | `read_pos = write_pos − delay_samples × 8`, wrapping at the ring size |
+| DMA | registers `0xfc045040/50/60/70`, count/control at `0xfc04505e/7e` |
+| tap processing | EMAC loop at `0x40003664`; two cascaded first-order sections, coefficients per track via `0x80006180` |
+| mix and feedback | EMAC loop at `0x40003734`; four gains, each linearly ramped across the frame |
+
+Two structural points worth carrying:
+
+- **There is no fractional-delay interpolation.** The read pointer is whole
+  8-byte frames. Time changes are handled by a **two-tap crossfade in time** —
+  this frame's and last frame's delay positions, both DMA-fetched, crossfaded
+  with a per-sample linear ramp across the 16-sample frame. TAPE off snaps the
+  length (an audible buffer discontinuity); TAPE on glides it, so the
+  inter-tap crossfade fires continuously and the tape-like repitch is a
+  staircase of integer jumps smoothed by frame-rate crossfades.
+- **Feedback is not recursive code.** There is no per-sample feedback loop
+  anywhere. Regeneration exists only because the ring's write stream contains
+  a scaled copy of its own filtered read stream, one frame-trip at a time.
+
+### What it changes for us
+
+Nothing in what we build — our effects are DSP-side and the delay never
+competed with them. But it retires a standing mystery, and it explains the
+thing that always looked wrong: **eight tracks can sustain full 4-second
+delays simultaneously** because each has its own ~1.4 MB ring in CPU SDRAM,
+always allocated. That was never a DSP budget question.
+
+❌ It also falsifies a claim of ours by name: *"the ColdFire does no
+per-sample audio arithmetic."* That was verified only for the audio ISR at
+`0x4000aad0` and does not survive this function.
+
+---
+
+## 2. ❌ The ESAI carries audio — RETRACTED, and re-verified here
+
+`docs/DSP.md` concluded that audio does **not** arrive over the serial audio
+interface, reasoning from the interrupt vector table: the ESAI vectors
+`0x30`–`0x3e` are all `jmp` to themselves, the unused-vector idiom.
+
+**The vector reading is right and the inference is wrong. A DMA-serviced
+peripheral needs no interrupt vectors at all.**
+
+✅ **We confirmed this ourselves** rather than adopting it, in our own
+`out/dsp/payload_A.asm`. Both ESAIs are fully configured at boot from
+`P:0x30026`:
+
+```
+030026: movep #>$40,x:<<M_SAICR
+03002c: movep #>$37d01,x:<<M_TCR    ; M_TE0 enabled, M_TMOD=1 (network), M_TSWS=$1f
+030036: movep #>$ff,x:<<M_TSMA      ; all 8 transmit slots enabled
+030045: movep a,x:<<M_TX0           ; and it transmits
+```
+
+with a second port configured identically right after (`M_*_1`). `M_TDC=$7`
+is 8 slots — the "8-slot network mode" the external note describes.
+
+**The lesson is the general one this project keeps relearning:** we drew a
+strong negative from an instrument that was structurally blind to the thing
+being ruled out. And the contradiction was already sitting in our own tree —
+`CHIP.md` has labelled that module "host-port loader + **ESAI setup**" the
+whole time. Two documents disagreed for weeks and nobody read them together.
+
+---
+
+## 3. Timestretch is a ColdFire feature
+
+🟡 The CPU renders the grains, including the crossfades, and ships finished
+audio to the DSP every frame. The per-track block crossing the chip boundary
+is **the next frame's audio**, not a parameter program. The DSP's playback
+engine is a 2-tap linear interpolator over a 128-word ring: it applies pitch
+and nothing else — no gain, no window, no position autonomy.
+
+- The crossfade is a numerically exact **Hann window** on the ColdFire: a
+  512-entry table at `0x80004000`, fitted as `T[i] = round(2³¹·sin²(π/2·(i+1)/513))`
+  with zero error on all 512 entries, and exactly complementary
+  (`T[i] + T[511−i] = 2³¹`). Fixed 512-source-sample (~11.6 ms) fade, minimum
+  grain body 2,048 samples (~46 ms) — constants, not tempo- or TSNS-dependent.
+- **No pre-analysis, definitively.** The `.ot` serializer persists only 64
+  slice records, trim points and a checksum. BEAT mode's "transients" are
+  slice markers, not detected onsets; transients stay hard because the read
+  head is *re-anchored* at each marker.
+- Segments within a frame are butt-spliced on the DSP; overlap-add happens on
+  the CPU before the audio ever arrives.
+
+### 🟡 Corrections to our `docs/DSP.md` module labels
+
+Adopted on their evidence, not re-verified by us, and applied in place:
+
+| module | we called it | it actually is |
+|---|---|---|
+| `P:0x3a1` | "parameter unpacking" | the **voice playback engine** (2-tap linear interpolator over the 128-word ring) |
+| `P:0x2bf` | "MAC/pointer-walk resampler" | the **summing mixdown** |
+| `func_00055a` | a 16-iteration gain routine | the **24-bit ↔ dual-16-bit host packer** (fixed power-of-two scaling, no gain) |
+
+None of this disturbs the conclusion those labels were serving — that no
+module on either payload is the delay.
+
+---
+
+## 4. Data-table atlas
+
+🟡 A shape-level catalog of every X/Y data module the ColdFire uploads at
+boot, from the payload module records with Q23 decode. Deliberately
+shape-only: it does not attribute tables to effects except where earlier work
+already had.
+
+Points that matter if we ever go looking for a table:
+
+- **Every substantive data module is byte-identical between payloads**, at
+  shifted addresses (upper X cluster: B = A − 0x540). The only real
+  per-chip differences are four small config/state modules.
+- `X:0x04840` is a **32 × 128-entry curve bank**, knob-indexed 0–127 — a
+  ready-made source of parameter warps.
+- `X:0x06c00` is now fully segmented, including a **single-cycle ramp/saw
+  wavetable at `0x7000`** beside the known sine at `0x6c00` — together they
+  read as an LFO waveform bank.
+- One prior guess is corrected: the curve at `X:0x01bd9` was attributed to
+  FRQ1 and is actually **GN1/GN2**; FRQ reads `X:0x015c7` with a ×4 index
+  (2 extra bits of resolution, unexplained).
+
+⚠️ Its own caveats are worth keeping: segment boundaries come from a
+discontinuity detector and merge smoothly-joined tables, stride findings are
+statistical, and Q23 decode is assumed throughout.
+
+---
+
+## 5. A toolchain warning we should heed
+
+🟡 The delay write-up reports that **`objdump -m m68k:5407` silently mangles
+every EMAC region into `.short` garbage**, because the ColdFire here is
+V4e-class with a four-accumulator EMAC; `-m m68k:547x` is required. Any prior
+ColdFire disassembly is correct for ordinary ISA code and **blind in
+MAC-heavy regions** — which is exactly where audio arithmetic lives.
+
+We do not use that flag: `scripts/disasm.sh` drives radare2 with `-a m68k`,
+and our cave assembly uses `m68k-elf-as -mcpu=5407` (assembling, not
+disassembling, and our caves contain no EMAC). 🟡 **But it is not established
+that radare2's plain `m68k` decodes EMAC any better**, so treat our ColdFire
+disassembly as potentially blind in MAC regions until someone checks. That is
+a live caveat for anyone hunting audio arithmetic on the CPU side.
+
+---
+
+## Open threads worth knowing about
+
+From the sources, unresolved by them:
+
+- Who writes the staged delay-time word at `0x80005fa0`, and its units — the
+  missing TIME → staging link.
+- The gain-to-knob mapping in the delay's EMAC block (FB, VOL, DIR, X);
+  needs hand-decoding of EMAC extension words that objdump mangles.
+- Whether the second DSP's tracks (5–8) share the delay function or a twin.
+- The marker-list writer that BEAT snapping reads, and with it what TSNS
+  actually parameterizes (inferred to select snap candidates).


### PR DESCRIPTION
Three third-party reverse-engineering documents, recorded in a new `docs/EXTERNAL.md` with a status key that keeps three things apart: **✅ we re-verified it** / **🟡 adopted on their evidence** / **❌ it retracts us**.

> ⚠️ **The author is uncredited.** The documents carry no author line. `docs/EXTERNAL.md` says so at the top, and nothing from them is presented as octabam's own finding.

## The delay mystery is solved

The project's oldest open question. Every negative we had established was correct — it genuinely is not on the DSP — but we never found the positive answer.

It is on the **ColdFire**: per-frame DMA descriptor arithmetic over per-track circular buffers in SDRAM based at `0x4F502C10`, frame routine `0x400031a0`, EMAC loops doing the gain and mix work. No fractional interpolation — a two-tap crossfade in *time* instead, which is why TAPE-off TIME changes snap audibly and TAPE-on glides. Feedback is not recursive code at all: the ring's write stream simply carries a scaled copy of its own read stream.

It also explains the thing that always looked wrong — **eight tracks sustaining full 4-second delays simultaneously** — because each has its own ~1.4 MB ring in CPU SDRAM, always allocated. That was never a DSP budget question.

Why we missed it: our sweeps keyed on parameter-storage addresses (it reads a *derived* time word), on the FX2-id field offset (the gate is a `moveq #8` against a copied byte), and on the `0x46xxxxxx` globals region (the rings are nowhere near it).

## Two retractions

**❌ "Audio does not arrive over the serial audio interface"** — and this one I **verified myself** rather than adopting. The vector reading was right; the inference was not. *A DMA-serviced peripheral needs no interrupt vectors.* Both ESAIs are configured at `P:0x30026` in our own `payload_A.asm`:

```
03002c: movep #>$37d01,x:<<M_TCR   ; M_TE0 enabled, M_TMOD=1 (network), M_TSWS=$1f
030036: movep #>$ff,x:<<M_TSMA     ; all 8 transmit slots
030045: movep a,x:<<M_TX0          ; and it transmits
```

Worth recording how long this sat: **`CHIP.md` has labelled that same module "host-port loader + ESAI setup" the entire time.** Two of our own documents contradicted each other for weeks and nobody read them together.

**❌ "The ColdFire does no per-sample audio arithmetic"** — verified only for the audio ISR at `0x4000aad0`, and it does not survive the delay's EMAC loops.

## Corrections adopted (🟡)

| module | we called it | it is |
|---|---|---|
| `P:0x3a1` | "parameter unpacking" | the voice playback engine — 2-tap linear interpolator over the 128-word ring |
| `P:0x2bf` | "MAC/pointer-walk resampler" | the summing mixdown |
| `func_00055a` | a gain routine | the 24-bit ↔ dual-16-bit host packer |

The conclusion those labels were serving — that no module on either payload is the delay — is undisturbed.

Also ingested: timestretch is a ColdFire feature (CPU renders grains *and* crossfades with an exact Hann window, ships finished audio; the DSP only interpolates pitch; no pre-analysis anywhere), and a shape-level atlas of the boot-uploaded data tables.

## A live caveat

They report that `objdump -m m68k:5407` **silently mangles every EMAC region into `.short` garbage** — this ColdFire is V4e-class with a four-accumulator EMAC. We use radare2 `-a m68k` instead, and it is *not* established that r2 does any better, so our ColdFire disassembly should be treated as possibly blind in MAC regions until someone checks.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)