### PR TITLE
Workbench: use the terminal's ANSI palette (WORKBENCH_THEME override)

### DIFF
--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -898,6 +898,14 @@ class Workbench(App):
         self.player = None                 # the running afplay
 
     def on_mount(self):
+        # ansi-dark renders in the TERMINAL's own 16-color palette, so the
+        # workbench wears whatever theme Alacritty wears instead of Textual's
+        # truecolor default. WORKBENCH_THEME picks any built-in Textual theme
+        # (e.g. gruvbox, nord, textual-dark) for anyone who wants otherwise.
+        import os
+        from textual.theme import BUILTIN_THEMES
+        want = os.environ.get("WORKBENCH_THEME", "ansi-dark")
+        self.theme = want if want in BUILTIN_THEMES else "ansi-dark"
         self.switch_mode("rig")
 
     def play(self, path):


### PR DESCRIPTION
Defaults the Textual theme to ansi-dark so the workbench renders in the terminal's own 16-color palette — Alacritty's colorscheme and background show through. WORKBENCH_THEME=<builtin> picks any other built-in theme; unknown names fall back safely. Pilot smokes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)