### PR TITLE
docs: the burn probe isn't blocked, the auto-gain law is 1/√N, and CHIP.md's memory map was wrong

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,14 +123,14 @@ verify-bus: ## Prove a bus-layout change is behaviour-preserving. STAMP FIRST: m
 	@# bus. It is an on-demand gate around one edit, like verify-roll:
 	@#   make verify-bus SAVE=1     <- on the tree you trust, BEFORE the edit
 	@#   ...make the bus change...
-	@#   make verify-bus            <- must be 17/17 bit-identical
+	@#   make verify-bus            <- every case bit-identical (the tool prints the count)
 	@# Needs the DEV hatch: the gate's whole point is exercising layouts that
 	@# carry BOTH servers, and only the hatch has a real delay in payload A.
 	DEV=1 XBUS=1 python3 tools/build_bus.py >/dev/null
 	python3 tools/verify_bus.py $(if $(SAVE),--save) $(if $(SELFTEST),--selftest)
 
 .PHONY: burn
-burn: ## Build the cycle-burn probe -- CURRENTLY DOES NOT PLACE (plain layout overruns by 10 words)
+burn: ## Build the flashable cycle-burn probe (p3 = the burn knob, 32 cycles/step)
 	XBUS=1 BURN=1 python3 tools/build_bus.py
 
 .PHONY: check

--- a/PLAN.md
+++ b/PLAN.md
@@ -231,11 +231,14 @@ measures the real ceiling.
 - ⚠️ **FX1 cycles are paid ×4 per core** — a 300-cycle FX1 effect costs
   1,200 cycles/core. *This*, not program space, is the ceiling on FX1
   ambition.
-- ⚠️ **Only the `BURN=1` hardware sweep can re-measure the real per-core
-  spare, and the probe currently does not build**: the plain layout overruns
-  the region (2,734 > 2,724 — 10 words short; an older ~70-word figure
-  predates the delay shrinking). `verify_burn` reports
-  SKIPPED in `make check` until words are found.
+- ✅ **The flashable burn probe BUILDS — `make burn` places it** (payload A
+  FREE 46, B FREE 9) with `p3` as the burn knob at 32 cycles/step. This
+  paragraph claimed the opposite until 30 Aug 2026 and an entire work-order
+  item was priced on it. What is blocked is only `verify_burn`'s **alias-probe
+  diagnostic**, which needs the non-XBUS *plain* layout where the delay
+  overruns — and that figure has rotted twice (2,794 → 2,734 → **2,766 today**,
+  42 words over), so read it from `verify_burn`'s own NOTE rather than from
+  any document.
 - **Priced cycle lever**: GRAIN 4 grains → 2 returns ~300 cycles for ~100
   words, at the voicing cost of half the simultaneous voices.
 
@@ -311,13 +314,20 @@ cycles. Highest value, highest risk. ✅ Taking the three reverbs cost FX1
 nothing — they were never on its menu; FX1's ten effects are the whole pool.
 
 ⚠️ Sequence FX1 ambition after the burn sweep (§3) — its real ceiling is
-cycles ×4, and the spare has never been measured per core.
+cycles ×4. Note the spare HAS been measured per core since 23 Aug 2026
+(704 with the reverb + 4× FILTER, 1,088 with 2×, one FILTER = 192 —
+`docs/CHIP.md` §2); the sweep is to re-measure it against whatever bank FX1
+work would actually run in.
 
-### 3. Unblock the burn probe
+### 3. Flash the burn probe and sweep the ceiling
 
-Find ~10 words in the plain layout so `BURN=1` places, flash it once, and
-sweep the real per-core cycle ceiling from the front panel. Everything in §2
-prices off that number.
+**Not blocked — `make burn` builds a flashable image today.** Flash it once
+and sweep the real per-core cycle ceiling from the front panel with `p3`
+(32 cycles/step). Everything in §2 prices off that number, so this is one
+flash away rather than a hunt for words.
+
+(The *only* thing needing words is `verify_burn`'s alias-probe diagnostic in
+the plain layout, which is a local check, not the measurement.)
 
 ---
 
@@ -393,6 +403,6 @@ make reverb IN=loop.wav ARGS='--sweep SIZE=0,64,127 --wet'
 make verify-delay CAND=modules/bongdelay/delay_new.asm   # bit-identity gate for delay refactors
 ```
 
-`make bus-plain` (both servers on both cores) and `make burn` do not
-currently build — both layouts overrun the donor region; the burn overrun is
-work-order §3.
+`make bus-plain` (both servers on both cores) does not build — that layout
+overruns the donor region. `make burn` **does** build and is flashable; only
+`verify_burn`'s plain-layout alias probe is blocked.

--- a/docs/CHIP.md
+++ b/docs/CHIP.md
@@ -437,7 +437,7 @@ Anything from that pass must be disassembled before it is believed.
 |---|---|
 | ChonVerb | `Y:0x4000–0xBFFF` — 32 768 words, **hardcoded**, both payloads (different cores, so no collision) |
 | BongDelay | `Y:0x30000–0x37FFF` (A) / `Y:0x38000–0x3FFFF` (B) — 32 768 words each ⚠️ **COLLIDES AT BOTH BASES**, see §3a. Renders locally under `DEV=1`; confirmed on hardware on its shipping payload-B path |
-| Bus scratch | `Y:0x900–0x980` — parity word, then 4 × 16-word accumulators and 4 × 16-word wet buffers |
+| Bus scratch | `Y:0x900–0x9d2` — **211 words**: rotation word, then per bus 4 × 16-word accumulators, 2 × 16-word wet buffers and 4 per-buffer send counts, plus both role locks and the delay's 1/√N reciprocal table. `modules/send/send_client.asm` is the authoritative map. ❌ This row read `0x900–0x980`, "parity word", 4 wet buffers until 30 Aug 2026 — wrong extent (it stopped before the role locks at `0x9c1`/`0x9c2`), wrong name ("parity" is the retired two-buffer term), wrong wet count. `XBUS.md` points HERE for the exact extent, so anyone sizing a module against it would have placed it on top of the locks. |
 | Per-instance base stash | `Y:0x795 + (r7>>8)` — one word per instance |
 | SEND | **nothing.** A zero-footprint client; never touches its own slot |
 
@@ -463,8 +463,11 @@ bisect); do not design around it.
 
 Placement, in address order (sizes from an earlier build): `SEND` 166 ·
 `REVERB SERVER` 2 040 · `DELAY SERVER` 507. In today's BURN plain layout
-`DELAY SERVER` is **2 794 words** — it overruns the 2 724-word region by 70
-on its own.
+`DELAY SERVER` overruns the 2 724-word region on its own. ⚠️ Do not quote the
+figure — it has rotted twice (2 794 → 2 734 → **2 766** as of 30 Aug 2026)
+because the delay keeps changing size; `verify_burn` prints the live number.
+And this blocks only that DIAGNOSTIC: the flashable probe places fine via
+`make burn`.
 
 **Exactly three stock effects are taken: PLATE REV, SPRING REV, DARK REV.**
 CHORUS was once a donor and is now byte-identical to stock. Relocating
@@ -482,11 +485,11 @@ whole module.
 | FX slots per track | FX1 (3 072 words) + FX2 (16 384 words) | ✅ |
 | Reverb/delay are FX2-only | FX1's 3 072 words are far too small | ✅ |
 | FX1 is **not** idle | dispatcher calls it every frame; a fresh part defaults FX1 = FILTER | ✅ |
-| Parameters per effect | **12** — 6 page-1 knobs, 3 page-2 knobs, 3 page-2 selects | ✅ `DSP.md` §9 |
-| Menu | 3 entries: ChonVerb / BongDelay / Send. **No selectable NONE** | ✅ |
+| Parameters per effect | **12** — 6 page-1 knobs, then 6 page-2 slots. The "3 knobs + 3 selects" split is how *stock* uses the fields, **not a hardware limit**: all six can be full-range knobs, measured on hardware (`DSP.md` §9 — which this row contradicted while citing it) | ✅ |
+| Menu | **remix-selected** — `make modules` lists what each carries; shipping `chongbong` has 3 entries, `mutables` 6. **No selectable NONE** in any | ✅ |
 | Unassigned tracks | id 0 is aliased to **SEND**, so every unassigned track feeds the bus | ✅ |
 | Track↔core mapping | **payload A serves tracks 5-8, payload B serves tracks 1-4** — inverted from the natural assumption; unobservable before specialization (both payloads carried every effect) | ✅ marker-flash test |
-| `r7` state block | `$00–$83` usable; **`$84–$8a` HANGS** (host-owned) | ✅ bisected |
+| `r7` state block | `$00–$83` usable. `$84–$8a` is host-owned and cannot hold state **across calls**; per-call scratch there is fine, and BongDelay ships using `$84`–`$88`. The blanket "HANGS" stood until 30 Aug 2026 | ✅ bisected |
 | ChonVerb's `r7` | **full** | ✅ |
 
 Persistent state does **not** have to live in `r7` — `dsp/cycleburn.asm`

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -128,9 +128,9 @@ version:
 | `tools/verify_menu.py` | the ColdFire menu edits against the real chooser mechanism, decompiled from the firmware — including the descriptor traps (formatter vs count) |
 | `tools/verify_slots.py` | static dead-store/aliasing check on the r7 state block — the family of bugs where one slot means two things |
 | `tools/verify_midi.py` | the note→PITCH interval path, locally, via a build override |
-| `tools/verify_burn.py` | the cycle-burn probe is the shipping engine plus an inert knob (currently SKIPs — the probe does not place) |
+| `tools/verify_burn.py` | the cycle-burn probe is the shipping engine plus an inert knob (its alias-probe diagnostic SKIPs — the plain layout overruns; the flashable probe itself places fine via `make burn`) |
 | `tools/remix/selftest.py` | the resource ledger still catches every collision it claims to (part of `make check`) |
-| `scripts/refhash.sh` | a change to the BUILD (not a module) changed nothing: 23+ configurations, artifacts *and* build reports, bit-identical — save a baseline on a tree you trust first |
+| `scripts/refhash.sh` | a change to the BUILD (not a module) changed nothing: 26 configurations, artifacts *and* build reports, bit-identical — save a baseline on a tree you trust first |
 
 ## 7. Hardware measurement and control
 

--- a/docs/XBUS.md
+++ b/docs/XBUS.md
@@ -123,10 +123,21 @@ defects below burned in:
 The naive bus rails: senders sum, and five tracks at moderate level clip
 the shared word. Instead every writer contributes with **3 bits of headroom**
 (`asr #3`, so eight full-scale clients sum to exactly 1.0) and registers in
-a per-block client count; the server multiplies the summed block by **1/N**
-from a reciprocal table and shifts back up. Measured flat: 1 through 7
-senders render identically (THD −44.6 dB at every count where the
-un-gained bus had railed to −0.6). Two hard-won rules:
+a per-block client count; the server multiplies the summed block by
+**1/√N** from a reciprocal table and shifts back up.
+
+❌ **This said 1/N until 30 Aug 2026, and the law changed on 17 Aug** (shipped
+as R27). N sources sum as N only when they are CORRELATED; real tracks are
+not, and sum as √N — so dividing by N over-corrects real material by √N,
+3 dB per doubling. `modules/chonverb/reverb_server.asm` §"THE LAW IS
+1/sqrt(N)" is the authority, and `docs/CAPTURE.md` capture E measured it.
+
+❌ The justification quoted here was worse than the number: *"Measured flat:
+1 through 7 senders render identically (THD −44.6 dB)"*. That measurement fed
+**the same tone** to every sender, so the senders were perfectly correlated —
+the one condition under which 1/N and √N summing agree. It is structurally
+blind to the very thing it was cited as proving, the same family as the THD
+metric that could not see an inharmonic spur. Two hard-won rules:
 
 - **Registration must be gated on the send knob.** A client that registers
   and contributes nothing dilutes every real sender by N/(N+1) — **−6 dB
@@ -137,9 +148,11 @@ un-gained bus had railed to −0.6). Two hard-won rules:
   "fixed" full-scale writer whose effective gain varies as 8/N with the
   sender count is not fixed at all.
 
-Perceptual consequence, by design: the law is 1/N across *registered*
-senders, so a quiet sender turns a loud sender's reverb down (measured to
-the dB against the 1/√N alternative — `docs/CAPTURE.md`, capture E).
+Perceptual consequence, by design: the law is **1/√N** across *registered*
+senders, so a quiet sender still turns a loud sender's reverb down, but by
+half as much in dB as 1/N did (`docs/CAPTURE.md`, capture E — where three
+senders, two of them 10–15 dB quieter, dropped the wet by 4.8 dB against the
+1/N prediction of −9.5).
 
 ## The three cross-core defects — why all of the above
 
@@ -183,12 +196,12 @@ it, swapping what ran on track 5 — is in `docs/history/XBUS_LOG.md`.
 
 ## Verification
 
-`make verify-bus` is the gate for any bus-layout change: **17 layouts** —
+`make verify-bus` is the gate for any bus-layout change: **19 layouts** (17 until 18 Aug 2026, when two `IN` cases were added — the delay's IN decode had been deleted by a splice and 17/17 still passed) —
 all three carriers of the housekeeping block, the election, 1–7 senders per
 bus, both cross-sends, split blocks — rendered and compared **bit-for-bit**
 against a stamp taken before the edit (`SAVE=1` first). The four-buffer
 restructure itself was proven exact by pointing the candidate's read at the
-same buffer *generation* as the reference — 17/17 bit-identical at lag 0 —
+same buffer *generation* as the reference — all cases bit-identical at lag 0 —
 separating the layout change from the latency change completely. See
 `docs/HARNESS.md` for where this sits in the wider rig.
 


### PR DESCRIPTION
Second batch of the stranding audit — the tools went in #17, these are the records that describe them.

## The burn probe is not blocked, and a work-order item was priced on believing it was

`make burn` places and produces a **flashable** image with `p3` as the burn knob — payload A FREE 46, B FREE 9. I ran it.

`PLAN.md` §3 read *"Find ~10 words in the plain layout so `BURN=1` places"*, and §2 — FX1 consolidation, the largest remaining piece of the project — was explicitly sequenced behind it. What is actually blocked is only `verify_burn`'s **alias-probe diagnostic**, which needs the non-XBUS plain layout.

So the hardware measurement that prices all FX1 work is **one flash away**, not a hunt for words.

The overrun figure that blocks that diagnostic has rotted twice: CHIP.md said 2,794, PLAN.md said 2,734, and it is **2,766** today. All three now point at `verify_burn`'s live NOTE instead of quoting a number that keeps changing.

## The auto-gain law has been 1/√N since 17 August

`XBUS.md` — the standing architecture record — still said **1/N** in two places, as did `verify_bus`'s case labels, so the gate that would catch a regression documented the wrong constant.

Worse than the number was its justification, quoted as proof: *"Measured flat: 1 through 7 senders render identically (THD −44.6 dB)"*. That measurement fed **the same tone to every sender**, so they were perfectly correlated — the one condition under which 1/N and √N summing agree. It was structurally blind to exactly what it was cited as proving. Same family as the THD metric that couldn't see an inharmonic spur.

## CHIP.md's memory map was wrong in a way that would place a module on the role locks

| row | said | actually |
|---|---|---|
| Bus scratch | `Y:0x900–0x980`, "parity word", 4 wet buffers | `0x900–0x9d2`, **211 words**, a *rotation* word ("parity" is the retired two-buffer term), 2 wet buffers — and it stopped short of both **role locks** at `0x9c1`/`0x9c2`. `XBUS.md` points at this row for the exact extent |
| Y per server | "**32 768 is the hard ceiling** … that lever is spent" | **65 536 / 1.49 s** since the XBUS split. Three other docs say so *while citing this table*; wrong by a factor of two |
| Menu | "3 entries: ChonVerb / BongDelay / Send" | remix-selected — `mutables` has 6 |
| Page-2 params | "3 knobs, 3 selects" | all six can be full-range knobs, measured on hardware — the row contradicted the `DSP.md` section it cited as evidence |
| `r7` | "`$84–$8a` **HANGS**" | cannot hold state *across calls*; per-call scratch is fine, and **BongDelay ships using `$84`–`$88`**. The blanket wording cost the delay a state-table detour it may not have needed |

Plus: `verify_bus` runs **19** cases, not 17 (two added 18 Aug, after a splice deleted the delay's `IN` decode and 17/17 still passed) — fixed in XBUS.md, TOOLING.md and the Makefile's pass criterion, which now defers to the count the tool prints. And CHIP.md's complaint that "`DSP.md` still says otherwise" about external memory **outlived the defect** — both sites were fixed.

`make check` green; all 26 refhash cases bit-identical.

Still to come: the `.asm` headers (a retired `→DELAY` send described as live, `base+0x7000` addresses that moved to the shared window, shimmer "excised by default") and `REVERB.md`'s MODE table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)