### PR TITLE
emu: live menu screen via detour harness (milestone 2)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -479,14 +479,19 @@ fault, and see the MAIN MENU walked from RAM with any patched-in entry
 highlighted. That is the crow-flies no-flash gate: a cave that breaks early
 init faults in the emulator, not on the unit. ~4 s per boot (native bursts).
 
-Remaining toward the full loop: **live screen** (render real param pages, not
-just the menu tables) needs the draw path to execute — its universal string
-primitive is located (`FUN_40012bd8`, hook `x`/`y`/`str` off the stack) but
-that runs in a task, so it needs the **fork** at the trap: emulate the RTOS
-(dispatch the trap, drive a timer tick) or the **detour-harness** route (call
-the UI draw/input functions directly, skip the scheduler). For iterating
-menu/cave patches the detour harness is very likely the right next cut;
-`docs/EMU.md` lays out both.
+**Milestone 2 is shipped too**: the **live screen**. `render_menu(r, cursor)`
+calls the firmware's own menu draw against the warm machine and captures it as
+`(x,y,text)` (the detour route — `ctl_flush_tb` + open + state/viewport pokes +
+draw); `make remix` → `e` shows a framed LCD with up/down navigating the main
+menu and the submenu preview following, as on the unit — on the *built* image,
+so a patched-in entry renders as the firmware would draw it. Recipe and the
+JIT-cache gotcha are in `docs/EMU.md`.
+
+Remaining toward full fidelity: entering submenus / param pages (same detour
+shape — drive the real key handler `FUN_40064e64` / stage a param page) and,
+only if something needs task-interleaving behaviour, route **A** (emulate the
+RTOS: dispatch the trap via VBR `[0x400b9668]`, drive a timer tick). Nothing
+built so far needs A; `docs/EMU.md` keeps it on the table.
 
 Not pursued: a gearmulator-style full-machine port with plugin packaging.
 `dsp_host` already runs on that project's DSP core; the ColdFire half above

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -108,59 +108,63 @@ stall is suspected. A stall is a PC confined to a small window across several
 bursts; a bounded loop (memset) is told from a flag-poll by an event-driven
 write counter that only a store advances.
 
-## Live screen — the next fidelity step (primitive located) ✅
+## Milestone 2 — the live screen, via the detour harness ✅
 
-Rendering the firmware's *actual* screen (real param pages, dialogs) rather
-than the menu tables means capturing text as the UI draws it. The universal
-primitive is **`FUN_40012bd8`** — the "draw string at (x,y)" call every
-renderer funnels through (189 call sites; the list/knob drawer `FUN_40037590`
+The firmware's *actual* menu now renders as text, navigable, out of the warm
+machine — `render_menu(r, cursor)` returns the real renderer's output as
+`(x, y, string)` tuples, and `make remix` → `e` shows it in a framed LCD with
+up/down moving the cursor and the submenu preview following, as on the unit.
+
+**The capture primitive** is `FUN_40012bd8` — the "draw string at (x,y)" call
+every renderer funnels through (189 call sites; the list drawer `FUN_40037590`
 and the PERSONALIZE renderer `FUN_40068e00` both reach it). ColdFire cdecl,
-all args on the stack at the callee entry:
+args on the stack at callee entry; **passive capture needs only `x`, `y`,
+`str`**, all on the stack / in RAM, so the hook is self-contained:
 
 ```
 FUN_40012bd8(font, canvas, x, y, count, char *str)
-  sp@(4)=font(0x400ba876)  sp@(8)=canvas  sp@(12)=x  sp@(16)=y
-  sp@(20)=count(-1=to NUL)  sp@(24)=str
+  sp@(12)=x  sp@(16)=y  sp@(24)=str        (font 0x400ba876, canvas=window+36)
 ```
 
-**Passive capture needs only `x`, `y`, and `str`** (all on the stack / in
-RAM), so the hook is self-contained — no canvas needed. Selection highlight
-is a separate XOR-rect op `FUN_40012254` (`mode<0`). Font descriptor
-`0x400ba876` (proportional, 256 glyphs, ~6 px, 7 px line pitch → ~9 lines on
-the 128×64 LCD); width-measure sibling `FUN_40012f30` reproduces the
-firmware's own centering. The framebuffer is 1bpp column-major at a
-runtime-allocated canvas (`*(0x400bc48c)+36`, fields width/height/stride/base
-at `+0/+4/+8/+12`) — harder to decode than the string hook, so **hook the
-string primitive, not the bitmap**.
+**The detour recipe** (the draw code runs in a task the boot never reaches, so
+we call it directly against the warm machine):
 
-The one dependency: the draw code only runs in a task, which the boot does
-not reach (it stops at `trap #0`). So live capture needs the fork below —
-either the RTOS runs the menu task, or the detour harness calls the draw
-path directly. Milestone 1 sidesteps this by reading the tables, not the
-pixels.
+1. Boot to the handoff (heap + window system are up).
+2. Install the string-capture hook at `FUN_40012bd8`, plus a map-on-fault
+   hook: a cold detour skips some setup, so a formatter can hold one stale
+   pointer — map a zero page under it so its `strlen` reads `""` and the real
+   row labels still render instead of faulting the whole draw.
+3. **`ctl_flush_tb()`** — the draw fns were JIT-cached during the boot splash
+   *without* the hooks, so a hook added afterward never fires on the cached
+   block until the translation cache is flushed. (This cost a real debugging
+   session: the loop ran but the string primitive "wasn't called" — it was,
+   the cached block just wasn't instrumented.)
+4. Call `FUN_40064c18` (menu open) — allocates the window from the heap.
+5. Set `[0x400cbf40]=1` (tree state) and **`[0x400cbd9c]=6`** (the visible-row
+   clamp; a cold detour leaves it 0, and the row loop bound is
+   `min(clamp, count)`, so 0 draws nothing).
+6. Poke `[0x400cbd98]` = cursor row, then call `FUN_40064d7c` (draw). The
+   selected row and the right-pane submenu preview follow the cursor.
 
-## The fork ahead — do not pick it silently
+The line pitch is 7 px and the origin is bottom-left-ish (the list drawer
+steps y DOWN per row), so `layout_screen` maps larger-y to higher rows.
+Selection highlight is a separate XOR-rect op `FUN_40012254` (`mode<0`) — not
+captured as text yet.
 
-Reaching the menu code past the trap is a design decision, not more of the
-same grind:
+**What is still table-driven, not live:** entering a submenu / backing out
+(the cursor demo pokes the selection global rather than driving the real key
+handler `FUN_40064e64`), and the param pages. Both are the same detour shape —
+call the state's key handler with a keycode, or stage a param page — and are
+the natural next increments.
 
-- **A. Emulate the RTOS.** Hand-dispatch `trap #0`, drive a periodic timer
-  interrupt for preemption, let the real scheduler run the real tasks. Most
-  faithful; the most work; the display and input still have to be modelled or
-  hooked on top.
-- **B. Detour harness.** Skip the scheduler. Set up a plausible task context
-  and call the UI functions directly — `FUN_40064c18` (menu open), the draw
-  path, feed keycodes to the key handler — stubbing RTOS calls. This is the
-  `emu_image.py`-shaped fallback in `PLAN.md` §5, and the cheaper route to the
-  stated goal (walk a patched menu, test a cave) because it never needs the
-  scheduler. It cannot catch anything that only emerges from real task
-  interleaving — but menu-patch testing does not need that.
+## The RTOS fork — still open, still not forced
 
-For the workbench's purpose (a text UI to iterate menu/cave patches without a
-flash) **B is very likely the right first cut**, with A as a later fidelity
-upgrade if something needs it. Either way the screen is read by hooking the
-decoded draw path (`docs/MAINMENU.md` §7, `PARAM_PAGES.md`) rather than
-emulating an LCD, and keys are injected at the software layer.
+Milestone 2 took route **B** (detour) and it carries the workbench: a menu- or
+cave-patch is visible and walkable without a flash. Route **A** (emulate the
+RTOS — dispatch `trap #0` via VBR `[0x400b9668]`, drive a timer tick, run the
+real scheduler) remains the later fidelity upgrade, the only one that could
+show behaviour emerging from real task interleaving. Nothing built so far
+needs it.
 
 ## Reproduce
 

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -36,6 +36,21 @@ BUDGET = 50_000_000
 MENU_ROOT_DESC = 0x400cbd8c
 ROW_STRIDE = 0x18
 
+# The universal "draw string at (x,y)" primitive (docs/EMU.md). cdecl, args on
+# the stack at callee entry: sp@(0)=return, then font/canvas/x/y/count/str.
+DRAW_STRING = 0x40012bd8
+
+# Live-screen detour (docs/EMU.md): open the MAIN MENU window, dispatch its
+# draw, and capture every string it emits. These run in task context normally;
+# we call them directly against the warm (post-boot) machine.
+MENU_OPEN = 0x40064c18       # allocates the menu window from the heap
+MENU_DRAW = 0x40064d7c       # dispatches the current menu-state's draw
+MENU_STATE = 0x400cbf40      # menu state index (1 = the tree)
+MENU_VIEWPORT = 0x400cbd9c   # visible-row clamp; 0 in a cold detour -> no rows
+MENU_SELROW = 0x400cbd98     # selected row in the current list (the cursor)
+CALL_SP = 0x47f00000         # scratch stack for a detour call
+CALL_RET = 0x000000f0        # sentinel return address a detour stops at
+
 
 class BootResult:
     def __init__(self):
@@ -55,8 +70,12 @@ class BootResult:
         return self.reached_handoff and self.error is None
 
 
-def boot(image=None, count=BUDGET):
-    """Boot an image to the RTOS handoff. Returns a BootResult."""
+def boot(image=None, count=BUDGET, on_draw=None):
+    """Boot an image to the RTOS handoff. Returns a BootResult.
+
+    on_draw(x, y, str): if given, a hook at the string primitive DRAW_STRING
+    reports every text draw as it happens — the screen-capture path.
+    """
     r = BootResult()
     if not HAVE_UNICORN:
         r.stopped = "unicorn not installed (pip install 'unicorn>=2.1')"
@@ -65,6 +84,18 @@ def boot(image=None, count=BUDGET):
 
     mu = Uc(UC_ARCH_M68K, UC_MODE_BIG_ENDIAN)
     mu.ctl_set_cpu_model(UC_CPU_M68K_CFV4E)
+
+    if on_draw is not None:
+        def _draw_hook(uc, address, size, user):
+            sp = uc.reg_read(UC_M68K_REG_A7)
+            try:
+                x = int.from_bytes(uc.mem_read(sp + 12, 4), "big")
+                y = int.from_bytes(uc.mem_read(sp + 16, 4), "big")
+                sptr = int.from_bytes(uc.mem_read(sp + 24, 4), "big")
+            except UcError:
+                return
+            on_draw(x, y, _cstr(uc, sptr))
+        mu.hook_add(UC_HOOK_CODE, _draw_hook, begin=DRAW_STRING, end=DRAW_STRING)
     for a, sz in {
         0x00000000: 0x00010000, 0x40000000: 0x02000000, 0x46000000: 0x02000000,
         0x48000000: 0x00100000, 0x80000000: 0x01000000, 0x100b0000: 0x00010000,
@@ -248,6 +279,95 @@ def read_menu_tree(uc, desc=MENU_ROOT_DESC, depth=0, _seen=None):
                             if child else []}
         out.append(node)
     return out
+
+
+def _call(uc, addr, count=20_000_000):
+    """Invoke a firmware function on a warm machine and run until it returns.
+
+    Sets a scratch stack with a sentinel return address and executes until the
+    function's rts pops it back. Faults propagate as UcError.
+    """
+    uc.reg_write(UC_M68K_REG_A7, CALL_SP)
+    uc.mem_write(CALL_SP, CALL_RET.to_bytes(4, "big"))
+    uc.reg_write(UC_M68K_REG_SR, 0x2700)
+    uc.emu_start(addr, CALL_RET, count=count)
+
+
+def _prime_menu(r):
+    """One-time setup so a warm machine can redraw the MAIN MENU on demand:
+    install the string-capture + fault-survival hooks, flush the JIT cache
+    (draw fns were cached during boot WITHOUT the hooks), and open the window.
+    """
+    uc = r.uc
+    r._draws = []
+
+    def draw_hook(u, address, size, user):
+        sp = u.reg_read(UC_M68K_REG_A7)
+        try:
+            x = int.from_bytes(u.mem_read(sp + 12, 4), "big")
+            y = int.from_bytes(u.mem_read(sp + 16, 4), "big")
+            sptr = int.from_bytes(u.mem_read(sp + 24, 4), "big")
+        except UcError:
+            return
+        t = _cstr(u, sptr)
+        if t:
+            r._draws.append((x, y, t))
+
+    def on_unmapped(u, access, addr, size, val, user):
+        # A cold detour skips some normal setup, so a formatter may hold a
+        # stale pointer; map a zero page so its strlen reads "" and the real
+        # (valid) row labels still render, instead of faulting the whole draw.
+        try:
+            u.mem_map(addr & ~0xFFF, 0x1000)
+        except UcError:
+            pass
+        return True
+
+    uc.hook_add(UC_HOOK_CODE, draw_hook, begin=DRAW_STRING, end=DRAW_STRING)
+    uc.hook_add(UC_HOOK_MEM_READ_UNMAPPED | UC_HOOK_MEM_WRITE_UNMAPPED
+                | UC_HOOK_MEM_FETCH_UNMAPPED, on_unmapped)
+    uc.ctl_flush_tb()
+    _call(uc, MENU_OPEN)                     # allocate + set the menu window
+    uc.mem_write(MENU_STATE, (1).to_bytes(4, "big"))       # tree state
+    uc.mem_write(MENU_VIEWPORT, (6).to_bytes(4, "big"))    # visible rows
+    r._menu_ready = True
+
+
+def render_menu(r, cursor=0):
+    """Open the MAIN MENU on a warm machine and capture what the firmware
+    draws, as a list of (x, y, text) — the live screen, the real renderer's
+    output rather than the tables. `cursor` selects the highlighted top-level
+    row (0..3); the right pane follows it, as on the unit. A patched-in entry
+    appears here exactly as the firmware would draw it.
+
+    Re-entrant: the first call primes the machine, later calls just redraw.
+    """
+    uc = r.uc
+    if uc is None or not r.reached_handoff:
+        return []
+    try:
+        if not getattr(r, "_menu_ready", False):
+            _prime_menu(r)
+        uc.mem_write(MENU_SELROW, int(cursor).to_bytes(4, "big"))
+        r._draws.clear()
+        _call(uc, MENU_DRAW)
+    except UcError:
+        pass
+    return list(r._draws)
+
+
+def layout_screen(draws, cols=42, rows=9):
+    """Arrange captured (x,y,text) draws into a text grid. The LCD is 128x64
+    with a bottom-left-ish origin (the list drawer steps y DOWN per row, so
+    larger y = higher on screen); map pixel x/y to character cells."""
+    grid = [[" "] * cols for _ in range(rows)]
+    for x, y, t in draws:
+        cx = min(cols - 1, max(0, x * cols // 128))
+        cy = min(rows - 1, max(0, (64 - y) * rows // 64))
+        for i, ch in enumerate(t):
+            if cx + i < cols:
+                grid[cy][cx + i] = ch
+    return ["".join(row).rstrip() for row in grid]
 
 
 def _cli():

--- a/tools/remix/tui.py
+++ b/tools/remix/tui.py
@@ -338,55 +338,62 @@ def emu_view(scr, image):
     scr.refresh()
 
     r = emu_bringup.boot(str(image))
-    tree = emu_bringup.read_menu_tree(r.uc) if r.uc and r.reached_handoff else []
+    # top-level root names, to move the cursor and to flag what a patch added
+    roots = ([n["name"] for n in emu_bringup.read_menu_tree(r.uc)]
+             if r.uc and r.reached_handoff else [])
 
-    # flatten the tree to display rows
-    rows = []
-    for n in tree:
-        added = n["name"] not in STOCK_ROOTS
-        rows.append((0, n["name"], added))
-        for c in n["children"]:
-            rows.append((1, c["name"], added))
-
-    top = 0
+    cursor = 0
     while True:
         scr.erase()
         ok = r.clean
         head = f" emulator — {image.name} — " + ("BOOTS CLEAN" if ok else "FAULT")
         scr.addstr(0, 0, head.ljust(w - 1),
                    curses.A_REVERSE | (0 if ok else curses.A_BOLD))
+
         def put(y, x, s, attr=0):
-            if 0 <= y < h and x < w - 1:
+            if 0 <= y < h and 0 <= x < w - 1:
                 scr.addstr(y, x, s[:w - x - 1], attr)
+
         put(2, 2, f"instructions : {r.instrs:,}")
         put(3, 2, f"stop         : {r.stopped}")
-        put(4, 2, f"auto-pokes   : {len(r.auto_pokes)} async-completion flags")
         if not r.uc:
-            put(6, 2, r.stopped, curses.A_BOLD)
-            put(6, 2, "emulator unavailable — pip install 'unicorn>=2.1'",
+            put(5, 2, "emulator unavailable — pip install 'unicorn>=2.1'",
                 curses.A_BOLD)
         elif not r.reached_handoff:
-            put(6, 2, "did not reach the RTOS handoff — a patch may have "
+            put(5, 2, "did not reach the RTOS handoff — a patch may have "
                       "broken early init.", curses.A_BOLD)
         else:
-            put(6, 2, "MAIN MENU (walked from booted RAM):", curses.A_BOLD)
-            view_h = h - 9
-            for i in range(top, min(len(rows), top + view_h)):
-                depth, name, added = rows[i]
-                y = 7 + (i - top)
-                mark = "NEW " if added and depth == 0 else ""
-                attr = (curses.A_BOLD if added else 0)
-                put(y, 4 + depth * 2, mark + name, attr)
-        put(h - 1, 0, " up/down scroll   q/esc back to workbench ".ljust(w - 1),
-            curses.A_REVERSE)
+            # LIVE screen: the firmware's own menu render (docs/EMU.md).
+            draws = emu_bringup.render_menu(r, cursor)
+            put(5, 2, "LIVE SCREEN — the firmware's own menu render:",
+                curses.A_BOLD)
+            # draw a little 128x64-proportioned LCD frame
+            grid = emu_bringup.layout_screen(draws)
+            fx, fy = 4, 7
+            put(fy - 1, fx, "+" + "-" * 44 + "+", curses.A_DIM)
+            for i, line in enumerate(grid):
+                put(fy + i, fx, "|", curses.A_DIM)
+                # highlight the selected root name
+                sel = roots[cursor] if cursor < len(roots) else ""
+                attr = curses.A_REVERSE if sel and line.strip() == sel else 0
+                put(fy + i, fx + 1, line.ljust(44), attr)
+                put(fy + i, fx + 45, "|", curses.A_DIM)
+            put(fy + len(grid), fx, "+" + "-" * 44 + "+", curses.A_DIM)
+            added = [n for n in roots if n not in STOCK_ROOTS]
+            if added:
+                put(fy + len(grid) + 2, 2,
+                    "patched-in entr" + ("y" if len(added) == 1 else "ies") +
+                    ": " + ", ".join(added), curses.A_BOLD)
+        put(h - 1, 0, " up/down move cursor   q/esc back to workbench ".ljust(
+            w - 1), curses.A_REVERSE)
         scr.refresh()
         c = scr.getch()
         if c in (ord("q"), 27, ord("e")):
             return
-        elif c in (curses.KEY_DOWN, ord("j")):
-            top = min(max(0, len(rows) - (h - 9)), top + 1)
-        elif c in (curses.KEY_UP, ord("k")):
-            top = max(0, top - 1)
+        elif c in (curses.KEY_DOWN, ord("j")) and roots:
+            cursor = (cursor + 1) % len(roots)
+        elif c in (curses.KEY_UP, ord("k")) and roots:
+            cursor = (cursor - 1) % len(roots)
 
 
 def main(scr):


### PR DESCRIPTION
The firmware's own MAIN MENU now renders as text, navigable, out of the emulator. `make remix` → **e** boots the built image and shows a framed LCD; up/down walk PROJECT·SYSTEM·CONTROL·MIDI and the submenu preview follows, as on the unit. A patched-in menu entry renders exactly as the firmware would draw it.

How: hook the universal string primitive `FUN_40012bd8` (x/y/str off the stack), call the menu open+draw functions directly against the warm post-boot machine, with `ctl_flush_tb()` so the hooks instrument the boot-cached draw blocks. Full recipe + the JIT-cache gotcha in `docs/EMU.md`.

Next increments (same detour shape): entering submenus / param pages via the real key handler. The RTOS-emulation fork stays open and unforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)