### PR TITLE
R59+R60 voicing rounds; workbench browses curated out/dry/

### DIFF
--- a/docs/VOICING.md
+++ b/docs/VOICING.md
@@ -1891,3 +1891,86 @@ on drums/bass/melody alike; PING 0 exactly symmetric (no shelf); FDBK 20
 worst case 17.5 -> 14.0 dB; no clipping on any render (drums peak -2.4).
 At FDBK 0 the right line still has no repeat to lift — inherent to the
 serial ping-pong, accepted. Tag 77. FLASHED + hardware-ratified the same night: lean +4.2/+4.6 dB on the unit (predicted 4.4), wet +3.8 dB (predicted +3.5), no clipping. (Flash detour for the record: a raw mainos_bus.bin on the card gives LENGTH ERROR — the card path needs `make image` ELUP packing, one OS bin on the root at a time; the "wrong checksum" complaints that evening were PROJECT files, not the OS.)
+
+## R59 — the VintageVerb refs revisited on the current engine (31 Aug 2026)
+
+The Round-12 A/B kit rebuilt from scratch against the CURRENT build:
+`out/vv_ab2/` (12 pairs, {pad,stab,hat,melody} x {ROOM,PLATE,BIG}, A = the
+9 Aug VV bounces, B = wet-only ChonVerb, 24-bit 44.1k STEREO — width has
+been pinned wide since v6, so the Round-11 mono limitation is gone), built
+by `out/vv_ab2/build_kit.py`: ffmpeg-sinc prep (no naive resample in the
+path), -20 dBFS active-RMS level match with the peak trim applied to the
+PAIR jointly, decay re-matched by peak->-40 dB tail time on the stab.
+
+**The Round-13 decay match had drifted with the engine**: ROOM = TIME 24
+(was 56 — ran ~0.5 s long), PLATE = 64 (unchanged, matches VV plate at
+2.20 s to the frame), BIG = 38 (was 44). DIFF=120 carried over from the
+old recipe for the kit renders.
+
+**Sam's verdicts** (stab PLATE/ROOM/BIG, hat BIG, pad BIG, melody ROOM
+played A/B): "ours are all wetter sounding but sound pretty good"; stab
+ROOM early tail "a bit" thicker than VV, "but the primary doesn't go as
+long. not necessarily a bad thing."
+
+**"Wetter" localized to DIFF in-session.** All pairs are level-matched
+wet-only, so wetter = energy distribution, and the early-tail slopes agree
+(every stab/hat B row shallower than its A: stab ROOM -18.4 vs -23.2, hat
+BIG -17.8 vs -29.9 dB/s). One knob change, stab PLATE DIFF 120 -> 64:
+early-tail slope -18.0 -> -21.3 dB/s against VV's -19.0, and Sam on the
+render: tightens up, "still a bit shorter but similar ballpark." The match
+point is ~DIFF 80-90, bracketed not measured.
+
+**Found while calibrating, parked as open items:**
+- **ROOM's early tail has a TIME-independent floor**: TIME 16->56 moves the
+  0.4-1.6 s stab slope only -19.0 -> -15.6 dB/s (VV room -23.2). Something
+  in the early tail (bloom/driven-line energy?) decays at its own rate.
+  Inferred candidate only — needs a probe, not a guess.
+- **BIG has a knee between TIME 38 and 44**: peak->-40 dB on the stab jumps
+  2.7 s -> 15.2 s (the inter-hit tail stops dropping 40 dB at all). Half of
+  BIG's dial is effectively infinite. Unknown whether real slow decay or a
+  scatter/truncation floor — one measurement would say.
+- **hat BIG still shows the inverted-HF signature** (-17.8 vs VV -29.9
+  dB/s) — the one row where HF outlives the mids on the current engine.
+- **The TIME dial's useful range has drifted off the knob**: a VV-matched
+  2 s room lives at TIME 24/127. Per-mode TIME re-mapping is settings work,
+  no engine change.
+
+Direction agreed in-session: settings first (DIFF character/default, TIME
+range re-map), the BIG damping + knee measurements after. The kit and its
+build script stay in out/vv_ab2/ (gitignored; script is self-contained).
+
+### R59 addendum — Sam, after the session's DIFF finding landed
+
+"verb is actually sounding really nice to me now." The reverb tuning
+urgency drops; the settings items (DIFF default/range, TIME re-map) stay
+queued but the sound itself passes. Focus moves to the delay.
+
+## R60 — REVERSE diagnosed: the ring is the segment comb (31 Aug 2026)
+
+Sam, from the workbench (piano_chords, TIME 68 FDBK 79 PING 16 -VRB 61
+DPTH 48 RATE 18 PTCH 1 DRV 55): REVERSE "sounds not great ... a fast
+metallicy ringing that seems to be specific to reverse."
+
+**Diagnosis, measured then source-confirmed — working as built, with a
+sweet-spot problem:**
+- No defect: no splice clicks in any variant (max inter-sample step
+  0.04 FS); wow, DRV and -VRB each exonerated by isolation renders
+  (out/vv_ab2/prep/rev_*.wav, journal-driven exact repro).
+- The ring is a comb at ODD multiples of ~10.8 Hz = the 2S period of
+  PTCH=1's 46 ms segment (REVERSE sizes: PTCH 0/1/2/3 = 93/46/23/12 ms,
+  delay_server.asm rsz table). On SUSTAINED harmonic material a reversed
+  46 ms chunk is the same chord re-phased, so the comb is all you hear;
+  FDBK 79 restacks it every repeat. Spectral diff vs CLEAN at identical
+  knobs: +13 to +23 dB on the comb lines (rev_spec.py).
+- Ear-confirmed: PTCH=0 (93 ms) on the piano "a bit" better; drums at the
+  same settings read as texture, not ringing. The wav wasn't wrong -- it
+  was the revealing case.
+
+**Work items opened:**
+1. SETTINGS: REVERSE's useful sustained-source range is basically PTCH=0;
+   1-3 are stutter/texture. Same family as the reverb's TIME drift (R59).
+2. STRUCTURAL: 93 ms is the CEILING -- reversing S samples spans 2S of
+   history and the 16K line caps S at 4096. A musical phrase-reverse
+   (0.5 s+) needs a longer line: a payload-B memory-layout item, not a
+   knob. Parked on the delay design list next to GRAIN makeup gain
+   (DENS = the DPTH/WOW knob in GRAIN; sparse still only subtracts).

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -64,9 +64,12 @@ per-knob help line, and the render history](img/workbench-rig.png)
 
 Row notes:
 
-- **SOURCE** cycles every `.wav` in `out/test_audio/` then
-  `out/demo_sources/` — drop files in either and restart. (No
-  browse-anywhere picker yet.)
+- **SOURCE** cycles every `.wav` in `out/dry/` — the curated DRY set
+  (31 Aug 2026; the old `out/test_audio/` + `out/demo_sources/` browse
+  mixed ~50 processed renders in with the dozen dry sources). Drop files
+  in `out/dry/` and restart. If `out/dry/` is missing or empty the old
+  two-directory browse comes back as the fallback. (No browse-anywhere
+  picker yet.)
 - **RENDER wet/full** applies to ChonVerb only (`render_reverb --wet`, an
   exact dry subtraction). Other effects always render their normal output.
 - **Knob rows** carry the manifest's names in the unit's own page layout:
@@ -245,7 +248,7 @@ through `rich.markup.escape`.
 ## Known gaps
 
 - A/B marks attach only to the most recent render (no history cursor).
-- No browse-anywhere source picker (two fixed directories).
+- No browse-anywhere source picker (one fixed directory, `out/dry/`).
 - Wet-only rendering is ChonVerb-only.
 - The emulator limits listed above (values, key injection, delay page
   under SPEC).

--- a/modules/bongdelay/manifest.py
+++ b/modules/bongdelay/manifest.py
@@ -70,7 +70,8 @@ MODULE = Module(
         # REVERSE's segment size -- which is why its count stays 4.
         Param(b"PTCH", 1, 4, active=True, formatter=_STEP,
               labels=("+12", "+7", "-12", "det"),
-              doc="PITCH: interval (det = 15-cent L/R spread) - REVERSE: segment size - GRAIN: width"),
+              doc="PITCH: interval - REVERSE: seg 93/46/23/12 ms, sustained "
+                  "wants 0 (R60) - GRAIN: width"),
         # DRV is drive in every mode but GRAIN, where the same byte is the
         # scatter depth. 0 = exact bypass, which outranks a scatter taste
         # that gets played by hand anyway.

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -59,7 +59,15 @@ def step_label(mod, name, v):
 
 
 def wav_sources():
-    """Source WAVs to audition, test_audio first (Sam's preferred set)."""
+    """Source WAVs to audition: out/dry/ -- the curated DRY set (31 Aug 2026;
+    test_audio + demo_sources are full of processed renders and made the
+    browser unusable). Falls back to the old dirs only when out/dry is
+    missing or empty (a fresh tree before anyone copies sources in)."""
+    d = ROOT / "out" / "dry"
+    if d.is_dir():
+        out = sorted(d.glob("*.wav"))
+        if out:
+            return out
     out = []
     for sub in ("test_audio", "demo_sources"):
         d = ROOT / "out" / sub
@@ -285,7 +293,7 @@ class RigScreen(Screen):
             end = "[/]" if cur else ""
             if name == "SOURCE":
                 src = app.source.name if app.source else "(none — add wavs "\
-                    "to out/test_audio/)"
+                    "to out/dry/)"
                 lines.append(f" {mark}SOURCE  {escape(src)}{end}")
             elif name == "WET":
                 w = "WET only (reverb render)" if app.wet else "full (dry+wet)"
@@ -308,7 +316,7 @@ class RigScreen(Screen):
         name, slot = rows[self.cursor]
         if name == "SOURCE":
             hint = ("the wav rendered through the effect -- drop files in "
-                    "out/test_audio/; left/right cycles")
+                    "out/dry/; left/right cycles")
         elif name == "WET":
             hint = ("WET = the reverb's wet alone (exact dry subtraction); "
                     "other effects always render their normal output")
@@ -406,7 +414,7 @@ class RigScreen(Screen):
         if mod is None:
             app.status = "no effect on this track — enter picks one"
         elif app.source is None:
-            app.status = "no source wav — put some in out/test_audio/"
+            app.status = "no source wav — put some in out/dry/"
         elif app.rendering:
             app.status = "a render is already running"
         else:


### PR DESCRIPTION
Two voicing rounds logged and one workbench fix, from the 31 Aug tuning session:

**R59 — VintageVerb refs revisited on the current engine.** A/B kit rebuilt from scratch (`out/vv_ab2/`, self-contained script, stereo now that width is pinned wide): decay re-matched by peak→−40 dB tail time (ROOM TIME 24 / PLATE 64 / BIG 38 — the Round-13 values had drifted). Verdict: verb passes the ear; the "wetter" quality localized to DIFF (~80–90 brackets VV). Opened: ROOM's TIME-independent early-tail floor, the BIG TIME 38→44 knee, hat-BIG's residual inverted-HF row, and the per-mode TIME range re-map.

**R60 — REVERSE's "fast metallic ringing" diagnosed.** Not a defect: the ring is the segment comb (odd multiples of 1/(2S); PTCH in REVERSE = 93/46/23/12 ms) and sustained material at 46 ms is the worst case — drums at identical settings read as texture. Items: PTCH range guidance (sustained wants 93 ms), and the structural ceiling — reversing S samples spans 2S of history, so the 16K line caps segments at 93 ms; musical phrase-reverse needs a longer line (payload B layout work).

**Workbench**: the SOURCE browser now reads the curated `out/dry/` (37 dry sources) instead of sweeping `test_audio` + `demo_sources`, which mixed ~50 processed renders into the list; the old dirs remain the fallback when `out/dry/` is empty. PTCH's `?` help carries the R60 segment guidance.

`make check` green (the 90-char knob-doc gate caught and trimmed the first PTCH text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)