### PR TITLE
docs: WORKBENCH.md — the full workbench manual

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -506,7 +506,11 @@ for every module (a `--pick` of an absent insert dies instead of rendering a
 plausible dry passthrough). The composer groups modules by category with
 track ranges, phrases its panel as the FX2 menu the unit will show, and
 builds/checks the LIVE selection; the emu view caches its boot until the
-image changes and follows the rig's selected track.
+image changes and follows the rig's selected track. Follow-ups landed the
+same day: esc stops audio, Rich-markup escaping, per-knob docs + select
+labels in the manifests with `?` help overlays, the audition journal
+(`out/_audition/log.jsonl`), and the terminal-ANSI theme. The manual is
+`docs/WORKBENCH.md`.
 
 Remaining toward full fidelity: item-level menu descent and live dial *values*
 (same detour shape — drive the real key handler `FUN_40064e64`, capture the

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ effect on each, its real knobs to dial and render and hear (every effect
 renders locally). Its composer view shows what would collide, what the FX2
 chooser ends up looking like on the panel, and what the selection costs
 against the donor region — then builds or saves it.
+**[docs/WORKBENCH.md](docs/WORKBENCH.md)** is the manual.
 
 See **[docs/MODULES.md](docs/MODULES.md)** to write a module.
 
@@ -274,7 +275,8 @@ make image     # repack as a card-flashable .bin
 `make remix` opens the workbench (`make emu-setup` provisions it): a rig of
 eight tracks to trial effects on by ear, a composer showing collisions, the
 panel your choice produces and its word cost against the donor region, and
-the built image booted in the local ColdFire emulator.
+the built image booted in the local ColdFire emulator — the manual is
+**[docs/WORKBENCH.md](docs/WORKBENCH.md)**.
 
 `make help` lists everything. The setup script assumes **macOS + Homebrew**;
 on Linux the substitutions are the obvious ones (the DSP toolchain itself is

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -93,8 +93,8 @@ Two facts for whoever crosses it:
 
 `emu_bringup.boot(image)` returns a warm machine; `read_menu_tree(uc)` walks
 the MAIN MENU tables (`docs/MAINMENU.md`) out of its RAM. `make remix`
-(the workbench, `tools/remix/app.py` — the curses `tui.py` is retired, in
-history) has an **`e`** view: it boots the *built* image
+(the workbench, `tools/remix/app.py` — manual in `docs/WORKBENCH.md`; the
+curses `tui.py` is retired, in history) has an **`e`** view: it boots the *built* image
 (`out/mainos_bus.bin` — byte-compatible with the raw section), confirms it
 reaches the RTOS handoff with no fault, and shows the firmware's own screens
 with any patched-in entry highlighted. This is the crow-flies form of the

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -51,7 +51,8 @@ what keeps `modules/_template/` out of every build.
 short, and its comments carry the reasoning behind each field.
 
 Copy `modules/_template/` to start, and `make remix` opens the workbench
-(`tools/remix/app.py`, Textual — provisioned by `make emu-setup`). Its home
+(`tools/remix/app.py`, Textual — provisioned by `make emu-setup`; the full
+manual is `docs/WORKBENCH.md`). Its home
 view is a RIG of eight tracks: assign effects, dial their manifest-named
 knobs, render and hear them. Its REMIX view is the composer: collisions, the
 FX2 menu your selection produces, its word cost against the donor region,

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -1,0 +1,244 @@
+# The workbench — `make remix`
+
+The interactive front end of the project, organized the way an Octatrack
+user thinks: **tracks and effects**, not modules and payloads. Shipped
+31 Aug 2026 (PRs #40–#44), replacing the curses composer; PLAN.md §5 is the
+decision record, this page is the manual.
+
+What it is for, in priority order (Sam's, stated when the redesign was
+commissioned):
+
+1. **Trial sounds** — put an effect on a track, dial its real knobs, render
+   a wav through the actual DSP code and hear it. A/B alternatives.
+2. **Build and save remixes** — compose the firmware image with collision
+   and fit feedback.
+3. **No-flash confidence** — boot the built image in the local ColdFire
+   emulator and see the firmware draw its own screens.
+
+Audio comes from the local DSP emulator (~6× real time, `docs/HARNESS.md`);
+the ColdFire emulator (`docs/EMU.md`) provides the screens. Nothing in the
+workbench touches hardware.
+
+## Setup
+
+```bash
+make emu-setup      # uv provisions .venv with unicorn + textual
+make remix          # the workbench (make bus first if out/mainos_bus.bin
+                    # doesn't exist yet — the EMU view boots it)
+```
+
+The frontend is `tools/remix/app.py` (Textual). `make remix` prefers
+`.venv/bin/python3`; on bare `python3` it exits with the setup hint. The
+build and every check remain dependency-free — only the interactive
+workbench lives in the venv.
+
+Playback is `afplay`, so hearing renders is macOS-only; everything else
+works anywhere the DSP toolchain does.
+
+## The three views
+
+`x` / `v` / `e` move between them; `?` on any view opens an overlay with
+this page's short form; `esc` stops audio from anywhere; `q` quits (from
+EMU, `q` returns to the rig).
+
+### RIG — the home view
+
+Eight tracks across the top, an effect assigned to each, the selected
+track's controls below. This is the trial-a-sound loop.
+
+| key | action |
+|---|---|
+| `1`–`8` | select track |
+| `enter` | pick the track's effect (only effects that can run there) |
+| `backspace` | clear the track's effect |
+| `up/down` (`j/k`) | move between rows: SOURCE, RENDER, then the knobs |
+| `left/right` (`h/l`) | adjust the row; `shift` steps by 10 |
+| `r` | render the track's effect over the source, then play it |
+| `space` | replay the last render |
+| `a` / `b` | mark the last render as A / B |
+| `,` / `.` | replay mark A / mark B |
+| `esc` | stop playback |
+
+Row notes:
+
+- **SOURCE** cycles every `.wav` in `out/test_audio/` then
+  `out/demo_sources/` — drop files in either and restart. (No
+  browse-anywhere picker yet.)
+- **RENDER wet/full** applies to ChonVerb only (`render_reverb --wet`, an
+  exact dry subtraction). Other effects always render their normal output.
+- **Knob rows** carry the manifest's names in the unit's own page layout:
+  slots 0–5 = page 1, encoders A–F; slots 6–11 = page 2, knob/select
+  alternation. Selects show their manifest labels (the delay's MODE reads
+  CLEAN/PITCH/(tape)/GRAIN/REVRS, not 0–4). The dim `?` line under the
+  rows explains whichever row the cursor is on — the text comes from
+  `Param.doc` in the effect's manifest.
+- ChonVerb's MODE renders as its own image, cached per mode
+  (`render_reverb`'s engine cache) — the first render after a MODE flip
+  pays a build, later ones don't.
+
+The RENDERS panel lists recent renders with the knobs that differed from
+defaults; `[A]`/`[B]` show where the marks sit. Marks always attach to the
+**most recent** render — walk-the-history marking is a known gap.
+
+**Why some effects are missing on some tracks:** the two bus servers each
+live on one DSP core, and the cores serve fixed track halves — ChonVerb
+(payload A) on **tracks 5–8**, BongDelay (payload B) on **tracks 1–4** —
+the measured 10 Aug 2026 track↔core inversion. Inserts run anywhere.
+SYSTEM modules (SEND, tempo-sync) are plumbing and never appear in the
+picker.
+
+### REMIX — the composer
+
+The old workbench's job, reframed. Left: the modules, grouped **BUS
+EFFECTS** (with track range) / **INSERTS** (any track) / **SYSTEM**, with
+the cursored module's one-line doc below. Right: what the selection *is* —
+the FX2 chooser exactly as the unit will show it, the program-fit bar
+against the donor region, and the ledger's collision verdict (the same
+`ledger.check` the build runs, not a reimplementation).
+
+| key | action |
+|---|---|
+| `space` | toggle the module under the cursor |
+| `f` | make it the fallback (absent ids alias to the fallback — normally SEND, so a stale project degrades to a send, not noise; `*` explicit, `~` auto) |
+| `w` | assemble the selection and keep the real word counts |
+| `b` / `c` | `make bus` / `make check` on the **live** selection (via the scratch-remix mechanism — no save needed) |
+| `l` / `s` | load / save a remix file |
+
+A successful `b`/`c` invalidates the EMU view's cached boot, so `e` shows
+the image you just built.
+
+The panel's "no LEDGER collisions" deliberately names what is *not*
+checked (the shared 64K window) and which selected module owns the
+per-core FX2 buffer region — see CLAUDE.md for why that caveat is written
+out each time.
+
+### EMU — the emulated unit
+
+The built image (`out/mainos_bus.bin`) booted in the Tier-0 ColdFire
+emulator, drawing **its own screens**: the MAIN MENU (patched-in entries
+render as the firmware would draw them), FX2/FX1 SETUP, and the PLAYBACK
+page. Booting is itself the no-flash gate — a cave that breaks early init
+faults here, not on the unit.
+
+| key | action |
+|---|---|
+| `m` | main menu (`up/down` moves the cursor) |
+| `f` | FX2 SETUP — follows the rig's selected track and its assigned effect |
+| `o` | FX1 SETUP (stock effects; `left/right` cycles the id) |
+| `p` | PLAYBACK page (`left/right` cycles FLEX/STATIC/THRU/NEIGHBOR) |
+| `1`–`8` | change track |
+
+The boot (~4 s) is cached at app level and repeats only when the image's
+mtime changes.
+
+Honest limits (all recorded in `docs/EMU.md`): no audio, no key matrix —
+navigation is done by poking state and re-calling draw functions. Knob
+**values** draw as dial graphics the string-capture hook cannot read, so
+the rig's numbers are always the truth for values. In a SPEC image the
+delay's DSP in payload A is the SEND alias, so its FX2 page can draw
+empty. Item-level menu descent needs the real key handler
+(`FUN_40064e64`) and is not built.
+
+## The audition backend
+
+`tools/remix/audition.py` is the one render entry point; the UI never knows
+which harness ran. All knobs are addressed by **manifest names** —
+`Module.knob_map()` (schema.py) is the single source of the name→slot map.
+
+| effect | path |
+|---|---|
+| chonverb | `tools/render_reverb.py` — manifest slot → its positional param name (the two tables are proven slot-aligned by the selftest); MODE via `--mode`, wet via `--wet` |
+| bongdelay | the DEV hatch (`DEV=1 XBUS=1` build → `out/dsp/mem_dev_A.mem`, rebuilt when stale) then `send_probe --layout DS --in … --wav …` |
+| inserts | a per-insert scratch image (`_audition` remix = the insert + SEND), dumped to `out/dsp/_audition_<name>_A.mem`; the build saves and restores `out/mainos_bus.bin` so the EMU view never silently boots a scratch |
+
+Knob overrides ride `send_probe --set=NAME=VAL` (one token — the delay's
+`-VRB` begins with a dash), resolved through the rendered module's own
+`knob_map()`; an unknown name dies rather than driving the wrong slot.
+
+**The SEND-alias guard is general.** An id absent from an image dispatches
+to the fallback, which renders a *plausible dry passthrough* — peak equals
+the input amplitude, THD at the noise floor, no error anywhere (this cost a
+session on 12 Aug 2026 and was reproduced live on 31 Aug with `--pick B`
+against a chongbong image). `send_probe` now refuses to render **any**
+module whose dispatch entry equals SEND's.
+
+Renders land in `out/_audition/`.
+
+## The journal
+
+Every render — and every A/B mark — appends one JSON line to
+`out/_audition/log.jsonl`:
+
+```json
+{"t": "2026-08-31T12:45:41", "event": "render", "label": "T5",
+ "effect": "chonverb", "source": "bass.wav", "wet": false,
+ "knobs": {"TIME": 80, "...": 0}, "out": "T5_bass_chonverb_BIG.wav"}
+```
+
+That makes a listening session addressable: "this sounds boxy" plus the
+journal tail is a full repro — track, effect, source, every knob. It is
+also how demo takes get captioned after the fact.
+
+## The rig file
+
+`out/_rig.json` persists the per-track assignments and knob values across
+restarts. It is a **bench fixture, not a firmware statement** — remix
+files say what the image contains; the rig says what the operator was
+listening to. Loading validates against the current manifests: a renamed
+knob does not resurrect a stale value under its old meaning, and an
+assignment a module can no longer honour is dropped.
+
+## Theming
+
+The app renders in the **terminal's own 16-color ANSI palette** (Textual's
+`ansi-dark` theme), so it wears whatever colorscheme the terminal wears,
+background included. `WORKBENCH_THEME=<name> make remix` picks any
+built-in Textual theme (`gruvbox`, `nord`, `tokyo-night`, `textual-dark`
+for Textual's stock look, …); unknown names fall back to `ansi-dark`.
+
+## Architecture and guarantees
+
+The UI is a shell; the model layers are headless and importable:
+
+| layer | file | job |
+|---|---|---|
+| composer | `tools/remix/state.py` | selection, `problems()`, `measure()`, scratch builds (extracted unchanged from the old TUI) |
+| tracks | `tools/remix/rig.py` | category + track-range derivation, per-track state, knob docs/labels/maxima |
+| rendering | `tools/remix/audition.py` | the per-effect dispatch above, the journal, a `__main__` for headless renders |
+| shell | `tools/remix/app.py` | Textual only — screens, keys, workers |
+
+Categories and track ranges are **derived from manifests**, never declared
+in the UI: `harness.is_server` + `dsp.payloads` (each server declares its
+single payload; a server without one is refused, not guessed at) →
+SERVER/T5-8 or T1-4; `DSP_EFFECT` with a menu → INSERT/any track;
+everything else → SYSTEM/no track.
+
+Three `Param` fields exist purely for the workbench and are **proven
+display-only** — `scripts/refhash.sh check` ran bit-identical (26/26)
+after each manifest change that introduced them:
+
+- `payloads` (on `DspSection`) — the server's core, hence its tracks.
+- `doc` — the one-line "what is this knob?" shown under the cursor.
+- `labels` — per-value labels for a stepped select (length pinned to
+  `count` by the schema).
+
+`tools/remix/selftest.py` (in `make verify`) holds the lines: the
+category/track-range derivation matches the measured facts for every
+module; a payload-less server is refused; chonverb's manifest slots stay
+aligned with `render_reverb`'s positional table; and **every named, drawn
+param of every menu-bearing module must carry a `doc`** — an undocumented
+knob fails the build's checks.
+
+UI regressions are caught headlessly with Textual's Pilot (`run_test`):
+scripts drive keys and assert on rendered text. The markup-artifacting fix
+(PR #42 — literal `[x]` parsed as a Rich style tag and bled styling across
+rows) is pinned that way; anything data-driven that reaches markup goes
+through `rich.markup.escape`.
+
+## Known gaps
+
+- A/B marks attach only to the most recent render (no history cursor).
+- No browse-anywhere source picker (two fixed directories).
+- Wet-only rendering is ChonVerb-only.
+- The emulator limits listed above (values, key injection, delay page
+  under SPEC).


### PR DESCRIPTION
Adds docs/WORKBENCH.md: what the workbench is for, setup, the RIG/REMIX/EMU views with key tables, the audition backend (per-effect render paths, --set, the generalized SEND-alias guard), the journal, the rig file, theming, the headless architecture, the selftest/refhash guarantees, and the known gaps. Cross-linked from README, MODULES.md, EMU.md and PLAN.md §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)