### PR TITLE
R61: GRAIN density decode fix + level makeup (ear-passed)

### DIFF
--- a/docs/VOICING.md
+++ b/docs/VOICING.md
@@ -1974,3 +1974,37 @@ sweet-spot problem:**
    (0.5 s+) needs a longer line: a payload-B memory-layout item, not a
    knob. Parked on the delay design list next to GRAIN makeup gain
    (DENS = the DPTH/WOW knob in GRAIN; sparse still only subtracts).
+
+## R61 — GRAIN density: the knob that barely existed, fixed + makeup gain
+## (31 Aug 2026, ear-passed on local renders)
+
+**The DENS knob was a two-position switch, and nobody knew.** The decode
+fed the 3-bit gate comparison knob>>1 (the $2d slot holds knob<<13 and the
+gate shifted down 14), so every knob value >=15 saturated to full density:
+the whole musical range lived in knob 0..14 and the shipped default (48)
+was silently "always full". Measured before the fix: FLAT from DENS 16 to
+127, -7.1 dB only at 0. Every GRAIN density impression ever formed on a
+default-ish knob was full-density. Fix: shift 17 (knob>>4 -> dens3 0..7),
+both draw sites; the dial now tapers smoothly across its full travel
+(0/-0.4/-1.0/-1.9/-2.8/-3.8/-5.4/-7.1 dB at dens3 7..0).
+
+**Makeup gain built on top** (the PLAN §1 item): per-sample coeff
+1/2 + (7-dens3)/14 (Q23, top of ramp $7FFFFF by construction), parked in
+GRAIN's $57 (dead from the pre-hoist park until the reader's t0 park),
+multiplied into the window in the builder -- 1/2 at full density is the
+old fixed halving exactly. Measured after: **flat within +-1.2 dB across
+the whole dial** (cap +6 dB, so DENS 0 keeps a -1.2 dB residue).
+
+Verified: CLEAN/PITCH/REVERSE renders BIT-IDENTICAL before/after;
+make check green; encodings proven by standalone dsp_asm listing
+(asr #$11,a,a = 0c1c22, mpy x0,y1 = 2000c8 signed, constant intact) and
+image bytes. Cost 25 words -- **payload B FREE 5, the pool is spent**.
+
+**Sam's ear, sparse (DENS 16) A/B before/after makeup: "sparse sounds way
+better now."** Committed on that verdict; hardware ear-ratify rides the
+next flash (DSP-side change only, no descriptor edit, no new publish
+risk).
+
+⚠️ Behavior change on stored settings: DPTH 48 in GRAIN now means MID
+density, not full. That is the knob working for the first time; the
+makeup holds the level through it.

--- a/modules/bongdelay/delay_server.asm
+++ b/modules/bongdelay/delay_server.asm
@@ -219,7 +219,10 @@
 ;                       SPRAY. Per-line candidates are what keep L and R
 ;                       decorrelated while they share ages and window gains
 ;   r7+$56..$5b         GRAIN per-sample scratch (builder: age_fx / age_int /
-;                       frac / gain / smoothstep temp; reader: phase / t0)
+;                       frac / gain / smoothstep temp; reader: phase / t0;
+;                       $57 also carries the density MAKEUP coeff from the
+;                       hoist into the builder -- dead there until the
+;                       reader's t0 park)
 ;   r7+$5c              SPRAY depth, Q23 (per block, from the SPRAY knob)
 ;   r7+$5d              GRAIN per-grain age cursor (the builder's running age)
 ;   r7+$5e              REVERSE segment phase, 23-bit (persistent, masked on
@@ -2229,7 +2232,13 @@ grcapok:
         move    b1,x0
         move    x0,b
         move    x:(r7+$2d),a            ; DENS (the WOW knob in GRAIN)
-        asr     #$e,a,a
+        asr     #$11,a,a                ; $2d holds knob<<13; >>17 = knob>>4,
+                                        ; 0..7 across the FULL dial. The old
+                                        ; >>14 left knob>>1 vs a 3-bit draw:
+                                        ; every value >=15 saturated to full
+                                        ; density and the knob's whole range
+                                        ; lived in 0..14 (measured 31 Aug
+                                        ; 2026 -- flat 16..127, -7 dB at 0)
         move    a1,x0
         move    x0,a
         sub     b,a                     ; N SET == this grain stays silent
@@ -2243,7 +2252,7 @@ grcapok:
         move    b1,x0
         move    x0,b
         move    x:(r7+$2d),a
-        asr     #$e,a,a
+        asr     #$11,a,a                ; same relaw as line L above
         move    a1,x0
         move    x0,a
         sub     b,a
@@ -2251,6 +2260,33 @@ grcapok:
         move    #>$1,x0
         tmi     x0,b
         move    b,x:(r7+$61)            ; candidate mute, line R
+; ---- density MAKEUP: coeff = 1/2 + (7-dens3)/14, Q23 ---------------------
+; The gate mutes grains but nothing restored the level, so sparse always
+; cost energy (measured 31 Aug 2026: -0.4/-1.0/-1.9/-2.8/-3.8/-5.4/-7.1 dB
+; at dens3 6..0). This linear law flattens it within ~1.2 dB; the top of
+; the ramp is $7FFFFF by construction (7 * $492492 = $1FFFFFE, so the sum
+; cannot wrap), i.e. the cap is +6 dB and dens3=0 keeps a -1.1 dB residue.
+; Parked in $57, which is DEAD from the pre-hoist park above until the
+; reader parks t0 there -- after the builder (the only consumer) is done.
+; x1 (the parked roll draw) and y0 are NOT touched; y1 is builder-clobbered
+; every pass anyway and is loaded fresh at the consuming mpy.
+        move    x:(r7+$2d),a            ; knob<<13
+        asr     #$11,a,a                ; dens3, 0..7
+        move    a1,x0
+        move    x0,a
+        move    #>7,b
+        sub     a,b                     ; 7-dens3
+        move    b1,x0                   ; through b1: sub is safe but asl
+        move    x0,b                    ; below leaves B2 stale
+        asl     #$14,b,b                ; (7-dens3)<<20 = n/8 in Q23
+        move    b1,x0
+        move    #>$492492,y1            ; 8/14 in Q23
+        mpy     x0,y1,b                 ; n/14 (x0,y1 -- a SIGNED encode)
+        move    #>$400000,x0
+        add     x0,b                    ; + 1/2
+        move    b1,x0
+        move    x0,b
+        move    b,x:(r7+$57)            ; GRAIN makeup coeff, this sample
 
 ; ---- BUILDER ------------------------------------------------------------
         move    r7,a
@@ -2259,16 +2295,20 @@ grcapok:
         move    a,r4                    ; -> record L0
         move    #>2,n4
         do      #4,>grnbz
-; window gain from the SCHEDULE phase alone, halved (four grains sum to 2.0)
+; window gain from the SCHEDULE phase alone, scaled by the density makeup
+; coeff (1/2 at full density == the old fixed halving; four grains sum to
+; 2.0, so 1/2 is unity and the coeff tops out at 1.0 = +6 dB of makeup)
         move    x:(r7+$5d),a
         bsr     smoothw                 ; smoothstepped triangle (v6 roll --
                                         ; y0's wrap flag is parked AFTER this
                                         ; point, and smoothw never touches y0
                                         ; anyway)
-        asr     #$1,a,a                 ; halved
-        move    a1,x0
+        move    a1,x0                   ; window, >= 0
+        move    x:(r7+$57),y1           ; density makeup coeff (hoist)
+        mpy     x0,y1,a                 ; x0,y1 -- a SIGNED encode
+        move    a1,x0                   ; a1: the plain fractional product
         move    x0,a
-        move    a,x:(r7+$59)            ; gain/2
+        move    a,x:(r7+$59)            ; gain * coeff
 ; ---- this grain's own wrap: prev = (phase - SSTEP) & mask ----------------
         move    x:(r7+$5d),a
         move    #>$400,x0

--- a/modules/bongdelay/manifest.py
+++ b/modules/bongdelay/manifest.py
@@ -58,7 +58,8 @@ MODULE = Module(
               doc="this track's own send into the delay; 0 = off (and off the bus)"),
         # ---- page 2 -------------------------------------------------------
         Param(b"DPTH", 48, 128, active=True, formatter=_PLAIN,
-              doc="tape wow depth -- pitch drift on the line; 0 = none"),
+              doc="tape wow depth; 0 = none - GRAIN: density, full dial, "
+                  "level-flat (R61)"),
         Param(b"MODE", 0, 5, active=True, formatter=_STEP,
               labels=("CLEAN", "PITCH", "(tape)", "GRAIN", "REVRS"),
               doc="engine select; 2 is the retired TAPE slot and runs CLEAN"),


### PR DESCRIPTION
Opens the delay quality pass with the GRAIN makeup-gain item from PLAN §1 — and the measurement found a real bug underneath it.

**The bug: the DENS knob barely existed.** The density gate compared `knob>>1` against a 3-bit PRNG draw, so every knob value ≥15 saturated to full density — the entire musical range lived in knob 0–14, and the shipped default (48) was silently "always full." The first level sweep proved it: dead flat from DENS 16 to 127, −7.1 dB only at exactly 0. Fixed to `knob>>4` (`asr #$11`, both draw sites); the dial now tapers smoothly across its full travel.

**The makeup gain**: per-sample coefficient `1/2 + (7−dens3)/14` (Q23; ramp top `$7FFFFF` by construction so it cannot wrap), parked in GRAIN's `$57` (dead between the pre-hoist park and the reader's t0 park), multiplied into the window in the builder. At full density the coefficient is exactly the old fixed halving. Measured after: density-vs-level **flat within ±1.2 dB across the whole dial** (cap +6 dB leaves a −1.2 dB residue at DENS 0).

**Verification**: CLEAN/PITCH/REVERSE renders bit-identical before/after; `make check` green; encodings proven by a standalone `dsp_asm` listing (`asr #$11,a,a` = 0c1c22, `mpy x0,y1` = the signed encode, constant intact) and by the image bytes. Cost 25 words — **payload B FREE 5, the pool is now spent**.

**Ear-passed** on sparse (DENS 16) before/after: "sparse sounds way better now." Hardware ear-ratify rides the next flash (DSP-side only, no descriptor change).

⚠️ Behavior change on stored settings: DPTH 48 in GRAIN now means MID density, not full — the knob doing its job for the first time; the makeup holds the level through it.

Full round: `docs/VOICING.md` R61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)