### PR TITLE
docs: decode the ColdFire MAIN MENU table system

### DIFF
--- a/docs/MAINMENU.md
+++ b/docs/MAINMENU.md
@@ -1,0 +1,154 @@
+# The MAIN MENU table system
+
+Decoded 31 Aug 2026 while assessing whether the custom delay/reverb could get
+dedicated menu entries (like the newer Elektron boxes) instead of living on a
+host track's FX2 setup pages. The parameter-*page* system was already fully
+decoded (`PARAM_PAGES.md`); the menu shell above it was not — `COVERAGE.md`
+still lists the UI framework as a gap. This page closes the *table* half of
+that gap: how the MAIN MENU tree is stored and walked. The renderer/input
+half is still open.
+
+Markers as in `CHIP.md`: ✅ measured (here: read out of the image and, where
+it matters, confirmed against `objdump -m m68k:cfv4e` disassembly of the code
+that consumes it), 🟡 inferred with falsifier.
+
+All addresses are SDRAM addresses; the raw image maps as
+`address = 0x40000400 + file offset` into `out/raw/section_3_MAIN_OS.bin`
+(the base `scripts/disasm.sh` already documents, re-confirmed here by string
+anchors).
+
+---
+
+## 1. The two record types ✅
+
+**Menu row — 0x18 (24) bytes:**
+
+| offset | field |
+|---|---|
+| +0x00 | label string pointer |
+| +0x04 | window/geometry descriptor pointer (0 on every leaf row observed) |
+| +0x08 | action function pointer — called by the firmware (see §3) |
+| +0x0c | 0 in every row observed |
+| +0x10 | child list-descriptor pointer (0 on a leaf) |
+| +0x14 | page id, dispatched when the action is the shared no-op (see §3) |
+
+**Menu list descriptor — 0x1c (28) bytes:** `+0x00` row count, `+0x04`
+scroll / first-visible index, `+0x18` pointer to the row array. Fields
+`+0x08..+0x14` are not yet interpreted (🟡 — falsified if the draw engine
+reads them for something load-bearing; only `+0x00`, `+0x04` and `+0x18`
+were seen consumed in the window disassembled).
+
+The stride is confirmed from code, not just layout: the draw/nav engine
+computes `d2 = d3*32 − d3*8` (= ×24) at `0x4006496a..0x40064970` and indexes
+the row array with it.
+
+## 2. The tree ✅
+
+| list descriptor | count | row array | contents |
+|---|---|---|---|
+| `0x400cbd8c` **ROOT** | 4 | `0x400cc698` | PROJECT · SYSTEM · CONTROL · MIDI |
+| `0x400cbcac` | 15 | `0x400cc308` | PROJECT submenu: CHANGE/SAVE/RELOAD/SYNC TO CARD/SAVE TO NEW/EXPORT TO SET/CHANGE(set)/COLLECT SAMPLES/PURGE SAMPLES/SAVE CUR BANK/RELOAD CUR BANK, plus four separator rows whose labels are runs of glyph `0x17` |
+| `0x400cbd1c` | 6 | `0x400cc4e8` | SYSTEM: USB DISK MODE, OS UPGRADE, DATE/TIME, PERSONALIZE, CARD TOOLS, STATUS |
+| `0x400cbd54` | 6 | `0x400cc5a8` | CONTROL: AUDIO, INPUT, SEQUENCER, MIDI SEQUENCER, MEMORY, METRONOME |
+| `0x400cbd70` | 4 | `0x400cc638` | MIDI: CONTROL, SYNC, CHANNELS, TURBO STATUS |
+
+Root rows have a non-zero window descriptor at `+0x04` and a child pointer at
+`+0x10` with action = 0; submenu leaf rows are the mirror image (window 0,
+child 0, action or page id set). The four root window descriptors
+(`0x400cbc34/48/5c/70`) are uniform 20-byte records
+`{0x13, 0x09, 0x01, ptr, ptr}` — plausibly geometry plus two resource
+pointers, uninterpreted (🟡).
+
+## 3. Dispatch ✅
+
+Two mechanisms coexist in the same field:
+
+- **Real handler.** OS UPGRADE's action is `0x400636bc`, USB DISK MODE's is
+  `0x40063728` — ordinary function pointers the firmware calls. This is what
+  makes the table extensible: a new row can carry its own cave-resident
+  handler.
+- **Shared no-op + page id.** Every other leaf points at `0x400648f8`, which
+  is a bare `rts` (bytes `4e 75`, read off the image), and is dispatched by
+  the id at `+0x14` instead: DATE/TIME `0x0f`, PERSONALIZE `0x0c`, CARD
+  TOOLS `0x0d`, STATUS `0x0e`; MIDI CONTROL/SYNC/CHANNELS/TURBO STATUS
+  `0x08..0x0b`. Where the id lands has not been traced (🟡 — presumably a
+  screen-constructor table; falsified/completed by following one id from the
+  nav engine).
+
+## 4. The draw/nav engine ✅ (the parts disassembled)
+
+Engine body around `0x40064908..0x40064fb2` (🟡 boundaries — taken from the
+xref cluster, not from function-boundary analysis). Confirmed with
+`scripts/disasm.sh emac 0x40064940`:
+
+```
+4006495e:  addl 0x400cbd90,%d3        ; += root descriptor's scroll field
+4006496a:  lsll #3,%d0                ; d3*8
+4006496e:  lsll #5,%d2                ; d3*32
+40064970:  subl %d0,%d2               ; d2 = d3*24  — row stride
+4006497a:  movel %a0@(4,%d2:l),%sp@-  ; push row+0x04 (window descriptor)
+40064982:  moveal 0x400cbda4,%a0      ; load the ROW ARRAY POINTER
+40064988:  addal %d2,%a0              ; index the row
+4006498a:  movel %a0@,%sp@-           ; push row+0x00 (label)
+```
+
+The root descriptor `0x400cbd8c` is referenced from eight code sites, all
+inside this engine (`0x400649b8`, `0x40064c72`, `0x40064d22`, `0x40064e9a`,
+`0x40064eaa`, `0x40064ef0`, `0x40064f40`, `0x40064f8e`) plus one data site,
+`0x400cbda8` — the word immediately after the descriptor's own rows pointer
+holds a pointer back to the descriptor (🟡 meaning unknown; maybe the record
+is longer than 0x1c, maybe an adjacent "current menu" cell; falsified by
+decoding the structure that owns `0x400cbda8`).
+
+## 5. Why this matters: adding a fifth top-level entry is two writes ✅
+
+**The root row array `0x400cc698` has exactly ONE reference in the whole
+image: the rows pointer at `0x400cbda4`** (single 4-byte match for the value,
+whole-image scan). The array cannot grow in place — live data follows it —
+but it doesn't need to:
+
+1. copy the four 24-byte rows into a cave, append a fifth,
+2. repoint `0x400cbda4` at the copy,
+3. bump the count at `0x400cbd8c` from 4 to 5.
+
+The new row's label string and its action handler (or child list) live in the
+same cave. Natural homes: the 1,024-byte `0xff` pad at `0x400c4702` (~5 KB
+from these tables, free, unclaimed — `MIDI.md`) or the unclaimed zero run at
+`0x400d24d0..0x400d2ce0`. The generic cave installer in `tools/build_bus.py`
+already handles hook/cave verification for modules.
+
+Hardware precedent: the PERSONALIZE menu was extended with two working items
+in the archaeology era by exactly this relocate-and-repoint move
+(`git show 40a1f19:tools/patch_menu.s`; `docs/history/NOTES.md` §PERSONALIZE).
+
+## 6. What a new entry could actually *do* — the honest constraints
+
+The menu shell is the cheap half. Feeding controls to the DSP is not, and
+the viable designs all reuse the existing descriptor pipeline
+(`PARAM_PAGES.md`, `MIDI.md`):
+
+- **Shortcut into the host track's FX2 page.** The action handler stages the
+  existing page (resolver `FUN_40031da4`, stager `FUN_400326d4`) for the
+  track hosting the effect. Real dials, formatters, Part storage, scene
+  locks — the host-track architecture stays as the data model; only the
+  navigation jank goes away. Open question: what per-screen state the stager
+  expects around it (🟡 — nothing here has been executed; the Unicorn
+  ColdFire harness was pruned, so a menu patch goes static-verify → flash).
+- **A bespoke PERSONALIZE-style list screen** whose setters call the stock
+  parameter writer `FUN_40054cd8(track, flat, value)` for the host track, so
+  values land in the Part and flow through the normal frame builder.
+- **Not viable: independent controls outside the pipeline.** They could only
+  reach the DSP via a ColdFire cave publishing into the r6 window, and after
+  tempo-sync + MIDI there is one free 16-bit word left (`r6+$a`, `DSP.md`).
+
+Also already ruled out elsewhere: the MIXER page as a control surface (it
+does not use the generic renderer — `PARAM_PAGES.md`).
+
+## 7. Still undecoded
+
+The renderer/input half: the window/geometry descriptor internals, how a
+child list becomes an open menu, where the `+0x14` page ids are consumed,
+key handling, and everything `verify_menu.py`'s warning about the indirect
+widget-setup pointers (`PTR_FUN_400bb7f0` etc.) covers. None of it blocks
+the two-write table extension in §5; all of it stands between the table and
+a *screen* you author yourself.


### PR DESCRIPTION
Decodes the MAIN MENU table half of the UI-framework gap: the 24-byte row record, the 28-byte list descriptor, the full tree (ROOT/PROJECT/SYSTEM/CONTROL/MIDI), both dispatch mechanisms, and the draw-engine stride + rows-pointer load confirmed with `objdump -m m68k:cfv4e`.

Key structural fact: the root row array has exactly one reference in the whole image, so a fifth top-level entry is a two-write patch (repoint rows, bump count) plus a cave row. §6 records what such an entry could honestly drive (reuse the descriptor pipeline; the outside-the-pipeline route is blocked at one free r6 word).

Everything marked measured was read off the image or disassembled this session; inferred items carry falsifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)