### PR TITLE
emu: render + navigate both FX param pages

### DIFF
--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -170,6 +170,37 @@ the row x from 2-pane state that a cold repoint leaves unset, so the labels
 land at a bogus x (`0x80003003`). Driving the key handler + capturing the XOR
 highlight is the next increment.
 
+## Both FX param pages, with the effect assigned ✅ (31 Aug 2026)
+
+`render_fx2(r, track, effect_id)` and `render_fx1(r, track, effect_id)` render
+the real FX2 / FX1 parameter pages — the effect's actual knob rows, not a
+default. `make remix` → `e` → `f` (FX2) / `1` (FX1); left/right cycle the
+effect. FX2 with `0x07` shows ChonVerb's knobs (SHMR/MODE/DIFF/SHFT/GATE/RATE/
+HP/LP/IN); FX1 shows the stock effects (FILTER's BASE/WDTH/ENV/ATK/DEC/…, EQ's
+FRQ/GN/…) — our inserts are all FX2, so the FX1 tables are stock.
+
+**How the effect resolves.** The page draws the descriptor `table[id]` where
+`id` is a per-track byte in the project Part: FX2 at `PART + PAT*0x18b2 +
+track + 0x8ed88`, FX1 at `+0x8ed80` (`PART = *(u32*)0x46c82456`, `PAT =
+*(u8*)0x100b14cf`). Our boot loads no project, so `PART` is null — `_prime_part`
+maps a zeroed scratch Part and points the DB pointer at it, then `assign_fx2`/
+the FX1 path write the id byte. In the BUILT image the id→descriptor tables
+are patched (`build_bus.py`), so `0x07` is ChonVerb; in the raw image those
+slots are NONE. (`0x06`/BongDelay aliases to SEND in the payload-A SPEC image
+and renders empty — it lives on payload B.)
+
+**Both SETUP windows** wrap the stage+draw: FX2 `FUN_4005996c` (drawer
+`FUN_40037590`), FX1 `FUN_40059afc` (drawer `FUN_4003792c`). Calling one after
+assigning the id is the whole recipe.
+
+**Values.** A knob's displayed value is a byte at `PART + PAT*0x18b2 +
+track*30 + slot + 0x8f084` (`set_fx2_value`), and the canonical writer is
+`FUN_40054cd8(track, flat, value)` with `flat = 24 + slot` for FX2 page-1.
+The value itself draws as a dial GRAPHIC, not text, so it is not captured by
+the string hook — the audio side (`render_reverb`, the `v` audition view) is
+where knob values are heard. Editing a value in the page + reading it back as
+text is the remaining nicety.
+
 ## The RTOS fork — still open, still not forced
 
 Milestone 2 took route **B** (detour) and it carries the workbench: a menu- or

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -55,7 +55,10 @@ MENU_FOCUS = 0x400cbda8      # focus descriptor
 CALL_SP = 0x47f00000         # scratch stack for a detour call
 CALL_RET = 0x000000f0        # sentinel return address a detour stops at
 
-# EFFECT 2 SETUP window opener (docs/MAINMENU.md §7) — the FX2 chooser + dials.
+# EFFECT 1 / EFFECT 2 SETUP window openers (docs/MAINMENU.md §7) — the chooser
+# + dials. FX1 is page_kind 3 (id byte +0x8ed80); our inserts are all FX2, so
+# FX1 shows the stock effects (FILTER, etc.).
+FX1_SETUP = 0x40059afc
 FX2_SETUP = 0x4005996c
 CUR_TRACK_B = 0x80000000     # current audio track (byte); UI mirror 0x100b14cc
 
@@ -470,6 +473,31 @@ def render_fx2(r, track=4, effect_id=0x07):
             assign_fx2(r, track, effect_id)
         r._draws.clear()
         _call(uc, FX2_SETUP)
+    except UcError:
+        pass
+    return list(r._draws)
+
+
+def render_fx1(r, track=4, effect_id=0x04):
+    """Detour to EFFECT 1 SETUP for `track` with `effect_id` assigned (FX1 id
+    byte +0x8ed80, table 0x400d5f58 — stock effects; 0x04 = FILTER). Same shape
+    as render_fx2. effect_id None leaves whatever is assigned."""
+    uc = r.uc
+    if uc is None or not r.reached_handoff:
+        return []
+    if not getattr(r, "_menu_ready", False):
+        _prime_menu(r)
+    try:
+        if effect_id is not None:
+            _prime_part(r)
+            uc.mem_write(CUR_TRACK_B, int(track).to_bytes(1, "big"))
+            uc.mem_write(0x100b14cc, int(track).to_bytes(4, "big"))
+            uc.mem_write(PAT_W, (0).to_bytes(1, "big"))
+            uc.mem_write(PAT_R, (0).to_bytes(1, "big"))
+            uc.mem_write(_part_addr(uc, FX1_ID_OFF, track),
+                         bytes([effect_id & 0xff]))
+        r._draws.clear()
+        _call(uc, FX1_SETUP)
     except UcError:
         pass
     return list(r._draws)

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -59,6 +59,20 @@ CALL_RET = 0x000000f0        # sentinel return address a detour stops at
 FX2_SETUP = 0x4005996c
 CUR_TRACK_B = 0x80000000     # current audio track (byte); UI mirror 0x100b14cc
 
+# Assigning an effect to a track's FX2 slot so its real param page resolves
+# (docs/EMU.md, the FX-page research). The project DB pointer at 0x46c82456 is
+# null on our boot (no project loaded), so we point it at a zeroed scratch Part
+# and write the id byte the resolver reads.
+PART_PTR = 0x46c82456        # -> project database base (null until we fake it)
+PART_STRIDE = 0x18b2         # per-pattern
+FX2_ID_OFF = 0x8ed88         # + PAT*stride + track  -> FX2 effect-id byte
+FX1_ID_OFF = 0x8ed80         # FX1 effect-id byte (inserts are all FX2, though)
+PARAM_VAL_OFF = 0x8f084      # + PAT*stride + track*30 + slot -> displayed value
+MACHINE_OFF = 0x8eda2        # + PAT*stride + track -> playback machine type
+FAKE_PART = 0x50000000       # where we map the scratch Part
+PAT_R = 0x100b14cf           # displayed pattern (resolver mirror)
+PAT_W = 0x80000003           # displayed pattern (window/drawer mirror)
+
 
 class BootResult:
     def __init__(self):
@@ -399,10 +413,52 @@ def render_menu(r, desc=MENU_ROOT_DESC, cursor=0):
     return list(r._draws)
 
 
-def render_fx2(r, track=4):
-    """Detour to the EFFECT 2 SETUP window for `track` (default 4 = track 5,
-    where ChonVerb is hosted) and capture what it draws — the FX2 chooser and
-    parameter labels. Shows the built remix's own effects.
+def _prime_part(r):
+    """Map a zeroed scratch Part and point the project-DB pointer at it, so the
+    FX-page resolvers have somewhere to read the per-track effect id and values.
+    The real boot loads a project here; ours (bootstrap-upgrade path) does not.
+    """
+    uc = r.uc
+    if getattr(r, "_part_ready", False):
+        return
+    uc.mem_map(FAKE_PART, 0x100000)
+    uc.mem_write(PART_PTR, FAKE_PART.to_bytes(4, "big"))
+    r._part_ready = True
+
+
+def _part_addr(uc, off, track=4, slot=0, track_stride=1):
+    part = int.from_bytes(uc.mem_read(PART_PTR, 4), "big")
+    pat = uc.mem_read(PAT_R, 1)[0]
+    return part + pat * PART_STRIDE + track * track_stride + slot + off
+
+
+def assign_fx2(r, track=4, effect_id=0x07):
+    """Assign an effect (by FX2 id) to a track so its param page resolves. In
+    the BUILT image the id->descriptor table is patched, so 0x07 is ChonVerb,
+    0x06 BongDelay, etc. (raw image: those slots are NONE)."""
+    uc = r.uc
+    _prime_part(r)
+    uc.mem_write(CUR_TRACK_B, int(track).to_bytes(1, "big"))
+    uc.mem_write(0x100b14cc, int(track).to_bytes(4, "big"))
+    uc.mem_write(PAT_W, (0).to_bytes(1, "big"))
+    uc.mem_write(PAT_R, (0).to_bytes(1, "big"))
+    uc.mem_write(_part_addr(uc, FX2_ID_OFF, track), bytes([effect_id & 0xff]))
+
+
+def set_fx2_value(r, track, slot, value):
+    """Poke a track's FX2 param display value (slot 0..11) — the byte the knob
+    drawer reads. Re-render to see it. (Page-2 slots 6..11 have the effect's
+    page-2 knobs; the drawer reads them from the same displayed-value array.)"""
+    _prime_part(r)
+    a = _part_addr(r.uc, PARAM_VAL_OFF, track, slot, track_stride=30)
+    r.uc.mem_write(a, bytes([value & 0xff]))
+
+
+def render_fx2(r, track=4, effect_id=0x07):
+    """Detour to EFFECT 2 SETUP for `track` (default 4 = track 5) with
+    `effect_id` assigned, and capture what it draws — the chooser plus the
+    effect's REAL parameter knobs (e.g. ChonVerb's SHMR/MODE/DIFF/SHFT/GATE/
+    RATE). effect_id None leaves whatever is assigned.
     """
     uc = r.uc
     if uc is None or not r.reached_handoff:
@@ -410,8 +466,8 @@ def render_fx2(r, track=4):
     if not getattr(r, "_menu_ready", False):
         _prime_menu(r)          # installs the capture + fault-survival hooks
     try:
-        uc.mem_write(CUR_TRACK_B, int(track).to_bytes(1, "big"))
-        uc.mem_write(0x100b14cc, int(track).to_bytes(4, "big"))
+        if effect_id is not None:
+            assign_fx2(r, track, effect_id)
         r._draws.clear()
         _call(uc, FX2_SETUP)
     except UcError:

--- a/tools/remix/tui.py
+++ b/tools/remix/tui.py
@@ -403,7 +403,8 @@ def emu_view(scr, image):
     ok = r.clean
     roots = emu_bringup.menu_children(r) if r.uc and r.reached_handoff else []
     cursor = 0
-    mode = "menu"          # "menu" or "fx2"
+    mode = "menu"                       # "menu" | "fx1" | "fx2"
+    eff = {"fx1": 0x04, "fx2": 0x07}    # assigned effect id per page (cyclable)
 
     def put(y, x, s, attr=0):
         if 0 <= y < h and 0 <= x < w - 1:
@@ -420,43 +421,51 @@ def emu_view(scr, image):
             put(4, 2, "emulator unavailable — run: make emu-setup"
                 if not r.uc else "did not reach the RTOS handoff — a patch may "
                 "have broken early init.", curses.A_BOLD)
-        elif mode == "fx2":
-            put(3, 2, "FX2 SETUP — the built remix's own effects & dials "
-                      "(track 5):", curses.A_BOLD)
-            _lcd(scr, emu_bringup.render_fx2(r), 6, 4)
-            put(h - 3, 2, "the chooser lists THIS image's effects; the labels "
-                          "are the FX2 param row.", curses.A_DIM)
+        elif mode in ("fx1", "fx2"):
+            slot = mode.upper()
+            eid = eff[mode]
+            put(3, 2, f"{slot} SETUP — the effect's real param page "
+                      f"(track 5, effect id 0x{eid:02x}):", curses.A_BOLD)
+            draws = (emu_bringup.render_fx2(r, effect_id=eid) if mode == "fx2"
+                     else emu_bringup.render_fx1(r, effect_id=eid))
+            _lcd(scr, draws, 6, 4)
+            put(h - 3, 2, "left/right cycles the effect · the left column is "
+                          "the chooser, the rows are its knobs.", curses.A_DIM)
         else:
             sel = roots[cursor][0] if roots else ""
             put(3, 2, "MAIN MENU — the firmware's own render "
                       f"(selected: {sel}):", curses.A_BOLD)
             draws = emu_bringup.render_menu(r, emu_bringup.MENU_ROOT_DESC, cursor)
             ny = _lcd(scr, draws, 6, 4, sel_label=sel)
-            # the right LCD pane previews the selected category's submenu, as
-            # on the unit; move the cursor to browse each one.
             added = [k[0] for k in roots if k[0] not in STOCK_ROOTS]
             if added:
                 put(ny + 1, 2, "patched-in: " + ", ".join(added), curses.A_BOLD)
 
-        keys = (" up/down browse categories   f FX2 dials   q back "
+        keys = (" up/down browse   1 FX1 page   f FX2 page   q back "
                 "to workbench ") if mode == "menu" else \
-               (" m back to menu   q back to workbench ")
+               (" left/right cycle effect   m menu   1 FX1   f FX2   q back ")
         put(h - 1, 0, keys.ljust(w - 1), curses.A_REVERSE)
         scr.refresh()
 
         c = scr.getch()
         if c in (ord("q"), 27):
             return
-        if mode == "fx2":
-            if c in (ord("m"), ord("f")):
-                mode = "menu"
+        if c == ord("m"):
+            mode = "menu"; continue
+        if c == ord("1"):
+            mode = "fx1"; continue
+        if c == ord("f"):
+            mode = "fx2"; continue
+        if mode in ("fx1", "fx2"):
+            if c in (curses.KEY_RIGHT, ord("l")):
+                eff[mode] = eff[mode] + 1 if eff[mode] < 0x0f else 0x04
+            elif c in (curses.KEY_LEFT, ord("h")):
+                eff[mode] = eff[mode] - 1 if eff[mode] > 0x04 else 0x0f
             continue
         if c in (curses.KEY_DOWN, ord("j")) and roots:
             cursor = (cursor + 1) % len(roots)
         elif c in (curses.KEY_UP, ord("k")) and roots:
             cursor = (cursor - 1) % len(roots)
-        elif c == ord("f"):
-            mode = "fx2"
 
 
 def _wav_sources():


### PR DESCRIPTION
make remix → e now renders BOTH effect parameter pages from the real firmware: **f** = FX2 (ChonVerb's actual knobs — SHMR/MODE/DIFF/SHFT/GATE/RATE/HP/LP/IN), **1** = FX1 (stock effects — FILTER/EQ/... knobs), left/right cycles the assigned effect. Effect assignment is a Part id-byte poke (a scratch Part is faked since our boot loads no project); the two SETUP windows (FUN_4005996c / FUN_40059afc) do the stage+draw. docs/EMU.md has the full poke reference. Answers 'control both fx pages' on the UI side; knob values are heard via the v audition view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)