### PR TITLE
Stock FX2 effects as remix entries; composer chooser order; Rungs/Nimbus off stock ids

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,15 @@ reason. A delay based at `0x30000` sweeps the rotation word, all four ACC
 buffers and both role locks every 16,384 samples and blows up any
 multi-server layout (found 12 Aug, RDS full-scale garbage).
 
+**AN FX2 ID IS ALSO AN FX1 ID: the DSP dispatch tables are indexed by the
+raw id and shared by both menus.** A module on a stock effect's id replaces
+that effect's code wherever it is selected, FX1 included, and a remix that
+omits the module then aliases the id to SEND and takes the stock effect
+away from FX1 too. Rungs sat on EQUALIZER's `0x0c` and Nimbus on DJ EQ's
+`0x0d` from 29 Aug to 2 Sep 2026, in every local image, unflashed. The
+schema now refuses `STOCK_FX2_IDS`; the stock effects themselves are kept
+in a chooser by listing them in the remix (`tools/remix/stock.py`).
+
 **A parameter slot can draw a knob and publish nothing.** The page descriptor
 and the DSP-side read are separate mechanisms; `dsp_host` pokes r6 directly, so
 everything looks live locally even when the real unit would publish nothing.

--- a/PLAN.md
+++ b/PLAN.md
@@ -77,6 +77,30 @@ What ships today is four modules: `chonverb`, `bongdelay`, `send`, and
 `tempo-sync` — the last being a ColdFire patch rather than an effect, and the
 worked example of changing what the firmware *does*.
 
+**What a remix does to the STOCK effects (made explicit 2 Sep 2026).** Every
+image replaces the FX2 chooser wholesale, but only three stock effects are
+*consumed* — PLATE, SPRING and DARK REV, whose code is the donor region.
+The other eleven (FILTER, EQ, DJ EQ, PHASER, FLANGER, CHORUS, SPATIALIZER,
+COMB, COMPRESSOR, LO-FI, the Echo Freeze DELAY) keep their code, descriptor
+and dispatch in every image and had merely lost their chooser row. A remix
+now keeps any of them by listing it by key (`tools/remix/stock.py`), in
+chooser order, at zero cost — the build writes the row and the cursor
+position and nothing else — and the composer shows a STOCK FX2 group, the
+consumed three, and the hidden count. `remixes/restored.py` is chongbong
+plus the seven that can sit beside the servers; the other four allocate a
+per-track instance buffer on the addresses the servers hardcode and the
+ledger refuses them beside one. Past seven rows the list relocates and the
+panel scrolls — ⚠️ inferred from stock's fifteen-row list, unflashed.
+`docs/MODULES.md` "Keeping STOCK effects in the chooser".
+
+Making them first-class exposed a latent id collision: the DSP dispatch
+tables are shared between FX1 and FX2, and Rungs (`0x0c`) and Nimbus
+(`0x0d`) sat on EQUALIZER's and DJ EQ's ids from 29 Aug, so every local
+image since ran Rungs where FX1 selected EQUALIZER, and chongbong aliased
+FX1's EQ and DJ EQ to SEND. Never flashed (tag 77 predates it). Both moved
+(`0x17`, `0x1a`); the schema refuses stock ids; the shipping image differs
+from before in exactly those four ids' entries, byte-diffed.
+
 The first **outsider modules** landed 29 Aug 2026 — three Mutable-
 Instruments-flavoured per-track **inserts** (no bus role, placed in BOTH
 payloads, run on any track, several at once — the class the servers cannot

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ make bus REMIX=<name>       # build a selection
 `make remix` is the workbench, organized like the unit: eight tracks, an
 effect on each, its real knobs to dial and render and hear (every effect
 renders locally). Its composer view shows what would collide, what the FX2
-chooser ends up looking like on the panel, and what the selection costs
+chooser ends up looking like on the panel — including which **stock**
+effects the image keeps, hides or consumes (only the three reverbs are
+consumed; the rest can be kept for free) — and what the selection costs
 against the donor region — then builds or saves it.
 **[docs/WORKBENCH.md](docs/WORKBENCH.md)** is the manual.
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -67,6 +67,8 @@ The workbench derives a **category** and a **track range** for every module
   not declare a single payload is refused, not guessed at.
 - **insert** (a `DSP_EFFECT` with a menu, no server role) — both payloads,
   any track.
+- **stock** (`Kind.STOCK`, `tools/remix/stock.py`) — a stock FX2 effect
+  kept in the chooser; any track, no knobs in the rig, no local render.
 - **system** (SEND, ColdFire patches) — plumbing; never sits on a track.
 
 Every effect is auditionable locally through `tools/remix/audition.py`, and
@@ -144,6 +146,71 @@ become continuous; it stays a select and reads as a near-boolean.
 `0x00`–`0x03` are the values stock treats as bare synonyms for "no effect".
 The first hardware test used them and got correct chooser names with dead
 knobs and garbage audio. The schema rejects them.
+
+**The fifteen STOCK ids are off limits too** (`schema.STOCK_FX2_IDS`), and
+the reason is not tidiness: the two DSP dispatch tables are indexed by the
+raw id and are **shared between FX1 and FX2**. A module on a stock id
+replaces that effect's descriptor in the FX2 lookup and its code wherever
+the id is selected — FX1 included — and a remix that *omits* the module
+then aliases the id to SEND, which takes the stock effect away from FX1 as
+well. Rungs shipped on `0x0c` (EQUALIZER) and Nimbus on `0x0d` (DJ EQ) from
+29 Aug until 2 Sep 2026, so every local image in between ran Rungs where
+FX1 selected EQUALIZER and the chongbong image aliased FX1's EQ to a send.
+It never reached the unit (tag 77 predates it); the schema now refuses at
+construction. Free ids: `0x06 0x07 0x09 0x0a 0x0b 0x0e 0x0f 0x17 0x1a 0x1b
+0x1d 0x1e 0x1f`, of which the first seven plus `0x17`/`0x1a` are taken.
+
+## Keeping STOCK effects in the chooser
+
+Every image replaces the FX2 chooser wholesale, and until 2 Sep 2026 that
+hid all fourteen stock FX2 effects although only **three are consumed** —
+PLATE, SPRING and DARK REV, whose 2,724 words of code are the donor region
+every module packs into. The other eleven keep their code, descriptor and
+dispatch entries in every image; they only lost their row.
+
+`tools/remix/stock.py` registers them under their own keys (`"FILTER"`,
+`"CHORUS"`, `"DELAY"`, …), so a remix keeps one by listing it exactly like
+a module, in the position it should draw at:
+
+```python
+modules=("REVERB SERVER", "DELAY SERVER", "SEND", "FILTER", "LO-FI", "TEMPO SYNC")
+```
+
+A stock row costs **nothing** — no clone, no placement, no words, and
+`make cycles` says so rather than counting it (only FILTER's cost is
+measured, 192 cycles per instance, ×4 at worst like an insert). What the
+build writes is its list row and its cursor position; `verify_menu` checks
+that its descriptor and id entry are byte-identical to stock. A stock
+effect a remix leaves *out* is left alone entirely — an old project that
+selects it still runs it, it just has no row — which is what keeps FX1
+whole. `remixes/restored.py` is chongbong plus the seven that can sit
+beside the servers.
+
+Two rules, both enforced:
+
+- **Four stock effects allocate an instance buffer** — SPATIALIZER,
+  FLANGER, CHORUS, COMB read `X:0x213` at init (measured 2 Sep 2026 by
+  scanning the payload disassembly; the other seven do not). The
+  allocator hands out a base **per track slot**, and those bases are the
+  addresses ChonVerb's tank, Nimbus's line and BongDelay's line hardcode:
+  CHORUS on track 6 beside ChonVerb on track 5 writes into the tank. The
+  chooser is one list for all eight tracks, so an image cannot keep them
+  apart; the ledger refuses the pair (`Claims.stock_instance_buffer`
+  against any module with `owns_fx2_buffers` or a non-`NEVER` `ybase`).
+  All four are legal in an insert-only remix.
+- **More than seven rows moves the list.** The list cave at `0x400d6b00`
+  holds seven rows before the first clone, so a longer list goes to the
+  tail of the stock zero run (`LONG_LIST`, 32 rows) and the viewport is
+  capped at the screen's seven, so it scrolls as stock's fifteen-row list
+  does. Seven or fewer stays where it was, byte for byte. ⚠️ Scrolling our
+  relocated list on the real panel is inferred from stock behaviour, not
+  yet measured — `restored` is the first image with more than seven rows
+  and is unflashed.
+
+Stock rows appear in the workbench (a STOCK FX2 group in the composer, any
+track in the rig) but have no manifest knobs and **no local render yet**:
+`send_probe` has no layout letter for a stock id, so the audition says so
+instead of rendering a plausible passthrough.
 
 ---
 

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -96,11 +96,22 @@ picker.
 ### REMIX — the composer
 
 The old workbench's job, reframed. Left: the modules, grouped **BUS
-EFFECTS** (with track range) / **INSERTS** (any track) / **SYSTEM**, with
-the cursored module's one-line doc below. Right: what the selection *is* —
-the FX2 chooser exactly as the unit will show it, the program-fit bar
-against the donor region, and the ledger's collision verdict (the same
-`ledger.check` the build runs, not a reimplementation).
+EFFECTS** (with track range) / **INSERTS** (any track) / **STOCK FX2** /
+**SYSTEM**, with the cursored module's one-line doc below. Right: what the
+selection *is* — the FX2 chooser exactly as the unit will show it, in
+**selection order** (`[` / `]` move the cursored module; a saved remix
+keeps that order), the program-fit bar against the donor region, and the
+ledger's collision verdict (the same `ledger.check` the build runs, not a
+reimplementation).
+
+**STOCK FX2** (since 2 Sep 2026) is the eleven stock effects the image
+would otherwise hide: every image replaces the whole chooser, but only
+PLATE/SPRING/DARK REV are actually consumed (their code is the donor
+region), and the panel now says so. Toggling a stock row costs nothing —
+no code, no words, no clone; the row is the only edit. The four that
+allocate a per-track buffer (SPAT, FLNG, CHOR, COMB) are refused beside
+ChonVerb, Nimbus or BongDelay, with the reason. Past seven rows the panel
+scrolls, and the composer says that too. `docs/MODULES.md` has the rules.
 
 ![The REMIX view: modules grouped by category with track ranges, the FX2
 menu as the unit will draw it, and the ledger's verdict —
@@ -109,6 +120,7 @@ chongbong loaded](img/workbench-remix.png)
 | key | action |
 |---|---|
 | `space` | toggle the module under the cursor |
+| `[` / `]` | move it earlier / later in the chooser |
 | `f` | make it the fallback (absent ids alias to the fallback — normally SEND, so a stale project degrades to a send, not noise; `*` explicit, `~` auto) |
 | `w` | assemble the selection and keep the real word counts |
 | `b` / `c` | `make bus` / `make check` on the **live** selection (via the scratch-remix mechanism — no save needed) |
@@ -221,7 +233,8 @@ Categories and track ranges are **derived from manifests**, never declared
 in the UI: `harness.is_server` + `dsp.payloads` (each server declares its
 single payload; a server without one is refused, not guessed at) →
 SERVER/T5-8 or T1-4; `DSP_EFFECT` with a menu → INSERT/any track;
-everything else → SYSTEM/no track.
+`Kind.STOCK` → STOCK/any track (no knobs, no render); everything else →
+SYSTEM/no track.
 
 Three `Param` fields exist purely for the workbench and are **proven
 display-only** — `scripts/refhash.sh check` ran bit-identical (26/26)
@@ -247,6 +260,8 @@ through `rich.markup.escape`.
 
 ## Known gaps
 
+- Stock rows have no knobs in the rig and no local render (the audition
+  says so rather than rendering a passthrough).
 - A/B marks attach only to the most recent render (no history cursor).
 - No browse-anywhere source picker (one fixed directory, `out/dry/`).
 - Wet-only rendering is ChonVerb-only.

--- a/modules/nimbus/manifest.py
+++ b/modules/nimbus/manifest.py
@@ -32,7 +32,11 @@ MODULE = Module(
     kind=Kind.DSP_EFFECT,
     doc="Clouds-style insert: 743 ms granular texture, 4 grains, freeze.",
     menu=MenuEntry(
-        fx2_id=0x0d,
+        fx2_id=0x1a,
+        # ⚠️ was 0x0c/0x0d until 2 Sep 2026: STOCK ids (EQUALIZER /
+        # DJ EQ). The dispatch tables are shared with FX1, so the old
+        # id hijacked that effect on both menus. schema.STOCK_FX2_IDS
+        # now rejects it at construction.
         donor_desc=0x400d58b8,        # DARK REV, the standing donor
         abbr=b"NMBS",
         fullname=b"Nimbus",

--- a/modules/rungs/manifest.py
+++ b/modules/rungs/manifest.py
@@ -26,7 +26,11 @@ MODULE = Module(
     kind=Kind.DSP_EFFECT,
     doc="Rings-style insert: 8-mode modal resonator, STRING/BELL/GLASS.",
     menu=MenuEntry(
-        fx2_id=0x0c,
+        fx2_id=0x17,
+        # ⚠️ was 0x0c/0x0d until 2 Sep 2026: STOCK ids (EQUALIZER /
+        # DJ EQ). The dispatch tables are shared with FX1, so the old
+        # id hijacked that effect on both menus. schema.STOCK_FX2_IDS
+        # now rejects it at construction.
         donor_desc=0x400d58b8,        # DARK REV, the standing donor
         abbr=b"RNGS",
         fullname=b"Rungs",

--- a/remixes/restored.py
+++ b/remixes/restored.py
@@ -1,0 +1,31 @@
+"""restored -- chongbong plus every stock FX2 effect that can sit beside it.
+
+The shipping trio and tempo sync, then the seven stock effects the build
+had been hiding for no resource reason: FILTER, EQUALIZER, DJ EQ, PHASER,
+COMPRESSOR, LO-FI and the Echo Freeze DELAY. They cost nothing -- no code
+is placed, no descriptor cloned, no words spent; each is one chooser row
+pointing at the descriptor stock already ships (tools/remix/stock.py).
+
+The four stock effects NOT here -- SPATIALIZER, FLANGER, CHORUS, COMB --
+allocate an instance buffer per track, on exactly the addresses ChonVerb's
+tank and BongDelay's line hardcode, so the ledger refuses them beside a
+server. They are legal in an insert-only remix (`mutables` could carry all
+eleven).
+
+Ten chooser rows, so this is also the remix that exercises the LONG list
+cave and the scrolling viewport (build_bus.py LONG_LIST) -- the first
+image with more than seven rows. ⚠️ Unflashed: scrolling past row seven on
+the real panel is inferred from stock's own fifteen-row list, not measured
+on ours.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="restored",
+    doc="chongbong + the seven stock FX2 effects that coexist with the servers.",
+    modules=("REVERB SERVER", "DELAY SERVER", "SEND",
+             "FILTER", "EQUALIZER", "DJ EQ", "PHASER", "COMPRESSOR", "LO-FI",
+             "DELAY", "TEMPO SYNC"),
+    fallback="SEND",
+)

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -109,6 +109,18 @@ DESC_LEN = 0x192
 NEW_LIST = 0x400d6b00
 CLONE_BASE = 0x400d6b20
 CLONE_STRIDE = 0x1a0
+# NEW_LIST holds SEVEN rows plus its terminator before it runs into the
+# first clone. A remix that keeps stock effects in the chooser (2 Sep 2026)
+# can have more, so a longer list goes at the tail of the stock zero run
+# instead -- 0x400d7bbc..0x400d7c3c, 32 entries -- and the clones and caves
+# must stay below it. A list of seven or fewer stays at NEW_LIST, so every
+# image that could be built before is byte-identical (refhash).
+LONG_LIST = 0x400d7bbc
+ZERO_RUN_END = 0x400d7c3c
+# The chooser draws this many rows and scrolls a longer list, as stock does
+# with its fifteen. A shorter list shrinks the viewport to match (below);
+# a longer one must NOT grow it past the screen.
+CHOOSER_ROWS = 7
 
 # DESC_DONORS, NEW_IDS, RENAMES, ABBR, FULLNAME, DEFAULTS, ACTIVE_PARAMS,
 # PAGE2_COUNTS and STEPPED_SLOTS are no longer written here. Each module
@@ -348,38 +360,45 @@ BUILD_TAG = b"78"
 # proved runs custom DSP code on real hardware. schema.py enforces the range.
 _MODS = remix_modules()
 _SEL = [_MODS[k] for k in ORDER]
+# A STOCK row (tools/remix/stock.py) gets no clone, no code and no words:
+# its descriptor and dispatch are where stock put them. The build writes
+# its list row and cursor position and nothing else, so everything derived
+# below that feeds a clone or a placement is over the CLONED modules only.
+_CLONED = [m for m in _SEL if not m.is_stock]
+CLONED_ORDER = [m.key for m in _CLONED]
+STOCK_ROWS = [m.key for m in _SEL if m.is_stock]
 
-DESC_DONORS = {m.key: m.menu.donor_desc for m in _SEL}
+DESC_DONORS = {m.key: m.menu.donor_desc for m in _CLONED}
 NEW_IDS = {m.key: m.menu.fx2_id for m in _SEL}
-ABBR = {m.key: m.menu.abbr for m in _SEL}
+ABBR = {m.key: m.menu.abbr for m in _CLONED}
 FULLNAME = {m.key: m.menu.fullname + (BUILD_TAG if m.menu.build_tag else b"")
-            for m in _SEL}
+            for m in _CLONED}
 # A name of None means "leave the donor's", which is a different thing from
 # b"" (blank the slot). Both are in use: SEND blanks ten of FILTER's names.
 RENAMES = {m.key: [(i, p.name) for i, p in enumerate(m.params)
-                   if p.name is not None] for m in _SEL}
+                   if p.name is not None] for m in _CLONED}
 # Explicit per-knob defaults -- NOT the donor's, which are sized for a
 # different algorithm on that slot. DARK REV's MIX default is 0 (a freshly
 # selected reverb would be silent) and SPRING's TONE-slot default is 0 (our
 # darkest setting); both look exactly like "the effect does nothing".
 DEFAULTS = {m.key: [(i, p.default) for i, p in enumerate(m.params)
-                    if p.default is not None] for m in _SEL}
+                    if p.default is not None] for m in _CLONED}
 # The enable bitmap. A slot missing here is unreachable on hardware no matter
 # how completely it is named, defaulted, counted and implemented -- and the
 # inverse of the trap that a slot can draw a knob and publish nothing. Both
 # have shipped.
-ACTIVE_PARAMS = {m.key: m.active_params for m in _SEL}
+ACTIVE_PARAMS = {m.key: m.active_params for m in _CLONED}
 # Value counts. Page 2 is THREE KNOBS AND THREE SELECTS: the knob fields take
 # 128, the companion byte fields take a small step count. Setting a companion
 # to 128 does not make it continuous -- it stays a select and reads as a
 # near-boolean, which is what hardware showed.
 PAGE2_COUNTS = {m.key: {i: p.count for i, p in enumerate(m.params)
-                        if p.count is not None} for m in _SEL}
+                        if p.count is not None} for m in _CLONED}
 # Membership here also GATES the display-formatter pass below: a module with
 # no stepped slot keeps its donor's formatters untouched, which is what SEND
 # wants (FILTER's plain-numeric zeros, hardware-confirmed).
-STEPPED_SLOTS = {m.key: m.stepped_slots for m in _SEL if m.stepped_slots}
-_DEF_ASM = {m.key: m.dsp.asm for m in _SEL}
+STEPPED_SLOTS = {m.key: m.stepped_slots for m in _CLONED if m.stepped_slots}
+_DEF_ASM = {m.key: m.dsp.asm for m in _CLONED}
 
 
 # ---- P-relative field offsets (PARAM_PAGES.md section 5b) ------------------
@@ -789,13 +808,13 @@ def main():
         FULLNAME["DELAY SERVER"] = b"BongDlyRPLY" + BUILD_TAG
     elif os.environ.get("NOTEMPO") == "1":
         FULLNAME["DELAY SERVER"] = b"BongDlyNOCF" + BUILD_TAG
-    cave_end = CLONE_BASE + CLONE_STRIDE * len(ORDER)
+    cave_end = CLONE_BASE + CLONE_STRIDE * len(CLONED_ORDER)
     if any(img[NEW_LIST - BASE:cave_end - BASE]):
         sys.exit("menu cave not free")
 
     clone_addr = {}
     print("=== ColdFire: three cloned descriptors (task 11) ===")
-    for i, name in enumerate(ORDER):
+    for i, name in enumerate(CLONED_ORDER):
         # from the donor's P, not its E -- the record is 0x192 bytes measured
         # FROM P, and its tail carries the parameter enable bitmap
         donor_P = DESC_DONORS[name] + 0x38
@@ -894,8 +913,22 @@ def main():
         print(f"  {name:14s} id 0x{new_id:02x}  clone P=0x{clone_P:08x}  "
               f"knobs {ACTIVE_PARAMS[name]}")
 
-    for name in ORDER:
+    for name in CLONED_ORDER:
         wr32(FX2_IDS + NEW_IDS[name] * 4, clone_addr[name])
+    # A stock row's descriptor is the one stock ships, at P = E + 0x38, and
+    # its FX2_IDS entry must still be stock's -- the two are the same
+    # pointer on a pristine image, and nothing above may have touched it.
+    for name in STOCK_ROWS:
+        stock_P = _MODS[name].menu.donor_desc + 0x38
+        if rd32(FX2_IDS + NEW_IDS[name] * 4) != stock_P:
+            sys.exit(f"{name}: FX2_IDS[0x{NEW_IDS[name]:02x}] is not its "
+                     f"stock descriptor -- refusing to list it")
+        clone_addr[name] = stock_P
+        print(f"  {name:14s} id 0x{NEW_IDS[name]:02x}  STOCK P=0x{stock_P:08x}"
+              f"  (no clone, no code: the row is the only edit)")
+    if delayprobe and "DELAY" in ORDER:
+        sys.exit("DELAYPROBE puts stock DELAY back in the menu, but this remix "
+                 "already lists it -- drop one")
 
     # Exactly the three real entries -- no NONE. SEND with both levels at 0 is
     # already identical to "no effect" (it never writes the audio buffer, only
@@ -909,17 +942,33 @@ def main():
         # back in the list so it can be selected.
         real = real + [("DELAY (stock)", STOCK_DELAY_P)]
     entries = [p for _, p in real] + [0]
-    assert len(entries) * 4 <= CLONE_BASE - NEW_LIST, "list overruns the clone cave"
+    if len(entries) * 4 <= CLONE_BASE - NEW_LIST:
+        list_addr, cave_limit = NEW_LIST, ZERO_RUN_END
+    else:
+        # More than seven rows: the list moves to the tail of the zero run
+        # and everything else (clones, caves) has to end below it.
+        list_addr, cave_limit = LONG_LIST, LONG_LIST
+        if len(entries) * 4 > ZERO_RUN_END - LONG_LIST:
+            sys.exit(f"chooser list of {len(real)} rows overruns the long "
+                     f"list cave ({(ZERO_RUN_END - LONG_LIST) // 4 - 1} max)")
+        if any(img[LONG_LIST - BASE:ZERO_RUN_END - BASE]):
+            sys.exit("long chooser list cave not free")
+        if cave_end > LONG_LIST:
+            sys.exit(f"{len(CLONED_ORDER)} descriptor clones run into the "
+                     f"long chooser list at 0x{LONG_LIST:08x}")
     for i, v in enumerate(entries):
-        wr32(NEW_LIST + i * 4, v)
-    # and shrink the viewport to match, so there are no rows left to pad
+        wr32(list_addr + i * 4, v)
+    # and size the viewport: shrink it to a short list so there are no rows
+    # left to pad, never grow it past the seven the screen has -- a longer
+    # list scrolls, as stock's fifteen-entry list does.
     if rd32(ROWCOUNT_INSN) != 0x48780007:
         sys.exit(f"row-count site 0x{ROWCOUNT_INSN:08x} is not `pea (0x7).w` -- refusing")
-    img[ROWCOUNT_AT - BASE:ROWCOUNT_AT - BASE + 2] = len(real).to_bytes(2, "big")
+    rows = min(CHOOSER_ROWS, len(real))
+    img[ROWCOUNT_AT - BASE:ROWCOUNT_AT - BASE + 2] = rows.to_bytes(2, "big")
     for r in LIST_REFS:
         if rd32(r) != FX2_LIST:
             sys.exit(f"list ref at 0x{r:08x} not stock FX2_LIST -- refusing")
-        wr32(r, NEW_LIST)
+        wr32(r, list_addr)
     for pos, name in enumerate(ORDER):
         wr32(ID2POS + NEW_IDS[name] * 4, pos)
     # ==== 1b. ColdFire caves, from whichever modules carry them =============
@@ -953,7 +1002,8 @@ def main():
     _cave_top = cave_end            # caves start past the descriptor clones
     for _c, _b in _plan:
         assert _c.cave_addr >= _cave_top, f"{_c.label} overlaps what precedes it"
-        assert _c.cave_addr + len(_b) <= 0x400d7c3c, "past the stock zero run"
+        assert _c.cave_addr + len(_b) <= cave_limit, \
+            "past the stock zero run (or into the long chooser list)"
         if _c.hook_addr is not None:
             got = bytes(img[_c.hook_addr - BASE:
                             _c.hook_addr - BASE + len(_c.hook_stock)])
@@ -1004,8 +1054,14 @@ def main():
     # aliased: the alternative is a chooser entry dispatching into whatever
     # code now occupies that address. Empty whenever the remix carries every
     # module the registry knows.
+    # A STOCK effect the remix leaves out is NOT aliased: its descriptor,
+    # id entry and dispatch stay stock, so an old project that selects it
+    # still runs it -- it simply has no chooser row. That is what every
+    # remix did to all fourteen before 2 Sep 2026, and it is what keeps
+    # FX1 (which shares the dispatch tables) whole.
     _omitted = [m for m in remix_modules().values()
-                if m.menu is not None and m.key not in REMIX.modules]
+                if m.menu is not None and m.key not in REMIX.modules
+                and not m.is_stock]
     for _m in _omitted:
         wr32(FX2_IDS + _m.menu.fx2_id * 4, clone_addr[REMIX.fallback])
         wr32(ID2POS + _m.menu.fx2_id * 4, ORDER.index(REMIX.fallback))
@@ -1020,7 +1076,12 @@ def main():
         print(f"  *** DELAY PROBE: stock DELAY restored to the menu at "
               f"position {len(real) - 1} ***")
     print(f"  chooser list = {len(real)} entries, no NONE, viewport shrunk to "
-          f"{len(real)} rows (no padding)")
+          f"{len(real)} rows (no padding)" if len(real) <= CHOOSER_ROWS else
+          f"  chooser list = {len(real)} entries at 0x{list_addr:08x} (the "
+          f"long list cave), no NONE, viewport {rows} rows -- it scrolls")
+    if STOCK_ROWS:
+        print(f"  stock rows kept: {', '.join(STOCK_ROWS)} -- descriptors, "
+              f"code and dispatch untouched on both cores")
     print(f"  id 0x00 aliased to SEND: a fresh/unassigned track is a send\n")
 
     # ==== 2. DSP code placement + dispatch (task 13) ========================

--- a/tools/cycle_count.py
+++ b/tools/cycle_count.py
@@ -512,6 +512,14 @@ def main():
     for m in rows:
         extra = f"   [{m['inner']}]" if m["inner"] else ""
         print(f"{m['name']:{w}}  {m['cycles']:>13}{extra}")
+    stock_rows = [m.key for m in registry.selected(remix) if m.is_stock]
+    if stock_rows:
+        # A stock row runs stock code this tool does not count (it measures
+        # our sources). FILTER is the one measured on hardware -- 192/instance,
+        # docs/CHIP.md -- and, like an insert, a stock effect can be picked
+        # on all four tracks of a core, so its cost is paid x4 at worst.
+        print(f"{'stock rows':{w}}  {'NOT COUNTED':>13}   "
+              f"[{', '.join(stock_rows)}] -- stock code; FILTER measured 192")
     print()
     mix = " + ".join(f"{n}x {k}" for k, n in picks) or "(nothing of ours)"
     print(f"{'WORST ONE CORE':{w}}  {worst:>13}   {mix}")

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -169,11 +169,23 @@ selecting an absent id is aliased to the FALLBACK (normally SEND), so
 it degrades to a send instead of noise. * marks an explicit fallback,
 ~ an automatic one.
 
+[bold]what happens to the stock effects[/]
+Every image replaces the whole FX2 chooser, but only THREE stock
+effects are consumed -- PLATE, SPRING and DARK REV, whose code is the
+donor region the modules pack into. The other eleven keep their code
+and knobs in every image and only lose their row. Toggle one under
+STOCK FX2 to keep its row: it costs nothing. Four of them (SPAT, FLNG,
+CHOR, COMB) take a per-track buffer where the servers keep theirs, so
+they are refused beside ChonVerb, Nimbus or BongDelay. Row order is
+selection order; [ and ] move the cursored module. More than seven
+rows and the chooser scrolls, as stock's does.
+
 [bold]keys[/]
   space  toggle module        f  make it the fallback
-  w      assemble + measure   b  build the live selection
-  c      build + full check   l  load a saved remix
-  s      save this selection  v  rig    e  emulated unit""",
+  [ / ]  move earlier/later   w  assemble + measure
+  b      build the selection  c  build + full check
+  l      load a saved remix   s  save this selection
+  v      rig                  e  emulated unit""",
     "emu": """[bold]THE EMULATED UNIT — the real firmware, screen only[/]
 
 Your built image, booted in a local ColdFire emulator, drawing its own
@@ -518,12 +530,18 @@ class RemixScreen(Screen):
     def grouped(self):
         """[(key or None, line-label)] with None rows as group headers."""
         st = self.app.state
-        cats = {rig.SERVER: [], rig.INSERT: [], rig.SYSTEM: []}
+        cats = {rig.SERVER: [], rig.INSERT: [], rig.STOCK: [],
+                rig.SYSTEM: []}
         for k in st.keys:
             cats[rig.category(st.mods[k])].append(k)
+        # Stock rows in stock's own chooser order, not alphabetical.
+        from remix import stock
+        cats[rig.STOCK] = [m.key for m in stock.MODULES]
         out = []
         for cat, title in ((rig.SERVER, "BUS EFFECTS (one per payload)"),
                            (rig.INSERT, "INSERTS (any track)"),
+                           (rig.STOCK, "STOCK FX2 (in every image; "
+                                       "toggle = keep its row, free)"),
                            (rig.SYSTEM, "SYSTEM (never on a track)")):
             if cats[cat]:
                 out.append((None, title))
@@ -549,7 +567,8 @@ class RemixScreen(Screen):
                   else "~" if k == st.eff_fallback else " ")
             tr = rig.track_range(m)
             trs = f"T{tr.start}-{tr.stop - 1}" if len(tr) else "     "
-            wd = f"{st.words[k]:>5}w" if k in st.words else "     -"
+            wd = (" stock" if m.is_stock
+                  else f"{st.words[k]:>5}w" if k in st.words else "     -")
             cur = krows[self.cursor] == i
             mark = "[reverse]" if cur else ("" if k in st.sel else "[dim]")
             end = "[/]" if mark else ""
@@ -571,11 +590,22 @@ class RemixScreen(Screen):
                         else " ← fallback")
             p.append(f"  {i}. {escape(m.menu.fullname.decode('latin1')):<13} "
                      f"0x{m.menu.fx2_id:02x}{star}")
+        from remix import stock
+        n_menu = len(st.menu_modules)
+        if n_menu > 7:
+            p.append(f"  [dim]{n_menu} rows: the panel shows 7 and scrolls[/]")
         absent = [m for m in st.mods.values()
-                  if m.menu is not None and m.key not in st.sel]
+                  if m.menu is not None and m.key not in st.sel
+                  and not m.is_stock]
         if absent and st.eff_fallback:
-            p.append(f"  [dim]{len(absent)} absent id(s) alias to "
+            p.append(f"  [dim]{len(absent)} absent module id(s) alias to "
                      f"{st.mods[st.eff_fallback].name}[/]")
+        hidden = [m.key for m in stock.MODULES if m.key not in st.sel]
+        if hidden:
+            p.append(f"  [dim]{len(hidden)} stock effects hidden (no row; "
+                     f"still run for old projects)[/]")
+        p.append(f"  [dim]consumed by every remix: {', '.join(stock.CONSUMED)}"
+                 f" — their code is the donor region[/]")
         p.append("")
         dsp = [m for m in st.selected if m.dsp is not None]
         known = [m for m in dsp if m.key in st.words]
@@ -615,6 +645,9 @@ class RemixScreen(Screen):
             self.cursor = min(len(krows) - 1, self.cursor + 1)
         elif ev.key in ("up", "k"):
             self.cursor = max(0, self.cursor - 1)
+        elif ev.character in ("[", "]"):
+            self.app.state.move(self.current_key(),
+                                -1 if ev.character == "[" else +1)
         else:
             return
         self.rerender()
@@ -626,7 +659,11 @@ class RemixScreen(Screen):
         self.app.push_screen(HelpScreen(view))
 
     def action_toggle(self):
-        self.app.state.toggle(self.current_key())
+        st = self.app.state
+        k = self.current_key()
+        st.toggle(k)
+        if k in st.sel and st.mods[k].is_stock:
+            st.msg = f"{k}: stock row kept -- no code, no words, no clone"
         self.rerender()
 
     def action_fallback(self):

--- a/tools/remix/audition.py
+++ b/tools/remix/audition.py
@@ -141,6 +141,10 @@ def render(key, values, source, wet=False, tail=None, label="", log=print):
     mod = registry.by_key(key)
     if rig.category(mod) == rig.SYSTEM:
         _die(f"{mod.name} is not an effect")
+    if rig.category(mod) == rig.STOCK:
+        _die(f"{mod.key} is a stock effect: no local render yet (dsp_host "
+             f"carries its code, but send_probe has no layout letter for a "
+             f"stock id) -- hear it on the unit")
     source = pathlib.Path(source)
     OUT.mkdir(parents=True, exist_ok=True)
     stem = f"{label + '_' if label else ''}{source.stem}_{mod.name}"

--- a/tools/remix/index.py
+++ b/tools/remix/index.py
@@ -21,6 +21,8 @@ def main():
     print("MODULES  (modules/<name>/manifest.py)\n")
     for key in sorted(mods):
         m = mods[key]
+        if m.is_stock:
+            continue
         bits = []
         if m.menu is not None:
             bits.append(f"FX2 id 0x{m.menu.fx2_id:02x}")
@@ -38,6 +40,16 @@ def main():
                 m.knob_map().items(), key=lambda kv: kv[1]))
             print(f"      knobs: {knobs}")
         print()
+
+    from remix import stock
+    print("STOCK FX2 EFFECTS  (tools/remix/stock.py -- already in every image;\n"
+          "list one in a remix to KEEP its chooser row, by key)\n")
+    for m in stock.MODULES:
+        buf = "  [instance buffer -- not beside ChonVerb/Nimbus/BongDelay]" \
+            if m.claims is not None and m.claims.stock_instance_buffer else ""
+        print(f"  {m.key:<12} FX2 id 0x{m.menu.fx2_id:02x}  {m.doc}{buf}")
+    print(f"\n  consumed by every remix (their code is the donor region): "
+          f"{', '.join(stock.CONSUMED)}\n")
 
     print("REMIXES  (remixes/<name>.py)\n")
     for name in registry.remix_names():

--- a/tools/remix/ledger.py
+++ b/tools/remix/ledger.py
@@ -22,6 +22,14 @@ WHAT IS CHECKED, and how it knows:
   core-private Y     DERIVED by scanning the module's own source for
                      `y:>$09xx`. Low Y is per CORE, not per instance, so
                      every effect sharing a core shares these words.
+  stock buffers      declared (Claims.stock_instance_buffer, from a scan
+                     of the payload disassembly). A stock effect that takes
+                     an instance buffer from the host's bump allocator gets
+                     a PER-TRACK base -- the very addresses ChonVerb,
+                     Nimbus and BongDelay hardcode -- and the chooser is
+                     one list for all eight tracks, so the build cannot
+                     know which track it lands on. Refused beside any
+                     module with fixed Y buffers.
 
 Derived beats declared wherever it is possible: a scan cannot go stale. Its
 limit is that it only sees what the code actually references, so a word a
@@ -40,6 +48,8 @@ from __future__ import annotations
 
 import pathlib
 import re
+
+from remix.schema import YBase
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 
@@ -112,6 +122,29 @@ def check(selected) -> list[str]:
             clash("FX2 instance buffers", a.name, b.name,
                   "Y:0x4000-0xBFFF -- that region is per CORE, so only one "
                   "of them can be hosted on a given core; each works alone")
+
+    # ---- stock effects that allocate an instance buffer -------------------
+    # The allocator's bases are per TRACK SLOT (docs/DSP.md section 10):
+    # core 0 hands out Y:0x4000 / 0x8000 / 0x30000 / 0x34000, core 1
+    # Y:0x4000 / 0x8000 / 0x38000 / 0x3c000. ChonVerb's tank is all four of
+    # core 0's, Nimbus's line the first two, BongDelay's line core 1's last
+    # two -- so CHORUS on track 6 beside ChonVerb on track 5 writes into the
+    # tank. Each works perfectly alone, and which track the operator picks
+    # is not something an image can constrain, so the PAIR is refused.
+    fixed = [m for m in selected
+             if (getattr(m, "claims", None) is not None
+                 and m.claims.owns_fx2_buffers)
+             or (m.dsp is not None and m.dsp.ybase is not YBase.NEVER)]
+    stocked = [m for m in selected
+               if getattr(m, "claims", None) is not None
+               and m.claims.stock_instance_buffer]
+    for a in stocked:
+        for b in fixed:
+            clash("stock instance buffer", a.name, b.name,
+                  "the allocator's per-track buffer slots -- the stock "
+                  "effect's buffer lands on whichever track hosts it and "
+                  "that is where the module's fixed buffers are; the chooser "
+                  "cannot keep them on different cores")
 
     # ---- core-private Y ---------------------------------------------------
     # Low Y is per CORE. Two effects that can share a core share these words,

--- a/tools/remix/registry.py
+++ b/tools/remix/registry.py
@@ -8,6 +8,11 @@ registry refuses duplicate keys and ids.
 
 Directories whose name starts with `_` or `.` are skipped, which is what
 keeps `modules/_template/` out of every build.
+
+The STOCK FX2 effects (tools/remix/stock.py) are registered alongside, under
+their own keys ("FILTER", "CHORUS", ...), so a remix keeps one in the chooser
+by listing it exactly as it lists a module. They are Kind.STOCK: no code, no
+clone, no words -- the build writes only their chooser row.
 """
 
 from __future__ import annotations
@@ -82,6 +87,19 @@ def modules() -> dict[str, object]:
                     f"{seen_ids[m.menu.fx2_id]} and {d.name}")
             seen_ids[m.menu.fx2_id] = d.name
         seen_dirs[m.key] = d.name
+        found[m.key] = m
+    from remix import stock
+    for m in stock.MODULES:
+        if m.key in found:
+            raise SystemExit(f"module {seen_dirs[m.key]} claims the key "
+                             f"{m.key!r}, which is a stock effect's")
+        if m.menu.fx2_id in seen_ids:
+            raise SystemExit(
+                f"module {seen_ids[m.menu.fx2_id]} claims FX2 id "
+                f"0x{m.menu.fx2_id:02x}, which is stock {m.key}'s -- the "
+                f"dispatch tables are shared with FX1, so it would hijack "
+                f"that effect on both menus")
+        seen_ids[m.menu.fx2_id] = m.key
         found[m.key] = m
     _cache = found
     return found

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -22,6 +22,10 @@ here -- the manifest is the single place a module states what it is
           track 5, not track 1).
   INSERT  a DSP_EFFECT with a menu entry and no server role -- sits in both
           payloads, runs on any track.
+  STOCK   a stock FX2 effect the remix keeps in the chooser (Kind.STOCK,
+          tools/remix/stock.py) -- code already in both payloads, any
+          track. No knobs here: the workbench has no manifest for stock
+          params, and no local render yet either.
   SYSTEM  everything else: the SEND client, ColdFire patches. Plumbing the
           image needs, never something you put on a track.
 """
@@ -45,12 +49,14 @@ TRACKS = range(1, 9)
 # one place the workbench states it.
 PAYLOAD_TRACKS = {"A": range(5, 9), "B": range(1, 5)}
 
-SERVER, INSERT, SYSTEM = "server", "insert", "system"
+SERVER, INSERT, STOCK, SYSTEM = "server", "insert", "stock", "system"
 
 
 def category(mod) -> str:
     if mod.harness is not None and mod.harness.is_server:
         return SERVER
+    if mod.kind is Kind.STOCK:
+        return STOCK
     if mod.kind is Kind.DSP_EFFECT and mod.menu is not None:
         return INSERT
     return SYSTEM
@@ -59,7 +65,7 @@ def category(mod) -> str:
 def track_range(mod) -> range:
     """Tracks this module can be selected on. Empty range for SYSTEM."""
     cat = category(mod)
-    if cat == INSERT:
+    if cat in (INSERT, STOCK):
         return TRACKS
     if cat == SYSTEM:
         return range(0)

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -33,6 +33,25 @@ class Kind(Enum):
     DSP_CLIENT = "dsp_client"   # DSP code + menu entry, but serves no bus
     CF_PATCH = "cf_patch"       # ColdFire behaviour only, no DSP code
     HYBRID = "hybrid"           # both, e.g. an engine plus a display cave
+    STOCK = "stock"             # a STOCK FX2 effect kept in the chooser: no
+                                # code, no clone, no words -- its descriptor
+                                # and dispatch are already in the image
+                                # (tools/remix/stock.py is the whole list)
+
+
+# The fifteen FX2 ids stock assigns (docs/PARAM_PAGES.md section 2). Both
+# dispatch tables (X:0x215 init / X:0x235 process) are indexed by the RAW id
+# and are SHARED BETWEEN FX1 AND FX2, so a module that answers to one of
+# these hijacks the stock effect on both menus: its descriptor replaces the
+# stock one in FX2_IDS and its code replaces the stock code wherever that id
+# is selected, FX1 included. Found 2 Sep 2026 by making the stock effects
+# first-class: Rungs had shipped on 0x0c (EQUALIZER's id) and Nimbus on 0x0d
+# (DJ EQ's), so every image built since 29 Aug 2026 ran Rungs where FX1
+# selected EQUALIZER -- and the remixes WITHOUT Rungs aliased 0x0c to SEND,
+# which took FX1's EQUALIZER away in the shipping chongbong image too. Only
+# a Kind.STOCK module may carry one of these.
+STOCK_FX2_IDS = frozenset({0x04, 0x05, 0x08, 0x0c, 0x0d, 0x10, 0x11, 0x12,
+                           0x13, 0x14, 0x15, 0x16, 0x18, 0x19, 0x1c})
 
 
 class YBase(Enum):
@@ -256,6 +275,21 @@ class Claims:
     # down honestly. The shared window's are not, and a plausible claim
     # there would read as a guarantee.
     owns_fx2_buffers: bool = False
+    # A STOCK effect that allocates an FX2 instance buffer through the host's
+    # bump allocator (it reads X:0x213 at init -- docs/DSP.md section 10).
+    # The allocator hands the buffer out PER TRACK SLOT: on core 0 the four
+    # slots are Y:0x4000, 0x8000, 0x30000 and 0x34000, on core 1 0x4000,
+    # 0x8000, 0x38000 and 0x3c000 -- and those are exactly the addresses
+    # ChonVerb's tank, Nimbus's line and BongDelay's line hardcode. So a
+    # buffered stock effect on the wrong track silently corrupts a server
+    # on the same core, and the chooser is one list for all eight tracks,
+    # so the build cannot tell which track it will land on. The ledger
+    # refuses the pair. Measured 2 Sep 2026 by scanning the payload
+    # disassembly for `x:>$213` reads: SPATIALIZER, FLANGER, CHORUS and
+    # COMB read it; FILTER, EQ, DJ EQ, PHASER, COMPRESSOR and LO-FI do not.
+    # (Falsifier: an effect reaching its base another way -- dsp_host's
+    # -guard would show a stray write.)
+    stock_instance_buffer: bool = False
 
 
 @dataclass(frozen=True)
@@ -293,6 +327,18 @@ class Module:
         if self.params and len(self.params) != 12:
             raise ValueError(f"{self.name}: expected 12 param slots, "
                              f"got {len(self.params)}")
+        if (self.menu is not None and self.kind is not Kind.STOCK
+                and self.menu.fx2_id in STOCK_FX2_IDS):
+            raise ValueError(
+                f"{self.name}: fx2 id 0x{self.menu.fx2_id:02x} belongs to a "
+                f"STOCK effect -- the dispatch tables are shared with FX1, so "
+                f"this id would hijack that effect on both menus (see "
+                f"STOCK_FX2_IDS). Free ids: "
+                f"{', '.join(f'0x{i:02x}' for i in range(0x04, 0x20) if i not in STOCK_FX2_IDS)}")
+        if self.kind is Kind.STOCK and (self.dsp is not None or self.params
+                                        or self.cf_patches):
+            raise ValueError(f"{self.name}: a STOCK entry carries no code, "
+                             f"params or caves -- they are already in the image")
         # Page 2's three selects ARE the three companion byte fields, so a
         # stepped control can only physically live on 7, 9 or 11.
         for i, p in enumerate(self.params):
@@ -315,6 +361,13 @@ class Module:
     def is_cf_patch(self) -> bool:
         return bool(self.cf_patches)
 
+    @property
+    def is_stock(self) -> bool:
+        """A stock FX2 effect kept in the chooser: nothing is cloned, placed
+        or measured for it; the build only writes its list row and cursor
+        position."""
+        return self.kind is Kind.STOCK
+
     def knob_map(self) -> dict[str, int]:
         """Panel label -> slot index, for the test harness.
 
@@ -334,6 +387,14 @@ class Remix:
     order IS their row on the panel. Modules with no menu entry (a ColdFire
     patch, say) may sit anywhere in the list; they are filtered out where a
     chooser order is wanted.
+
+    STOCK effects are listed by the same keys ("FILTER", "CHORUS", ...):
+    tools/remix/stock.py. A stock effect NOT listed is not removed from the
+    image -- its code, descriptor and dispatch stay stock, so an old project
+    that selects it still runs it -- it just has no chooser row, which is
+    what every remix did to all fourteen of them before 2 Sep 2026. Only
+    the three reverbs are actually consumed (their code is the donor region
+    every module packs into) and they cannot be listed.
 
     THE FALLBACK IS NOT OPTIONAL, and it is the question a selective build
     forces. The FX2 chooser is one list shared by all eight tracks, and a

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -17,10 +17,11 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from remix import ledger  # noqa: E402
 from remix.schema import (CavePatch, Claims, DspSection, Kind, MenuEntry,  # noqa: E402
-                          Module, Param)
+                          Module, Param, YBase)
 
 
-def _effect(name, fx2_id, priority=0, reserved=(), buffers=False):
+def _effect(name, fx2_id, priority=0, reserved=(), buffers=False,
+            ybase=YBase.NEVER):
     return Module(
         name=name, key=name.upper(), kind=Kind.DSP_EFFECT,
         doc="fixture",
@@ -30,9 +31,20 @@ def _effect(name, fx2_id, priority=0, reserved=(), buffers=False):
         # No asm path on disk, so the ledger's scan finds nothing and only
         # the reserved words below are claimed -- which is what lets these
         # fixtures test the claim path in isolation.
-        dsp=DspSection(asm="does/not/exist.asm", priority=priority),
+        dsp=DspSection(asm="does/not/exist.asm", priority=priority,
+                       ybase=ybase),
         claims=Claims(reserved_private_y=reserved,
                       owns_fx2_buffers=buffers),
+    )
+
+
+def _stock(name, fx2_id, buffer):
+    """A stock FX2 effect as the registry carries it (tools/remix/stock.py)."""
+    return Module(
+        name=name, key=name.upper(), kind=Kind.STOCK, doc="fixture",
+        menu=MenuEntry(fx2_id=fx2_id, donor_desc=0x400d4772,
+                       abbr=b"STK", fullname=b"Stock"),
+        claims=Claims(stock_instance_buffer=buffer) if buffer else None,
     )
 
 
@@ -57,19 +69,38 @@ CASES = [
       _cave("beta", 0x400d7100, hook_addr=0x40004d40)], "hook site"),
     ("two effects claiming one core-private Y word",
      [_effect("alpha", 0x07, reserved=(0x0905,)),
-      _effect("beta", 0x08, reserved=(0x0905,))], "core-private Y"),
+      _effect("beta", 0x1e, reserved=(0x0905,))], "core-private Y"),
     # The shape this one guards is a module that works perfectly in every
     # test done alone: ChonVerb's tank and Nimbus's granular line are both
     # hardcoded into Y:0x4000-0xBFFF, which is per CORE.
     ("two effects owning the FX2 instance buffer region",
      [_effect("alpha", 0x07, buffers=True),
-      _effect("beta", 0x08, buffers=True)], "FX2 instance buffers"),
+      _effect("beta", 0x1e, buffers=True)], "FX2 instance buffers"),
+    # A BUFFERED stock effect takes a per-track base from the host's
+    # allocator, and those bases are the addresses the servers hardcode:
+    # CHORUS on T6 beside ChonVerb on T5 writes into the tank. Refused
+    # beside a module that owns the region ...
+    ("a buffered stock effect beside a module owning FX2 buffers",
+     [_stock("chorus", 0x12, True), _effect("beta", 0x07, buffers=True)],
+     "stock instance buffer"),
+    # ... and beside one whose lines live in the shared window (BongDelay:
+    # ybase ALWAYS), which is core 1's tracks 3-4 slots.
+    ("a buffered stock effect beside a shared-window module",
+     [_stock("comb", 0x13, True), _effect("beta", 0x07, ybase=YBase.ALWAYS)],
+     "stock instance buffer"),
 ]
 
 CLEAN = [_effect("alpha", 0x07, reserved=(0x0905,)),
-         _effect("beta", 0x08, reserved=(0x0906,)),
+         _effect("beta", 0x1e, reserved=(0x0906,), buffers=True),
          _cave("gamma", 0x400d7000, 64, hook_addr=0x40004d40),
-         _cave("delta", 0x400d7040, 64, hook_addr=0x40004d50)]
+         _cave("delta", 0x400d7040, 64, hook_addr=0x40004d50),
+         # Stock effects with NO buffer sit beside anything, and two
+         # buffered stock effects sit beside each other (the allocator
+         # keeps them apart -- that is what it is for).
+         _stock("filter", 0x04, False),
+         _stock("compressor", 0x18, False)]
+CLEAN_STOCK_PAIR = [_stock("chorus", 0x12, True), _stock("comb", 0x13, True),
+                    _effect("alpha", 0x07)]
 
 
 def main():
@@ -85,12 +116,25 @@ def main():
             bad += 1
             print(f"  [FAIL] {label}: expected a {expect!r} collision naming "
                   f"both modules, got {found}")
-    found = ledger.check(CLEAN)
-    if found:
+    for label, mods in (("modules that do not collide", CLEAN),
+                        ("two buffered stock effects + a zero-buffer insert",
+                         CLEAN_STOCK_PAIR)):
+        found = ledger.check(mods)
+        if found:
+            bad += 1
+            print(f"  [FAIL] {label} were reported: {found}")
+        else:
+            print(f"  [PASS] {label} are left alone")
+
+    # A module on a STOCK id would hijack that effect on BOTH menus (the
+    # dispatch tables are shared with FX1). Rungs shipped on EQUALIZER's
+    # 0x0c and Nimbus on DJ EQ's 0x0d before this line existed (2 Sep 2026).
+    try:
+        _effect("hijack", 0x0c)
         bad += 1
-        print(f"  [FAIL] modules that do not collide were reported: {found}")
-    else:
-        print("  [PASS] modules that do not collide are left alone")
+        print("  [FAIL] a module on a stock FX2 id (0x0c, EQUALIZER) was accepted")
+    except ValueError:
+        print("  [PASS] a module on a stock FX2 id is refused")
 
     # ---- the rig's derivations (tools/remix/rig.py) ---------------------
     # The track model is DERIVED, so hold the derivation to the measured
@@ -105,7 +149,7 @@ def main():
                     if mod.dsp.payloads == frozenset({"A"})
                     else rig.PAYLOAD_TRACKS["B"])
             ok = len(mod.dsp.payloads) == 1 and tr == want
-        elif cat == rig.INSERT:
+        elif cat in (rig.INSERT, rig.STOCK):
             ok = tr == rig.TRACKS
         else:
             ok = len(tr) == 0
@@ -165,7 +209,7 @@ def main():
     # (Length is capped so the help row stays one line; the schema already
     # pins labels to the declared count.)
     for mod in registry.modules().values():
-        if mod.menu is None:
+        if mod.menu is None or mod.is_stock:
             continue
         undocumented = [p.name.decode() for p in mod.params
                         if p.name and p.active and not p.doc]

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -33,6 +33,11 @@ class State:
         self.mods = registry.modules()
         self.keys = sorted(self.mods)
         self.sel: set[str] = set()
+        # Chooser ORDER. A remix's module list is ordered and that order is
+        # the panel's row order, so the composer keeps it too -- the old set
+        # alone wrote every saved remix alphabetically, which silently
+        # reordered the chooser on save.
+        self.order: list[str] = []
         self.fallback: str | None = None
         self.cursor = 0
         self.words: dict[str, int] = {}      # key -> words, from a real build
@@ -47,20 +52,36 @@ class State:
             return
         r = registry.remix(name)
         self.sel = set(r.modules)
+        self.order = list(r.modules)
         self.fallback = r.fallback
         self.msg = f"loaded remix {name!r}"
 
     def toggle(self, key):
         if key in self.sel:
             self.sel.discard(key)
+            self.order.remove(key)
             if self.fallback == key:
                 self.fallback = None
         else:
             self.sel.add(key)
+            self.order.append(key)
+
+    def move(self, key, delta):
+        """Shift a selected module earlier (-1) or later (+1) in chooser order."""
+        if key not in self.sel:
+            self.msg = "select it first -- only selected modules have a row"
+            return
+        i = self.order.index(key)
+        j = max(0, min(len(self.order) - 1, i + delta))
+        self.order[i], self.order[j] = self.order[j], self.order[i]
+        rows = [m.key for m in self.menu_modules]
+        self.msg = (f"{self.mods[key].name} -> chooser row {rows.index(key)}"
+                    if key in rows else "no menu entry: order is moot")
 
     @property
     def selected(self):
-        return [self.mods[k] for k in self.keys if k in self.sel]
+        """Selected modules in CHOOSER order (the remix's declared order)."""
+        return [self.mods[k] for k in self.order]
 
     @property
     def menu_modules(self):
@@ -75,9 +96,8 @@ class State:
         automatic pick (any real effect would PROCESS the unknown id), so
         return None and let problems() ask for an explicit choice.
         """
-        for k in self.keys:
-            if k in self.sel and self.mods[k].name == "send" \
-                    and self.mods[k].menu is not None:
+        for k in self.order:
+            if self.mods[k].name == "send" and self.mods[k].menu is not None:
                 return k
         menu = [m.key for m in self.menu_modules]
         return menu[0] if len(menu) == 1 else None
@@ -184,7 +204,7 @@ class State:
 
     # ---- saving ---------------------------------------------------------
     def as_remix(self, name, doc):
-        mods = ", ".join(f'"{k}"' for k in self.keys if k in self.sel)
+        mods = ", ".join(f'"{k}"' for k in self.order)
         fb = f'"{self.eff_fallback}"' if self.eff_fallback else "None"
         return (f'"""{name} -- {doc}\n\n'
                 f'Written by the remix workbench. Edit freely: the docstring\n'

--- a/tools/remix/stock.py
+++ b/tools/remix/stock.py
@@ -1,0 +1,87 @@
+"""The stock FX2 effects, as things a remix can keep in the chooser.
+
+Every octabam image replaces the FX2 chooser wholesale with the remix's
+modules. Until 2 Sep 2026 that hid all fourteen stock FX2 effects, although
+only three of them are actually CONSUMED -- PLATE, SPRING and DARK REV,
+whose 2,724 words of DSP code are the donor region every module packs into.
+The other eleven keep their code, their descriptor and their dispatch
+entries in every image; they merely had no chooser row. This table makes
+them first-class so a remix can list them by name, in chooser order, next
+to the modules -- and so the composer can say what is kept, what is hidden
+and what is replaced instead of leaving the operator to guess.
+
+A stock entry costs NOTHING: no clone (its descriptor is where stock put
+it), no placement (its code is where stock put it), no words, no cycles
+charged by `make cycles` (which cannot see it -- the FILTER figure of 192
+cycles is the only one measured, docs/CHIP.md). What the build writes for
+it is its list row and its cursor position, and nothing else.
+
+Two of them are special:
+
+  DELAY (0x08)   the Echo Freeze delay. Its DSP dispatch is stock's null
+                 stub -- a passthrough -- because the delay itself runs on
+                 the ColdFire (DMA over SDRAM rings, docs/EXTERNAL.md). It
+                 works from this row exactly as it does on a stock unit.
+  the four with  SPATIALIZER, FLANGER, CHORUS, COMB allocate an FX2
+  a buffer       instance buffer through the host's bump allocator (they
+                 read X:0x213 at init; docs/DSP.md section 10), and the
+                 allocator hands out per-TRACK bases that are exactly the
+                 addresses ChonVerb, Nimbus and BongDelay hardcode. The
+                 ledger refuses them beside any module with fixed Y
+                 buffers; see Claims.stock_instance_buffer.
+
+Addresses are the descriptors' E addresses from docs/PARAM_PAGES.md
+section 2 (P = E + 0x38 is what the chooser list holds). Words are the
+module spans from docs/DSP.md section 7c, for the index only.
+"""
+
+from __future__ import annotations
+
+from remix.schema import Claims, Kind, MenuEntry, Module
+
+
+def _stock(key, name, fx2_id, desc, abbr, fullname, words, doc, buffer=False):
+    return Module(
+        name=name, key=key, kind=Kind.STOCK, doc=doc,
+        menu=MenuEntry(fx2_id=fx2_id, donor_desc=desc, abbr=abbr,
+                       fullname=fullname),
+        claims=Claims(stock_instance_buffer=buffer) if buffer else None,
+    )
+
+
+# Chooser order here is stock's own (docs/PARAM_PAGES.md: FLTR->1 ... DARK->14).
+MODULES = (
+    _stock("FILTER", "filter", 0x04, 0x400d4772, b"FLTR", b"FILTER", 727,
+           "Stock multimode filter, the default FX1 effect. 727 words, "
+           "~192 cycles measured."),
+    _stock("EQUALIZER", "equalizer", 0x0c, 0x400d4c28, b"EQ", b"EQUALIZER", 282,
+           "Stock two-band parametric EQ."),
+    _stock("DJ EQ", "djeq", 0x0d, 0x400d4dba, b"DJEQ", b"DJ EQUALIZER", 345,
+           "Stock three-band DJ kill EQ."),
+    _stock("PHASER", "phaser", 0x10, 0x400d4f4c, b"PHSR", b"PHASER", 207,
+           "Stock phaser."),
+    _stock("FLANGER", "flanger", 0x11, 0x400d50de, b"FLNG", b"FLANGER", 289,
+           "Stock flanger. Allocates an instance buffer.", buffer=True),
+    _stock("CHORUS", "chorus", 0x12, 0x400d5270, b"CHOR", b"CHORUS", 329,
+           "Stock chorus. Allocates an instance buffer.", buffer=True),
+    _stock("SPATIALIZER", "spatializer", 0x05, 0x400d4904, b"SPAT",
+           b"SPATIALIZER", 261,
+           "Stock stereo spatializer. Allocates an instance buffer.",
+           buffer=True),
+    _stock("COMB FILTER", "comb", 0x13, 0x400d5402, b"COMB", b"COMB FILTER", 277,
+           "Stock comb filter. Allocates an instance buffer.", buffer=True),
+    _stock("COMPRESSOR", "compressor", 0x18, 0x400d5a4a, b"COMP", b"COMPRESSOR",
+           180, "Stock compressor."),
+    _stock("LO-FI", "lofi", 0x1c, 0x400d5d6e, b"LOFI", b"LO-FI", 537,
+           "Stock lo-fi (bit/rate reduction, distortion)."),
+    _stock("DELAY", "delay", 0x08, 0x400d4a96, b"DEL", b"DELAY", 0,
+           "Stock Echo Freeze delay -- runs on the ColdFire, so it costs the "
+           "DSP nothing; the row works as on a stock unit."),
+)
+
+# What every remix consumes, whether it lists anything or not: the three
+# reverbs whose code IS the donor region. Named here so the composer can
+# say so rather than leaving it to be inferred from a manifest comment.
+CONSUMED = ("PLATE REV", "SPRING REV", "DARK REV")
+
+BY_KEY = {m.key: m for m in MODULES}

--- a/tools/verify_menu.py
+++ b/tools/verify_menu.py
@@ -43,7 +43,11 @@ STOCK = pathlib.Path("out/raw/section_3_MAIN_OS.bin")
 BUILT = pathlib.Path("out/mainos_bus.bin")
 
 FX2_IDS = 0x400d5fdc
-FX2_LIST_LIVE = 0x400d6b00              # NEW_LIST, after the 3 refs repoint
+# Where the list lives: NEW_LIST (0x400d6b00, seven rows) or the LONG list
+# at the tail of the zero run (0x400d7bbc, up to 32) when a remix keeps
+# stock rows. Read from the image's own list refs rather than assumed.
+LIST_CAVES = (0x400d6b00, 0x400d7bbc)
+CHOOSER_ROWS = 7                        # the screen's rows; longer lists scroll
 ID2POS = 0x400d6150
 LIST_REFS = [0x400375f4, 0x40052496, 0x40059a42]
 FX1_ID_LOOKUP = 0x400d5f58
@@ -60,6 +64,10 @@ _MODS = _reg.modules()
 _ORDER = [k for k in REMIX.modules if _MODS[k].menu is not None]
 EXPECT = {k: (_MODS[k].menu.fx2_id, i) for i, k in enumerate(_ORDER)}
 N_REAL = len(EXPECT)                    # no NONE entry any more
+# STOCK rows (tools/remix/stock.py): the build writes their list row and
+# cursor position only, so what is checked for them is that everything
+# else -- descriptor bytes, FX2_IDS entry -- is byte-identical to stock.
+STOCK_KEYS = {k for k in _ORDER if _MODS[k].is_stock}
 FALLBACK = REMIX.fallback               # id 0 and every absent id alias here
 ROWCOUNT_AT = 0x40059a56
 NONE_ID = 0x00                          # aliased to SEND
@@ -78,7 +86,8 @@ P_PENABLE_HI = 0x18a                    # params 8..11
 # declares -- the R19 formatter-gate class of bug. What no static check can
 # see is a manifest that under-declares its own effect; that class rides the
 # standing on-unit reconfirm rule (docs/PARAM_PAGES.md).
-ACTIVE_PARAMS = {k: _MODS[k].active_params for k in _ORDER}
+ACTIVE_PARAMS = {k: _MODS[k].active_params for k in _ORDER
+                 if k not in STOCK_KEYS}
 
 
 # P-relative: the per-parameter value-COUNT array and the defaults array.
@@ -115,10 +124,15 @@ def main():
 
     print("=== FUN_40052474 / FUN_4005996c both embed 0x400d6090 as an "
           "absolute operand at these 3 sites (GhidraChooser.java found them "
-          "inside those two functions); confirm the operand now reads NEW_LIST ===")
+          "inside those two functions); confirm all three now read the SAME "
+          "relocated list, in one of the two list caves ===")
+    FX2_LIST_LIVE = rd32(img, LIST_REFS[0])
+    check(FX2_LIST_LIVE in LIST_CAVES,
+          f"list ref 0x{LIST_REFS[0]:08x} points into a list cave "
+          f"(0x{FX2_LIST_LIVE:08x})")
     for r in LIST_REFS:
         check(rd32(img, r) == FX2_LIST_LIVE,
-              f"list-ref operand at 0x{r:08x} == NEW_LIST (0x{FX2_LIST_LIVE:08x})")
+              f"list-ref operand at 0x{r:08x} == 0x{FX2_LIST_LIVE:08x}")
 
     print("\n=== FUN_4005996c's list-length scan: walk FX2_LIST to the "
           "terminator, exactly as the decompiled do/while does ===")
@@ -137,7 +151,9 @@ def main():
           "terminator (the hardware-test-1 garbage) ===")
     check(length == N_REAL, f"list length == {N_REAL} (got {length})")
     rows = int.from_bytes(img[ROWCOUNT_AT - BASE:ROWCOUNT_AT - BASE + 2], "big")
-    check(rows == N_REAL, f"viewport row count == {N_REAL} (got {rows})")
+    want_rows = min(CHOOSER_ROWS, N_REAL)
+    check(rows == want_rows, f"viewport row count == {want_rows} (got {rows})"
+          + (" -- the list scrolls" if N_REAL > CHOOSER_ROWS else ""))
 
     print(f"\n=== id 0 (a fresh/unassigned track) is aliased to the remix's "
           f"fallback ({FALLBACK}), so every track degrades to it by default ===")
@@ -178,6 +194,13 @@ def main():
           "E instead of P and losing the record's last 0x38 bytes ===")
     for name, (fx_id, pos) in EXPECT.items():
         P = rd32(img, FX2_IDS + fx_id * 4)
+        if name in STOCK_KEYS:
+            # Nothing of a stock row is ours to check but its untouchedness.
+            check(P == rd32(stock, FX2_IDS + fx_id * 4),
+                  f"{name}: FX2_IDS[0x{fx_id:02x}] is stock's own descriptor")
+            check(img[P - BASE:P - BASE + 0x192] == stock[P - BASE:P - BASE + 0x192],
+                  f"{name}: stock descriptor bytes at P=0x{P:08x} unchanged")
+            continue
         lo, hi = rd32(img, P + P_PENABLE_LO), rd32(img, P + P_PENABLE_HI)
         got = {i for i in range(12)
                if ((lo if i < 8 else hi) >> (4 * (i if i < 8 else i - 8))) & 1}


### PR DESCRIPTION
## What

- **Stock FX2 effects are first-class remix entries** (`tools/remix/stock.py`, `Kind.STOCK`). Only PLATE/SPRING/DARK REV are consumed by any image; the other 11 were merely unlisted. A remix keeps one by listing its key in chooser order; cost is zero (list row + ID2POS only). `verify_menu` checks their descriptors and id entries are byte-identical to stock.
- **>7 chooser rows**: list relocates to `LONG_LIST` (0x400d7bbc, 32 entries), viewport capped at 7 → scrolls. `remixes/restored.py` = chongbong + FILTER/EQ/DJ EQ/PHASER/COMP/LO-FI/DELAY (10 rows). ⚠️ Unflashed — scrolling our relocated list is inferred from stock's 15-row list.
- **Ledger rule**: SPATIALIZER/FLANGER/CHORUS/COMB allocate a per-track instance buffer (`x:>$213` scan) on the servers' hardcoded addresses → refused beside `owns_fx2_buffers` / `ybase != NEVER` modules. Selftest covers both directions.
- **Composer**: STOCK FX2 group, `[`/`]` reorder, "consumed / hidden" lines; saved remixes keep selection order (they were written alphabetically). Rig offers stock effects; audition refuses with a reason (no local render yet).
- **Latent bug fixed**: DSP dispatch tables are shared FX1/FX2 by raw id. Rungs (0x0c = EQUALIZER) and Nimbus (0x0d = DJ EQ) hijacked those effects on FX1 in every local image since 29 Aug; chongbong aliased FX1's EQ/DJ EQ to SEND. Never flashed (unit on tag 77). Moved to 0x17/0x1a; schema rejects `STOCK_FX2_IDS`.

## Proof

- `make check` green on `chongbong` and `restored`; mutables/nimbus/verbonly/warped build + verify_menu green.
- `scripts/refhash.sh check`: **26/26 bit-identical** against a baseline of main + only the id move → the build refactor is inert.
- Byte-diff of the shipping image vs main: 42 bytes, exactly the 23 fields of ids 0x0c/0x0d/0x17/0x1a (FX2_IDS, ID2POS, both cores' dispatch).
- Headless Textual Pilot run: STOCK group renders, toggle/reorder/refusal/save order all as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)