### PR TITLE
Decode the delay's gate byte, and evaluate the stock tables against our own modules

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -344,24 +344,58 @@ so physically**: those rings are outside the DSP's 18-bit external address
 range, so no DSP code can ever read them. Delay→reverb stays BongDelay's
 `→VERB`.
 
-**The crack.** The audio path does not read the FX2 id field at all (all 18
-references to it are UI/menu code). The delay's enable is a `moveq #8` against
-a **copied byte in a per-track record** — which is exactly why every id-keyed
-sweep missed it. 🟡 That gate is *inferred*, not measured.
+**The crack — now ✅ MEASURED, 31 Aug 2026, by disassembling it here.** The
+audio path does not read the FX2 id field at all (all 18 references to it are
+UI/menu code). What the delay actually gates on, at `0x40003230`:
+
+```
+a2 = 0x80001b87 + 64*track                  ; 0x400031e0..e6
+mvzb (a2),d0 ; moveq #8,d1 ; cmp ; bne      ; the gate
+mvsb (fp),d0 ; moveq #7,d2 ; cmp ; bne      ; a SECOND condition, fp =
+                                            ; 0x80000eb4 + 8*[0x800000e0]
+```
+
+So the gate byte is **offset +7 of a 64-byte per-track record based at
+`0x80001b80`**, and that record is filled by the frame builder at
+`0x4000d13c..46` in an eight-iteration per-track loop (`a3 += 64`), with
+offsets 6–7 coming from a staging word at `0x80000128 + 512*bank +
+64*track + 32`.
+
+**The consequence, and it is what makes the experiment worth a flash: the gate
+byte is a PER-FRAME COPY in shared RAM, not the FX2 id itself.** The DSP
+dispatch reads the id from the instance table (`r6+$1c`); the CPU delay reads
+this staged copy. They are different storage fed from the same source — so a
+cave running between the builder's write and the delay's read can set one
+without touching the other. That is precisely the decoupling step 2 was meant
+to test, and it is now established statically rather than on the unit.
+
+⚠️ The **second condition** (`0x80000eb4 + 8*bank == 7`) is unexplained;
+`0x80000eb4` is machine-type storage in the timestretch work. It may gate
+which TIME path runs rather than whether the delay runs at all — the two
+branches lead to two different time derivations, not to a bypass. Read it
+before assuming.
+
+✅ **Closed one of Bryan's open threads while in there:** the writer of the
+staged TIME word at `0x80005fa0` is this same routine, at `0x40003284..88`,
+copying a word from the *other* per-track record at `0x80001a00 + 96*track`.
 
 **The experiment.** If that byte is decoupled from the dispatch id, a ColdFire
 cave — infrastructure we already fly — can set it for a track whose FX2 slot
 is running ChonVerb, giving **reverb → stock delay in series on one track**.
 Steps, cheapest first:
 
-1. Confirm the gate by reading it, not by patching: with a `cfv4e`
-   disassembly of `0x400031a0`, identify the record byte and its address.
-   (⚠️ `scripts/disasm.sh emac`, never radare2 — see `docs/EXTERNAL.md` §5.)
-2. On the unit, select DELAY on a track and read that byte; select ChonVerb
-   and read it again. If it tracks the FX2 id, the byte is the id and this
-   is dead. If it is set by a separate write, it is reachable.
-3. Only then write a cave that sets it. Its hook site must satisfy the
-   standing rule: assert the stock bytes, replay what you displace.
+1. ✅ **DONE** — the gate, its record and its filler are decoded above.
+2. Pick the hook window. It must be **after** the frame builder fills the
+   record (`0x4000d146`) and **before** the delay routine reads it
+   (`0x40003230`), on the same frame. Find a site in that window whose stock
+   bytes can be replayed.
+3. Write the cave: force record+7 to 8 for the chosen track. Flash, select
+   ChonVerb on that track, and listen for repeats. The standing rule applies
+   — assert the stock bytes, replay what you displace.
+
+⚠️ **Before spending the flash, settle the second condition** (the `==7`
+above) statically; if it turns out to gate the delay's existence rather than
+its time source, step 3's cave needs to satisfy both.
 
 **Known unknowns before spending a flash on step 3.** The delay's TIME comes
 from a staged word at `0x80005fa0` whose writer is unmapped, so the delay may

--- a/docs/EXTERNAL.md
+++ b/docs/EXTERNAL.md
@@ -163,6 +163,48 @@ Points that matter if we ever go looking for a table:
   FRQ1 and is actually **GN1/GN2**; FRQ reads `X:0x015c7` with a ×4 index
   (2 extra bits of resolution, unexplained).
 
+### ✅ Evaluated against our own modules, 31 Aug 2026
+
+The atlas is shape-only, so the question it leaves open is *"is any of this
+useful to us?"*. Measured, not guessed:
+
+**The 32 × 128 bank is mostly one-pole COEFFICIENT PAIRS, not knob warps.**
+Extracted and characterised all 32: they come in pairs — a near-1.0 falling
+curve beside a small rising one — which is the (pole radius, complementary
+gain) shape you index by a knob to sweep a one-pole filter. Useful to a future
+module that wants a cutoff map with the stock feel; not what we assumed.
+
+**Not worth swapping our existing tapers, and this is a negative result worth
+recording so nobody re-runs it.** Fitting every curve (plus reversals and
+inversions) against the shapes our modules compute by hand:
+
+| our taper | best stock curve | RMS error | verdict |
+|---|---|---|---|
+| `k²` (BodeShift FREQ, Ripple FREQ, Rungs FREQ) | 14 | 0.040 | rough — audible difference in feel |
+| `(1−k)³` (Streamz FALL) | 12 reversed | 0.040 | rough |
+| an exponential we do *not* currently use | 0 | 0.016 | usable, if a module wants that shape |
+
+And the arithmetic goes the wrong way regardless: `k²` is **three
+instructions** (`move`, `move`, `mpy`) with no address register, while a table
+read costs ~5 *and* an AGU register. Computing wins for cheap shapes. Tables
+only pay for shapes that are expensive to compute.
+
+**Which is exactly BodeShift's sine.** ✅ The 1,024-point sine at `X:0x06c00`
+is at **the same address in BOTH payloads** (checked — so an insert, which
+must live in both, may use it) and is exact to 1.75e-7, i.e. Q23 quantisation.
+BodeShift computes its carrier with a refined parabola instead: **21
+instructions, twice per sample**, for a max error of 1.09e-3 (≈ −59 dB).
+
+Swapping it for a table lookup with modulo addressing (`m = 1023` makes the
+wrap free; r1–r3 are unused in that module) would be **cheaper *and* cleaner** —
+roughly 20 of its 344 cycles back, and the oscillator's distortion drops ~76 dB,
+below the Hilbert pair's own residual, so the shifter's sideband suppression
+would be limited by the pair alone rather than by its oscillator.
+
+🟡 **Not done.** BodeShift is verified as it stands, and this would need the
+sideband and shift-accuracy measurements re-run. Logged as a priced option,
+not a pending change.
+
 ⚠️ Its own caveats are worth keeping: segment boundaries come from a
 discontinuity detector and merge smoothly-joined tables, stride findings are
 statistical, and Q23 decode is assumed throughout.
@@ -265,8 +307,12 @@ in one document.** Nothing consumed it: not the script that drives r2, not
 
 Bryan flags these as still open:
 
-- Who writes the staged delay-time word at `0x80005fa0`, and its units — the
-  missing TIME → staging link.
+- ~~Who writes the staged delay-time word at `0x80005fa0`~~ ✅ **CLOSED here,
+  31 Aug 2026**: the delay routine writes it itself, at `0x40003284..88`,
+  copying a word from the per-track record at `0x80001a00 + 96*track` — on the
+  branch taken when the gate byte is 8 but the second condition fails. Units
+  still open. (`PLAN.md` work order §4 has the full decode, including the gate
+  byte's own provenance.)
 - The gain-to-knob mapping in the delay's EMAC block (FB, VOL, DIR, X);
   needs hand-decoding of EMAC extension words that objdump mangles.
 - Whether the second DSP's tracks (5–8) share the delay function or a twin.


### PR DESCRIPTION
Two pieces of local work that needed no hardware.

## 1. The delay's gate byte is decoded — §4 step 1 done

At `0x40003230`:

```
a2 = 0x80001b87 + 64*track
mvzb (a2),d0 ; moveq #8,d1 ; cmp ; bne
```

So the gate is **offset +7 of a 64-byte per-track record based at `0x80001b80`**. That record is filled by the frame builder at `0x4000d13c..46` in an eight-iteration per-track loop, with offsets 6–7 coming from a staging word at `0x80000128 + 512*bank + 64*track + 32`.

**The consequence is what makes the experiment worth a flash: the gate byte is a per-frame *copy* in shared RAM, not the FX2 id.** The DSP dispatch reads the id from the instance table; the CPU delay reads this staged copy. Different storage, same source — so a cave running between the builder's write and the delay's read can set one without touching the other.

That was step 2's question, and it's now settled **statically instead of on the unit**. §4's steps are rewritten: pick a hook window between `0x4000d146` and `0x40003230`, then write the cave.

⚠️ A second condition (`0x80000eb4 + 8*bank == 7`) is unexplained and flagged. Both its branches lead to *different TIME derivations* rather than to a bypass, so it may gate which time source is used rather than whether the delay runs. Read it before assuming.

✅ Also closes one of Bryan's open threads: the writer of the staged TIME word at `0x80005fa0` is the delay routine itself (`0x40003284..88`), copying from the other per-track record at `0x80001a00 + 96*track`.

## 2. The tables, evaluated against our modules rather than admired

The 32 × 128 bank at `X:0x04840` turns out to be mostly **one-pole coefficient pairs** — a pole radius beside its complementary gain — not knob warps.

**Negative result, recorded so nobody re-runs it.** Fitting all 32 curves plus reversals and inversions against the tapers we compute by hand:

| our taper | best stock curve | RMS | verdict |
|---|---|---|---|
| `k²` (BodeShift, Ripple, Rungs FREQ) | 14 | 0.040 | rough |
| `(1−k)³` (Streamz FALL) | 12 reversed | 0.040 | rough |
| an exponential we don't use | 0 | 0.016 | usable if wanted |

And the arithmetic goes the wrong way regardless: `k²` is **three instructions** with no address register; a table read costs ~5 **and** an AGU register. Computing wins for cheap shapes.

**Where a table does pay is a shape that's expensive to compute — and BodeShift has one.** It builds its carrier from a refined parabola: 21 instructions, twice per sample, max error 1.09e-3 (≈ −59 dB). The stock 1,024-point sine at `X:0x06c00` is exact to 1.75e-7 **and sits at the same address in both payloads**, which is exactly what an insert needs.

Swapping would return ~20 of BodeShift's 344 cycles *and* drop the oscillator's distortion ~76 dB — below the Hilbert pair's own residual, so the shifter's suppression would be limited by the pair alone rather than by its oscillator.

🟡 **Priced and logged, not done.** BodeShift is verified as it stands and this would need the sideband and shift-accuracy measurements re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)