### PR TITLE
plan: queue the stock-delay-in-series experiment onto the next flash

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -329,6 +329,47 @@ flash away rather than a hunt for words.
 (The *only* thing needing words is `verify_burn`'s alias-probe diagnostic in
 the plain layout, which is a local check, not the measurement.)
 
+### 4. Piggyback on that flash: can the STOCK delay run downstream of our reverb?
+
+Cheap experiment, no new engine, and it would buy a routing the hardware has
+no path for. **Everything about it is hardware-only** — the mechanism is
+entirely CPU-side, so no local test can say anything.
+
+**What is settled.** The stock Echo Freeze Delay is applied *downstream of the
+FX2 insert* (measured here by listening test) and lives on the ColdFire as DMA
+over SDRAM rings at `0x4F502C10` (`docs/EXTERNAL.md`, Bryan T). So the signal
+order for "our reverb into the stock delay" is already the right way round.
+The reverse — stock delay into our bus — is **impossible and now known to be
+so physically**: those rings are outside the DSP's 18-bit external address
+range, so no DSP code can ever read them. Delay→reverb stays BongDelay's
+`→VERB`.
+
+**The crack.** The audio path does not read the FX2 id field at all (all 18
+references to it are UI/menu code). The delay's enable is a `moveq #8` against
+a **copied byte in a per-track record** — which is exactly why every id-keyed
+sweep missed it. 🟡 That gate is *inferred*, not measured.
+
+**The experiment.** If that byte is decoupled from the dispatch id, a ColdFire
+cave — infrastructure we already fly — can set it for a track whose FX2 slot
+is running ChonVerb, giving **reverb → stock delay in series on one track**.
+Steps, cheapest first:
+
+1. Confirm the gate by reading it, not by patching: with a `cfv4e`
+   disassembly of `0x400031a0`, identify the record byte and its address.
+   (⚠️ `scripts/disasm.sh emac`, never radare2 — see `docs/EXTERNAL.md` §5.)
+2. On the unit, select DELAY on a track and read that byte; select ChonVerb
+   and read it again. If it tracks the FX2 id, the byte is the id and this
+   is dead. If it is set by a separate write, it is reachable.
+3. Only then write a cave that sets it. Its hook site must satisfy the
+   standing rule: assert the stock bytes, replay what you displace.
+
+**Known unknowns before spending a flash on step 3.** The delay's TIME comes
+from a staged word at `0x80005fa0` whose writer is unmapped, so the delay may
+run with no controllable time; and a track hosting ChonVerb has no free
+parameter slot to put a delay control on. Treat a first result of "it makes
+delayed sound at some arbitrary time" as success for the experiment and a
+separate problem for the design.
+
 ---
 
 ## Open items and standing caveats

--- a/docs/FLASHING.md
+++ b/docs/FLASHING.md
@@ -197,6 +197,23 @@ whole test.
 `docs/BUS.md` has the menu layout; `docs/PARAM_PAGES.md` explains how a knob
 reaches the DSP; `docs/MODULES.md` is what to read before writing one.
 
+### While you are at the unit — the hardware-only questions
+
+These cannot be answered anywhere else, so they are worth queueing onto any
+flash rather than spending a cycle of their own (`PLAN.md` work order):
+
+- **Sweep the cycle ceiling.** A `make burn` image puts the burn on `p3` at
+  32 cycles/step. The number prices every FX1 decision.
+- **Does the stock delay's enable track the FX2 id?** Select DELAY on a
+  track, read the per-track record byte the delay gates on; select ChonVerb
+  and read it again. If it is written separately from the dispatch id, then
+  a cave can enable the CPU-side delay *downstream of our reverb* — a
+  series routing the stock firmware has no path for. If it simply mirrors
+  the id, the idea is dead and should be recorded as such.
+- **Any new module's page-2 selects and knob publishes.** A slot can draw a
+  knob and publish nothing, and a formatter outranks the value count beside
+  it; both are invisible locally.
+
 ---
 
 ## 5. Reverting to the official firmware


### PR DESCRIPTION
Bryan T's delay architecture turns a closed question into a cheap hardware experiment, so it goes in the work order as **§4** rather than staying a conversation.

## Settled, and in the useful direction

The stock delay is applied **downstream of the FX2 insert** (measured here by listening test) and lives on the ColdFire as DMA over SDRAM rings. So *"our reverb into the stock delay"* is already the right way round.

The reverse is now known to be impossible **physically**, not merely unsolved: those rings sit outside the DSP's 18-bit external address range, so no DSP code can ever read them. Delay-into-reverb remains BongDelay's `→VERB` and always will.

## The crack

The audio path **never reads the FX2 id field** — all 18 references to it are UI/menu code. The delay gates on a `moveq #8` against a **copied byte in a per-track record**. That is why every id-keyed sweep missed it, and it is also why the enable may be *decoupled* from the dispatch id.

If it is, a ColdFire cave — infrastructure we already fly — can enable the CPU-side delay for a track whose FX2 slot is running ChonVerb: **reverb → stock delay in series on one track**, which the stock firmware has no path for.

## Written as an experiment, not a plan

Three steps, cheapest first, and **step 1 is read, not patch**:

1. Confirm the gate from a `cfv4e` disassembly of `0x400031a0` — identify the record byte and its address. (⚠️ never radare2 here, see EXTERNAL.md §5.)
2. On the unit: select DELAY on a track and read that byte, select ChonVerb and read it again. **If it tracks the FX2 id, the idea is dead** and should be recorded dead.
3. Only then write a cave, under the standing rule — assert the stock bytes, replay what you displace.

The gate is marked 🟡 *inferred*, because that is what Bryan marked it.

**Known unknowns, recorded before anyone spends a flash on step 3:** the delay's TIME comes from a staged word at `0x80005fa0` whose writer is unmapped, so it may run at some arbitrary uncontrollable time; and a track hosting ChonVerb has no free parameter slot for a delay control. A first result of *"delayed sound at some arbitrary time"* is a **success for the experiment** and a separate problem for the design.

`docs/FLASHING.md` gains a "while you are at the unit" section, since that is where someone standing at the hardware actually looks — carrying this, the burn sweep, and the standing page-2 publish reconfirm.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)