### PR TITLE
emu: PLAYBACK (sample) page render

### DIFF
--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -193,6 +193,13 @@ and renders empty — it lives on payload B.)
 `FUN_40037590`), FX1 `FUN_40059afc` (drawer `FUN_4003792c`). Calling one after
 assigning the id is the whole recipe.
 
+**The PLAYBACK page** (`render_playback`, `e` → `p`) is the same idea for
+page_kind 0: set the machine-type byte at `PART + PAT*0x18b2 + track + 0x8eda2`
+(0/1 = FLEX/STATIC sample players), stage the page (`FUN_400554e0(0)`), then
+redraw the track screen (`FUN_4004d948`) — the sample row LEV/PTCH/STRT/LEN/
+RATE draws. That is "a sample loaded on the track", on the UI side; the audio
+side (loading a WAV and hearing it) is the `v` audition view.
+
 **Values.** A knob's displayed value is a byte at `PART + PAT*0x18b2 +
 track*30 + slot + 0x8f084` (`set_fx2_value`), and the canonical writer is
 `FUN_40054cd8(track, flat, value)` with `flat = 24 + slot` for FX2 page-1.

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -60,6 +60,8 @@ CALL_RET = 0x000000f0        # sentinel return address a detour stops at
 # FX1 shows the stock effects (FILTER, etc.).
 FX1_SETUP = 0x40059afc
 FX2_SETUP = 0x4005996c
+PAGE_STAGE = 0x400554e0      # FUN_400554e0(kind): stage a page kind
+TRACK_DRAW = 0x4004d948      # redraw the track screen (playback page)
 CUR_TRACK_B = 0x80000000     # current audio track (byte); UI mirror 0x100b14cc
 
 # Assigning an effect to a track's FX2 slot so its real param page resolves
@@ -306,14 +308,18 @@ def read_menu_tree(uc, desc=MENU_ROOT_DESC, depth=0, _seen=None):
     return out
 
 
-def _call(uc, addr, count=20_000_000):
+def _call(uc, addr, args=(), count=20_000_000):
     """Invoke a firmware function on a warm machine and run until it returns.
 
-    Sets a scratch stack with a sentinel return address and executes until the
-    function's rts pops it back. Faults propagate as UcError.
+    Sets a scratch stack with a sentinel return address (and cdecl args above
+    it) and executes until the function's rts pops it back. Faults propagate
+    as UcError.
     """
-    uc.reg_write(UC_M68K_REG_A7, CALL_SP)
-    uc.mem_write(CALL_SP, CALL_RET.to_bytes(4, "big"))
+    sp = CALL_SP - 4 * len(args)
+    uc.reg_write(UC_M68K_REG_A7, sp)
+    uc.mem_write(sp, CALL_RET.to_bytes(4, "big"))
+    for i, a in enumerate(args):
+        uc.mem_write(sp + 4 + 4 * i, (a & 0xFFFFFFFF).to_bytes(4, "big"))
     uc.reg_write(UC_M68K_REG_SR, 0x2700)
     uc.emu_start(addr, CALL_RET, count=count)
 
@@ -473,6 +479,32 @@ def render_fx2(r, track=4, effect_id=0x07):
             assign_fx2(r, track, effect_id)
         r._draws.clear()
         _call(uc, FX2_SETUP)
+    except UcError:
+        pass
+    return list(r._draws)
+
+
+def render_playback(r, track=4, machine=1):
+    """Render the PLAYBACK page (page_kind 0) with a sample machine assigned —
+    the sample-loaded track view (LEV/PTCH/STRT/LEN/RATE). `machine` indexes
+    the machine-type table: 0/1 = FLEX/STATIC (sample players), higher = THRU/
+    NEIGHBOR (input/routing). Stages the page then redraws the track screen.
+    """
+    uc = r.uc
+    if uc is None or not r.reached_handoff:
+        return []
+    if not getattr(r, "_menu_ready", False):
+        _prime_menu(r)
+    try:
+        _prime_part(r)
+        uc.mem_write(CUR_TRACK_B, int(track).to_bytes(1, "big"))
+        uc.mem_write(0x100b14cc, int(track).to_bytes(4, "big"))
+        uc.mem_write(PAT_W, (0).to_bytes(1, "big"))
+        uc.mem_write(PAT_R, (0).to_bytes(1, "big"))
+        uc.mem_write(_part_addr(uc, MACHINE_OFF, track), bytes([machine & 0xff]))
+        _call(uc, PAGE_STAGE, (0,))          # stage page_kind 0 (playback)
+        r._draws.clear()
+        _call(uc, TRACK_DRAW)
     except UcError:
         pass
     return list(r._draws)

--- a/tools/remix/tui.py
+++ b/tools/remix/tui.py
@@ -404,7 +404,7 @@ def emu_view(scr, image):
     roots = emu_bringup.menu_children(r) if r.uc and r.reached_handoff else []
     cursor = 0
     mode = "menu"                       # "menu" | "fx1" | "fx2"
-    eff = {"fx1": 0x04, "fx2": 0x07}    # assigned effect id per page (cyclable)
+    eff = {"fx1": 0x04, "fx2": 0x07, "play": 1}   # per-page selection (cyclable)
 
     def put(y, x, s, attr=0):
         if 0 <= y < h and 0 <= x < w - 1:
@@ -421,6 +421,15 @@ def emu_view(scr, image):
             put(4, 2, "emulator unavailable — run: make emu-setup"
                 if not r.uc else "did not reach the RTOS handoff — a patch may "
                 "have broken early init.", curses.A_BOLD)
+        elif mode == "play":
+            names = ["FLEX", "STATIC", "THRU", "NEIGHBOR"]
+            mi = eff["play"]
+            put(3, 2, "PLAYBACK — the track's sample page "
+                      f"(track 5, machine {names[mi] if mi < 4 else mi}):",
+                curses.A_BOLD)
+            _lcd(scr, emu_bringup.render_playback(r, machine=mi), 6, 4)
+            put(h - 3, 2, "left/right cycles the machine · FLEX/STATIC show the "
+                          "sample params (LEV/PTCH/STRT/LEN).", curses.A_DIM)
         elif mode in ("fx1", "fx2"):
             slot = mode.upper()
             eid = eff[mode]
@@ -441,9 +450,9 @@ def emu_view(scr, image):
             if added:
                 put(ny + 1, 2, "patched-in: " + ", ".join(added), curses.A_BOLD)
 
-        keys = (" up/down browse   1 FX1 page   f FX2 page   q back "
+        keys = (" up/down browse   p PLAYBACK   1 FX1   f FX2   q back "
                 "to workbench ") if mode == "menu" else \
-               (" left/right cycle effect   m menu   1 FX1   f FX2   q back ")
+               (" left/right cycle   m menu   p PLAY   1 FX1   f FX2   q back ")
         put(h - 1, 0, keys.ljust(w - 1), curses.A_REVERSE)
         scr.refresh()
 
@@ -452,6 +461,8 @@ def emu_view(scr, image):
             return
         if c == ord("m"):
             mode = "menu"; continue
+        if c == ord("p"):
+            mode = "play"; continue
         if c == ord("1"):
             mode = "fx1"; continue
         if c == ord("f"):
@@ -461,6 +472,12 @@ def emu_view(scr, image):
                 eff[mode] = eff[mode] + 1 if eff[mode] < 0x0f else 0x04
             elif c in (curses.KEY_LEFT, ord("h")):
                 eff[mode] = eff[mode] - 1 if eff[mode] > 0x04 else 0x0f
+            continue
+        if mode == "play":
+            if c in (curses.KEY_RIGHT, ord("l")):
+                eff["play"] = (eff["play"] + 1) % 4
+            elif c in (curses.KEY_LEFT, ord("h")):
+                eff["play"] = (eff["play"] - 1) % 4
             continue
         if c in (curses.KEY_DOWN, ord("j")) and roots:
             cursor = (cursor + 1) % len(roots)


### PR DESCRIPTION
Adds the PLAYBACK page to the emulator (make remix → e → p): with a FLEX/STATIC sample machine assigned, the sample row (LEV/PTCH/STRT/LEN/RATE) draws — the 'sample loaded' view on the UI side. Completes the page set alongside MENU/FX1/FX2. The audio side (load a WAV + hear) stays the v audition view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)