### PR TITLE
R62: REVERSE default = the 93 ms segment

### DIFF
--- a/docs/VOICING.md
+++ b/docs/VOICING.md
@@ -2008,3 +2008,26 @@ risk).
 ⚠️ Behavior change on stored settings: DPTH 48 in GRAIN now means MID
 density, not full. That is the knob working for the first time; the
 makeup holds the level through it.
+
+## R62 — REVERSE's default is the musical segment; the -19 check closes
+## (31 Aug 2026)
+
+**The R60 settings item, done in zero words**: REVERSE's size table indices
+0 and 1 swapped, so the PANEL DEFAULT (PTCH=1) now selects the 93 ms
+segment -- the one R60's ear round preferred on sustained sources -- and
+46 ms moves to index 0. 23/12 ms stay at 2/3. Sizes unchanged, order
+changed; the 93 ms line-ceiling item stays open (structural, and payload
+B FREE 5 means it needs a space lever first).
+
+Verified by exact exchange: new PTCH=1 render == the old PTCH=0 render
+(rev_seg93, the one Sam ear-approved in R60) BIT-FOR-BIT, new PTCH=0 ==
+the old PTCH=1 bit-for-bit, CLEAN/PITCH bit-identical, GRAIN untouched by
+inspection ($62 unread by GRAIN; $60/$61 rewritten per-sample by its hoist
+before any read). make check green; FREE unchanged at 5.
+
+**GRAIN -19 interval: the reference-match swap LANDED long ago** -- the
+shipping 4-entry set is +12 / unison / -19 / -12 (no +7; the wide 8-entry
+set keeps +7 at entry 7). Verified in the set table this session; the
+open-item note in the 30 Aug memory was stale. With this and R61, the
+delay quality pass's buildable items are done: what remains on the list
+is structural (REVERSE line length) or taste (a future ear round).

--- a/modules/bongdelay/delay_server.asm
+++ b/modules/bongdelay/delay_server.asm
@@ -354,11 +354,12 @@
 ;              TIME is tempo-locked (always, see p0) is a tempo-locked loop.
 ;              `DFRZ=n` is the local override (it forces the decoded VALUE;
 ;              dsp_host also drives companions via -params 7/9/11).
-;   p9 PTCH  -> in REVERSE this same select is SIZE: 0 = 4096 samples (93 ms,
+;   p9 PTCH  -> in REVERSE this same select is SIZE: 1 = 4096 samples (93 ms,
 ;              the longest the line allows -- playing S samples backwards
-;              spans 2S of history), 1 = 2048, 2 = 1024, 3 = 512. One select,
-;              two meanings, because MODE already says which is in force and
-;              page 2 has no spare slot.
+;              spans 2S of history, and 1 is the PANEL DEFAULT, R62),
+;              0 = 2048, 2 = 1024, 3 = 512. One select, two meanings,
+;              because MODE already says which is in force and page 2 has
+;              no spare slot.
 ;   p9 PTCH  -> PITCH interval select, page-2 slot 9 companion (r6+$d low
 ;              bits), count 4: 0 = +12, 1 = +7, 2 = -12, 3 = +-detune
 ;              (~15 cents, L up / R down). Selects, not smooth knobs -- the
@@ -1419,18 +1420,21 @@ drvw:
         move    #>$3,x0
         cmp     x0,a
         beq     rsz3
-        move    #>4096,a                ; index 0 (and any garbage): 93 ms
-        move    a,x:(r7+$60)
-        move    #>2048,a                ; step = 2^23 / S
-        move    a,x:(r7+$61)
-        move    #>8128,a                ; cap = 16320 - 2S
+        move    #>2048,a                ; index 0 (and any garbage): 46 ms
+        move    a,x:(r7+$60)            ; (index 0 and 1 SWAPPED, R62: the
+        move    #>4096,a                ; step = 2^23 / S      panel default
+        move    a,x:(r7+$61)            ; is PTCH=1, and R60 measured 46 ms
+        move    #>12224,a               ; cap = 16320 - 2S     as comb
+                                        ; territory on sustained sources --
+                                        ; the default deserves the musical
+                                        ; segment, not the ring)
         bra     rszend
 rsz1:
-        move    #>2048,a                ; 46 ms
-        move    a,x:(r7+$60)
-        move    #>4096,a
+        move    #>4096,a                ; 93 ms -- the DEFAULT, and the size
+        move    a,x:(r7+$60)            ; R60's ear round preferred
+        move    #>2048,a
         move    a,x:(r7+$61)
-        move    #>12224,a
+        move    #>8128,a
         bra     rszend
 rsz2:
         move    #>1024,a                ; 23 ms

--- a/modules/bongdelay/manifest.py
+++ b/modules/bongdelay/manifest.py
@@ -71,8 +71,8 @@ MODULE = Module(
         # REVERSE's segment size -- which is why its count stays 4.
         Param(b"PTCH", 1, 4, active=True, formatter=_STEP,
               labels=("+12", "+7", "-12", "det"),
-              doc="PITCH: interval - REVERSE: seg 93/46/23/12 ms, sustained "
-                  "wants 0 (R60) - GRAIN: width"),
+              doc="PITCH: interval - REVERSE: seg 46/93/23/12 ms, default 1 "
+                  "= 93 musical (R62) - GRAIN: width"),
         # DRV is drive in every mode but GRAIN, where the same byte is the
         # scatter depth. 0 = exact bypass, which outranks a scatter taste
         # that gets played by hand anyway.


### PR DESCRIPTION
Closes out the delay quality pass's buildable items (with #48 / R61).

**The R60 settings fix, zero words**: REVERSE's segment-size table indices 0 and 1 swapped, so the panel default (PTCH=1) now selects the **93 ms** segment — the size R60's ear round preferred on sustained sources — and 46 ms moves to index 0; 23/12 ms unchanged at 2/3.

**Verified by exact exchange**: new PTCH=1 render == the ear-approved old PTCH=0 render (`rev_seg93` from the R60 session) bit-for-bit; new PTCH=0 == old PTCH=1 bit-for-bit; CLEAN/PITCH bit-identical; GRAIN untouched by inspection (`$62` unread by GRAIN, `$60/$61` rewritten per-sample by its hoist before any read). `make check` green, payload B FREE unchanged at 5.

**Also closed**: the GRAIN −19 reference-match item was already landed — the shipping 4-entry interval set is +12/unison/−19/−12 (the stale open-item note was in memory, not the code).

Remaining on the delay list is structural (REVERSE line length — needs a space lever, payload B is spent) or taste (future ear rounds). Full round: `docs/VOICING.md` R62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)