### PR TITLE
tools: five instruments were reporting the wrong thing

### DIFF
--- a/tools/capture_hw.py
+++ b/tools/capture_hw.py
@@ -29,8 +29,14 @@ that are easy to tell apart in a spectrum:
   * BROADBAND HASH with no relation to the input: the server is reading memory
     that is not audio at all.
   * HARMONIC DISTORTION at 2f/3f/5f of a test tone with the fundamental still
-    dominant: ordinary overload, which is a known and separate weakness (the
-    reverb saturates above ~0.35 FS input) and is NOT this bug.
+    dominant: ordinary overload, which is a known and separate weakness and is
+    NOT this bug.
+    ⚠️ The threshold quoted here was "~0.35 FS input" until 30 Aug 2026, and
+    that figure is RETRACTED (docs/VOICING.md): it came from an unconfirmed
+    FWHT-store hypothesis. The engine is linear to the measurement floor below
+    -6 dBFS, the knee sits between input gain 0.6 and 0.7, and the 24 Aug 2026
+    hardware pass found it unreachable from a sane mix. Do not dismiss a real
+    distortion report by comparing against 0.35.
 
 HOW TO USE IT. Play a steady tone or a simple loop into the send with ChonVerb
 on the receiving track, capture ~8 s, then run --analyse. Capture the WORKING

--- a/tools/cycle_count.py
+++ b/tools/cycle_count.py
@@ -45,8 +45,11 @@ ASM = ROOT / "vendor/dsp56300/build/source/dsp_host/dsp_asm"
 # against by every design decision from the density pass onward. Retracted
 # twice in the docs and still printed here until 8 Aug.
 #
-#   FILTER on all four core-0 tracks   froze at 32*76 = 1392 spare
-#   FILTER disabled everywhere         2032 and never broke (probe ran out)
+#   FILTER on all four core-0 tracks   froze at BURN=87 on the 16x probe -> 1392
+#   FILTER disabled everywhere         froze at BURN=76 on the 32x probe -> 2432
+# (⚠️ the arithmetic here read "32*76 = 1392" until 30 Aug 2026, which is
+# neither row: it fused the two, used the filters-OFF freeze point, and got a
+# product of 2432 while printing 1392. CHIP.md section 2 has both rows.)
 #
 # 1392 spare was measured with the FULL BANK plus the heaviest FX1 config
 # already running, so the budget for OUR code is that spare plus what the bank
@@ -71,6 +74,13 @@ ASM = ROOT / "vendor/dsp56300/build/source/dsp_host/dsp_asm"
 # so spare for new work today is BURN_SPARE minus however much the bank has
 # grown since. Anything else prices FX1 against cycles we do not have -- and
 # FX1 spends them x4 per core, so the error is multiplied by four.
+# ⚠️ SUPERSEDED AS A HEADLINE, kept because the delta arithmetic below is
+# anchored to it. The 23 Aug 2026 sweeps re-measured this properly and
+# CHIP.md section 2 is the authority: spare 704 with the R46 reverb + 4x
+# FILTER, 1088 with 2x, one FILTER = 192 (not the old ~260 inference), total
+# DSP-usable budget ~3120, stock's own share ~1410. Those are what the
+# WORST-CORE line below prices against; this constant only feeds the legacy
+# 7 Aug comparison, which is labelled as such.
 BURN_SPARE = 1392       # measured, worst realistic FX1 load, 7 Aug 2026
 # 🟡 RECONSTRUCTED, not measured: the bank the 1392 was measured on top of.
 # Pre-roll four-line reverb 763 (PLAN records the roll as 763 -> 778) + delay
@@ -79,6 +89,14 @@ BURN_SPARE = 1392       # measured, worst realistic FX1 load, 7 Aug 2026
 # does not build.
 BANK_AT_MEASURE = 763 + 163 + 2 * 19
 CORE_TOTAL = 4535       # 200 MIPS / 44100, arithmetic
+# ✅ hardware, 23 Aug 2026 (CHIP.md section 2), triangulated from three sweeps.
+USABLE = 3120           # what our code may actually spend, per core
+STOCK_SHARE = CORE_TOTAL - USABLE      # ~1410, by subtraction
+# ⚠️ THE PRICER IS KNOWN TO BE OFF, and by how much: CHIP.md measures the R46
+# reverb's true cost at ~1650 against the 1384 counted here (~270 LOW), and
+# the delay ~264 HIGH since the phead roll. The counts below are exact for the
+# code as written and blind to memory contention; treat them as a floor and
+# the hardware sweep as the authority.
 
 
 def room_for_new_work(bank):
@@ -505,6 +523,12 @@ def main():
     # against. Printing "% used" against a fixed budget is exactly what made
     # 1080 dangerous -- it turned an unknown into a pass/fail.
     print(f"{'budget/core':{w}}  {CORE_TOTAL:>13}   (200 MIPS / 44.1 kHz)")
+    print(f"{'usable by us':{w}}  {USABLE:>13}   measured 23 Aug 2026; stock takes "
+          f"the other ~{STOCK_SHARE}")
+    print(f"{'headroom':{w}}  {USABLE - worst:>13}   against the worst core above"
+          + ("   *** OVER ***" if worst > USABLE else ""))
+    print(f"{'':{w}}  {'':>13}   ⚠️ the counter reads ~270 LOW on the reverb "
+          f"(CHIP.md s2); the wall is a CLIFF")
     if bank is None:
         print()
         print("  This remix carries none of the modules the 7 Aug hardware sweep")

--- a/tools/render_reverb.py
+++ b/tools/render_reverb.py
@@ -413,6 +413,12 @@ def run(mem, src, values, tail_s, verbose, entry=None):
 
 
 # ---- reporting -----------------------------------------------------------
+# ⚠️ "tail to -60 dB" CANNOT TELL DECAY FROM RUNAWAY. It scores the last
+# window above -60 dB RELATIVE TO THE TAIL'S OWN PEAK, so a tail that GROWS
+# scores as a magnificent one -- it reported 7.90 s for an engine that was
+# diverging, and that number was written down as proof the eight-line tank
+# worked (docs/VOICING.md, "a single scalar cannot tell decay from runaway").
+# Read the per-second envelope before believing it.
 def report(label, L, R, src_len, normalized=False):
     peak = max((abs(v) for v in L + R), default=0)
     clip = sum(1 for v in L + R if abs(v) >= 8388607)

--- a/tools/send_probe.py
+++ b/tools/send_probe.py
@@ -258,17 +258,29 @@ def run(mem, dur, tail, rev_params, send_params, verbose=False, amp=0.5,
     _present = [c for c in layout.upper() if c in SERVER_CHARS]
     tgt = pick or ("R" if "R" in layout.upper() else
                    "D" if "D" in layout.upper() else
-                   (_present[0] if _present else "R"))
+                   (_present[0] if _present else None))
+    # ⚠️ NO SILENT FALLBACK TO "R". It used to default to the reverb when it
+    # could not work out a target, which meant `--direct` on an insert
+    # rendered ChonVerb and said so in the wrong words. If we cannot tell what
+    # to run, say so.
+    if tgt is None or tgt not in SERVER_ID:
+        die(f"cannot tell which module to render from layout {layout!r}. "
+            f"Pass --pick <letter> -- one of {''.join(sorted(SERVER_ID))} "
+            f"(see --layout help).")
     live = [(0, tgt)]
     if direct:
         ri, rp = entry(tgt)
+        # Params for whichever module is being rendered: the two servers keep
+        # their CLI-driven sets, anything else uses its own manifest defaults.
+        _par = (rev_params if tgt == "R" else dpar if tgt == "D"
+                else MODULE_DEFAULTS.get(tgt, [0] * 12))
         cmd = [str(HOST), "-mem", str(mem),
                "-init", f"{ri:x}", "-proc", f"{rp:x}",
                "-inst", "1", "-r7", "2", "-alloc", "1",
-               "-inmask", "1",                   # tone straight into the server
+               "-inmask", "1",                   # tone straight into the module
                "-blocks", str(blocks), "-in", str(src), "-out", str(out),
                *(["-split", str(split)] if str(split) not in ("0", "") else []),
-               "-params", ",".join(map(str, rev_params if tgt == "R" else dpar))]
+               "-params", ",".join(map(str, _par))]
     else:
         # Nothing in send_client divides by the number of clients, so N sends put
         # N x the contribution into one accumulator word.
@@ -371,15 +383,38 @@ def fft(x):
     return x
 
 
-def analyse(sig, label):
-    """Report the spur floor of a steady-state window. Returns (ratio_dB, rms)."""
+def analyse(sig, label, tone_end=None):
+    """Report the spur floor of a steady-state window. Returns (ratio_dB, rms).
+
+    ⚠️ THE DEFAULT WINDOW IS THE LAST NFFT SAMPLES OF THE BUFFER, which is
+    the `--tail` SILENCE APPENDED AFTER THE TONE, not "the last part of the
+    tone" this comment used to claim. A reverb hides that: its tail is a loud
+    decaying one, so the window is full of signal. A MEMORYLESS module has
+    nothing there, so the window is digital silence and the tool announced
+    `SILENT -- the bus carried nothing` about a perfectly good render. That is
+    what made every insert look broken (found 30 Aug 2026).
+
+    The fix is deliberately ADDITIVE, not a correction of the window: every
+    THD in `docs/VOICING.md` was measured against the tail, and moving the
+    window silently would invalidate the lot (the reverb reads -36.5 dB on the
+    tail and -21.7 dB on the tone -- they are different measurements, not a
+    better and a worse one). So the tail stays the default, and `tone_end` is
+    used only when the tail turns out to be silent. Anything comparing against
+    a logged number keeps comparing against the same thing.
+    """
     rms = math.sqrt(sum(v * v for v in sig) / max(len(sig), 1)) / 8388607
-    # Take the window from the LAST part of the tone, so the tank is fully
-    # built up and the measurement is steady state.
     if len(sig) < NFFT:
         die(f"{label}: only {len(sig)} samples, need {NFFT}")
     seg = sig[-NFFT:]
     pk = max(abs(v) for v in seg) / 8388607
+    if pk < 1e-4 and tone_end is not None and tone_end >= NFFT:
+        # No tail to measure -- a module with no memory. Fall back to the end
+        # of the tone and SAY SO, because it is not the same measurement.
+        seg = sig[tone_end - NFFT:tone_end]
+        pk = max(abs(v) for v in seg) / 8388607
+        if pk >= 1e-4:
+            print("  (no tail: measured over the end of the TONE, so this THD "
+                  "is not comparable with a server's tail figure)")
     if pk < 1e-4:
         return None, rms, pk, []
 
@@ -484,7 +519,7 @@ def main():
     ap.add_argument("--mod", type=int, default=0,
                     help="MOD depth (slot 1). Zeroed in the THD tests to keep LFO\nsidebands out of the metric -- which also suppressed any\ninterpolation artifact the modulation would have caused.")
     ap.add_argument("--shmr", type=int, default=0,
-                    help="SHIMMER amount (param slot 6 -> r6+$b). v101 replaced\nSPEED with SHMR; render_reverb.py still calls this slot SPEED.\nBuilds before 41d252c default it to 48, not 0.")
+                    help="SHIMMER amount (param slot 6 -> the KNOB field of r6+$c, NOT $b -- the $b\nreading is why the delay's WOW worked locally and never on hardware; see\nPARAM_PAGES.md). v101 replaced\nSPEED with SHMR; render_reverb.py still calls this slot SPEED.\nBuilds before 41d252c default it to 48, not 0.")
     ap.add_argument("--dtime", type=int, default=None,
                     help="DELAY TIME 0..127 (delay slot 0, default 40 -- the\nboot default). PITCH mode caps the lag at 14335 samples,\ni.e. TIME ~111.")
     ap.add_argument("--dfdbk", type=int, default=None,
@@ -563,16 +598,27 @@ def main():
                     help="source .wav instead of the tone (THD is then not meaningful)")
     ap.add_argument("--split", default="0",
                     help="frames in the a=0 sub-block call. NONZERO IS THE POST-TRIG\nSTATE: proc() runs TWICE a block and the bus split bookkeeping\n(r7+$65/$66/$67) actually executes. Split 0 never touches it.")
+    _alpha = ", ".join(f"{c}={registry.by_id(SERVER_ID[c]).name}"
+                       for c in sorted(SERVER_ID))
     ap.add_argument("--layout", default="RS",
-                    help="dispatch slots in hardware order: R=reverb, D=delay, "
-                         "S=send, .=neither. Slot 0 is position 0, the "
-                         "housekeeper. e.g. SR, .RS, SSR, DS. D needs a DEV=1 "
-                         "image (see build_bus.py)")
-    ap.add_argument("--pick", choices=["R", "D"],
-                    help="which server's output to analyse when the layout runs "
-                         "both (default: R if present, else D)")
+                    help=f"dispatch slots in hardware order: {_alpha}, "
+                         ".=neither. Slot 0 is position 0, the housekeeper. "
+                         "e.g. SR, .RS, SSR, DS. D needs a DEV=1 image. "
+                         "Only R/D own a bus accumulator and can be ANALYSED; "
+                         "render an insert with --direct --pick <letter>.")
+    # ⚠️ NOT hard-coded to R/D. This was choices=["R","D"] until 30 Aug 2026,
+    # which made the documented insert-render command
+    # (`--direct --pick W`) die in argparse -- and dropping --pick was worse:
+    # the target fell back to "R", so it instantiated ChonVerb and LABELLED
+    # the output "DELAY". Six documents described that command as the way to
+    # render an insert. Derive the choices, like everything else here.
+    ap.add_argument("--pick", choices=sorted(SERVER_ID),
+                    help="which module's output to analyse. Defaults to the "
+                         "layout's server (R, else D). REQUIRED with --direct "
+                         "for an insert, which has no bus and so no default")
     ap.add_argument("--direct", action="store_true",
-                    help="CONTROL: no SEND, tone into the reverb's own input")
+                    help="CONTROL / the insert path: no SEND, tone straight "
+                         "into the picked module's own track input")
     ap.add_argument("-v", "--verbose", action="store_true")
     a = ap.parse_args()
 
@@ -636,20 +682,34 @@ def main():
     L, R = run(mem, a.dur, a.tail, rev, snd, a.verbose, a.amp, a.direct, wsrc,
                a.split, a.layout, delay_params=dpar, pick=a.pick,
                inall=a.inall)
-    thd, rms, pk, extra = analyse(L, a.label) if not a.infile else (None, 0, 0, None)
+    # Where the tone stops, so the analysis window is the end of the TONE
+    # rather than the silence after it -- see analyse().
+    _tone_end = len(wsrc) if wsrc is not None else int(a.dur * SR)
+    thd, rms, pk, extra = (analyse(L, a.label, _tone_end) if not a.infile
+                           else (None, 0, 0, None))
     if a.infile:
         pk = max((abs(v) for v in L + R), default=0) / 8388607
-        _srv = "DELAY" if (a.pick == "D" or "R" not in a.layout.upper()) else "REVERB"
+        _t = a.pick or ("R" if "R" in a.layout.upper() else
+                        "D" if "D" in a.layout.upper() else None)
+        _mm = registry.by_id(SERVER_ID[_t]) if _t in SERVER_ID else None
+        _srv = _mm.menu.fullname.decode("latin1").strip() if _mm else "?"
         print(f'{a.label}: {a.infile} through '
-              f"{_srv + ' direct (CONTROL)' if a.direct else 'SEND -> bus -> ' + _srv}"
+              f"{_srv + ' (--direct)' if a.direct else 'SEND -> bus -> ' + _srv}"
               f'  amp {a.amp}  peak {pk:.3f} FS')
         if a.wav:
             write_wav(ROOT / a.wav if not os.path.isabs(a.wav) else a.wav, L, R)
             print(f'  -> {a.wav}')
         return 0
 
-    _srv = "DELAY" if (a.pick == "D" or "R" not in a.layout.upper()) else "REVERB"
-    path = (f"{_srv} direct input (CONTROL)" if a.direct
+    # Name the module that ACTUALLY ran. This used to be a two-way guess
+    # between REVERB and DELAY, so an insert render was labelled "DELAY" while
+    # executing the reverb -- a mislabel of exactly the kind this project has
+    # lost sessions to.
+    _tgt = a.pick or ("R" if "R" in a.layout.upper() else
+                      "D" if "D" in a.layout.upper() else None)
+    _m = registry.by_id(SERVER_ID[_tgt]) if _tgt in SERVER_ID else None
+    _srv = _m.menu.fullname.decode("latin1").strip() if _m else "?"
+    path = (f"{_srv} on its own track (--direct)" if a.direct
             else f"SEND -> bus -> {_srv}")
     print(f"{a.label}:  tone {TONE_HZ:.2f} Hz through {path} "
           f"(amp {a.amp}, ->REVERB {snd[1]}, ->DELAY {snd[0]})")

--- a/tools/verify_delay.py
+++ b/tools/verify_delay.py
@@ -80,11 +80,21 @@ import send_probe
 SCRATCH = ROOT / "out" / "delayverify"
 SR = 44100
 
-# TIME FDBK TONE PING MIX VRBW WOW p7 VRBD SPRAY -- send_probe.DELAY_PARAMS
-# order. Indices 6..9 are the page-2 KNOB fields r6+$b/$c/$d/$e (dsp_host
-# writes value<<16, the knob field only -- which is why the companion selects
-# MODE/PTCH/FRZE need build overrides and cannot appear here).
-BASE = [40, 60, 100, 64, 90, 0, 0, 0, 0, 0]
+# send_probe.DELAY_PARAMS order, which since the 18 Aug 2026 swap is:
+#   0 TIME  1 FDBK  2 TONE  3 PING  4 -VRB  5 IN  6 DPTH  7 MODE  8 RATE
+#   9 PTCH  10 DRV  11 FRZE
+# ⚠️ Slot 6 is the KNOB field of r6+$c, NOT $b -- the old "$b/$c/$d/$e"
+# reading is the exact error PARAM_PAGES.md names as why the delay's WOW
+# worked locally and never on hardware. Odd slots (7/9/11) are companion
+# fields; dsp_host drives them via -params too since 17 Aug 2026.
+#
+# ⚠️ The 90 was on index 4 until 30 Aug 2026, described as "MIX 90 so a render
+# is audibly wet". After the swap index 4 is -VRB, so every run pinned the
+# REVERB SEND to 90 and left the delay's own IN at 0. Harmless for the
+# bit-compare (both sides got the same wrong knob) and wrong as a description
+# of what was exercised -- the same shape as the SLOT fix below, which landed
+# on 23 Aug and did not reach this line.
+BASE = [40, 60, 100, 64, 0, 90, 0, 0, 0, 0, 0, 0]
 
 SLOT = {"TIME": 0, "FDBK": 1, "TONE": 2, "PING": 3, "MIX": 5,
         "WOW": 6, "SPRAY": 9}


### PR DESCRIPTION
A stranding audit — three agents over the docs, looking for corrections recorded in one place and never applied where they're acted on. This PR is the **tools**, which matter most because they emit numbers people then believe.

## 1. The documented way to render an insert did not work

`--pick` was `choices=["R","D"]`, so the command **six documents** name as the insert path died in argparse:

```
send_probe.py: error: argument --pick: invalid choice: 'W' (choose from 'R', 'D')
```

Dropping `--pick` was worse — the target fell back to `"R"`, so it instantiated **ChonVerb**, rendered it, and printed **"DELAY direct input"**. A different effect, under a third effect's name. That is precisely the mislabel class `CLAUDE.md` collects.

I wrote those six documents yesterday and never ran the command. Same failure as `make remix` in #16: documenting a capability without executing it.

`--pick` and the `--layout` help now derive from the manifests, the label names the module that actually ran, and an unresolvable target dies rather than guessing.

## 2. …and the analysis window was the silence *after* the tone

`analyse()` took `sig[-NFFT:]` while its own comment claimed "the last part of the tone". `run()` appends `--tail` seconds of silence, so the window landed in it. A reverb hides this — its tail is loud and decaying. A **memoryless** module has nothing there, so every insert render announced `SILENT -- the bus carried nothing` about a perfectly good render.

Fixed **additively on purpose**: the tail stays the default, because every THD in `VOICING.md` was measured against it — the reverb reads −36.5 dB on the tail and −21.7 dB on the tone, which are *different measurements*, not a better and a worse one. The tone window is used only when the tail proves silent, and says so.

## 3–5. Three stale numbers in three tools

| tool | said | actually |
|---|---|---|
| `cycle_count.py` | priced against `BURN_SPARE = 1392` (7 Aug) | CHIP.md superseded it 23 Aug: usable 3120/core, stock ~1410, one FILTER 192. Now prints headroom against the worst core, and carries CHIP.md's own note that the counter reads **~270 low on the reverb** |
| `verify_delay.py` | `BASE[4] = 90`, "MIX 90 so a render is audibly wet" | index 4 is `-VRB` since the 18 Aug swap — every run drove the **reverb send** to 90 and left the delay's `IN` at 0. The `SLOT` map was fixed 23 Aug; this line wasn't. Gate re-run, still passes |
| `capture_hw.py` | "the reverb saturates above ~0.35 FS input" | retracted in VOICING.md — linear to the measurement floor below −6 dBFS. Would have dismissed a real distortion report |

Also: `render_reverb.py`'s `tail to -60 dB` now carries the caveat that **it cannot tell decay from runaway** (it scored 7.90 s for a diverging engine, and that number was recorded as proof the tank worked), and `send_probe`'s shimmer help no longer says slot 6 is `r6+$b` — the `$b` reading is exactly why the delay's WOW worked locally and never on hardware.

`make check` green, `make verify-delay` green.

Docs and `.asm` headers have their own stranded set (a retired `→DELAY` send still described as live, `base+0x7000` addresses, a MODE table with seven superseded numbers) — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)