### PR TITLE
emu: FX2 dials render + menu browser

### DIFF
--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -151,11 +151,24 @@ steps y DOWN per row), so `layout_screen` maps larger-y to higher rows.
 Selection highlight is a separate XOR-rect op `FUN_40012254` (`mode<0`) — not
 captured as text yet.
 
-**What is still table-driven, not live:** entering a submenu / backing out
-(the cursor demo pokes the selection global rather than driving the real key
-handler `FUN_40064e64`), and the param pages. Both are the same detour shape —
-call the state's key handler with a keycode, or stage a param page — and are
-the natural next increments.
+**The FX2 dials page renders too** — `render_fx2(r)` detours to the EFFECT 2
+SETUP window (`FUN_4005996c`) for track 5 and captures the chooser + param
+row; it lists the *built remix's own effects* (`ChonVerb77`, `BongDelay77`,
+`Send`). `make remix` → `e` → `f` shows it. (The effect's specific dial
+*values* — the reverb's SIZE/MODE — need the effect assigned to the track,
+i.e. a loaded project or a poked part-record; the chooser + param labels
+render without one.)
+
+**What is still not live: item-level descent inside the menu.** The MAIN MENU
+is a fixed two-pane widget (categories left, the selected category's submenu
+right), so moving the cursor already *previews* every submenu — but selecting
+a submenu ITEM (to reach a param page, or PROJECT▸SAVE) needs the real key
+handler `FUN_40064e64`, whose keycodes are position-dependent, and the
+selection highlight is an XOR rect (`FUN_40012254`), not text. Repointing the
+display at a submenu descriptor directly does NOT work: the firmware computes
+the row x from 2-pane state that a cold repoint leaves unset, so the labels
+land at a bogus x (`0x80003003`). Driving the key handler + capturing the XOR
+highlight is the next increment.
 
 ## The RTOS fork — still open, still not forced
 

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -48,8 +48,15 @@ MENU_DRAW = 0x40064d7c       # dispatches the current menu-state's draw
 MENU_STATE = 0x400cbf40      # menu state index (1 = the tree)
 MENU_VIEWPORT = 0x400cbd9c   # visible-row clamp; 0 in a cold detour -> no rows
 MENU_SELROW = 0x400cbd98     # selected row in the current list (the cursor)
+MENU_ROWS = 0x400cbda4       # current display list: rows pointer
+MENU_COUNT = 0x400cbda0      # current display list: row count
+MENU_FOCUS = 0x400cbda8      # focus descriptor
 CALL_SP = 0x47f00000         # scratch stack for a detour call
 CALL_RET = 0x000000f0        # sentinel return address a detour stops at
+
+# EFFECT 2 SETUP window opener (docs/MAINMENU.md §7) — the FX2 chooser + dials.
+FX2_SETUP = 0x4005996c
+CUR_TRACK_B = 0x80000000     # current audio track (byte); UI mirror 0x100b14cc
 
 
 class BootResult:
@@ -330,17 +337,47 @@ def _prime_menu(r):
     _call(uc, MENU_OPEN)                     # allocate + set the menu window
     uc.mem_write(MENU_STATE, (1).to_bytes(4, "big"))       # tree state
     uc.mem_write(MENU_VIEWPORT, (6).to_bytes(4, "big"))    # visible rows
+    # The root descriptor's rows field (0x400cbd8c+0x18) IS the MENU_ROWS
+    # global that render repoints, so capture the root list ONCE now — after
+    # this, reading the root descriptor gives whatever we last rendered.
+    r._root_rows = _u32(uc, MENU_ROOT_DESC + 0x18)
+    r._root_count = _u32(uc, MENU_ROOT_DESC)
     r._menu_ready = True
 
 
-def render_menu(r, cursor=0):
-    """Open the MAIN MENU on a warm machine and capture what the firmware
-    draws, as a list of (x, y, text) — the live screen, the real renderer's
-    output rather than the tables. `cursor` selects the highlighted top-level
-    row (0..3); the right pane follows it, as on the unit. A patched-in entry
-    appears here exactly as the firmware would draw it.
+def _list_of(r, desc):
+    """(rows_ptr, count) for a menu descriptor, using the captured root list
+    for the root (whose live fields get repointed by rendering)."""
+    if desc == MENU_ROOT_DESC and getattr(r, "_root_rows", None):
+        return r._root_rows, r._root_count
+    return _u32(r.uc, desc + 0x18), _u32(r.uc, desc)
 
-    Re-entrant: the first call primes the machine, later calls just redraw.
+
+def menu_children(r, desc=MENU_ROOT_DESC):
+    """The rows of a menu descriptor as [(label, child_desc, action)]. A row
+    with a non-zero child_desc is a submenu you can descend into."""
+    uc = r.uc
+    if uc is None:
+        return []
+    if not getattr(r, "_menu_ready", False) and r.reached_handoff:
+        _prime_menu(r)
+    rows, count = _list_of(r, desc)
+    if not (0 < count < 64) or not (0x40000000 <= rows < 0x40200000):
+        return []
+    out = []
+    for i in range(count):
+        row = rows + ROW_STRIDE * i
+        label = _cstr(uc, _u32(uc, row + 0x00))
+        if label:
+            out.append((label, _u32(uc, row + 0x10), _u32(uc, row + 0x08)))
+    return out
+
+
+def render_menu(r, desc=MENU_ROOT_DESC, cursor=0):
+    """Point the MAIN MENU display at descriptor `desc`, select `cursor`, and
+    capture what the firmware draws, as (x, y, text) — the live screen. The
+    root renders two panes (categories + the selected one's children); a
+    submenu descriptor renders its items. Re-entrant: first call primes it.
     """
     uc = r.uc
     if uc is None or not r.reached_handoff:
@@ -348,9 +385,34 @@ def render_menu(r, cursor=0):
     try:
         if not getattr(r, "_menu_ready", False):
             _prime_menu(r)
+        rows, count = _list_of(r, desc)
+        uc.mem_write(MENU_ROWS, rows.to_bytes(4, "big"))
+        uc.mem_write(MENU_COUNT, count.to_bytes(4, "big"))
+        uc.mem_write(MENU_VIEWPORT, max(count, 6).to_bytes(4, "big"))
+        uc.mem_write(MENU_FOCUS, desc.to_bytes(4, "big"))
         uc.mem_write(MENU_SELROW, int(cursor).to_bytes(4, "big"))
         r._draws.clear()
         _call(uc, MENU_DRAW)
+    except UcError:
+        pass
+    return list(r._draws)
+
+
+def render_fx2(r, track=4):
+    """Detour to the EFFECT 2 SETUP window for `track` (default 4 = track 5,
+    where ChonVerb is hosted) and capture what it draws — the FX2 chooser and
+    parameter labels. Shows the built remix's own effects.
+    """
+    uc = r.uc
+    if uc is None or not r.reached_handoff:
+        return []
+    if not getattr(r, "_menu_ready", False):
+        _prime_menu(r)          # installs the capture + fault-survival hooks
+    try:
+        uc.mem_write(CUR_TRACK_B, int(track).to_bytes(1, "big"))
+        uc.mem_write(0x100b14cc, int(track).to_bytes(4, "big"))
+        r._draws.clear()
+        _call(uc, FX2_SETUP)
     except UcError:
         pass
     return list(r._draws)
@@ -362,6 +424,8 @@ def layout_screen(draws, cols=42, rows=9):
     larger y = higher on screen); map pixel x/y to character cells."""
     grid = [[" "] * cols for _ in range(rows)]
     for x, y, t in draws:
+        if not (0 <= x <= 128 and 0 <= y <= 64):     # skip bogus coords
+            continue
         cx = min(cols - 1, max(0, x * cols // 128))
         cy = min(rows - 1, max(0, (64 - y) * rows // 64))
         for i, ch in enumerate(t):

--- a/tools/remix/tui.py
+++ b/tools/remix/tui.py
@@ -324,11 +324,32 @@ def shell_out(scr, argv, env=None):
     return r.returncode
 
 
+def _lcd(scr, draws, y0, x0, sel_label=""):
+    """Draw captured (x,y,text) as a framed 128x64-proportioned LCD panel."""
+    h, w = scr.getmaxyx()
+    grid = emu_bringup.layout_screen(draws)
+    width = 46
+
+    def put(y, x, s, attr=0):
+        if 0 <= y < h and 0 <= x < w - 1:
+            scr.addstr(y, x, s[:w - x - 1], attr)
+    put(y0 - 1, x0, "." + "-" * width + ".", curses.A_DIM)
+    for i, line in enumerate(grid):
+        put(y0 + i, x0, "|", curses.A_DIM)
+        attr = (curses.A_REVERSE if sel_label and line.strip() == sel_label
+                else 0)
+        put(y0 + i, x0 + 1, line.ljust(width), attr)
+        put(y0 + i, x0 + width + 1, "|", curses.A_DIM)
+    put(y0 + len(grid), x0, "'" + "-" * width + "'", curses.A_DIM)
+    return y0 + len(grid) + 1
+
+
 def emu_view(scr, image):
-    """Boot a built image in the Tier-0 emulator and show it booted clean and
-    what its MAIN MENU resolves to -- a patched-in entry (docs/MAINMENU.md)
-    shows up highlighted. This is the no-flash gate: a cave that breaks early
-    init faults here instead of on the unit.
+    """Boot a built image in the Tier-0 emulator and NAVIGATE its firmware UI:
+    the MAIN MENU (up/down/enter/back through real rendered screens) and the
+    FX2 dials page, both drawn by the real firmware (docs/EMU.md). A patched-in
+    entry shows up as the firmware would draw it. Booting also IS the no-flash
+    gate: a cave that breaks early init faults here, not on the unit.
     """
     h, w = scr.getmaxyx()
     scr.erase()
@@ -338,62 +359,63 @@ def emu_view(scr, image):
     scr.refresh()
 
     r = emu_bringup.boot(str(image))
-    # top-level root names, to move the cursor and to flag what a patch added
-    roots = ([n["name"] for n in emu_bringup.read_menu_tree(r.uc)]
-             if r.uc and r.reached_handoff else [])
-
+    ok = r.clean
+    roots = emu_bringup.menu_children(r) if r.uc and r.reached_handoff else []
     cursor = 0
+    mode = "menu"          # "menu" or "fx2"
+
+    def put(y, x, s, attr=0):
+        if 0 <= y < h and 0 <= x < w - 1:
+            scr.addstr(y, x, s[:w - x - 1], attr)
+
     while True:
         scr.erase()
-        ok = r.clean
         head = f" emulator — {image.name} — " + ("BOOTS CLEAN" if ok else "FAULT")
-        scr.addstr(0, 0, head.ljust(w - 1),
-                   curses.A_REVERSE | (0 if ok else curses.A_BOLD))
+        put(0, 0, head.ljust(w - 1),
+            curses.A_REVERSE | (0 if ok else curses.A_BOLD))
+        put(1, 2, f"{r.instrs:,} instrs · {r.stopped}", curses.A_DIM)
 
-        def put(y, x, s, attr=0):
-            if 0 <= y < h and 0 <= x < w - 1:
-                scr.addstr(y, x, s[:w - x - 1], attr)
-
-        put(2, 2, f"instructions : {r.instrs:,}")
-        put(3, 2, f"stop         : {r.stopped}")
-        if not r.uc:
-            put(5, 2, "emulator unavailable — pip install 'unicorn>=2.1'",
-                curses.A_BOLD)
-        elif not r.reached_handoff:
-            put(5, 2, "did not reach the RTOS handoff — a patch may have "
-                      "broken early init.", curses.A_BOLD)
+        if not r.uc or not r.reached_handoff:
+            put(4, 2, "emulator unavailable — pip install 'unicorn>=2.1'"
+                if not r.uc else "did not reach the RTOS handoff — a patch may "
+                "have broken early init.", curses.A_BOLD)
+        elif mode == "fx2":
+            put(3, 2, "FX2 SETUP — the built remix's own effects & dials "
+                      "(track 5):", curses.A_BOLD)
+            _lcd(scr, emu_bringup.render_fx2(r), 6, 4)
+            put(h - 3, 2, "the chooser lists THIS image's effects; the labels "
+                          "are the FX2 param row.", curses.A_DIM)
         else:
-            # LIVE screen: the firmware's own menu render (docs/EMU.md).
-            draws = emu_bringup.render_menu(r, cursor)
-            put(5, 2, "LIVE SCREEN — the firmware's own menu render:",
-                curses.A_BOLD)
-            # draw a little 128x64-proportioned LCD frame
-            grid = emu_bringup.layout_screen(draws)
-            fx, fy = 4, 7
-            put(fy - 1, fx, "+" + "-" * 44 + "+", curses.A_DIM)
-            for i, line in enumerate(grid):
-                put(fy + i, fx, "|", curses.A_DIM)
-                # highlight the selected root name
-                sel = roots[cursor] if cursor < len(roots) else ""
-                attr = curses.A_REVERSE if sel and line.strip() == sel else 0
-                put(fy + i, fx + 1, line.ljust(44), attr)
-                put(fy + i, fx + 45, "|", curses.A_DIM)
-            put(fy + len(grid), fx, "+" + "-" * 44 + "+", curses.A_DIM)
-            added = [n for n in roots if n not in STOCK_ROOTS]
+            sel = roots[cursor][0] if roots else ""
+            put(3, 2, "MAIN MENU — the firmware's own render "
+                      f"(selected: {sel}):", curses.A_BOLD)
+            draws = emu_bringup.render_menu(r, emu_bringup.MENU_ROOT_DESC, cursor)
+            ny = _lcd(scr, draws, 6, 4, sel_label=sel)
+            # the right LCD pane previews the selected category's submenu, as
+            # on the unit; move the cursor to browse each one.
+            added = [k[0] for k in roots if k[0] not in STOCK_ROOTS]
             if added:
-                put(fy + len(grid) + 2, 2,
-                    "patched-in entr" + ("y" if len(added) == 1 else "ies") +
-                    ": " + ", ".join(added), curses.A_BOLD)
-        put(h - 1, 0, " up/down move cursor   q/esc back to workbench ".ljust(
-            w - 1), curses.A_REVERSE)
+                put(ny + 1, 2, "patched-in: " + ", ".join(added), curses.A_BOLD)
+
+        keys = (" up/down browse categories   f FX2 dials   q back "
+                "to workbench ") if mode == "menu" else \
+               (" m back to menu   q back to workbench ")
+        put(h - 1, 0, keys.ljust(w - 1), curses.A_REVERSE)
         scr.refresh()
+
         c = scr.getch()
-        if c in (ord("q"), 27, ord("e")):
+        if c in (ord("q"), 27):
             return
-        elif c in (curses.KEY_DOWN, ord("j")) and roots:
+        if mode == "fx2":
+            if c in (ord("m"), ord("f")):
+                mode = "menu"
+            continue
+        if c in (curses.KEY_DOWN, ord("j")) and roots:
             cursor = (cursor + 1) % len(roots)
         elif c in (curses.KEY_UP, ord("k")) and roots:
             cursor = (cursor - 1) % len(roots)
+        elif c == ord("f"):
+            mode = "fx2"
 
 
 def main(scr):


### PR DESCRIPTION
The FX2 SETUP page now renders in the emulator (make remix → e → f), listing the built remix's own effects (ChonVerb77/BongDelay77/Send) + param row. The menu view is a faithful two-pane browser (up/down browse categories, right pane previews each submenu). Item-level descent + live dial values need the real key handler / part state — documented as the next increment in docs/EMU.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)