### PR TITLE
emu: Tier-0 ColdFire bring-up to the RTOS handoff

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -464,6 +464,19 @@ the TUI is a shell around it.**
 *walk the patched firmware* under `make check` — an automated no-flash gate
 for every ColdFire cave, present and future.
 
+**Tier-0 bring-up is underway and de-risked** (`docs/EMU.md`,
+`tools/emu_bringup.py`, 31 Aug 2026): with SP+SR seeded and MMIO modelled,
+the real image executes **~7,000,000 instructions with zero decode faults**,
+through all early hardware init, and stops exactly at the RTOS handoff
+(`trap #0`, `0x40000e46`). The one load-bearing peripheral value is decoded
+(the clock register must report a 264 MHz sysclk or the boot halts); async
+completion-flag spins are auto-satisfied. What remains is the **fork** at the
+trap: emulate the RTOS (dispatch the trap, drive a timer tick) or take the
+**detour-harness** route (call the UI functions directly, skip the
+scheduler). For the stated goal — a text UI to iterate menu/cave patches —
+the detour harness is very likely the right first cut; `docs/EMU.md` lays out
+both.
+
 Not pursued: a gearmulator-style full-machine port with plugin packaging.
 `dsp_host` already runs on that project's DSP core; the ColdFire half above
 is the slice of that road worth having.

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -1,0 +1,123 @@
+# Local ColdFire emulator — Tier-0 bring-up
+
+The workbench emu of `PLAN.md` §5. Goal: an iterate-with-a-cycle loop for
+ColdFire/UI work (a menu patch, a cave) without a flash. This page is the
+Tier-0 record — how far the real firmware boots under emulation and what it
+needs on the way. `tools/emu_bringup.py` is the harness; re-run it to
+reproduce every number here.
+
+Markers as in `CHIP.md`: ✅ measured (here: observed in the emulator and
+cross-checked against `objdump cfv4e` disassembly), 🟡 inferred + falsifier.
+
+## The core is not the problem ✅
+
+**Unicorn 2.1.4 with `ctl_set_cpu_model(UC_CPU_M68K_CFV4E)` executes this CPU
+correctly.** Point-checked before trusting it: `mvz`/`mvs` extend right, and
+EMAC `macl`+`movclrl` gives the exact product (32769 × −32767 = `0xC0000001`)
+— the instructions r2 and the default plain-68k core both mangle
+(`docs/EXTERNAL.md`). The pruned archaeology `emu_*.py` harnesses ran the
+default core; the model flag is the fix, and the reason a boot is now
+possible at all.
+
+**With SP and SR seeded, the image runs ~7,000,000 instructions with zero
+illegal-instruction faults**, through the whole early hardware init, and
+stops exactly at the RTOS multitasking handoff. No decode wall anywhere in
+between.
+
+## What the boot needs, in order ✅
+
+Seed the reset state the (absent) vector preamble would set — **SR before A7**,
+or the supervisor/user stack banks swap and A7 lands in the wrong one:
+
+```
+SR = 0x2700   (supervisor, IRQs masked)   A7 = 0x48000000
+```
+
+RAM windows are `docs/ARCHITECTURE.md` §7; the stack grows down from
+`0x48000000` into the `0x46000000` region.
+
+**Peripheral MMIO** is modelled by callback, not backed by RAM, so every
+access is logged — the log is the register map. Default read = all-ones,
+which satisfies every "wait until bit SET" poll the boot uses. The boot map
+(first touch of each register, from the harness):
+
+| region | what it is (🟡 unless noted) | notes |
+|---|---|---|
+| `0xfc0c4000` | clock/PLL config | **load-bearing** ✅ — see below |
+| `0xfc0a4066/69` | serial/UART-ish | writes `0x43`,`0x33` |
+| `0xfc064000..01c` | a serial/timer module | heavy init, status polled at `+4` |
+| `0xfc048018..05b` | another module | writes `0x1b`,`0x06` |
+| `0xfc088000/02` | serial shift-out (LCD? ✅ shift-done in bit 2) | write datum, poll bit 2, 8×; ran 896× clean |
+
+**One register's value is load-bearing, not just its presence:** the firmware
+reads `0xfc0c4000`, takes the top byte as the PLL multiplier, computes
+`sysclk = (reg>>24) × 12 MHz`, and **halts (`bra *` at `0x4000fa8c`) unless it
+equals 264 MHz**. So the top byte must be 22 (`0x16`) — the harness returns
+`0x16000000`. (entry read `0x40000418`; gate `0x4000fa78`.) This is the
+pattern to expect: most peripherals only need to be "present", a few gate the
+boot on a specific reply, and each announces itself as a halt you then decode.
+
+## Async completion flags ✅
+
+The boot polls flags that an interrupt handler — or the second DSP core —
+would set, shaped `move.w (abs),d0 ; [mvz] ; cmpi.[wl] #imm,d0 ; bne self`.
+Observed: word@`0x0` and word@`0x2000`, each awaited `== 0xffff`, each after a
+kick subroutine (🟡 plausibly the two DSP cores' boot handshake, or a
+memory-region test). The harness auto-satisfies them: a watchdog spots the
+spin, decodes the read address and compared immediate, and writes it —
+**at the LOAD width (`move.w`, 2 bytes), not the `cmpi.l` width**, or the low
+word reads back wrong. A memset is told apart from a poll by a climbing write
+counter (a bounded loop makes progress; a poll does not), so long BSS clears
+(e.g. the ~90k-iteration one at `0x40000530`) are not mistaken for spins.
+
+## The boundary: `trap #0`, the RTOS handoff ✅
+
+Execution stops at `trap #0` (`0x40000e46`). It is preceded by
+`movew #0x2000,%sr` (drop the interrupt mask) and followed by `bra *` (the
+safety net if the scheduler ever returns) — the textbook "start multitasking:
+enable interrupts, trap into the scheduler." This is the Tier-0/Tier-1
+boundary named in `PLAN.md` §5.
+
+Two facts for whoever crosses it:
+- **Unicorn's CFV4E treats VBR as a no-op register** (`UC_M68K_REG_CR_VBR`
+  reads back 0 with a deprecation warning) and does **not** auto-dispatch the
+  trap — the `UC_HOOK_INTR` hook fires with `intno = 32` and the CPU
+  otherwise faults. Crossing the boundary means dispatching the exception by
+  hand: push the frame, fetch the vector, set PC.
+- **VBR is loaded from the runtime variable `[0x400b9668]`** at `0x40000db6`
+  (`movec %a0,%vbr`), and the table is built right after (default handler
+  `0x40000d74` written to every slot). So the vector base is known at run
+  time from that variable, which sidesteps the no-op register read.
+
+## The fork ahead — do not pick it silently
+
+Reaching the menu code past the trap is a design decision, not more of the
+same grind:
+
+- **A. Emulate the RTOS.** Hand-dispatch `trap #0`, drive a periodic timer
+  interrupt for preemption, let the real scheduler run the real tasks. Most
+  faithful; the most work; the display and input still have to be modelled or
+  hooked on top.
+- **B. Detour harness.** Skip the scheduler. Set up a plausible task context
+  and call the UI functions directly — `FUN_40064c18` (menu open), the draw
+  path, feed keycodes to the key handler — stubbing RTOS calls. This is the
+  `emu_image.py`-shaped fallback in `PLAN.md` §5, and the cheaper route to the
+  stated goal (walk a patched menu, test a cave) because it never needs the
+  scheduler. It cannot catch anything that only emerges from real task
+  interleaving — but menu-patch testing does not need that.
+
+For the workbench's purpose (a text UI to iterate menu/cave patches without a
+flash) **B is very likely the right first cut**, with A as a later fidelity
+upgrade if something needs it. Either way the screen is read by hooking the
+decoded draw path (`docs/MAINMENU.md` §7, `PARAM_PAGES.md`) rather than
+emulating an LCD, and keys are injected at the software layer.
+
+## Reproduce
+
+```sh
+pip install 'unicorn>=2.1'          # the DEFAULT m68k core is plain-68k; the
+tools/emu_bringup.py                 # CFV4E model is what decodes this CPU
+```
+
+Prints the instruction count, the stop reason (the `trap #0` boundary), the
+auto-pokes applied, and the peripheral boot map.

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -38,6 +38,7 @@ ones — the DSP toolchain itself is plain CMake). It builds:
 |---|---|---|
 | `dsp_asm` | `vendor/dsp56300` | the DSP56300 assembler. ⚠️ It **mis-encodes some instructions silently** — `CLAUDE.md`'s trap list is required reading before trusting it |
 | `dsp_host` | `tools/dsp_host/` (staged into `vendor/dsp56300` and built there) | this project's emulator harness: runs assembled effects on the dsp56300 emulator core. `docs/HARNESS.md` |
+| `emu_bringup.py` | `tools/` | Tier-0 ColdFire bring-up: boots the real MAIN OS image on Unicorn's CFV4E core to the RTOS handoff (the workbench emu, `PLAN.md` §5). Needs `pip install 'unicorn>=2.1'`. `docs/EMU.md` |
 | `elektron-firmware-tool` | `vendor/elektron-firmware-tool` (patched) | packs/unpacks Elektron's OS container formats |
 
 The disassembler from the same dsp56300 project is the other half of the

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Tier-0 ColdFire bring-up harness (PLAN.md §5, the workbench).
+
+Boots the real MAIN OS image on Unicorn's ColdFire V4e core, modelling only
+as much of the hardware as the boot path actually touches. It is NOT a full
+machine emulator: there is no display, no real peripherals, no scheduler yet.
+Its job is to prove the CPU core runs the firmware and to MAP what the boot
+needs — the console log is that map.
+
+Run:  tools/emu_bringup.py           (needs `unicorn` with the CFV4E model:
+      pip install unicorn>=2.1 ; the DEFAULT m68k core is plain-68k and will
+      NOT decode this CPU — see docs/EXTERNAL.md on the ColdFire ISA.)
+
+State of the boot, 31 Aug 2026 (docs/EMU.md has the detail):
+  * With SP+SR seeded and MMIO modelled, the image executes ~7,000,000
+    instructions with zero illegal-instruction faults, through the entire
+    early hardware init, and stops at the RTOS multitasking handoff
+    (`trap #0` at 0x40000e46). That trap is the Tier-0/Tier-1 boundary.
+  * Everything below the trap is modelled here. Reaching the menu code past
+    it needs either full RTOS/interrupt emulation or the detour-harness
+    approach (call UI functions directly) — a design fork, see docs/EMU.md.
+"""
+import collections
+import os
+import sys
+
+try:
+    from unicorn import *
+    from unicorn.m68k_const import *
+except ImportError:
+    sys.exit("needs unicorn: pip install 'unicorn>=2.1'")
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+IMG = open(os.path.join(REPO, "out/raw/section_3_MAIN_OS.bin"), "rb").read()
+BASE = ENTRY = 0x40000400          # image load base = 0x40000000 + 0x400 header
+BUDGET = 50_000_000
+
+mu = Uc(UC_ARCH_M68K, UC_MODE_BIG_ENDIAN)
+mu.ctl_set_cpu_model(UC_CPU_M68K_CFV4E)
+
+# RAM windows (docs/ARCHITECTURE.md §7). The stack top is 0x48000000 and grows
+# down into the 0x46000000 region.
+for a, sz in {
+    0x00000000: 0x00010000, 0x40000000: 0x02000000, 0x46000000: 0x02000000,
+    0x48000000: 0x00100000, 0x80000000: 0x01000000, 0x100b0000: 0x00010000,
+}.items():
+    mu.mem_map(a, sz)
+mu.mem_write(BASE, IMG)
+# Reset state the vector table would seed. ORDER MATTERS: SR before A7, or the
+# supervisor/user stack banks swap and A7 lands in the wrong one.
+mu.reg_write(UC_M68K_REG_SR, 0x2700)   # supervisor, IRQs masked
+mu.reg_write(UC_M68K_REG_A7, 0x48000000)
+
+# ---- peripheral MMIO model ------------------------------------------------
+# Default read = all-ones, which satisfies every "wait until bit SET" poll the
+# boot uses (I2C/serial shift-done at 0xfc088000, UART/serial status at
+# 0xfc064004, ...). OVERRIDES hold registers whose exact value is load-bearing.
+OVERRIDES = {
+    # Clock/PLL config. The firmware computes sysclk = (reg>>24)*12MHz and
+    # HALTS (`bra *` at 0x4000fa8c) unless it equals 264MHz, so the top byte
+    # must be 22 (0x16). Entry reads it at 0x40000418; gate at 0x4000fa78.
+    0xfc0c4000: 0x16000000,
+}
+events = []          # ordered unique (kind, pc, addr[, val]) for the boot map
+seen = set()
+def _log(kind, pc, addr, size, val=None):
+    key = (kind, pc, addr)
+    if key not in seen and len(events) < 80:
+        seen.add(key); events.append((kind, pc, addr, size, val))
+
+def periph_read(uc, off, size, b):
+    a = b + off
+    _log("R", uc.reg_read(UC_M68K_REG_PC), a, size)
+    if a in OVERRIDES:
+        return OVERRIDES[a]
+    return (1 << (size * 8)) - 1
+
+def periph_write(uc, off, size, val, b):
+    _log("W", uc.reg_read(UC_M68K_REG_PC), b + off, size, val)
+
+for a, sz in {0xfc000000: 0x100000, 0x20000000: 0x1000, 0x90000000: 0x1000}.items():
+    mu.mmio_map(a, sz,
+                (lambda u, o, s, d, base=a: periph_read(u, o, s, base)), None,
+                (lambda u, o, s, v, d, base=a: periph_write(u, o, s, v, base)), None)
+
+# ---- auto-satisfy async completion-flag spins -----------------------------
+# Boot polls flags an ISR / the other DSP core would set:
+#   `move.w (abs),d0 ; [mvz] ; cmpi.[wl] #imm,d0 ; bne self`
+# (word@0 and word@0x2000 == 0xffff observed). A watchdog spots the spin, then
+# we decode the read address + compared immediate and write it, faking the
+# completion. The write width matches the LOAD (move.w), not the cmpi.
+auto_pokes = []
+def try_auto_poke(lo, hi):
+    blk = mu.mem_read(lo, min(hi - lo + 8, 32))
+    if blk[0:2] == b"\x30\x38":                       # move.w (abs).w,d0
+        addr = int.from_bytes(blk[2:4], "big", signed=True) & 0xFFFFFFFF; j = 4
+    elif blk[0:2] == b"\x30\x39":                     # move.w (abs).l,d0
+        addr = int.from_bytes(blk[2:6], "big"); j = 6
+    else:
+        return False
+    imm = None
+    while j < len(blk) - 2:
+        op = blk[j:j+2]
+        if op == b"\x0c\x80":                          # cmpi.l #imm,d0
+            imm = int.from_bytes(blk[j+2:j+6], "big"); break
+        if op == b"\x0c\x40":                          # cmpi.w #imm,d0
+            imm = int.from_bytes(blk[j+2:j+4], "big"); break
+        j += 2
+    if imm is None:
+        return False
+    try:
+        mu.mem_write(addr, (imm & 0xFFFF).to_bytes(2, "big"))   # load is move.w
+    except UcError:
+        return False
+    auto_pokes.append((lo, addr, imm))
+    return True
+
+# ---- watchdog: tell a real spin from a long bounded loop -------------------
+# A memset/memcpy writes to advancing addresses and exits; a poll does not.
+# Track a write COUNTER and require it to climb, or the window is a spin.
+st = {"n": 0, "maxpc": ENTRY, "wc": 0, "stuck": None, "trap": None}
+mu.hook_add(UC_HOOK_MEM_WRITE, lambda u, ac, ad, sz, v, x: st.update(wc=st["wc"] + 1))
+recent = collections.deque(maxlen=16)
+wd = {"win": None, "since": 0, "wc_mark": 0}
+def hook_code(uc, address, size, user):
+    st["n"] += 1
+    recent.append(address)
+    if 0x40000000 < address < 0x40200000 and address > st["maxpc"]:
+        st["maxpc"] = address
+    lo, hi = min(recent), max(recent)
+    if hi - lo <= 40 and len(recent) == 16:
+        if wd["win"] == (lo, hi):
+            wd["since"] += 1
+            if wd["since"] % 4096 == 0:
+                if st["wc"] - wd["wc_mark"] > 64:      # writes climbing => progress
+                    wd["since"] = 0
+                wd["wc_mark"] = st["wc"]
+            if wd["since"] > 300_000:
+                if try_auto_poke(lo, hi):
+                    wd["win"] = None; wd["since"] = 0; recent.clear()
+                else:
+                    st["stuck"] = (lo, hi); uc.emu_stop()
+        else:
+            wd["win"] = (lo, hi); wd["since"] = 0; wd["wc_mark"] = st["wc"]
+    else:
+        wd["win"] = None; wd["since"] = 0
+mu.hook_add(UC_HOOK_CODE, hook_code)
+
+def on_intr(uc, intno, user):
+    # trap #n => exception vector 32+n. Unicorn's CFV4E treats VBR as a no-op,
+    # so it will not dispatch: we record and stop. trap #0 (intno 32) is the
+    # RTOS scheduler handoff; VBR is loaded from [0x400b9668] at 0x40000db6.
+    st["trap"] = (intno, uc.reg_read(UC_M68K_REG_PC)); uc.emu_stop()
+mu.hook_add(UC_HOOK_INTR, on_intr)
+
+try:
+    mu.emu_start(ENTRY, 0, count=BUDGET)
+    outcome = "count cap / clean stop"
+except UcError as e:
+    outcome = f"UcError: {e}"
+
+print(f"instructions : {st['n']:,}")
+print(f"max PC       : 0x{st['maxpc']:08x}")
+print(f"outcome      : {outcome}")
+if st["trap"]:
+    intno, pc = st["trap"]
+    print(f"TRAP         : #{intno-32} (vector {intno}) at pc=0x{pc:08x}  "
+          f"— RTOS handoff, the Tier-0/Tier-1 boundary")
+if st["stuck"]:
+    print(f"STUCK        : unrecognised spin 0x{st['stuck'][0]:08x}..0x{st['stuck'][1]:08x}")
+print(f"auto-pokes   : {len(auto_pokes)}  " +
+      ", ".join(f"@0x{a:x}={v:#x}" for _, a, v in auto_pokes))
+print("\nperipheral boot map (first touch of each register):")
+for ev in events:
+    k, pc, addr, size, val = ev
+    v = f" val=0x{val:x}" if k == "W" else ""
+    print(f"  {k} 0x{addr:08x} sz{size}{v}   (pc 0x{pc:08x})")


### PR DESCRIPTION
First artifact of the workbench emu (PLAN §5). `tools/emu_bringup.py` boots the real MAIN OS image on Unicorn's CFV4E core: ~7M instructions, zero decode faults, through all early hardware init, stopping exactly at `trap #0` (the RTOS multitasking handoff).

Decoded on the way: the 264MHz clock-register gate (halts the boot otherwise), the async completion-flag polls (auto-satisfied), and VBR's runtime source for whoever dispatches the trap. `docs/EMU.md` has the boot map and the design fork past the trap (emulate the RTOS vs. the detour-harness route; the latter is very likely the right first cut for a menu-patch workbench).

🤖 Generated with [Claude Code](https://claude.com/claude-code)