### PR TITLE
Workbench: param docs, select labels, ? help overlays, audition journal

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -70,7 +70,18 @@ The workbench derives a **category** and a **track range** for every module
 
 Every effect is auditionable locally through `tools/remix/audition.py`, and
 `tools/send_probe.py --set NAME=VAL` drives any knob of any module through
-its own `knob_map()` — no per-effect wrapper flags to go stale.
+its own `knob_map()` — no per-effect wrapper flags to go stale. Every render
+and A/B mark is journalled to `out/_audition/log.jsonl` (track, effect,
+source, every knob), so a listening note like "this sounds boxy" plus the
+journal tail is a full repro.
+
+Two `Param` fields exist purely for the workbench (the build never reads
+them — the refhash gate proves it): **`doc`**, one line saying what the knob
+does, shown under the knob cursor; and **`labels`**, one short label per
+value of a stepped select (the schema pins the length to `count`). The
+selftest requires a `doc` on every named, drawn param of every menu-bearing
+module — a knob without one is a knob the operator has to reverse-engineer
+by ear.
 
 ---
 

--- a/modules/bodeshift/manifest.py
+++ b/modules/bodeshift/manifest.py
@@ -39,14 +39,20 @@ MODULE = Module(
         # ---- page 1 -------------------------------------------------------
         # FREQ 0 with FINE 0 is a shift of zero, which is a (near) bypass --
         # so a freshly selected instance does not leap out at you.
-        Param(b"FREQ", 0, active=True, formatter=_PLAIN),
-        Param(b"FINE", 20, active=True, formatter=_PLAIN),
-        Param(b"FDBK", 0, active=True, formatter=_PLAIN),
-        Param(b"MIX", 100, active=True, formatter=_PLAIN),
+        Param(b"FREQ", 0, active=True, formatter=_PLAIN,
+              doc="coarse shift in Hz -- every partial moves by the same amount"),
+        Param(b"FINE", 20, active=True, formatter=_PLAIN,
+              doc="fine shift -- small values give slow metallic phasing"),
+        Param(b"FDBK", 0, active=True, formatter=_PLAIN,
+              doc="feedback -- each pass shifts again: the Bode barber-pole spiral"),
+        Param(b"MIX", 100, active=True, formatter=_PLAIN,
+              doc="dry/wet; 0 = exact passthrough"),
         Param(), Param(),
         # ---- page 2 -------------------------------------------------------
         Param(),
-        Param(b"MODE", 2, 3, active=True, formatter=_STEP),   # UP/DOWN/WIDE
+        Param(b"MODE", 2, 3, active=True, formatter=_STEP,
+              labels=("UP", "DOWN", "WIDE"),
+              doc="shift direction; WIDE goes up-left / down-right and beats in stereo"),
         Param(), Param(), Param(), Param(),
     ),
     dsp=DspSection(

--- a/modules/bongdelay/manifest.py
+++ b/modules/bongdelay/manifest.py
@@ -35,35 +35,50 @@ MODULE = Module(
     ),
     params=(
         # ---- page 1 -------------------------------------------------------
-        Param(b"TIME", 40, active=True, formatter=_PLAIN),
-        Param(b"FDBK", 60, active=True, formatter=_PLAIN),
-        Param(b"TONE", 100, active=True, formatter=_PLAIN),
+        Param(b"TIME", 40, active=True, formatter=_PLAIN,
+              doc="delay time -- a free dial that sticky-snaps to tempo divisions"),
+        Param(b"FDBK", 60, active=True, formatter=_PLAIN,
+              doc="feedback -- how much each repeat regenerates"),
+        Param(b"TONE", 100, active=True, formatter=_PLAIN,
+              doc="tone of the repeats -- lower = darker every pass"),
         # PING 127, not 64. Measured 17 Aug 2026: 64 was the worst place on
         # the knob to boot -- it leaned +14.7 dB left with correlation 0.185,
         # i.e. more lean than 127 and no audible bounce. 127 is the classic
         # ping-pong, and where the lean is smallest.
-        Param(b"PING", 127, active=True, formatter=_PLAIN),
+        Param(b"PING", 127, active=True, formatter=_PLAIN,
+              doc="stereo ping-pong spread; 127 = the classic alternation (least lean)"),
         # -VRB: this delay's wet send into the reverb. 0 for the same
         # load-bearing reason as IN -- a non-zero default would register the
         # delay as a reverb client whenever it exists, idle or not, diluting
         # every real sender.
-        Param(b"-VRB", 0, active=True, formatter=_PLAIN),
+        Param(b"-VRB", 0, active=True, formatter=_PLAIN,
+              doc="wet send into ChonVerb over the bus -- delay into reverb in series"),
         # IN sits bottom-right to match the reverb's IN (the 18 Aug swap).
-        Param(b"IN", 0, active=True, formatter=_PLAIN),
+        Param(b"IN", 0, active=True, formatter=_PLAIN,
+              doc="this track's own send into the delay; 0 = off (and off the bus)"),
         # ---- page 2 -------------------------------------------------------
-        Param(b"DPTH", 48, 128, active=True, formatter=_PLAIN),
-        Param(b"MODE", 0, 5, active=True, formatter=_STEP),
+        Param(b"DPTH", 48, 128, active=True, formatter=_PLAIN,
+              doc="tape wow depth -- pitch drift on the line; 0 = none"),
+        Param(b"MODE", 0, 5, active=True, formatter=_STEP,
+              labels=("CLEAN", "PITCH", "(tape)", "GRAIN", "REVRS"),
+              doc="engine select; 2 is the retired TAPE slot and runs CLEAN"),
         # RATE 64 IS LOAD-BEARING: exactly 1x, the pre-knob modulation speed.
         # The DPTH=0 bypass gate only holds with the law exact here.
-        Param(b"RATE", 64, 128, active=True, formatter=_PLAIN),
+        Param(b"RATE", 64, 128, active=True, formatter=_PLAIN,
+              doc="wow LFO speed; 64 = exactly 1x (the DPTH=0 bypass law)"),
         # PTCH is triple-meaning: the PITCH interval, GRAIN's set width, and
         # REVERSE's segment size -- which is why its count stays 4.
-        Param(b"PTCH", 1, 4, active=True, formatter=_STEP),
+        Param(b"PTCH", 1, 4, active=True, formatter=_STEP,
+              labels=("+12", "+7", "-12", "det"),
+              doc="PITCH: interval (det = 15-cent L/R spread) - REVERSE: segment size - GRAIN: width"),
         # DRV is drive in every mode but GRAIN, where the same byte is the
         # scatter depth. 0 = exact bypass, which outranks a scatter taste
         # that gets played by hand anyway.
-        Param(b"DRV", 0, 128, active=True, formatter=_PLAIN),
-        Param(b"FRZE", 0, 2, active=True, formatter=_STEP),
+        Param(b"DRV", 0, 128, active=True, formatter=_PLAIN,
+              doc="drive on the repeats; in GRAIN it is the scatter depth; 0 = bypass"),
+        Param(b"FRZE", 0, 2, active=True, formatter=_STEP,
+              labels=("RUN", "HOLD"),
+              doc="freeze the line as a loop -- loop length = TIME"),
     ),
     dsp=DspSection(
         asm="modules/bongdelay/delay_server.asm",

--- a/modules/chonverb/manifest.py
+++ b/modules/chonverb/manifest.py
@@ -30,11 +30,16 @@ MODULE = Module(
     ),
     params=(
         # ---- page 1 -------------------------------------------------------
-        Param(b"TIME", 64, active=True, formatter=_PLAIN),
-        Param(b"MOD", 30, active=True, formatter=_PLAIN),
-        Param(b"SIZE", 100, active=True, formatter=_PLAIN),
-        Param(b"HP", 0, active=True, formatter=_PLAIN),
-        Param(b"LP", 127, active=True, formatter=_PLAIN),
+        Param(b"TIME", 64, active=True, formatter=_PLAIN,
+              doc="decay time -- how long the tail rings"),
+        Param(b"MOD", 30, active=True, formatter=_PLAIN,
+              doc="tank modulation depth -- 0 static, high = chorused tail; speed is RATE"),
+        Param(b"SIZE", 100, active=True, formatter=_PLAIN,
+              doc="room size -- scales the eight tank lines (taps up to ~89 ms)"),
+        Param(b"HP", 0, active=True, formatter=_PLAIN,
+              doc="low cut inside the feedback path -- thins mud out of the tail"),
+        Param(b"LP", 127, active=True, formatter=_PLAIN,
+              doc="high cut / damping -- darkens the tail; 127 = wide open"),
         # IN is this track's own send into its own reverb. 0 IS LOAD-BEARING
         # (v4, the return conversion): a non-zero default registers every idle
         # host as a bus client, and the 1/sqrt(N) auto-gain then hands it a
@@ -42,23 +47,33 @@ MODULE = Module(
         # exactly -6.02 dB for one such phantom client. Since v5 the host's
         # dry rides under the wet at unity, so IN=0 is an exact passthrough
         # rather than a silent track.
-        Param(b"IN", 0, active=True, formatter=_PLAIN),
+        Param(b"IN", 0, active=True, formatter=_PLAIN,
+              doc="this track's own send into the reverb; 0 = exact passthrough"),
         # ---- page 2: three knobs and three selects, in that alternation ----
         # SHMR defaults OFF. The slot used to be SPEED (the LFO rate) with a
         # default of 48; when it became the shimmer amount the default was
         # never revisited, so a fresh part booted with the shimmer half up.
         # SHMR=0 is bit-identical to the pre-shimmer engine.
-        Param(b"SHMR", 0, 128, active=True, formatter=_PLAIN),
-        Param(b"MODE", 2, 3, active=True, formatter=_STEP),      # ROOM/PLATE/BIG
-        Param(b"DIFF", 64, 128, active=True, formatter=_PLAIN),
+        Param(b"SHMR", 0, 128, active=True, formatter=_PLAIN,
+              doc="shimmer -- pitch-shifted regeneration in the tail; 0 = off"),
+        Param(b"MODE", 2, 3, active=True, formatter=_STEP,
+              labels=("ROOM", "PLATE", "BIG"),
+              doc="voicing; the modes sit 7-9 dB apart and BIG clips first"),
+        Param(b"DIFF", 64, 128, active=True, formatter=_PLAIN,
+              doc="diffusion -- low = discrete repeats, high = smooth wash"),
         # SHFT selects the shimmer interval +12/+19/+7/-12 (v6; was WIDTH,
         # which is retired and pinned wide). An old project's stored WIDTH=3
         # loads here as -12, which is benign at SHMR's 0 default.
-        Param(b"SHFT", 0, 4, active=True, formatter=_STEP),
-        Param(b"GATE", 0, 128, active=True, formatter=_PLAIN),
+        Param(b"SHFT", 0, 4, active=True, formatter=_STEP,
+              labels=("+12", "+19", "+7", "-12"),
+              doc="shimmer interval in semitones -- heard once SHMR is up"),
+        Param(b"GATE", 0, 128, active=True, formatter=_PLAIN,
+              doc="gated-reverb hold -- higher holds longer; the useful range is low (8-20)"),
         # MOD speed select, 0.5/1/2/4x. Index 1 is 1x; the panel shows it
         # 1-based, so it reads as "2".
-        Param(b"RATE", 1, 4, active=True, formatter=_STEP),
+        Param(b"RATE", 1, 4, active=True, formatter=_STEP,
+              labels=("0.5x", "1x", "2x", "4x"),
+              doc="MOD speed multiplier; the panel shows it 1-based"),
     ),
     dsp=DspSection(
         asm="modules/chonverb/reverb_server.asm",

--- a/modules/nimbus/manifest.py
+++ b/modules/nimbus/manifest.py
@@ -40,14 +40,20 @@ MODULE = Module(
     ),
     params=(
         # ---- page 1 -------------------------------------------------------
-        Param(b"POS", 30, active=True, formatter=_PLAIN),
-        Param(b"SIZE", 70, active=True, formatter=_PLAIN),
-        Param(b"DENS", 40, active=True, formatter=_PLAIN),
-        Param(b"MIX", 100, active=True, formatter=_PLAIN),
+        Param(b"POS", 30, active=True, formatter=_PLAIN,
+              doc="how far back into the 743 ms buffer the grains read"),
+        Param(b"SIZE", 70, active=True, formatter=_PLAIN,
+              doc="grain length, 23/46/93/186 ms"),
+        Param(b"DENS", 40, active=True, formatter=_PLAIN,
+              doc="per-grain start scatter, up to ~92 ms -- 0 is coherent, high is cloud"),
+        Param(b"MIX", 100, active=True, formatter=_PLAIN,
+              doc="dry/wet; 0 = exact passthrough"),
         Param(), Param(),
         # ---- page 2 -------------------------------------------------------
         Param(),
-        Param(b"FRZE", 0, 2, active=True, formatter=_STEP),   # OFF / FROZEN
+        Param(b"FRZE", 0, 2, active=True, formatter=_STEP,
+              labels=("RUN", "HOLD"),
+              doc="stop the write head -- the last 743 ms becomes a frozen cloud"),
         Param(), Param(), Param(), Param(),
     ),
     dsp=DspSection(

--- a/modules/ripple/manifest.py
+++ b/modules/ripple/manifest.py
@@ -34,14 +34,20 @@ MODULE = Module(
     ),
     params=(
         # ---- page 1 -------------------------------------------------------
-        Param(b"FREQ", 90, active=True, formatter=_PLAIN),
-        Param(b"RES", 40, active=True, formatter=_PLAIN),
-        Param(b"DRV", 0, active=True, formatter=_PLAIN),
-        Param(b"MIX", 127, active=True, formatter=_PLAIN),
+        Param(b"FREQ", 90, active=True, formatter=_PLAIN,
+              doc="cutoff, ~24 Hz..7.2 kHz on a squared taper"),
+        Param(b"RES", 40, active=True, formatter=_PLAIN,
+              doc="resonance, up to a screaming Q~30 -- just short of self-oscillation"),
+        Param(b"DRV", 0, active=True, formatter=_PLAIN,
+              doc="drive into the filter -- the clip is the character; 0 = unity"),
+        Param(b"MIX", 127, active=True, formatter=_PLAIN,
+              doc="dry/wet; 0 = exact passthrough"),
         Param(), Param(),
         # ---- page 2 -------------------------------------------------------
         Param(),
-        Param(b"MODE", 0, 3, active=True, formatter=_STEP),   # LP/BP/HP
+        Param(b"MODE", 0, 3, active=True, formatter=_STEP,
+              labels=("LP", "BP", "HP"),
+              doc="filter response: low-pass, band-pass or high-pass"),
         Param(), Param(), Param(), Param(),
     ),
     dsp=DspSection(

--- a/modules/rungs/manifest.py
+++ b/modules/rungs/manifest.py
@@ -34,14 +34,20 @@ MODULE = Module(
     ),
     params=(
         # ---- page 1 -------------------------------------------------------
-        Param(b"FREQ", 60, active=True, formatter=_PLAIN),
-        Param(b"STRC", 0, active=True, formatter=_PLAIN),
-        Param(b"DAMP", 80, active=True, formatter=_PLAIN),
-        Param(b"MIX", 100, active=True, formatter=_PLAIN),
+        Param(b"FREQ", 60, active=True, formatter=_PLAIN,
+              doc="the resonator's fundamental, ~55 Hz..1.25 kHz"),
+        Param(b"STRC", 0, active=True, formatter=_PLAIN,
+              doc="structure -- stretches the partial series toward inharmonic"),
+        Param(b"DAMP", 80, active=True, formatter=_PLAIN,
+              doc="ring time, T60 ~0.1..9 s -- how long the modes sing"),
+        Param(b"MIX", 100, active=True, formatter=_PLAIN,
+              doc="dry/wet; 0 = exact passthrough"),
         Param(), Param(),
         # ---- page 2 -------------------------------------------------------
         Param(),
-        Param(b"MODE", 0, 3, active=True, formatter=_STEP),  # STRING/BELL/GLASS
+        Param(b"MODE", 0, 3, active=True, formatter=_STEP,
+              labels=("STRING", "BELL", "GLASS"),
+              doc="partial series: harmonic string, bell, or stretched glass"),
         Param(), Param(), Param(), Param(),
     ),
     dsp=DspSection(

--- a/modules/send/manifest.py
+++ b/modules/send/manifest.py
@@ -33,8 +33,10 @@ MODULE = Module(
         build_tag=False,
     ),
     params=(
-        Param(b"-DEL", 0, active=True),
-        Param(b"-VRB", 0, active=True),
+        Param(b"-DEL", 0, active=True,
+              doc="this track's send level onto the DELAY bus"),
+        Param(b"-VRB", 0, active=True,
+              doc="this track's send level onto the REVERB bus"),
         _BLANK, _BLANK, _BLANK, _BLANK,
         _BLANK, _BLANK, _BLANK, _BLANK, _BLANK, _BLANK,
     ),

--- a/modules/streamz/manifest.py
+++ b/modules/streamz/manifest.py
@@ -37,20 +37,26 @@ MODULE = Module(
         # ---- page 1 -------------------------------------------------------
         # SENS drives the follower. 64 is roughly unity: a signal peaking at
         # full scale opens the gate fully.
-        Param(b"SENS", 64, active=True, formatter=_PLAIN),
+        Param(b"SENS", 64, active=True, formatter=_PLAIN,
+              doc="follower sensitivity; 64 ~ unity (full-scale peaks open it fully)"),
         # FALL is the vactrol's sluggishness -- short is plucky and percussive,
         # long is a slow swell. Attack is fixed and fast; an LPG whose attack
         # you can slow down stops sounding like an LPG.
-        Param(b"FALL", 50, active=True, formatter=_PLAIN),
+        Param(b"FALL", 50, active=True, formatter=_PLAIN,
+              doc="vactrol release -- short is plucky, long is a slow swell"),
         # COLR is how dark the gate gets when CLOSED. 0 is a full gate (shut
         # is silent and black); higher leaves the filter partly open, which is
         # the difference between a gate and a gentle tone-follower.
-        Param(b"COLR", 10, active=True, formatter=_PLAIN),
-        Param(b"MIX", 127, active=True, formatter=_PLAIN),
+        Param(b"COLR", 10, active=True, formatter=_PLAIN,
+              doc="how dark the gate gets when closed; 0 = fully shut and silent"),
+        Param(b"MIX", 127, active=True, formatter=_PLAIN,
+              doc="dry/wet; 0 = exact passthrough"),
         Param(), Param(),
         # ---- page 2 -------------------------------------------------------
         Param(),
-        Param(b"MODE", 0, 3, active=True, formatter=_STEP),   # LPG/VCF/VCA
+        Param(b"MODE", 0, 3, active=True, formatter=_STEP,
+              labels=("LPG", "VCF", "VCA"),
+              doc="LPG = filter+amp together; VCF = envelope filter; VCA = gate only"),
         Param(), Param(), Param(), Param(),
     ),
     dsp=DspSection(

--- a/modules/warpfold/manifest.py
+++ b/modules/warpfold/manifest.py
@@ -45,16 +45,22 @@ MODULE = Module(
         # reaches the reflection), so a fresh instance in FOLD mode passes
         # audio untouched until the knob moves -- deliberate, after SHMR's
         # lesson about defaults that were never revisited.
-        Param(b"DRV", 0, active=True, formatter=_PLAIN),
-        Param(b"FREQ", 48, active=True, formatter=_PLAIN),
+        Param(b"DRV", 0, active=True, formatter=_PLAIN,
+              doc="fold drive, 1..8x into the reflection; 0 = exact identity"),
+        Param(b"FREQ", 48, active=True, formatter=_PLAIN,
+              doc="ring carrier pitch, ~20 Hz..3 kHz -- heard in RING and BOTH"),
         # TONE 127 is the filter nearly wide open (one-pole coefficient
         # ~0.98); it exists to tame fold harshness, not to be a filter.
-        Param(b"TONE", 127, active=True, formatter=_PLAIN),
-        Param(b"MIX", 127, active=True, formatter=_PLAIN),
+        Param(b"TONE", 127, active=True, formatter=_PLAIN,
+              doc="post-fold low-pass to tame harshness; 127 = nearly open"),
+        Param(b"MIX", 127, active=True, formatter=_PLAIN,
+              doc="dry/wet; 0 = exact passthrough"),
         Param(), Param(),
         # ---- page 2: knob, select, knob, select, knob, select -------------
         Param(),
-        Param(b"MODE", 0, 3, active=True, formatter=_STEP),   # FOLD/RING/BOTH
+        Param(b"MODE", 0, 3, active=True, formatter=_STEP,
+              labels=("FOLD", "RING", "BOTH"),
+              doc="wavefold, ring-mod against the carrier, or fold then ring"),
         Param(), Param(), Param(), Param(),
     ),
     dsp=DspSection(

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -52,17 +52,9 @@ from remix import audition, registry, rig  # noqa: E402
 from remix.state import (BUILT_IMAGE, DONOR_WORDS, ROOT,  # noqa: E402
                          STOCK_ROOTS, State)
 
-# Display sugar for chonverb's three selects; values come from the manifest,
-# these labels from modules/chonverb (MODE order is reverb_server.asm's).
-STEP_LABELS = {
-    ("chonverb", "MODE"): ["ROOM", "PLATE", "BIG"],
-    ("chonverb", "SHFT"): ["+12", "+19", "+7", "-12"],
-    ("chonverb", "RATE"): ["0.5x", "1x", "2x", "4x"],
-}
-
-
 def step_label(mod, name, v):
-    lab = STEP_LABELS.get((mod.name, name))
+    """A select's value as the manifest labels it, else the raw number."""
+    lab = rig.knob_labels(mod, name)
     return lab[v] if lab and v < len(lab) else str(v)
 
 
@@ -134,6 +126,89 @@ class Chooser(ModalScreen[str]):
             self.dismiss("")
 
 
+HELP = {
+    "rig": """[bold]THE RIG — your bench, not the unit[/]
+
+Assign an effect to a track, dial its knobs, render a source wav through
+the effect's real DSP code and hear it. Audio comes from the local DSP
+emulator (~6x real time); nothing here touches hardware.
+
+[bold]keys[/]
+  1-8       select track             enter      pick the track's effect
+  up/down   move between rows        left/right adjust (shift = coarse)
+  r         render + play            space      replay the last render
+  a / b     mark the last render     , / .      replay mark A / B
+  esc       stop audio               backspace  clear the effect
+  x         the remix composer       e          the emulated unit
+
+[bold]why some effects are missing on a track[/]
+The two BUS EFFECTS each live on one of the unit's two DSP cores:
+ChonVerb serves tracks 5-8 and BongDelay tracks 1-4 (measured, and
+inverted from what you'd guess). INSERTS run on any track. The knob
+rows mirror the unit's two FX2 SETUP pages: page 1 = encoders A-F,
+page 2 alternates knob/select. The dim ? line explains whichever
+knob the cursor is on.""",
+    "remix": """[bold]THE COMPOSER — what the firmware image contains[/]
+
+A remix is a named selection of modules built into one firmware image.
+Toggle modules here; the right panel answers, continuously: what the
+FX2 chooser will show on the unit, whether anything collides (the same
+ledger the build runs), and whether the DSP fits the 2724-word donor
+region (w assembles for real numbers).
+
+Effects the image leaves out don't vanish on the unit: an old project
+selecting an absent id is aliased to the FALLBACK (normally SEND), so
+it degrades to a send instead of noise. * marks an explicit fallback,
+~ an automatic one.
+
+[bold]keys[/]
+  space  toggle module        f  make it the fallback
+  w      assemble + measure   b  build the live selection
+  c      build + full check   l  load a saved remix
+  s      save this selection  v  rig    e  emulated unit""",
+    "emu": """[bold]THE EMULATED UNIT — the real firmware, screen only[/]
+
+Your built image, booted in a local ColdFire emulator, drawing its own
+screens: the MAIN MENU (patched-in entries render exactly as the unit
+would), the FX2/FX1 SETUP pages and the PLAYBACK page. There is no
+audio and no key matrix — this view is the no-flash confidence check:
+does the image boot cleanly, does the panel draw what the manifests
+promised.
+
+Knob VALUES draw as dial graphics the text capture cannot read, so the
+rig's numbers are always the truth for values. The boot is cached and
+repeats only when the image changes.
+
+[bold]keys[/]
+  m  main menu      f  FX2 (follows the rig's track + effect)
+  o  FX1 (stock)    p  playback page
+  1-8  track        up/down  menu cursor   left/right  cycle""",
+}
+
+
+class HelpScreen(ModalScreen[None]):
+    """The ? overlay: what this view is, its keys, and the concepts."""
+
+    CSS = """
+    HelpScreen { align: center middle; }
+    #box { width: 76; height: auto; max-height: 90%;
+           border: round $primary; padding: 1 2; }
+    """
+
+    def __init__(self, view):
+        super().__init__()
+        self.view = view
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="box"):
+            yield Static(HELP[self.view])
+            yield Static("[dim]any key closes[/]")
+
+    def on_key(self, ev):
+        ev.stop()
+        self.dismiss(None)
+
+
 # ---- RIG -------------------------------------------------------------------
 class RigScreen(Screen):
     """Eight tracks; the selected one shows its pages and renders."""
@@ -149,6 +224,7 @@ class RigScreen(Screen):
         Binding("full_stop", "play_mark('B')", "play B"),
         Binding("x", "app.switch_mode('remix')", "remix"),
         Binding("e", "app.switch_mode('emu')", "emu"),
+        Binding("question_mark", "help('rig')", "what is this?"),
         Binding("q", "app.quit", "quit"),
     ]
 
@@ -228,8 +304,21 @@ class RigScreen(Screen):
                 knob = "ABCDEF"[slot % 6]
                 lines.append(f" {mark}{name:<6} {val} \\[{bar}]  "
                              f"p{page}·{knob}{end}")
+        # -- the "what is this?" line for whatever the cursor is on ------
+        name, slot = rows[self.cursor]
+        if name == "SOURCE":
+            hint = ("the wav rendered through the effect -- drop files in "
+                    "out/test_audio/; left/right cycles")
+        elif name == "WET":
+            hint = ("WET = the reverb's wet alone (exact dry subtraction); "
+                    "other effects always render their normal output")
+        elif mod:
+            hint = rig.knob_doc(mod, name) or "(this knob has no doc yet)"
+        else:
+            hint = ""
+        lines.append("")
+        lines.append(f"[dim]? {escape(hint)}[/]")
         if mod and mod.name == "chonverb":
-            lines.append("")
             lines.append("[dim]MODE renders as its own image (cached per "
                          "mode); WET applies to the reverb only.[/]")
         self.query_one("#detail", Static).update("\n".join(lines))
@@ -290,7 +379,7 @@ class RigScreen(Screen):
     def action_pick_effect(self):
         app = self.app
         opts = [(m.key, f"{escape(m.menu.fullname.decode('latin1')):<13} "
-                        f"\\[{rig.category(m)}]")
+                        f"\\[{rig.category(m)}]\n[dim]{escape(m.doc)}[/]")
                 for m in rig.available(app.track)] + [("__none__", "(none)")]
 
         def done(key):
@@ -307,6 +396,9 @@ class RigScreen(Screen):
         self.app.rig.save()
         self.cursor = 0
         self.rerender()
+
+    def action_help(self, view):
+        self.app.push_screen(HelpScreen(view))
 
     def action_render(self):
         app = self.app
@@ -362,8 +454,11 @@ class RigScreen(Screen):
     def action_mark(self, which):
         app = self.app
         if app.history:
-            app.marks[which] = app.history[-1][1]
-            app.status = f"marked {which}: {app.history[-1][0]}"
+            label, path = app.history[-1]
+            app.marks[which] = path
+            app.status = f"marked {which}: {label}"
+            audition._journal({"event": "mark", "which": which,
+                               "label": label, "out": path.name})
         self.rerender()
 
     def action_play_mark(self, which):
@@ -395,6 +490,7 @@ class RemixScreen(Screen):
         Binding("s", "save", "save"),
         Binding("v", "app.switch_mode('rig')", "rig"),
         Binding("e", "app.switch_mode('emu')", "emu"),
+        Binding("question_mark", "help('remix')", "what is this?"),
         Binding("q", "app.quit", "quit"),
     ]
 
@@ -454,6 +550,8 @@ class RemixScreen(Screen):
         lines.append("[bold dim]REMIXES[/] [dim]" + " ".join(
             n for n in registry.remix_names() if not n.startswith("_"))
             + "[/]")
+        lines.append("")
+        lines.append(f"[dim]? {escape(st.mods[self.current_key()].doc)}[/]")
         self.query_one("#mods", Static).update("\n".join(lines))
 
         # -- right panel: the unit's FX2 menu + fit + problems --------------
@@ -515,6 +613,9 @@ class RemixScreen(Screen):
 
     def current_key(self):
         return self.grouped()[self.key_rows()[self.cursor]][0]
+
+    def action_help(self, view):
+        self.app.push_screen(HelpScreen(view))
 
     def action_toggle(self):
         self.app.state.toggle(self.current_key())
@@ -624,6 +725,7 @@ class EmuScreen(Screen):
         Binding("p", "view('play')", "playback"),
         Binding("v", "app.switch_mode('rig')", "rig"),
         Binding("x", "app.switch_mode('remix')", "remix"),
+        Binding("question_mark", "help('emu')", "what is this?"),
         Binding("q", "app.switch_mode('rig')", "back"),
     ]
 
@@ -731,6 +833,9 @@ class EmuScreen(Screen):
                         + ["'" + "-" * 46 + "'"])
         self.query_one("#lcd", Static).update(lcd)
         self.query_one("#emunote", Static).update(f"[dim]{note}[/]")
+
+    def action_help(self, view):
+        self.app.push_screen(HelpScreen(view))
 
     def action_view(self, v):
         self.view = v

--- a/tools/remix/audition.py
+++ b/tools/remix/audition.py
@@ -29,6 +29,8 @@ Headless smoke (also the CI-of-one):
 
 from __future__ import annotations
 
+import datetime
+import json
 import os
 import pathlib
 import subprocess
@@ -116,6 +118,20 @@ def _ensure_insert_mem(mod, log=print):
     return mem
 
 
+def _journal(entry):
+    """Append one event to the audition journal, out/_audition/log.jsonl.
+
+    The journal is how a listening session becomes addressable: "this
+    sounds boxy" plus the tail of this file is a full repro -- track,
+    effect, source, wet flag, every knob. One JSON object per line,
+    newest last; renders and A/B marks both land here."""
+    OUT.mkdir(parents=True, exist_ok=True)
+    entry = {"t": datetime.datetime.now().isoformat(timespec="seconds"),
+             **entry}
+    with open(OUT / "log.jsonl", "a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
 def render(key, values, source, wet=False, tail=None, label="", log=print):
     """Render module `key` over `source` with manifest-named knob `values`.
 
@@ -151,6 +167,9 @@ def render(key, values, source, wet=False, tail=None, label="", log=print):
         got = base.with_name(f"{base.name}_{render_reverb.MODES[mode]}.wav")
         if not got.exists():
             _die(f"render_reverb reported success but {got.name} is missing")
+        _journal({"event": "render", "label": label, "effect": mod.name,
+                  "source": source.name, "wet": wet, "knobs": values,
+                  "out": got.name})
         return got
 
     # Everything else goes through send_probe --wav.
@@ -178,6 +197,9 @@ def render(key, values, source, wet=False, tail=None, label="", log=print):
         _die("send_probe failed: " + (tl[-1] if tl else "(no output)"))
     if not out.exists():
         _die(f"send_probe reported success but {out.name} is missing")
+    _journal({"event": "render", "label": label, "effect": mod.name,
+              "source": source.name, "wet": False, "knobs": values,
+              "out": out.name})
     return out
 
 

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -93,6 +93,16 @@ def default_knobs(mod) -> dict[str, int]:
             for p in mod.params if p.name and p.active}
 
 
+def knob_doc(mod, name: str) -> str:
+    """The manifest's one-line answer to "what is this knob?"."""
+    return mod.params[mod.knob_map()[name]].doc or ""
+
+
+def knob_labels(mod, name: str):
+    """Per-value labels for a select, or None for a plain dial."""
+    return mod.params[mod.knob_map()[name]].labels
+
+
 def knob_max(mod, name: str) -> int:
     """Highest legal value: count-1 where the manifest states a count,
     else the stock 0..127 dial."""

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -100,10 +100,23 @@ class Param:
     count: int | None = None           # value count; None leaves the donor's
     active: bool = False               # drawn at all (the enable bitmap)
     formatter: Formatter = Formatter.INHERIT
+    # Display-only, consumed by the workbench and never by the build (the
+    # refhash gate proves it): one line saying what the knob DOES, and for a
+    # select, what each value means. The unit's panel cannot show either, so
+    # this is where a contributor answers "what is this?" once instead of in
+    # a comment only readers of the manifest ever see.
+    doc: str | None = None             # one line, ~70 chars, for the help row
+    labels: tuple[str, ...] | None = None   # one short label per select value
 
     def __post_init__(self):
         if self.name is not None and len(self.name) > 6:
             raise ValueError(f"param name {self.name!r} exceeds 6 bytes")
+        if self.labels is not None:
+            if self.count is None or len(self.labels) != self.count:
+                raise ValueError(
+                    f"param {self.name!r}: {len(self.labels)} labels for a "
+                    f"count of {self.count} -- one label per value, and only "
+                    f"where a count is declared")
         # A default outside its own count is used as an INDEX. That shipped
         # once -- slot 7 defaulted to 64 with a count of 5 -- and stalled the
         # sequencer on hardware after two steps.

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -157,6 +157,27 @@ def main():
     else:
         print("  [PASS] chonverb's manifest slots align with render_reverb")
 
+    # ---- every drawn knob answers "what is this?" -----------------------
+    # The workbench shows Param.doc as the help line under the knob cursor,
+    # and a select's labels beside its value. A knob with neither is a knob
+    # the operator has to reverse-engineer by ear, so hold the line: every
+    # named, drawn param of every menu-bearing module carries a doc.
+    # (Length is capped so the help row stays one line; the schema already
+    # pins labels to the declared count.)
+    for mod in registry.modules().values():
+        if mod.menu is None:
+            continue
+        undocumented = [p.name.decode() for p in mod.params
+                        if p.name and p.active and not p.doc]
+        toolong = [p.name.decode() for p in mod.params
+                   if p.name and p.doc and len(p.doc) > 90]
+        if undocumented or toolong:
+            bad += 1
+            print(f"  [FAIL] {mod.name}: undocumented knobs {undocumented}, "
+                  f"over-long docs {toolong}")
+        else:
+            print(f"  [PASS] {mod.name}: every drawn knob has a doc")
+
     # And the real thing: every shipped remix must be clean.
     for name in registry.remix_names():
         r = registry.remix(name)


### PR DESCRIPTION
Adds the 'what is this?' layer: every drawn knob of every effect gets a manifest-sourced one-line doc (shown live under the knob cursor), stepped selects get per-value labels (delay MODE reads CLEAN/PITCH/GRAIN/REVRS), the effect picker and composer show module docs, and '?' opens a per-view help overlay (what RIG/REMIX/EMU are, keys, why some effects are missing on some tracks). All content sourced from manifest comments and the DSP sources. The new Param.doc/labels fields are display-only — refhash 26/26 bit-identical — and the selftest now fails any undocumented drawn knob. Every render and A/B mark is journalled to out/_audition/log.jsonl (track, effect, source, every knob) so a listening note is a full repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)