### PR TITLE
fix: make remix never existed, plus three stale figures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,10 @@ check: bus cycles verify ## Everything that can be checked without hardware
 modules: ## List the module index and the available remixes
 	python3 tools/remix/index.py
 
+.PHONY: remix
+remix: ## The remix workbench: compose a selection, see what it costs, build it
+	python3 tools/remix/tui.py
+
 # -------------------------------------------------------------------- misc --
 
 .PHONY: disasm
@@ -167,3 +171,4 @@ help: ## Show this help
 	@echo
 	@echo "Cold start:  read PLAN.md, then  make setup && make os && make recon && make bus"
 	@echo "Modules:     make modules      (then: make bus REMIX=<name>)"
+	@echo "             make remix        compose a selection interactively"

--- a/PLAN.md
+++ b/PLAN.md
@@ -122,12 +122,14 @@ All five ship together in the `mutables` remix (2,410/2,724 words with SEND;
 contract; the build's three-source special-casing was generalized the same
 day under the refhash gate (bit-identical before any module existed), and
 `verify_menu` now derives its expectations from the selected remix instead of
-a hand table. All three are **not yet flashed** — every MODE select and knob
-publish rides the standing on-unit reconfirm. Known tool gaps: `make cycles`
-is remix-blind (still prices the chongbong engines whatever REMIX says;
-by inspection the inserts are ~80/~90/~190 cycles/sample worst 🟡), and
-send_probe's layout charset is still hard-coded RDS. — inserts render
-through dsp_host directly.
+a hand table. **None of the six is flashed** — every MODE select and knob
+publish rides the standing on-unit reconfirm, and that is the only gate left.
+
+Both tool gaps this paragraph used to list are now CLOSED: `make cycles` is
+remix-aware (measured costs in the ledger below, and they were dearer than
+the inspection estimates this paragraph once carried — Rungs 238 against a
+guessed ~190), and `send_probe`'s layout alphabet is derived from the
+manifests, so an insert renders with `--direct` rather than by hand.
 
 Three things follow that are worth knowing before editing anything:
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -224,7 +224,7 @@ because it assembled.
 
 **If you changed the build rather than adding a module, prove it changed
 nothing.** `scripts/refhash.sh save` on a tree you trust, make your change,
-`scripts/refhash.sh check` — 23 build configurations must come back
+`scripts/refhash.sh check` — 26 build configurations must come back
 bit-identical, artifacts *and* build reports. This is how every refactor in
 the remix work proved itself, and it caught things reading the diff did not.
 


### PR DESCRIPTION
An audit for **stranded findings** — things recorded in one place and consumed nowhere. Four landed, three of them mine from the last two days.

## `make remix` did not exist

It is documented in `README.md`, `docs/MODULES.md`, `CLAUDE.md` and `PLAN.md` as *the* way to compose a remix. The target was never in the Makefile.

My edit script matched on `modules: ## The module index...` while the real line reads `modules: ## **List** the module index...`, so the replace silently did nothing. I then reported success from the script's own `print()` and my verification `grep` returned empty without my noticing, because the `make check` output that followed scrolled past it.

Added, and verified three ways this time: the rule is in the file, `make -n remix` resolves it, and it shows up in `make help`. The help footer points at it too.

## Three stale figures

| where | said | actually |
|---|---|---|
| `docs/MODULES.md` | refhash is "23 build configurations" | 26 — CLAUDE.md and README were updated yesterday, the contributor guide was missed |
| `PLAN.md` | "`make cycles` is remix-blind" and "send_probe's layout charset is hard-coded RDS." | both fixed; the paragraph sat directly above the measured cycle table that exists *because* they were fixed |
| `PLAN.md` | inserts are "~80/~90/~190 cycles/sample" by inspection | measured 101/93/238 — the guesses were low, Rungs by 25% |

## Checked and clean

Every other make target and file path referenced in the docs resolves. `PLAN.md`'s free-word figures (A 74 / B 30) match what the build prints today. The knob-to-slot maps are derived from the manifests, so they cannot drift.

Three background agents are still auditing `CHIP/DSP/XBUS`, `VOICING/REVERB/BUS` and the process docs for the same pattern; further fixes will follow separately.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)