### PR TITLE
Close out FLANGER: dsp_host's audio block must sit at X:0 for stock code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,16 @@ away from FX1 too. Rungs sat on EQUALIZER's `0x0c` and Nimbus on DJ EQ's
 schema now refuses `STOCK_FX2_IDS`; the stock effects themselves are kept
 in a chooser by listing them in the remix (`tools/remix/stock.py`).
 
+**`dsp_host`'S DEFAULT AUDIO BLOCK (X:0x80) SITS INSIDE THE SCRATCH THE
+STOCK EFFECTS USE.** On hardware the dispatcher passes `r0 = 0`: the audio
+block is at X:0 and stock code scratches X:0x20–0xff every block. Our
+modules never touch low X, so the default was harmless for months and then
+made the stock FLANGER render as Nyquist-rate hash and five other stock
+effects 5–17 dB dirtier while passing as "credible" (2 Sep 2026). Eight
+instruction probes were spent clearing the emulator first. `send_probe`
+passes `-audio 0` for a stock render; if a stock effect sounds wrong
+locally, suspect the harness before the effect.
+
 **A parameter slot can draw a knob and publish nothing.** The page descriptor
 and the DSP-side read are separate mechanisms; `dsp_host` pokes r6 directly, so
 everything looks live locally even when the real unit would publish nothing.

--- a/PLAN.md
+++ b/PLAN.md
@@ -94,11 +94,16 @@ panel scrolls — ⚠️ inferred from stock's fifteen-row list, unflashed.
 `docs/MODULES.md` "Keeping STOCK effects in the chooser". Later the same
 day the rig learned to **render them**: knobs read from the stock
 descriptors, audio from a dump of the pristine image through `dsp_host`.
-Nine of eleven render credibly; DELAY cannot (ColdFire-side); FLANGER's
-render is not credible and is open (a negative-immediate `mpyi` is the
-suspect). LO-FI needed the project's first patch to the vendored emulator
-(`tools/dsp56300.patch`, MPYRI) — worth knowing: stock code exercises
-instructions our own modules never did.
+Ten of eleven render, each a bit-exact dry pass at neutral settings;
+DELAY cannot (ColdFire-side). FLANGER looked broken until eight
+instruction probes cleared the emulator and the cause turned out to be the
+harness: hardware puts the audio block at X:0 and stock effects scratch
+right above it, while `dsp_host` defaulted to X:0x80 — fixing that also
+cleaned five other stock renders that had passed as "credible". LO-FI
+needed the project's first patch to the vendored emulator
+(`tools/dsp56300.patch`, MPYRI) and still passes at +6 dB at zero settings
+(open, needs a hardware A/B). Worth knowing: stock code exercises both
+instructions and conventions our own modules never did.
 
 Making them first-class exposed a latent id collision: the DSP dispatch
 tables are shared between FX1 and FX2, and Rungs (`0x0c`) and Nimbus

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -224,20 +224,35 @@ every build null-stubs the reverbs. dsp_host's `-alloc 1` gives a buffered
 effect Y:0x4000, as the hardware gives track 1. Measured 2 Sep 2026 on a
 438 Hz tone at 0.5 FS:
 
-| effect | result |
+| effect | result (audio block at X:0 — see below) |
 |---|---|
 | FILTER | unity at defaults; BASE=20 WDTH=10 Q=100 takes the tone down 27 dB |
-| EQ, DJ EQ, PHASER, COMPRESSOR | pass at defaults, THD −44…−54 dB |
+| EQ, DJ EQ, PHASER, SPATIALIZER, COMB, COMPRESSOR | bit-exact unity at defaults (THD −54 dB = the tone's own) |
+| FLANGER | MIX=0 is a **bit-exact** dry pass (THD −143 dB); full modulation gives a flanged tone |
 | CHORUS | MIX=0 is exactly dry; MIX=127 puts sidebands on the tone (THD −31 dB) |
-| SPATIALIZER, COMB | render, COMB's THD −36 dB is its comb |
-| LO-FI | rendered only after `tools/dsp56300.patch`: the vendored emulator had `mpyri` unimplemented in both interpreter and JIT and aborted at init |
+| LO-FI | rendered only after `tools/dsp56300.patch` (the vendored emulator had `mpyri` unimplemented in both interpreter and JIT and aborted at init). DIST, SRR and AMF/AMD all act. ⚠️ At all-zero settings it passes a clean tone at **exactly 2× the input** (+6 dB), independent of the control flags; whether the unit does the same is unmeasured — falsifier: a hardware A/B at zero settings |
 | DELAY | **no DSP code** — the Echo Freeze delay is ColdFire-side; the audition refuses with that reason |
-| FLANGER | **not credible**: MIX=0 is not dry, DEP=0/FB=0 still measures THD −2 dB (hash), all-zero knobs give near silence. Its process loop multiplies by a NEGATIVE immediate (`mpyi #>$f84c00`), which is the standing suspect for an emulator sign-handling defect; falsifier: a three-instruction probe of `mpyi` with that immediate in dsp_host. Open. |
+
+**The harness lesson that closed FLANGER (2 Sep 2026).** Its first render
+was a Nyquist-rate alternation (+0.94, −0.02, …) that read as hash and
+earned a "not credible" verdict; the emulator's handling of its negative
+immediate multiply was the suspect. Eight instruction probes with exact
+predicted results (modulo copies, `lua (r0)+n0,r4`, `asr #$a`, `lsr`,
+long moves, `move n7,a`) all passed, and its coefficient table was loaded.
+The cause was the harness: the dispatcher's `move #$0,r0` puts the audio
+block at **X:0** on hardware, and stock effects use the X memory right
+after it as scratch — the flanger writes X:0x20–0xff every block —
+while `dsp_host` defaulted the audio block to X:0x80, inside that
+scratch. `send_probe` now passes `-audio 0` for a stock render, which also
+cleaned EQ, DJ EQ, PHASER, SPATIALIZER and COMB by 5–17 dB (they had been
+quietly reading their own scratch as input). Our own modules never touch
+low X, which is why the default never mattered before. The selftest holds
+the line with FLANGER at MIX=0 being bit-exact dry.
 
 ⚠️ These are emulator renders of stock code that was never exercised under
 `dsp_host` before; the servers and inserts were written against it. A
-stock effect that sounds wrong locally is evidence about the emulator
-before it is evidence about the effect.
+stock effect that sounds wrong locally is evidence about the **harness or
+emulator** before it is evidence about the effect — twice now.
 
 ---
 

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -118,13 +118,13 @@ value counts read from the stock descriptor in the pristine image (a
 select shows its count, not stock's word labels) — and **renders** like
 an insert, from a one-time dump of the stock image's payload A
 (`out/dsp/_stock_A.mem`), so nothing about the currently built remix
-matters. Nine of the eleven render credibly (2 Sep 2026: FILTER, EQ,
-DJ EQ, PHASER, CHORUS, SPATIALIZER, COMB, COMPRESSOR, LO-FI — LO-FI
-needed an emulator patch, `tools/dsp56300.patch`, for the `mpyri`
-instruction). Two do not: **DELAY** runs on the ColdFire, so there is no
-DSP code to render and the audition says so; **FLANGER** renders but its
-output is not credible — MIX=0 is not dry and DEP=0/FB=0 still measures
-as broadband hash — cause open (`docs/MODULES.md`).
+matters. Ten of the eleven render (2 Sep 2026): FILTER, EQ, DJ EQ,
+PHASER, FLANGER, CHORUS, SPATIALIZER, COMB, COMPRESSOR, LO-FI — every one
+a bit-exact dry pass at its neutral settings, LO-FI at +6 dB (open) and
+after an emulator patch (`tools/dsp56300.patch`, `mpyri`). **DELAY** runs
+on the ColdFire, so there is no DSP code to render and the audition says
+so. `docs/MODULES.md` has the measurements and the harness lesson (the
+audio block sits at X:0 for a stock render, as on hardware).
 
 ![The REMIX view: modules grouped by category with track ranges, the FX2
 menu as the unit will draw it, and the ledger's verdict —
@@ -273,9 +273,9 @@ through `rich.markup.escape`.
 
 ## Known gaps
 
-- DELAY (stock) has no local render (ColdFire-side); FLANGER's local
-  render is not credible (open). Stock select labels are counts, not
-  stock's word labels.
+- DELAY (stock) has no local render (ColdFire-side); LO-FI renders at
+  +6 dB at zero settings (unexplained). Stock select labels are counts,
+  not stock's word labels.
 - A/B marks attach only to the most recent render (no history cursor).
 - No browse-anywhere source picker (one fixed directory, `out/dry/`).
 - Wet-only rendering is ChonVerb-only.

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -14,6 +14,7 @@ import pathlib
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 from remix import ledger  # noqa: E402
 from remix.schema import (CavePatch, Claims, DspSection, Kind, MenuEntry,  # noqa: E402
@@ -250,6 +251,46 @@ def main():
         print(f"  [FAIL] duplicate layout letters: {sorted(chars)}")
     else:
         print(f"  [PASS] {len(chars)} distinct layout letters")
+
+    # ---- the stock-render harness puts the audio block where hardware does --
+    # The dispatcher's `move #$0,r0`: the audio block is at X:0 and stock
+    # effects use the X right after it as scratch (the flanger writes
+    # X:0x20-0xff every block). dsp_host's default of X:0x80 sat inside that
+    # scratch and turned FLANGER into a Nyquist-rate alternation while EQ,
+    # DJ EQ, PHASER, SPATIALIZER and COMB were quietly 5-17 dB dirtier than
+    # they should be (2 Sep 2026). Hold the line with the sharpest of them:
+    # FLANGER at MIX=0 is a BIT-EXACT dry passthrough at the right address.
+    import subprocess
+    _host = ROOT / "vendor/dsp56300/build/source/dsp_host/dsp_host"
+    _dump = ROOT / "out/dsp/_stock_A.mem"
+    if _host.exists() and stock.STOCK_IMAGE.exists():
+        if not _dump.exists():
+            import dsp_modmap
+            _dump.parent.mkdir(parents=True, exist_ok=True)
+            dsp_modmap.dumpmem(stock.STOCK_IMAGE.read_bytes(), ["A", str(_dump)])
+        r = subprocess.run([sys.executable, "tools/send_probe.py", "--mem",
+                            str(_dump), "--direct", "--pick", "flanger",
+                            "--dur", "0.45", "--tail", "0.05", "--set=MIX=0"],
+                           cwd=ROOT, capture_output=True, text=True)
+        import re as _re
+        m = _re.search(r"THD \(2f\.\.9f\) = *(-?[\d.]+) dB", r.stdout)
+        pk = _re.search(r"peak +([\d.]+) FS", r.stdout)
+        thd = float(m.group(1)) if m else None
+        peak = float(pk.group(1)) if pk else None
+        # The tone metric floors around -54 dB in send_probe's window (a
+        # unity pass of the 0.5 FS tone reads -53.8); the broken state read
+        # peak 1.000 / THD -2 dB. Either number alone discriminates.
+        if (r.returncode == 0 and thd is not None and peak is not None
+                and thd < -50 and abs(peak - 0.5) < 0.005):
+            print(f"  [PASS] stock FLANGER at MIX=0 is a dry pass (peak "
+                  f"{peak:.3f} FS, THD {thd:.0f} dB) -- the audio block is at X:0")
+        else:
+            bad += 1
+            print(f"  [FAIL] stock FLANGER at MIX=0 is not dry (peak {peak}, "
+                  f"THD {thd}) -- is dsp_host's audio block back inside "
+                  f"stock scratch?")
+    else:
+        print("  [SKIP] stock render harness: dsp_host or the stock image is missing")
 
     # And the real thing: every shipped remix must be clean.
     for name in registry.remix_names():

--- a/tools/send_probe.py
+++ b/tools/send_probe.py
@@ -287,10 +287,20 @@ def run(mem, dur, tail, rev_params, send_params, verbose=False, amp=0.5,
         _par = (rev_params if tgt == "R" else dpar if tgt == "D"
                 else insert_params if insert_params is not None
                 else MODULE_DEFAULTS.get(tgt, [0] * 12))
+        # THE AUDIO BLOCK IS AT X:0 ON HARDWARE (the dispatcher's `move #$0,r0`,
+        # P:0x42e) and the STOCK effects use the X memory right after it as
+        # scratch -- the flanger writes X:0x20-0xff every block. dsp_host's
+        # default puts the audio at X:0x80, inside that scratch, which turned
+        # the flanger's output into a Nyquist-rate alternation (+0.94/-0.02)
+        # and cost a false "not credible" verdict (2 Sep 2026). None of our
+        # own modules touch low X, so the default never mattered for them;
+        # a stock render gets the hardware address.
+        _tm = registry.by_id(SERVER_ID[tgt])
         cmd = [str(HOST), "-mem", str(mem),
                "-init", f"{ri:x}", "-proc", f"{rp:x}",
                "-inst", "1", "-r7", "2", "-alloc", "1",
                "-inmask", "1",                   # tone straight into the module
+               *(["-audio", "0"] if _tm is not None and _tm.is_stock else []),
                "-blocks", str(blocks), "-in", str(src), "-out", str(out),
                *(["-split", str(split)] if str(split) not in ("0", "") else []),
                "-params", ",".join(map(str, _par))]


### PR DESCRIPTION
## What
- FLANGER was a **harness** bug: hardware passes `r0 = 0` (audio block at X:0) and stock effects scratch X:0x20–0xff above it; dsp_host defaulted the audio block to X:0x80, inside that scratch. Output was a Nyquist-rate alternation, not hash.
- Eight instruction probes with exact predictions (negative-immediate `mpyi`, modulo copies, `lua (r0)+n0,r4`, `asr #imm`, `lsr`, `l:` moves, `move n7,a`) all passed first — the emulator was innocent.
- `send_probe --direct` passes `-audio 0` for a stock pick. FLANGER MIX=0 is now a bit-exact dry pass; EQ, DJ EQ, PHASER, SPATIALIZER, COMB clean up 5–17 dB (they had been reading their own scratch). Module renders untouched (they never use low X).
- Selftest guard: FLANGER MIX=0 → peak 0.500, THD < −50.
- LO-FI: knobs act, but zero settings pass at exactly 2× — left open with a hardware A/B as the falsifier.

## Proof
- `make check` green (incl. the new guard).
- Tone table in docs/MODULES.md; CLAUDE.md carries the trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)