### PR TITLE
analyze.sh: fix SIGPIPE abort + missing out/raw extraction

### DIFF
--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -43,7 +43,9 @@ for f in "${ARTIFACTS[@]}"; do
   echo
 
   echo "--- [4] Long strings (versions, menus, paths) ---"
-  strings -n 6 "$f" | sort -u | head -40 | tee "$OUT/${base}.strings.txt" >/dev/null
+  # No head in this pipeline: under pipefail, head's early exit SIGPIPEs sort
+  # (exit 141) once the dump exceeds the pipe buffer — the .syx does.
+  strings -n 6 "$f" | sort -u > "$OUT/${base}.strings.txt"
   head -20 "$OUT/${base}.strings.txt"
   echo "    (full dump in $OUT/${base}.strings.txt)"
   echo
@@ -55,6 +57,10 @@ for f in "${ARTIFACTS[@]}"; do
     if [ -x "$EFT" ]; then
       "$EFT" "$f" 2>&1 | tee "$OUT/${base}.eft.txt" || \
         echo "    (tool exited non-zero; check its usage: $EFT --help)"
+      # The call above only reports; this one extracts the section every
+      # build script reads as its base image.
+      "$EFT" -i "$f" -d 3 -o "$OUT/raw" || \
+        echo "    (extraction failed; $OUT/raw/section_3_MAIN_OS.bin not refreshed)" >&2
     else
       echo "    (elektron-firmware-tool not built; run scripts/setup.sh)"
     fi


### PR DESCRIPTION
Two bugs in `scripts/analyze.sh`, the first masking the second:

1. **SIGPIPE abort under pipefail.** `strings -n 6 | sort -u | head -40 | tee` kills `sort` (exit 141) as soon as the sorted dump exceeds the 64K pipe buffer — the .syx yields 130K, so `make recon` died mid-run **before the elektron-firmware-tool step ever ran**. Reproduced on OCTATRACK_OS1.40C.syx. Fixed by writing the full dump straight to the file (which also makes the "full dump in out/….strings.txt" message true — it previously saved only 40 lines) and reading `head -20` back from it.

2. **Report-only EFT call.** The tool was invoked with just the input file, which reports layers/checksums but extracts nothing, so the script never produced `out/raw/section_3_MAIN_OS.bin` despite its own header comment and the `make recon` help text. Added `-d 3 -o out/raw` after the report call.

Verified: full `scripts/analyze.sh` run now exits 0, extraction runs, and the refreshed `section_3_MAIN_OS.bin` is bit-identical to the existing base image (sha256 `164f3122…`). No build script changed, so no refhash run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)