### PR TITLE
Stock effects render in the rig (descriptor knobs, pristine dump, MPYRI emulator patch)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -91,7 +91,14 @@ plus the seven that can sit beside the servers; the other four allocate a
 per-track instance buffer on the addresses the servers hardcode and the
 ledger refuses them beside one. Past seven rows the list relocates and the
 panel scrolls — ⚠️ inferred from stock's fifteen-row list, unflashed.
-`docs/MODULES.md` "Keeping STOCK effects in the chooser".
+`docs/MODULES.md` "Keeping STOCK effects in the chooser". Later the same
+day the rig learned to **render them**: knobs read from the stock
+descriptors, audio from a dump of the pristine image through `dsp_host`.
+Nine of eleven render credibly; DELAY cannot (ColdFire-side); FLANGER's
+render is not credible and is open (a negative-immediate `mpyi` is the
+suspect). LO-FI needed the project's first patch to the vendored emulator
+(`tools/dsp56300.patch`, MPYRI) — worth knowing: stock code exercises
+instructions our own modules never did.
 
 Making them first-class exposed a latent id collision: the DSP dispatch
 tables are shared between FX1 and FX2, and Rungs (`0x0c`) and Nimbus

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -208,9 +208,36 @@ Two rules, both enforced:
   and is unflashed.
 
 Stock rows appear in the workbench (a STOCK FX2 group in the composer, any
-track in the rig) but have no manifest knobs and **no local render yet**:
-`send_probe` has no layout letter for a stock id, so the audition says so
-instead of rendering a plausible passthrough.
+track in the rig) **with their real knobs**: `stock.py` reads each
+descriptor's names, defaults, value counts and enable bitmap out of the
+pristine image (`out/raw/section_3_MAIN_OS.bin`), so `knob_map()`,
+`send_probe --set NAME=VAL` and the rig's knob rows all work by the panel's
+own names (a duplicated label, FILTER's two Qs, gets a `2` suffix on the
+later slot). Nothing is ever written back — a stock row is not cloned.
+Each has a `layout_char` (L E J P A C Z O K I Y), so `--pick` takes it —
+or, more usefully, the key or name: `--pick chorus`.
+
+**They render locally the way an insert does**, from a dump of the STOCK
+image's payload A (`out/dsp/_stock_A.mem`, made once by the audition):
+the pristine dump, because a DEV build takes CHORUS as a fourth donor and
+every build null-stubs the reverbs. dsp_host's `-alloc 1` gives a buffered
+effect Y:0x4000, as the hardware gives track 1. Measured 2 Sep 2026 on a
+438 Hz tone at 0.5 FS:
+
+| effect | result |
+|---|---|
+| FILTER | unity at defaults; BASE=20 WDTH=10 Q=100 takes the tone down 27 dB |
+| EQ, DJ EQ, PHASER, COMPRESSOR | pass at defaults, THD −44…−54 dB |
+| CHORUS | MIX=0 is exactly dry; MIX=127 puts sidebands on the tone (THD −31 dB) |
+| SPATIALIZER, COMB | render, COMB's THD −36 dB is its comb |
+| LO-FI | rendered only after `tools/dsp56300.patch`: the vendored emulator had `mpyri` unimplemented in both interpreter and JIT and aborted at init |
+| DELAY | **no DSP code** — the Echo Freeze delay is ColdFire-side; the audition refuses with that reason |
+| FLANGER | **not credible**: MIX=0 is not dry, DEP=0/FB=0 still measures THD −2 dB (hash), all-zero knobs give near silence. Its process loop multiplies by a NEGATIVE immediate (`mpyi #>$f84c00`), which is the standing suspect for an emulator sign-handling defect; falsifier: a three-instruction probe of `mpyi` with that immediate in dsp_host. Open. |
+
+⚠️ These are emulator renders of stock code that was never exercised under
+`dsp_host` before; the servers and inserts were written against it. A
+stock effect that sounds wrong locally is evidence about the emulator
+before it is evidence about the effect.
 
 ---
 

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -113,6 +113,19 @@ allocate a per-track buffer (SPAT, FLNG, CHOR, COMB) are refused beside
 ChonVerb, Nimbus or BongDelay, with the reason. Past seven rows the panel
 scrolls, and the composer says that too. `docs/MODULES.md` has the rules.
 
+In the RIG a stock effect shows its **real knobs** — names, defaults and
+value counts read from the stock descriptor in the pristine image (a
+select shows its count, not stock's word labels) — and **renders** like
+an insert, from a one-time dump of the stock image's payload A
+(`out/dsp/_stock_A.mem`), so nothing about the currently built remix
+matters. Nine of the eleven render credibly (2 Sep 2026: FILTER, EQ,
+DJ EQ, PHASER, CHORUS, SPATIALIZER, COMB, COMPRESSOR, LO-FI — LO-FI
+needed an emulator patch, `tools/dsp56300.patch`, for the `mpyri`
+instruction). Two do not: **DELAY** runs on the ColdFire, so there is no
+DSP code to render and the audition says so; **FLANGER** renders but its
+output is not credible — MIX=0 is not dry and DEP=0/FB=0 still measures
+as broadband hash — cause open (`docs/MODULES.md`).
+
 ![The REMIX view: modules grouped by category with track ranges, the FX2
 menu as the unit will draw it, and the ledger's verdict —
 chongbong loaded](img/workbench-remix.png)
@@ -260,8 +273,9 @@ through `rich.markup.escape`.
 
 ## Known gaps
 
-- Stock rows have no knobs in the rig and no local render (the audition
-  says so rather than rendering a passthrough).
+- DELAY (stock) has no local render (ColdFire-side); FLANGER's local
+  render is not credible (open). Stock select labels are counts, not
+  stock's word labels.
 - A/B marks attach only to the most recent render (no history cursor).
 - No browse-anywhere source picker (one fixed directory, `out/dry/`).
 - Wet-only rendering is ChonVerb-only.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -91,6 +91,15 @@ if [ ! -x "$DIS" ]; then
     [ -d vendor/dsp56300 ] || git clone --depth 1 \
       https://github.com/dsp56300/dsp56300.git vendor/dsp56300
     git -C vendor/dsp56300 submodule update --init --depth 1 --recursive
+    # MPYRI (immediate multiply, rounded) is unimplemented upstream in both
+    # the interpreter and the JIT; Elektron's stock LO-FI uses it, so a
+    # render of LO-FI aborted with "Not Implemented: MPYRI" (2 Sep 2026).
+    EMUPATCH=$(pwd)/tools/dsp56300.patch
+    if git -C vendor/dsp56300 apply --check "$EMUPATCH" 2>/dev/null; then
+      git -C vendor/dsp56300 apply "$EMUPATCH" && echo "   emulator patch applied (MPYRI)"
+    else
+      echo "   emulator patch already applied (or upstream changed: check $EMUPATCH)"
+    fi
     stage_dsp_host
     cmake -S vendor/dsp56300 -B vendor/dsp56300/build -DCMAKE_BUILD_TYPE=Release \
       && cmake --build vendor/dsp56300/build \

--- a/tools/dsp56300.patch
+++ b/tools/dsp56300.patch
@@ -1,0 +1,73 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index ffbf791..350a71a 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -56,3 +56,5 @@ if(DSP56300_DEBUGGER)
+ 
+ 	set_property(TARGET dsp56kDebugger PROPERTY FOLDER "dsp56300")
+ endif()
++
++add_subdirectory(dsp_host)
+diff --git a/source/dsp56kEmu/dsp_ops_alu.inl b/source/dsp56kEmu/dsp_ops_alu.inl
+index 386e30f..996c82a 100644
+--- a/source/dsp56kEmu/dsp_ops_alu.inl
++++ b/source/dsp56kEmu/dsp_ops_alu.inl
+@@ -1160,7 +1160,16 @@ namespace dsp56k
+ 	}
+ 	inline void DSP::op_Mpyri(const TWord op)
+ 	{
+-		errNotImplemented("MPYRI");
++		// MPYI, then round -- the same shape as Mpyr_SD against Mpy_SD.
++		const bool	ab = getFieldValue<Mpyri, Field_d>(op);
++		const bool	negate = getFieldValue<Mpyri, Field_k>(op);
++		const TWord qq = getFieldValue<Mpyri, Field_qq>(op);
++
++		const TReg24 s		= TReg24(immediateDataExt<Mpyri>());
++		const TReg24 reg	= decode_qq_read(qq);
++
++		alu_mpy( ab, reg, s, negate, false );
++		alu_rnd( ab );
+ 	}
+ 	inline void DSP::op_Neg(const TWord op)
+ 	{
+diff --git a/source/dsp56kEmu/jitops.h b/source/dsp56kEmu/jitops.h
+index 0be2c03..5d51f90 100644
+--- a/source/dsp56kEmu/jitops.h
++++ b/source/dsp56kEmu/jitops.h
+@@ -240,7 +240,7 @@ namespace dsp56k
+ 		template<Instruction Inst, bool Accumulate> void op_Mpy_su(TWord op);
+ 		void op_Mpyi(TWord op);
+ 		void op_Mpyr_S1S2D(TWord op)			{ alu_multiply(op); }
+-		void op_Mpyri(TWord op)					{ errNotImplemented(op); }
++		void op_Mpyri(TWord op);
+ 		void op_Neg(TWord op);
+ 		void op_Nop(TWord op);
+ 		void op_Norm(TWord op)					{ errNotImplemented(op); }
+diff --git a/source/dsp56kEmu/jitops_alu.cpp b/source/dsp56kEmu/jitops_alu.cpp
+index f9f8180..714776e 100644
+--- a/source/dsp56kEmu/jitops_alu.cpp
++++ b/source/dsp56kEmu/jitops_alu.cpp
+@@ -999,6 +999,23 @@ namespace dsp56k
+ 		alu_mpy(ab, reg, s, negate, false, false, false, false);
+ 	}
+ 
++	// MPYRI: MPYI with the result rounded (Mpyri differs from Mpyi only in
++	// the low opcode bits). Elektron's LO-FI effect uses `mpyri #>$2000,x1,a`.
++	void JitOps::op_Mpyri(TWord op)
++	{
++		const bool	ab = getFieldValue<Mpyri, Field_d>(op);
++		const bool	negate = getFieldValue<Mpyri, Field_k>(op);
++		const TWord qq = getFieldValue<Mpyri, Field_qq>(op);
++
++		DspValue s(m_block);
++		getOpWordB(s);
++
++		DspValue reg(m_block);
++		decode_qq_read(reg, qq, true);
++
++		alu_mpy(ab, reg, s, negate, false, false, false, true);
++	}
++
+ 	void JitOps::op_Maci_xxxx(TWord op)
+ 	{
+ 		const bool	ab = getFieldValue<Maci_xxxx, Field_d>(op);

--- a/tools/remix/audition.py
+++ b/tools/remix/audition.py
@@ -37,7 +37,7 @@ import subprocess
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
-from remix import registry, rig  # noqa: E402
+from remix import registry, rig, stock  # noqa: E402
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 OUT = ROOT / "out/_audition"
@@ -118,6 +118,23 @@ def _ensure_insert_mem(mod, log=print):
     return mem
 
 
+def _ensure_stock_mem(log=print):
+    """A dump of the PRISTINE image's payload A: every stock effect's code
+    and dispatch exactly as the unit ships them, independent of whatever
+    remix is currently built. (A DEV build takes CHORUS's module as a fourth
+    donor, and every build null-stubs the three reverbs, so no built image
+    is the right source for this.)"""
+    mem = ROOT / "out/dsp/_stock_A.mem"
+    if mem.exists() and mem.stat().st_mtime > stock.STOCK_IMAGE.stat().st_mtime:
+        return mem
+    log("dumping the stock image's payload A ...")
+    sys.path.insert(0, str(ROOT / "tools"))
+    import dsp_modmap
+    mem.parent.mkdir(parents=True, exist_ok=True)
+    dsp_modmap.dumpmem(stock.STOCK_IMAGE.read_bytes(), ["A", str(mem)])
+    return mem
+
+
 def _journal(entry):
     """Append one event to the audition journal, out/_audition/log.jsonl.
 
@@ -141,10 +158,11 @@ def render(key, values, source, wet=False, tail=None, label="", log=print):
     mod = registry.by_key(key)
     if rig.category(mod) == rig.SYSTEM:
         _die(f"{mod.name} is not an effect")
-    if rig.category(mod) == rig.STOCK:
-        _die(f"{mod.key} is a stock effect: no local render yet (dsp_host "
-             f"carries its code, but send_probe has no layout letter for a "
-             f"stock id) -- hear it on the unit")
+    if rig.category(mod) == rig.STOCK and mod.key in stock.NO_DSP:
+        _die(f"{mod.key} runs on the ColdFire (DMA over SDRAM rings), not the "
+             f"DSP -- its DSP dispatch is stock's passthrough stub, so there "
+             f"is nothing here to render. It works from its chooser row on "
+             f"the unit.")
     source = pathlib.Path(source)
     OUT.mkdir(parents=True, exist_ok=True)
     stem = f"{label + '_' if label else ''}{source.stem}_{mod.name}"
@@ -181,6 +199,10 @@ def render(key, values, source, wet=False, tail=None, label="", log=print):
         mem = _ensure_delay_mem(log)
         route = ["--layout", "DS"]        # SEND -> bus -> delay, the rig path
         tail = 3.0 if tail is None else tail
+    elif mod.is_stock:
+        mem = _ensure_stock_mem(log)
+        route = ["--direct", "--pick", mod.harness.layout_char]
+        tail = 1.0 if tail is None else tail
     else:
         mem = _ensure_insert_mem(mod, log)
         route = ["--direct", "--pick", mod.harness.layout_char]

--- a/tools/remix/index.py
+++ b/tools/remix/index.py
@@ -48,6 +48,10 @@ def main():
         buf = "  [instance buffer -- not beside ChonVerb/Nimbus/BongDelay]" \
             if m.claims is not None and m.claims.stock_instance_buffer else ""
         print(f"  {m.key:<12} FX2 id 0x{m.menu.fx2_id:02x}  {m.doc}{buf}")
+        if m.params:
+            knobs = ", ".join(f"{n}@{i}" for n, i in sorted(
+                m.knob_map().items(), key=lambda kv: kv[1]))
+            print(f"      knobs: {knobs}")
     print(f"\n  consumed by every remix (their code is the donor region): "
           f"{', '.join(stock.CONSUMED)}\n")
 

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -35,7 +35,9 @@ class Kind(Enum):
     HYBRID = "hybrid"           # both, e.g. an engine plus a display cave
     STOCK = "stock"             # a STOCK FX2 effect kept in the chooser: no
                                 # code, no clone, no words -- its descriptor
-                                # and dispatch are already in the image
+                                # and dispatch are already in the image; its
+                                # params are read FROM that descriptor for the
+                                # workbench and harness, never written back
                                 # (tools/remix/stock.py is the whole list)
 
 
@@ -335,10 +337,11 @@ class Module:
                 f"this id would hijack that effect on both menus (see "
                 f"STOCK_FX2_IDS). Free ids: "
                 f"{', '.join(f'0x{i:02x}' for i in range(0x04, 0x20) if i not in STOCK_FX2_IDS)}")
-        if self.kind is Kind.STOCK and (self.dsp is not None or self.params
-                                        or self.cf_patches):
-            raise ValueError(f"{self.name}: a STOCK entry carries no code, "
-                             f"params or caves -- they are already in the image")
+        if self.kind is Kind.STOCK and (self.dsp is not None or self.cf_patches):
+            raise ValueError(f"{self.name}: a STOCK entry carries no code or "
+                             f"caves -- they are already in the image (its "
+                             f"params are READ from the stock descriptor, "
+                             f"never written)")
         # Page 2's three selects ARE the three companion byte fields, so a
         # stepped control can only physically live on 7, 9 or 11.
         for i, p in enumerate(self.params):

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -209,7 +209,7 @@ def main():
     # (Length is capped so the help row stays one line; the schema already
     # pins labels to the declared count.)
     for mod in registry.modules().values():
-        if mod.menu is None or mod.is_stock:
+        if mod.menu is None:
             continue
         undocumented = [p.name.decode() for p in mod.params
                         if p.name and p.active and not p.doc]
@@ -221,6 +221,35 @@ def main():
                   f"over-long docs {toolong}")
         else:
             print(f"  [PASS] {mod.name}: every drawn knob has a doc")
+
+    # ---- stock rows carry their descriptor's knobs -----------------------
+    # Read from the pristine image, so the rig shows a stock effect's real
+    # controls and send_probe can drive them by name. Only checkable when
+    # the image is on disk (make setup); a fresh clone gets params=().
+    from remix import stock
+    if stock.STOCK_IMAGE.exists():
+        for mod in stock.MODULES:
+            names = sorted(mod.knob_map())
+            if not names or len(mod.params) != 12:
+                bad += 1
+                print(f"  [FAIL] {mod.name}: no knobs read from its descriptor")
+            elif len(set(names)) != len(names):
+                bad += 1
+                print(f"  [FAIL] {mod.name}: duplicate knob names {names}")
+            else:
+                print(f"  [PASS] {mod.name}: {len(names)} stock knobs read "
+                      f"({' '.join(names)})")
+    else:
+        print("  [SKIP] stock knobs: out/raw/section_3_MAIN_OS.bin not on disk")
+    # Every module in the registry needs a distinct layout letter or the
+    # send_probe alphabet silently drops one.
+    chars = [m.harness.layout_char for m in registry.modules().values()
+             if m.harness is not None and m.harness.layout_char]
+    if len(set(chars)) != len(chars):
+        bad += 1
+        print(f"  [FAIL] duplicate layout letters: {sorted(chars)}")
+    else:
+        print(f"  [PASS] {len(chars)} distinct layout letters")
 
     # And the real thing: every shipped remix must be clean.
     for name in registry.remix_names():

--- a/tools/remix/stock.py
+++ b/tools/remix/stock.py
@@ -16,12 +16,28 @@ charged by `make cycles` (which cannot see it -- the FILTER figure of 192
 cycles is the only one measured, docs/CHIP.md). What the build writes for
 it is its list row and its cursor position, and nothing else.
 
+ITS KNOBS ARE READ FROM THE STOCK DESCRIPTOR, not declared: names, defaults,
+value counts and the enable bitmap come out of the pristine image
+(out/raw/section_3_MAIN_OS.bin, the same record the panel draws from), so
+the workbench shows a stock effect's real page-1/page-2 controls and
+`send_probe --set` can drive them by name. The build never writes these
+params back (a stock row is not cloned), and when the image is absent --
+a fresh clone before `make setup` -- the entry simply carries no params.
+
+RENDERING. A stock effect renders locally the way an insert does: dsp_host
+runs its code straight from a dump of the STOCK image's payload A
+(tools/remix/audition.py), with `-alloc 1` so an effect that takes an
+instance buffer gets Y:0x4000 as the hardware would give track 1. Measured
+2 Sep 2026: FILTER passes at unity and a narrow LP takes a tone down 27 dB,
+CHORUS at MIX=127 modulates, COMPRESSOR passes at defaults. The one that
+cannot render is DELAY: its DSP dispatch is stock's null stub because the
+Echo Freeze delay runs on the ColdFire (DMA over SDRAM rings,
+docs/EXTERNAL.md), so there is no DSP code to run.
+
 Two of them are special:
 
-  DELAY (0x08)   the Echo Freeze delay. Its DSP dispatch is stock's null
-                 stub -- a passthrough -- because the delay itself runs on
-                 the ColdFire (DMA over SDRAM rings, docs/EXTERNAL.md). It
-                 works from this row exactly as it does on a stock unit.
+  DELAY (0x08)   works from its row exactly as on a stock unit, costs the
+                 DSP nothing, and has no local render (above).
   the four with  SPATIALIZER, FLANGER, CHORUS, COMB allocate an FX2
   a buffer       instance buffer through the host's bump allocator (they
                  read X:0x213 at init; docs/DSP.md section 10), and the
@@ -37,15 +53,78 @@ module spans from docs/DSP.md section 7c, for the index only.
 
 from __future__ import annotations
 
-from remix.schema import Claims, Kind, MenuEntry, Module
+import pathlib
+
+from remix.schema import Claims, Harness, Kind, MenuEntry, Module, Param
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+STOCK_IMAGE = ROOT / "out/raw/section_3_MAIN_OS.bin"
+BASE = 0x40000400                      # dsp_modmap.BASE, without the cwd-relative path
+
+# P-relative descriptor offsets (docs/PARAM_PAGES.md section 5b; the same
+# constants tools/build_bus.py writes through).
+_P_NAMES, _P_DEFAULTS, _P_COUNTS = 0x16, 0x5e, 0x9a
+_P_PENABLE_LO, _P_PENABLE_HI = 0x18e, 0x18a
+
+_img: bytes | None = None
 
 
-def _stock(key, name, fx2_id, desc, abbr, fullname, words, doc, buffer=False):
+def _image():
+    global _img
+    if _img is None and STOCK_IMAGE.exists():
+        _img = STOCK_IMAGE.read_bytes()
+    return _img
+
+
+def _params(desc_E: int, effect: str) -> tuple[Param, ...]:
+    """The twelve slots as the stock descriptor declares them, or () when
+    the image is not on disk."""
+    img = _image()
+    if img is None:
+        return ()
+    P = desc_E + 0x38 - BASE
+
+    def rd32(off):
+        return int.from_bytes(img[P + off:P + off + 4], "big")
+
+    lo, hi = rd32(_P_PENABLE_LO), rd32(_P_PENABLE_HI)
+    out, seen = [], set()
+    for i in range(12):
+        active = bool(((lo if i < 8 else hi) >> (4 * (i if i < 8 else i - 8))) & 1)
+        name = img[P + _P_NAMES + i * 6:P + _P_NAMES + i * 6 + 6].split(b"\0")[0]
+        count = rd32(_P_COUNTS + i * 4)
+        default = img[P + _P_DEFAULTS + i]
+        if not active or not name:
+            out.append(Param())
+            continue
+        # Two slots can share a panel label (FILTER draws Q on page 1 and a
+        # 4-step Q select on page 2). knob_map() is name-keyed, so the later
+        # one gets its page number appended for the workbench and the
+        # harness; the panel itself is untouched (nothing here is written).
+        if name in seen:
+            name = name[:5] + b"2"
+        seen.add(name)
+        kind = (f"{count}-way select" if count < 128 else "knob")
+        out.append(Param(
+            name=name, default=min(default, max(count - 1, 0)),
+            count=count if count < 128 else None, active=True,
+            doc=f"stock {effect} {name.decode('latin1')}: {kind}, page "
+                f"{1 if i < 6 else 2} -- see the Octatrack manual"))
+    return tuple(out)
+
+
+def _stock(key, name, fx2_id, desc, abbr, fullname, words, doc, char,
+           buffer=False):
     return Module(
         name=name, key=key, kind=Kind.STOCK, doc=doc,
         menu=MenuEntry(fx2_id=fx2_id, donor_desc=desc, abbr=abbr,
                        fullname=fullname),
+        params=_params(desc, fullname.decode("latin1")),
         claims=Claims(stock_instance_buffer=buffer) if buffer else None,
+        # The letter is what send_probe's layout alphabet and --pick use;
+        # every module in the registry needs a distinct one, and R D S W F
+        # M N G B are the modules'.
+        harness=Harness(layout_char=char, is_server=False),
     )
 
 
@@ -53,35 +132,39 @@ def _stock(key, name, fx2_id, desc, abbr, fullname, words, doc, buffer=False):
 MODULES = (
     _stock("FILTER", "filter", 0x04, 0x400d4772, b"FLTR", b"FILTER", 727,
            "Stock multimode filter, the default FX1 effect. 727 words, "
-           "~192 cycles measured."),
+           "~192 cycles measured.", "L"),
     _stock("EQUALIZER", "equalizer", 0x0c, 0x400d4c28, b"EQ", b"EQUALIZER", 282,
-           "Stock two-band parametric EQ."),
+           "Stock two-band parametric EQ.", "E"),
     _stock("DJ EQ", "djeq", 0x0d, 0x400d4dba, b"DJEQ", b"DJ EQUALIZER", 345,
-           "Stock three-band DJ kill EQ."),
+           "Stock three-band DJ kill EQ.", "J"),
     _stock("PHASER", "phaser", 0x10, 0x400d4f4c, b"PHSR", b"PHASER", 207,
-           "Stock phaser."),
+           "Stock phaser.", "P"),
     _stock("FLANGER", "flanger", 0x11, 0x400d50de, b"FLNG", b"FLANGER", 289,
-           "Stock flanger. Allocates an instance buffer.", buffer=True),
+           "Stock flanger. Allocates an instance buffer.", "A", buffer=True),
     _stock("CHORUS", "chorus", 0x12, 0x400d5270, b"CHOR", b"CHORUS", 329,
-           "Stock chorus. Allocates an instance buffer.", buffer=True),
+           "Stock chorus. Allocates an instance buffer.", "C", buffer=True),
     _stock("SPATIALIZER", "spatializer", 0x05, 0x400d4904, b"SPAT",
            b"SPATIALIZER", 261,
-           "Stock stereo spatializer. Allocates an instance buffer.",
+           "Stock stereo spatializer. Allocates an instance buffer.", "Z",
            buffer=True),
     _stock("COMB FILTER", "comb", 0x13, 0x400d5402, b"COMB", b"COMB FILTER", 277,
-           "Stock comb filter. Allocates an instance buffer.", buffer=True),
+           "Stock comb filter. Allocates an instance buffer.", "O", buffer=True),
     _stock("COMPRESSOR", "compressor", 0x18, 0x400d5a4a, b"COMP", b"COMPRESSOR",
-           180, "Stock compressor."),
+           180, "Stock compressor.", "K"),
     _stock("LO-FI", "lofi", 0x1c, 0x400d5d6e, b"LOFI", b"LO-FI", 537,
-           "Stock lo-fi (bit/rate reduction, distortion)."),
+           "Stock lo-fi (bit/rate reduction, distortion).", "I"),
     _stock("DELAY", "delay", 0x08, 0x400d4a96, b"DEL", b"DELAY", 0,
            "Stock Echo Freeze delay -- runs on the ColdFire, so it costs the "
-           "DSP nothing; the row works as on a stock unit."),
+           "DSP nothing; the row works as on a stock unit. No local render.",
+           "Y"),
 )
 
 # What every remix consumes, whether it lists anything or not: the three
 # reverbs whose code IS the donor region. Named here so the composer can
 # say so rather than leaving it to be inferred from a manifest comment.
 CONSUMED = ("PLATE REV", "SPRING REV", "DARK REV")
+
+# The one stock row with nothing on the DSP to render.
+NO_DSP = frozenset({"DELAY"})
 
 BY_KEY = {m.key: m for m in MODULES}

--- a/tools/send_probe.py
+++ b/tools/send_probe.py
@@ -625,10 +625,13 @@ def main():
     # the target fell back to "R", so it instantiated ChonVerb and LABELLED
     # the output "DELAY". Six documents described that command as the way to
     # render an insert. Derive the choices, like everything else here.
-    ap.add_argument("--pick", choices=sorted(SERVER_ID),
-                    help="which module's output to analyse. Defaults to the "
+    ap.add_argument("--pick",
+                    help="which module's output to analyse: its layout letter "
+                         f"({''.join(sorted(SERVER_ID))}), or its module key/"
+                         "name (e.g. FILTER, chorus). Defaults to the "
                          "layout's server (R, else D). REQUIRED with --direct "
-                         "for an insert, which has no bus and so no default")
+                         "for an insert or a stock effect, which has no bus "
+                         "and so no default")
     ap.add_argument("--direct", action="store_true",
                     help="CONTROL / the insert path: no SEND, tone straight "
                          "into the picked module's own track input")
@@ -641,6 +644,16 @@ def main():
                          "driving the wrong slot.")
     ap.add_argument("-v", "--verbose", action="store_true")
     a = ap.parse_args()
+    if a.pick is not None and a.pick not in SERVER_ID:
+        # A module key or name, resolved to its letter -- the letters are
+        # derived and nobody should have to know them.
+        _pm = next((m for m in registry.modules().values()
+                    if a.pick in (m.key, m.name, m.key.lower())
+                    and m.harness is not None and m.harness.layout_char), None)
+        if _pm is None:
+            die(f"--pick {a.pick!r}: not a layout letter "
+                f"({''.join(sorted(SERVER_ID))}) or a module key/name")
+        a.pick = _pm.harness.layout_char
 
     if a.build:
         r = subprocess.run([sys.executable, "tools/build_bus.py"], cwd=ROOT,


### PR DESCRIPTION
## What

- **Stock rows render locally** like inserts: `tools/remix/stock.py` reads knobs (names, defaults, counts, enable bits) from the stock descriptors in the pristine image; each has a layout letter; `send_probe --pick` also takes a key/name. The audition dumps the **stock** image's payload A once (`out/dsp/_stock_A.mem`) and runs `dsp_host --direct` against it.
- **9 of 11 render credibly** (438 Hz tone, 0.5 FS): FILTER (narrow LP takes it down 27 dB), EQ, DJ EQ, PHASER, CHORUS (MIX=0 exactly dry, MIX=127 sidebands), SPATIALIZER, COMB, COMPRESSOR, LO-FI.
- **DELAY**: no DSP code (ColdFire-side Echo Freeze) → the audition refuses with the reason.
- **FLANGER**: renders but not credible (MIX=0 not dry; DEP=0/FB=0 still THD −2 dB). Open; suspect is emulator sign handling of `mpyi #>$f84c00`. Documented in MODULES.md with the falsifier.
- **First vendored-emulator patch**: `tools/dsp56300.patch` implements MPYRI (unimplemented upstream in interpreter and JIT); `setup.sh` applies it. LO-FI aborted at init without it. Existing renders byte-identical across the rebuilt host.

## Proof
- `make check` green; refhash 26/26 (build untouched).
- Selftest: stock knobs read for all 11, distinct layout letters, doc rule covers stock knobs.
- Headless rig run: FILTER on T3 shows BASE/WDTH/Q/…/DIST rows, a render lands and is journalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)