### PR TITLE
build: uv-managed venv for the emulator dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ vendor/
 .DS_Store
 .playwright-mcp/
 __pycache__/
+.venv/
 *.pyc

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ VERSION ?= OCTABAM$(BUILD)
 # remixes/<name>.py is the selection. chongbong is the shipping one.
 REMIX   ?= chongbong
 
+# The tools run on bare python3 (stdlib only). The ONE exception is the local
+# ColdFire emulator (docs/EMU.md), which needs `unicorn` from the uv-managed
+# `.venv` (the `emu` extra). Prefer that venv when present, else bare python3 —
+# where the emulator view degrades to "unavailable" and everything else works.
+PY := $(shell [ -x .venv/bin/python3 ] && echo .venv/bin/python3 || echo python3)
+
 .DEFAULT_GOAL := help
 
 # ---------------------------------------------------------------- toolchain --
@@ -150,7 +156,12 @@ modules: ## List the module index and the available remixes
 
 .PHONY: remix
 remix: ## The remix workbench: compose a selection, see what it costs, build it
-	python3 tools/remix/tui.py
+	$(PY) tools/remix/tui.py
+
+.PHONY: emu-setup
+emu-setup: ## Provision the emulator's dependency (unicorn) into .venv via uv
+	uv sync --extra emu
+	@echo "emulator ready — 'make remix' then 'e' (docs/EMU.md)"
 
 # -------------------------------------------------------------------- misc --
 

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -182,10 +182,16 @@ needs it.
 ## Reproduce
 
 ```sh
-pip install 'unicorn>=2.1'           # the DEFAULT m68k core is plain-68k; the
-tools/emu_bringup.py [image]         # CFV4E model is what decodes this CPU
-make remix                           # ... then press e to boot the built image
+make emu-setup                       # uv sync --extra emu -> .venv with unicorn
+make remix                           # then press e to boot the built image
+.venv/bin/python3 tools/emu_bringup.py [image]   # or the CLI directly
 ```
+
+The emulator's one dependency (`unicorn`, with QEMU's CFV4E core — the DEFAULT
+m68k core is plain-68k and cannot decode this CPU) lives in the uv-managed
+`.venv` as the optional `emu` extra (`pyproject.toml`). `make remix` prefers
+`.venv/bin/python3` and falls back to bare `python3`, where the emulator view
+reports itself unavailable and the rest of the workbench is unaffected.
 
 The CLI prints the boot outcome (the `trap #0` boundary), the auto-pokes, the
 MAIN MENU walked from booted RAM, and the peripheral boot map. In the

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -38,7 +38,7 @@ ones — the DSP toolchain itself is plain CMake). It builds:
 |---|---|---|
 | `dsp_asm` | `vendor/dsp56300` | the DSP56300 assembler. ⚠️ It **mis-encodes some instructions silently** — `CLAUDE.md`'s trap list is required reading before trusting it |
 | `dsp_host` | `tools/dsp_host/` (staged into `vendor/dsp56300` and built there) | this project's emulator harness: runs assembled effects on the dsp56300 emulator core. `docs/HARNESS.md` |
-| `emu_bringup.py` | `tools/` | Tier-0 ColdFire bring-up: boots the real MAIN OS image on Unicorn's CFV4E core to the RTOS handoff (the workbench emu, `PLAN.md` §5). Needs `pip install 'unicorn>=2.1'`. `docs/EMU.md` |
+| `emu_bringup.py` | `tools/` | Tier-0 ColdFire bring-up: boots the real MAIN OS image on Unicorn's CFV4E core to the RTOS handoff (the workbench emu, `PLAN.md` §5). Needs `unicorn` — `make emu-setup` (uv, the `emu` extra). `docs/EMU.md` |
 | `elektron-firmware-tool` | `vendor/elektron-firmware-tool` (patched) | packs/unpacks Elektron's OS container formats |
 
 The disassembler from the same dsp56300 project is the other half of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+# octabam is a scripts + Makefile project, not an installable package — the
+# build and analysis tools deliberately run on bare `python3` with the stdlib
+# only. This file exists for ONE reason: the local ColdFire emulator
+# (docs/EMU.md, the workbench's `e` view) needs `unicorn`, the project's only
+# external dependency, and it is optional. uv provisions it into `.venv` as
+# the `emu` extra; the tooling prefers that venv and falls back to bare
+# `python3` (where the emulator view simply reports itself unavailable).
+#
+#   uv sync --extra emu     # or: make emu-setup
+#
+[project]
+name = "octabam"
+version = "0.0.0"
+description = "Custom DSP effects and firmware tooling for the Elektron Octatrack"
+requires-python = ">=3.9"
+dependencies = []
+
+[project.optional-dependencies]
+emu = ["unicorn>=2.1"]
+
+[tool.uv]
+# Virtual project: do not try to build/install octabam itself, just manage the
+# environment its scripts run in.
+package = false

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -12,9 +12,10 @@ real peripherals, no scheduler. Two uses:
     freshly built image and show that it boots clean and that a patched-in
     menu entry (docs/MAINMENU.md) actually resolves.
 
-Needs `unicorn` with the CFV4E model: `pip install 'unicorn>=2.1'`. The
-DEFAULT m68k core is plain-68k and will NOT decode this CPU (mvz/mvs/EMAC) —
-see docs/EXTERNAL.md. Boot details and the fork past the trap: docs/EMU.md.
+Needs `unicorn` with the CFV4E model — `make emu-setup` provisions it into
+the uv-managed `.venv` (the `emu` extra). The DEFAULT m68k core is plain-68k
+and will NOT decode this CPU (mvz/mvs/EMAC) — see docs/EXTERNAL.md. Boot
+details and the fork past the trap: docs/EMU.md.
 """
 import collections
 import os
@@ -85,7 +86,7 @@ def boot(image=None, count=BUDGET, on_draw=None):
     """
     r = BootResult()
     if not HAVE_UNICORN:
-        r.stopped = "unicorn not installed (pip install 'unicorn>=2.1')"
+        r.stopped = "unicorn not installed — run: make emu-setup"
         return r
     img = open(image or STOCK_IMAGE, "rb").read()
 

--- a/tools/remix/tui.py
+++ b/tools/remix/tui.py
@@ -378,7 +378,7 @@ def emu_view(scr, image):
         put(1, 2, f"{r.instrs:,} instrs · {r.stopped}", curses.A_DIM)
 
         if not r.uc or not r.reached_handoff:
-            put(4, 2, "emulator unavailable — pip install 'unicorn>=2.1'"
+            put(4, 2, "emulator unavailable — run: make emu-setup"
                 if not r.uc else "did not reach the RTOS handoff — a patch may "
                 "have broken early init.", curses.A_BOLD)
         elif mode == "fx2":

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,35 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+
+[[package]]
+name = "octabam"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.optional-dependencies]
+emu = [
+    { name = "unicorn" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "unicorn", marker = "extra == 'emu'", specifier = ">=2.1" }]
+provides-extras = ["emu"]
+
+[[package]]
+name = "unicorn"
+version = "2.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/1b/b4248aa8422e86de690cf8e85cf8feae4c33405a097d1ebe71570bdaa6f5/unicorn-2.1.4.tar.gz", hash = "sha256:00567a70e323f749b419cd86bee4f9115beab7ebba32194581c090cbb7c59cff", size = 2900334, upload-time = "2025-09-09T17:10:48.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/a7/92b47771e2107a201632a199cec91e8a81ee8a071ca6b7e7d600d8c61ac9/unicorn-2.1.4-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2a6f738fab5fabffa56af1e7bbf16ea1e91466c342f8dc64f125bd70f36c6b80", size = 12958220, upload-time = "2025-09-09T17:10:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ae/4943c6f8524d729ec7d5e69df6407ea05d710fe77471d91cecf3fc64eb57/unicorn-2.1.4-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:d6c93e0f60328d8f4a1792af3f834137a28050fcc2305f2ec01efe8558a9844e", size = 12142730, upload-time = "2025-09-09T17:10:07.48Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9f/32d41eb942221bcf4417cdc65537fc8b3bbbd6079d6c161e621f1dd4e94a/unicorn-2.1.4-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd1fb0c9af5f57e356d8a96928b4fe045b2e18f308ef23b481d5f970008aa722", size = 15372569, upload-time = "2025-09-09T17:10:09.765Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7f/83161916dedff22ddb187bd2751150a1bc53c88b7c1a8d6fa1cc9e144c64/unicorn-2.1.4-cp37-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8f4e63b76ac4faa7cd32a4c436e96eabc24b91d52e73bde7699ec886bddf9277", size = 19842875, upload-time = "2025-09-09T17:10:11.795Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/df/ded5e3684c2d7600b30cc8a7530277b8cb36644a1a9d34cade7ebb45604c/unicorn-2.1.4-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d6e6dea140560de4ebd8446661f7ef84a357d428c14a3ef09dacd306ec8c239", size = 16436886, upload-time = "2025-09-09T17:10:14.079Z" },
+    { url = "https://files.pythonhosted.org/packages/70/38/ba5a051c844026e59ab6e0017db8cec77dbe20ab5f1d6edae1ce9d885b06/unicorn-2.1.4-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:01d744ba01c5cc68f1d7afe3d183f1868720fd440ec4eaedc4d1d5d9bf54b84c", size = 16089431, upload-time = "2025-09-09T17:10:16.557Z" },
+    { url = "https://files.pythonhosted.org/packages/35/07/0b2fb9d2a462066aa24b7d18b463300df79cc4eaa471379f8af7d216261c/unicorn-2.1.4-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:ce5c3bfd05f2a5749a0d8a960e1dfc26519a2d09377dc01cfa1378b936a953f8", size = 20531342, upload-time = "2025-09-09T17:10:19.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4b/4628ccb20eb3ad1af400de8181d1f4e5c1a3fc2affa1b3410c1b2d71af36/unicorn-2.1.4-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d348a90ee90219d141cb115ef8ed7e3fd1af42afaee105f7580761d775b25e32", size = 16925029, upload-time = "2025-09-09T17:10:21.089Z" },
+    { url = "https://files.pythonhosted.org/packages/08/23/6ae96f8efa8ede707cc67d18d76a08de498bd818483cf8211baf855eabb2/unicorn-2.1.4-cp37-abi3-win32.whl", hash = "sha256:9be89e69be5e2631299f39a7fb8e47b8d3bfaa70ae746e9c4c5f9476a2df9778", size = 11798091, upload-time = "2025-09-09T17:10:23.477Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3d/de7be9bd1addabe6d8a1369381f8a080400c349850e978689c5e18287957/unicorn-2.1.4-cp37-abi3-win_amd64.whl", hash = "sha256:d7107500c64ce5c168fbff6bef9485b5db1350050036f4cea568650cf8bdbdf5", size = 15943079, upload-time = "2025-09-09T17:10:25.265Z" },
+]


### PR DESCRIPTION
Formalizes unicorn (the local ColdFire emulator's only dep) as an optional `emu` extra provisioned by uv into `.venv`. `make emu-setup` runs `uv sync --extra emu`; `make remix` prefers `.venv/bin/python3` and falls back to bare python3. The rest of the tooling stays stdlib-only. `uv.lock` + `pyproject.toml` tracked, `.venv` ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)