### PR TITLE
HELLO WORLD: the reference minimal insert, contributed by Bryan T

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,23 @@ instruction probes were spent clearing the emulator first. `send_probe`
 passes `-audio 0` for a stock render; if a stock effect sounds wrong
 locally, suspect the harness before the effect.
 
+**A DESCRIPTOR NAME THAT EXACTLY FILLS ITS FIELD LEAVES NO NUL, AND THE
+CRASH LANDS SOMEWHERE ELSE ENTIRELY.** `abbr` is a 5-byte field holding FOUR
+characters plus a terminator; `fullname` is 13 bytes holding TWELVE (and the
+build tag is appended after your string). A 5-character abbr assembled,
+built, drew correctly on the panel and behaved normally under manual knob
+use — and threw a line-F exception (VEC:0B) the moment a parameter was
+**LFO-MODULATED**, faulting PC `0x48454C4C` = `"HELL"`. It presented as
+"custom effects can't be modulated", which points at the clone mechanism,
+not at a string. Found 2 Sep 2026 by Bryan T contributing `modules/hello/`,
+after the build accepted it silently. A faulting PC made of the field's own
+ASCII is a smashed return address, so the copy destination is fixed-size —
+INFERRED, the copy is not located; the rule itself is measured (all 30 stock
+page descriptors are ≤4 chars with byte 5 zero). `schema.MenuEntry` now
+refuses both over-lengths and `build_bus.py` re-checks the string it writes,
+tag included — which caught two diagnostic delay names (`BongDlyRPLY`,
+`BongDlyNOCF`) that had been filling all 13 bytes since 24 Aug 2026.
+
 **A parameter slot can draw a knob and publish nothing.** The page descriptor
 and the DSP-side read are separate mechanisms; `dsp_host` pokes r6 directly, so
 everything looks live locally even when the real unit would publish nothing.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ real budget decision, not a label.
 | **`nimbus`** | Nimbus + send | the granular texture, which needs a buffer region to itself |
 | **`warped`** | WarpFold + send | the smallest real selection |
 | **`verbonly`** | ChonVerb + send | the reverb alone; proves selection works |
+| **`hello`** | HELLO WORLD + send | the reference minimal build, and the worked example to read first |
 
 ```bash
 make remix                  # the workbench: 8 tracks, hear effects, compose
@@ -74,9 +75,9 @@ See **[docs/MODULES.md](docs/MODULES.md)** to write a module.
 
 ## The modules
 
-**Ten ship today.** Two are bus *servers*, six are per-track *inserts*, one is
-the bus client they all lean on, and one patches the ColdFire rather than the
-audio at all.
+**Eleven ship today.** Two are bus *servers*, seven are per-track *inserts*,
+one is the bus client they all lean on, and one patches the ColdFire rather
+than the audio at all.
 
 ### Effects that serve a bus
 
@@ -88,9 +89,10 @@ audio at all.
 
 ### Effects that run on one track
 
-Six inserts, Mutable-Instruments-flavoured. They need no bus, sit in both
-payloads, run on any track, and **stack** — `make bus REMIX=mutables` puts
-five of them on one card.
+Seven inserts. They need no bus, sit in both payloads, run on any track, and
+**stack** — `make bus REMIX=mutables` puts five of them on one card. Six are
+Mutable-Instruments-flavoured; the seventh is a volume knob that exists to be
+read.
 
 | | |
 |---|---|
@@ -100,6 +102,7 @@ five of them on one card.
 | **Streamz** | A vactrol lowpass gate: the envelope opens a filter and an amplifier *together*, so quiet is dark as well as quiet. LPG / VCF / VCA. |
 | **BodeShift** | A Bode frequency shifter — every partial moves by the same number of *hertz*, so it is not a pitch shifter. UP / DOWN / WIDE, plus a feedback spiral. |
 | **Nimbus** | Four grains reading back out of a continuously-recorded 743 ms buffer, with a freeze. |
+| **Hello World** | A linear volume knob — 27 words, one knob, no state. The reference minimal insert and the worked example a new module is copied from. Contributed by Bryan T. |
 
 ### Firmware behaviour, not audio
 
@@ -108,9 +111,10 @@ five of them on one card.
 | **Tempo sync** | Two ColdFire code caves: one publishes the project tempo, crossfader and held MIDI note where the DSP can read them; the other draws a TIME knob as a tempo division. The worked example of patching what the firmware *does*. |
 
 ⚠️ **ChonVerb, BongDelay, Send and Tempo sync are confirmed on hardware. The
-six inserts are not** — they are verified by local render and measurement and
-have never been flashed. Whoever flashes them is the first to run them on a
-real machine.
+six Mutable-flavoured inserts are not** — they are verified by local render
+and measurement and have never been flashed. Whoever flashes them is the
+first to run them on a real machine. Hello World was flashed and measured by
+its author on his own unit, not on this project's.
 
 The reverse-engineering in `docs/` is infrastructure, not the product. It
 exists because you cannot write an effect for a machine whose memory map,
@@ -128,7 +132,7 @@ claims no shared memory, is placed in *both* payloads, and therefore runs on
 any of the eight tracks — several at once, all different, or four copies of
 the same one. Nothing negotiates with anything, so inserts **stack**: one
 image can carry a whole set of them. This is far the easier thing to
-contribute, and the six above are all of this kind.
+contribute, and the seven above are all of this kind.
 
 A **server** owns a bus accumulator and is *bank-bound*. ChonVerb exists only
 on core 0 and BongDelay only on core 1, one per core by design rule. That
@@ -393,15 +397,18 @@ emulator and disassembler this project assembles and auditions against) and
 
 Issues, listening reports and findings are welcome, and so are modules.
 
-**To add one**, copy `modules/_template/` and read
+**To add one**, read `modules/hello/` — a complete module small enough to
+read in one sitting: one knob, 27 words of DSP, its own remix and its own
+render gates — then copy `modules/_template/` and follow
 **[docs/MODULES.md](docs/MODULES.md)**. Your module declares what it is and
 what it claims; the build refuses to start if two selected modules claim the
 same FX2 id, cave, hook site, core-private word, or the per-core FX2 buffer
 region, and names both.
 
 **An insert is the easiest first module** — no bus role, no shared window, no
-payload asymmetry to reason about. The six above were each built against
-`docs/MODULES.md` alone.
+payload asymmetry to reason about. The seven above were each built against
+`docs/MODULES.md` alone, and the most recent of them, Hello World, came from
+outside the project.
 
 If you open a PR: `make check` is the floor, and read the traps in
 `CLAUDE.md` first — several are the kind that assemble clean and do the wrong

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -18,8 +18,9 @@ An **insert** processes its own track's frames in place: no bus role, no
 shared-window claim, placed in both payloads, runnable on any track and
 several at once. Nothing negotiates with anything. `bus_role=BusRole.NONE`,
 `ybase=YBase.NEVER`, and most of the hazards below simply do not apply.
-**Start here** — six of the ten shipping modules are inserts, and each was
-built against this document alone.
+**Start here** — seven of the eleven shipping modules are inserts, and each
+was built against this document alone. `modules/hello/` is the worked example
+below.
 
 A **server** owns a bus accumulator, is bank-bound to one core, and has to
 take part in the rotation, the housekeeping election and the auto-gain. It
@@ -29,6 +30,52 @@ reason before writing a third.
 
 A module can also be neither: a **bus client** (`send`) or a **ColdFire
 patch** (`tempo-sync`) that changes firmware behaviour and touches no audio.
+
+---
+
+## Your first module: read HELLO WORLD
+
+`modules/hello/` is a linear volume knob and the **complete worked example**:
+one page-1 knob, 27 words of DSP, no state, no bus role, no shared window. It
+is the smallest thing the contract can express, and every piece a real module
+needs is there and no piece it does not:
+
+```
+modules/hello/manifest.py    the declaration -- one knob, one donor, one id
+modules/hello/gain.asm       the engine -- init, proc, in place, 27 words
+modules/hello/README.md      status, measured vs inferred, what is open
+remixes/hello.py             a two-module remix: HELLO WORLD + SEND
+tools/verify_hello.py        render gates with exactly predictable arithmetic
+```
+
+Build and hear it in three commands:
+
+```bash
+make check REMIX=hello
+python3 tools/remix/audition.py hello out/dry/drums_110.wav GAIN=64
+python3 tools/verify_hello.py            # ALL GATES PASSED, 0 LSB
+```
+
+`modules/_template/` is the *skeleton* to copy — a manifest with every field
+commented and nothing else. Read `hello` for what a finished one looks like;
+copy `_template` when you start typing.
+
+**Its gates are the part worth stealing.** `verify_hello.py` drives the effect
+with a full-scale bipolar ramp and asserts the output *exactly*: unity at
+GAIN=127 is bit-identical, GAIN=0 is all zero, and every intermediate gain is
+`(in × g) >> 23` to 0 LSB. Arithmetic you can predict to the bit is what turns
+"it rendered and sounded plausible" into a measurement — and the negative half
+of that ramp is what proves the `mpy` did not silently become an `mpysu`.
+Nimbus's double-rate window (`CLAUDE.md`) got through *ear* review and every
+existing check; a DC gate caught it. Give your module one gate whose answer
+you can compute by hand.
+
+⚠️ And make it name the effect it thinks it is measuring. An id the image does
+not implement **aliases to the fallback**, and dsp_host renders a perfectly
+plausible dry passthrough — `verify_hello.py` shipped with a hardcoded id,
+measured SEND after the module moved, and its unity gate *passed*. It now
+reads the id and the knob slot out of the manifest and refuses if they
+resolve to SEND's entry points. Do the same.
 
 ---
 
@@ -50,7 +97,8 @@ what keeps `modules/_template/` out of every build.
 `tools/remix/schema.py` is the vocabulary and is worth reading in full — it is
 short, and its comments carry the reasoning behind each field.
 
-Copy `modules/_template/` to start, and `make remix` opens the workbench
+Copy `modules/_template/` to start (and read `modules/hello/` for a
+finished one), and `make remix` opens the workbench
 (`tools/remix/app.py`, Textual — provisioned by `make emu-setup`; the full
 manual is `docs/WORKBENCH.md`). Its home
 view is a RIG of eight tracks: assign effects, dial their manifest-named
@@ -133,6 +181,18 @@ things you might assume:
   named, defaulted and implemented — set `active=True`. The inverse trap is
   real too: a slot can draw a knob and publish nothing. See
   `docs/PARAM_PAGES.md`.
+- **Both name fields are NUL-terminated, so the usable length is one less
+  than the field.** `abbr` is 5 bytes = **4 characters**; `fullname` is 13
+  bytes = **12** (and the build tag is appended *after* your string, so a
+  tagged name has 2 fewer). Filling a field exactly leaves no terminator.
+  A 5-character abbr drew correctly, behaved normally under manual knob use,
+  and threw a line-F exception the moment a parameter was **LFO-modulated** —
+  faulting PC `0x48454C4C`, which is `"HELL"`. It presented as "custom
+  effects can't be modulated". Found on hardware 2 Sep 2026 by Bryan T while
+  contributing HELLO WORLD, after the build had silently accepted it; the
+  schema rejects both over-lengths now, and `build_bus.py` re-checks the
+  string it actually writes. `modules/hello/README.md` separates what was
+  measured there from what is still inferred about the mechanism.
 
 ### Page 2 is three knobs and three selects
 
@@ -158,7 +218,14 @@ well. Rungs shipped on `0x0c` (EQUALIZER) and Nimbus on `0x0d` (DJ EQ) from
 FX1 selected EQUALIZER and the chongbong image aliased FX1's EQ to a send.
 It never reached the unit (tag 77 predates it); the schema now refuses at
 construction. Free ids: `0x06 0x07 0x09 0x0a 0x0b 0x0e 0x0f 0x17 0x1a 0x1b
-0x1d 0x1e 0x1f`, of which the first seven plus `0x17`/`0x1a` are taken.
+0x1d 0x1e 0x1f`, of which all but `0x1d 0x1e 0x1f` are taken.
+
+The **registry** is the arbiter, not the ledger: `registry.modules()` refuses
+two modules on one id at import, whether or not any remix selects both. So a
+contributed module can arrive on an id that was free when it was written and
+is not when it lands — HELLO WORLD arrived on `0x17` and was moved to `0x1b`,
+`0x17` having become Rungs's on 2 Sep 2026. `make modules` prints what is
+claimed today.
 
 ## Keeping STOCK effects in the chooser
 

--- a/modules/_template/README.md
+++ b/modules/_template/README.md
@@ -2,6 +2,9 @@
 
 One paragraph: what it is and why it exists.
 
+(`modules/hello/README.md` is this template filled in, for a module small
+enough to read whole.)
+
 ## Status
 
 Where it actually stands. Separate **measured** from **inferred** — this
@@ -18,3 +21,10 @@ would falsify a claim rather than writing "found it" for something reasoned.
 
 What you know is unresolved. A named open question is worth more than a
 clean-looking README.
+
+## Gates
+
+How a reader reproduces your measurements, in the order they must run.
+`tools/verify_hello.py` is the pattern: predict the arithmetic exactly, drive
+both signs, and make the tool refuse to run if the id it resolves is the
+fallback rather than your effect.

--- a/modules/_template/manifest.py
+++ b/modules/_template/manifest.py
@@ -9,6 +9,10 @@ still open about it. Then delete every comment below that you have answered
 
 Read docs/MODULES.md first, and tools/remix/schema.py for the full field
 list; both carry the reasoning that these comments only summarise.
+
+This file is the SKELETON -- every field, commented, and no engine. For a
+finished module small enough to read in one sitting, see modules/hello/:
+one knob, 27 words of DSP, its own remix and its own render gates.
 """
 
 from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
@@ -30,8 +34,13 @@ MODULE = Module(
         # WRITE STAYS THE DONOR'S -- including formatters, which override the
         # value counts you do write.
         donor_desc=0x400d58b8,     # DARK REV
-        abbr=b"TMPL",              # 5 bytes
-        fullname=b"Template",      # 13 bytes
+        # BOTH FIELDS ARE NUL-TERMINATED, so the usable length is one less
+        # than the field: abbr is 5 bytes = FOUR characters, fullname 13
+        # bytes = TWELVE. Filling one exactly leaves no terminator; a 5-char
+        # abbr drew fine and crashed the unit on LFO modulation. The schema
+        # rejects both over-lengths -- see modules/hello/README.md.
+        abbr=b"TMPL",              # <=4 chars
+        fullname=b"Template",      # <=12 chars, before any build tag
         build_tag=False,           # append the image's build tag to the name
     ),
 

--- a/modules/hello/README.md
+++ b/modules/hello/README.md
@@ -148,11 +148,20 @@ actually writes, tag included.
   `KERN_INVALID_ADDRESS`, which is the "wild memory reads" half of the
   original report — a second, separate defect the hang had been masking.
 
-  **Inferred, not chased:** the likely candidate is that each block is
-  entered with `dsp.setPC(0x372)` without resetting the DSP's stack, loop
-  and status state, so whatever block 0 left on the stack accumulates. That
-  is a harness modelling gap in the same family as the TX one. Falsifier:
-  reset SP/LA/LC between blocks and see whether block 1 survives. **Nobody
-  has done this**, and until someone does, faithful mode remains unusable —
-  which matters, because it is the only thing that would validate the
-  hand-rolled calling convention the rest of the harness assumes.
+  **FALSIFIED, 2 Sep 2026 — it is not the register file.** The standing
+  guess was that each block inherits block 0's registers, because the
+  dispatcher is entered per audio interrupt on hardware while we break at
+  `0x53e` and force the PC back, leaving every AGU modifier, loop register
+  and stack word live. Restoring the **entire** `SRegs` struct to its
+  post-init state before each block changes nothing: still SIGSEGV on block
+  1, at 1 track and at 4. The experiment was reverted rather than left in —
+  it bought no behaviour and would have read as a fix.
+
+  So the state that kills block 1 is in **memory**, not registers: the
+  dispatcher mutates `x:0x20a`, `x:0x213`, `x:0x418`, `x:0x420` and the
+  pending/current track blocks, and one of those does not survive being
+  re-entered. Next falsifier for whoever picks this up: snapshot and restore
+  X/Y alongside the registers; if block 1 then survives, bisect the restored
+  range to name the word. Until then faithful mode is unusable — which
+  matters, because it is the only thing that would validate the hand-rolled
+  calling convention the rest of the harness assumes.

--- a/modules/hello/README.md
+++ b/modules/hello/README.md
@@ -1,0 +1,131 @@
+# HELLO WORLD
+
+A linear volume knob, and the reference minimal insert: the smallest complete
+module the contract can express — one page-1 knob, 27 words of DSP, no state.
+It exists to be read (the worked example `modules/_template` points at) and to
+stay permanently buildable as a canary: if this stops building or stops
+nulling at GAIN=127, the build system moved under everyone.
+
+Contributed by **Bryan T**, 2 Sep 2026, to fill the gap the module docs left:
+`_template` had a manifest skeleton and no engine, and the smallest shipping
+insert was ~300 lines.
+
+## Status
+
+**Hardware-confirmed by its author** (2 Sep 2026, OS 1.40C base, Bryan T's
+unit — not Sam's): GAIN=64 measures −6 dB against GAIN=127; GAIN=127 is
+level-identical to SEND (the de facto NONE in this remix) on the same source;
+sequencer and project load normal, including a pre-existing project saved
+under stock.
+
+One anomaly on record, **not reproduced**: the first flash of this image
+froze the sequencer ~2 steps after play (the classic DSP-stall signature).
+A reflash of the byte-identical image ran clean — same unit, same project.
+Suspected bad flash; unproven. If it recurs, note that this is the first
+remix ever flashed with NO bus server (SEND housekeeps alone), and check
+that layout before blaming the 27 words.
+
+**Measured here** (`tools/verify_hello.py`, dsp_host, payload A, entries
+resolved from the dispatch tables of the built image; input a full-scale
+bipolar ramp), reproducing the author's numbers exactly:
+
+- GAIN=127 is a **bit-exact** passthrough — the early-out returns before any
+  arithmetic, and inserts process in place, so unity is "touch nothing".
+- GAIN=0 is exact silence.
+- GAIN 32/64/96/126: every output sample is exactly `(in × GAIN<<16) >> 23`,
+  0 LSB error, negative half included — which also confirms behaviourally
+  (not just by disassembly) that the one `mpy` encodes signed. A silent
+  `mpysu` here would corrupt exactly the negative half; it doesn't.
+- L and R identical for identical input.
+
+**Disassembled** (2 Sep 2026, out of the built image at `P:0x10d8`, not out
+of the source): the compare encodes `cmp x0,a` and not `max a,b`, and both
+multiplies encode `mpy x0,y1,a` and not `mpysu` — the two mis-encodings that
+would each leave this file assembling clean and doing the wrong thing.
+
+**Inferred**: nothing load-bearing remains inferred. The mpy-scaling question
+(plain product vs an extra `asl`) was settled by the gain-law gate — the
+factor-2 alternative misses by ~2²¹ LSB.
+
+Remaining unchecked by ear: GAIN=0 silence (verified exact in the emulator).
+
+The original falsification protocol, kept for re-runs: flash `hello`, put
+HELLO WORLD on any track's FX2, play a source. GAIN=127 must be
+indistinguishable from NONE; GAIN=64 must be −6 dB; the knob must be silent
+at 0 and clickless in between (the coefficient updates per block, ~0.34 ms —
+a full-throw sweep may zipper slightly, which a taper/slew is the eventual
+answer to, not a bug in v1).
+
+## Parameters
+
+| slot | name | what it does |
+|---|---|---|
+| 0 | GAIN | linear level, out = in × GAIN/128; 127 = exact passthrough, 0 = silence. Default 127. |
+
+The 126→127 step is 0.984→1.0 (~0.14 dB): the price of a bit-exact top.
+
+## Running the gates
+
+```bash
+make check REMIX=hello
+python3 tools/remix/audition.py hello out/dry/drums_110.wav GAIN=64
+python3 tools/verify_hello.py            # expects ALL GATES PASSED, 0 LSB
+```
+
+The audition builds the scratch image the gates measure, so it comes first.
+
+⚠️ `verify_hello.py` derives the fx2 id and the GAIN slot from this manifest
+and refuses to run if they resolve to SEND's entry points. That is not
+defensive decoration. As contributed it hardcoded `FXID = 0x17`; hello moved
+to `0x1b` on integration (0x17 became Rungs's on 2 Sep), and the tool then
+measured **the send client** for all six gains — and its `GAIN=127 bit-exact
+passthrough` gate PASSED, because a dry passthrough is exactly what unity
+gain looks like. Only the gain-law gates dissented. Same family as the 12 Aug
+2026 "BongDelay outputs nothing" session: an id an image does not implement
+aliases to the fallback and renders plausible, wrong audio.
+
+## The 5-char abbr crash (found on hardware by Bryan T, 2 Sep 2026)
+
+The first cut used `abbr=b"HELLO"` — 5 characters. The descriptor's abbr field
+is **5 bytes, NUL-terminated** (`docs/PARAM_PAGES.md` §2), i.e. 4 characters
+plus a terminator. "HELLO" filled all 5 bytes with no NUL. Manual knob use
+never showed anything wrong, but **LFO-modulating a parameter** threw a
+line-F exception (VEC:0B) whose faulting address was `0x48454C4C` — "HELL".
+
+It presented as "custom effects can't be modulated," and looked at first like
+a bug in the descriptor-clone mechanism. It is not. Confirmed on hardware by
+modulating WarpFold and BodeShift (no crash) against hello (crash), then
+fixed by shortening the abbr to 4 chars.
+
+**The rule is measured; the mechanism is partly inferred.** What is measured:
+all 30 of the firmware's own page descriptors carry an abbr of 4 characters
+or fewer with byte 5 zero (audited across the pristine image, 2 Sep 2026),
+every shipping module already did, and hello at 5 was the sole crash.
+
+What is inferred: the author's account is that a C-string read ran past the
+field into `fullname`. That alone does not explain the *faulting PC*, which
+is the field's own ASCII — an overrunning read yields a wrong string, not a
+jump. A PC made of the copied bytes is the signature of a **smashed return
+address**: something copies the abbreviation into a fixed 5-byte destination
+and the extra characters land past it. The copy has not been located in the
+disassembly. Falsifier: a 5-char abbr whose overrun stays printable and does
+not fault. Either way the remedy is the same, and it is now a build refusal
+rather than a convention — `schema.MenuEntry` rejects an abbr over 4
+characters and a fullname over 12, and `build_bus.py` re-checks the string it
+actually writes, tag included.
+
+## Open
+
+- **Taper select** (page-2 slot 7, LIN/LOG/…): planned, not started. The
+  stepped-control budget puts it on 7, 9 or 11 only.
+- **FX1 availability**: the module contract is FX2-only. `tools/build_fx1.py`
+  proved the FX1 chooser can be extended (relocated to a cave — it cannot
+  grow in place), but that machinery is not in the manifest schema. A
+  bufferless insert has neither of the reasons DELAY/reverbs can't be FX1,
+  so this is schema work, not a hardware wall.
+- **Per-block coefficient step**: no slew. Fine for a gain; a future taper
+  pass could add one if knob sweeps zipper audibly on hardware.
+- **`dsp_host -dispatch` (faithful mode) wedges** with wild memory reads on
+  any image the author tested, on two machines. Reported with the module,
+  **not verified here** — the gates drive `-init`/`-proc` directly and never
+  touch that path.

--- a/modules/hello/README.md
+++ b/modules/hello/README.md
@@ -125,7 +125,34 @@ actually writes, tag included.
   so this is schema work, not a hardware wall.
 - **Per-block coefficient step**: no slew. Fine for a gain; a future taper
   pass could add one if knob sweeps zipper audibly on hardware.
-- **`dsp_host -dispatch` (faithful mode) wedges** with wild memory reads on
-  any image the author tested, on two machines. Reported with the module,
-  **not verified here** — the gates drive `-init`/`-proc` directly and never
-  touch that path.
+- **`dsp_host -dispatch` (faithful mode) is broken, and it is TWO faults,
+  not one.** Reported with the module as "wedges with wild memory reads on
+  any image, on two machines"; reproduced here 2 Sep 2026 and taken apart.
+
+  **Measured:** block 0 always completes; block 1 never does. The process
+  sits at **0% CPU**, sleeping — it is not a runaway. A stack sample puts
+  it inside `HDI08::writeTX` → `ConditionVariable::wait`: faithful mode runs
+  the firmware's own host writes, the emulator's TX ring is 8192 words and
+  **blocking**, and dsp_host models no ColdFire to read them, so once the
+  ring fills `movep a,x:<<M_HTX` parks forever. It is not the image and not
+  the DSP code — the 400,000-step ceiling cannot catch it, because the
+  process is stuck inside a single instruction. Draining the ring between
+  instructions does **not** fix it: the writes happen inside a hardware DO
+  loop that the emulator runs to completion in one `execInterpreter()` call,
+  so the harness never gets a turn.
+
+  `setTransmitDataAlwaysEmpty(false)` (now set, scoped to dispatch mode
+  only — every other path is byte-for-byte unaffected, `make check` and the
+  gates above confirm) makes the write overwrite and return instead of
+  waiting. The wedge is gone. **Faithful mode then SIGSEGVs on block 1**,
+  `KERN_INVALID_ADDRESS`, which is the "wild memory reads" half of the
+  original report — a second, separate defect the hang had been masking.
+
+  **Inferred, not chased:** the likely candidate is that each block is
+  entered with `dsp.setPC(0x372)` without resetting the DSP's stack, loop
+  and status state, so whatever block 0 left on the stack accumulates. That
+  is a harness modelling gap in the same family as the TX one. Falsifier:
+  reset SP/LA/LC between blocks and see whether block 1 survives. **Nobody
+  has done this**, and until someone does, faithful mode remains unusable —
+  which matters, because it is the only thing that would validate the
+  hand-rolled calling convention the rest of the harness assumes.

--- a/modules/hello/gain.asm
+++ b/modules/hello/gain.asm
@@ -1,0 +1,60 @@
+; ---------------------------------------------------------------------------
+; HELLO WORLD -- a linear volume knob. The reference minimal insert.
+;
+; A per-track INSERT: reads this track's stereo frames from x:(r0) (L) and
+; x:(r0+n0) (R) and writes them back IN PLACE, warpfold's exact convention.
+; No bus role, no shared window, no absolute Y, and -- unlike every other
+; module -- no r7 state at all: the effect is stateless, so nothing persists
+; and the two-track-freeze discipline has nothing to protect.
+;
+; ---- knobs ----------------------------------------------------------------
+;   p0 GAIN  x:(r6+$0)  val<<16, so as a Q23 fraction it is raw/128
+;            (0 .. 0.9921875). out = in * GAIN/128.
+;            GAIN >= $7f0000 takes the early-out below: frames are already
+;            in place, so unity gain is "touch nothing" -- a BIT-EXACT
+;            passthrough, and the render harness's null gate. `bge`, not
+;            `beq`, so any nonzero low bits in the knob word cannot defeat
+;            it. GAIN=0 is exact silence (zero coefficient through mpy).
+;
+; ---- arithmetic notes -----------------------------------------------------
+; * The one mpy is `mpy x0,y1` -- one of the two operand orders dsp_asm is
+;   known to encode SIGNED (CLAUDE.md). The SAMPLE sits in x0 and goes
+;   negative every other half-cycle; a silent mpysu here is precisely the
+;   stock AMF bug class, and the render's negative-sample check is aimed
+;   at it. Audit by disassembly, not by reading this source.
+; * mpy is the toolchain's plain product (warpfold's DRV block is the
+;   precedent: gq = 0.125 + DRV*0.875, mpy with no shift). in (-1,1) times
+;   g [0,1) needs no pre-halve and no asl.
+; * No logical ops anywhere, so no A1/A2 staleness to clean. The only
+;   accumulator loads are plain moves.
+; ---------------------------------------------------------------------------
+
+init:
+        rts                             ; stateless: nothing to seed
+
+proc:
+; ---- per-block: fetch GAIN, take the unity early-out ----------------------
+        move    x:(r6+$0),a             ; GAIN, val<<16, positive
+        move    #>$7f0000,x0
+        cmp     x0,a                    ; a - $7f0000
+        bge     hw_unity                ; raw 127 (or above): exact pass
+        move    a,y1                    ; g = GAIN/128, Q23, in [0, 0.992)
+
+; ---- per-frame: out = in * g, both channels, in place ---------------------
+        move    #>$1,n0
+        do      n7,>hw_end
+        move    x:(r0),x0               ; L
+        mpy     x0,y1,a                 ; signed encoding order
+        move    a,x:(r0)                ; L in place
+        move    x:(r0+n0),x0            ; R
+        mpy     x0,y1,a
+        move    a,x:(r0+n0)             ; R in place
+        move    #>$2,n0
+        move    (r0)+n0                 ; next stereo frame
+        move    #>$1,n0
+hw_end:
+        nop
+        rts
+
+hw_unity:
+        rts                             ; in place already: unity is a no-op

--- a/modules/hello/manifest.py
+++ b/modules/hello/manifest.py
@@ -1,0 +1,63 @@
+"""HELLO WORLD -- a linear volume knob, and the reference minimal insert.
+
+The smallest complete module: one page-1 knob (GAIN), out = in * GAIN/128,
+processed in place per the insert contract. It exists to be read -- the
+worked example of manifest + engine + render gates that _template describes
+-- and to stay permanently buildable as a canary for the pipeline.
+
+GAIN >= 127 takes an early-out before any arithmetic, so 127 is a BIT-EXACT
+passthrough (frames are in place; unity gain is "touch nothing"). GAIN=0 is
+exact silence (a zero coefficient through mpy). Both are render gates.
+The cost of the exact top: 126 -> 127 steps 0.984 -> 1.0 (~0.14 dB).
+
+Planned, not present: a taper select on page-2 slot 7 (LIN/LOG/...), and
+FX1 availability once build_fx1.py's chooser-relocation is folded into the
+module contract. Neither is started.
+"""
+
+from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
+                          MenuEntry, Module, Param, YBase)
+
+MODULE = Module(
+    name="hello",
+    key="HELLO WORLD",
+    kind=Kind.DSP_EFFECT,
+    doc="Reference minimal insert: one GAIN knob, out = in * GAIN/128.",
+
+    menu=MenuEntry(
+        # Free on BOTH sides: not one of stock's fifteen (so no stock effect
+        # is displaced on FX1 either -- schema.STOCK_FX2_IDS), and no module
+        # claims it. The registry is the arbiter and refuses a duplicate at
+        # import, remix membership notwithstanding; 0x17 -- which this module
+        # arrived on -- is Rungs's since 2 Sep 2026.
+        fx2_id=0x1b,
+        donor_desc=0x400d58b8,        # DARK REV -- the proven insert donor
+        abbr=b"HELO",                 # <=4 chars: the field is 5 bytes and must
+                                      # stay NUL-terminated. "HELLO" filled all 5
+                                      # with no terminator, so a C-string read ran
+                                      # into fullname -- crashing on LFO modulation
+                                      # (line-F, faulting addr = the abbr bytes).
+        fullname=b"HELLO WORLD",      # 11 of 13 bytes
+        build_tag=False,
+    ),
+
+    params=(
+        # ---- page 1 -------------------------------------------------------
+        Param(b"GAIN", 127, 128, active=True, formatter=Formatter.PLAIN,
+              doc="linear level, out = in x GAIN/128; 127 exact pass, 0 silence"),
+        Param(), Param(), Param(), Param(), Param(),
+        # ---- page 2: none in v1 (taper select will land on slot 7) --------
+        Param(), Param(), Param(), Param(), Param(), Param(),
+    ),
+
+    dsp=DspSection(
+        asm="modules/hello/gain.asm",
+        priority=11,                  # after bodeshift (10); byte-load-bearing
+        bus_role=BusRole.NONE,
+        ybase=YBase.NEVER,            # no absolute Y anywhere in the source
+        r7_latch_slot=None,
+        gate_label=None,
+    ),
+
+    harness=Harness(layout_char="H", is_server=False),
+)

--- a/remixes/hello.py
+++ b/remixes/hello.py
@@ -1,0 +1,18 @@
+"""HELLO -- the reference minimal build: one gain insert, nothing else.
+
+The smallest image the module system can produce: HELLO WORLD (a linear
+volume knob) plus SEND, which every insert remix carries because the
+absent-server alias needs its entry points to exist. This remix is the
+worked example `modules/_template` points at, and doubles as a pipeline
+canary: if this stops building or stops nulling at GAIN=127, the build
+system moved under everyone.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="hello",
+    doc="Reference minimal build: HELLO WORLD gain insert + SEND.",
+    modules=("HELLO WORLD", "SEND"),
+    fallback="SEND",
+)

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -804,13 +804,39 @@ def main():
     # ==== 1. ColdFire menu tables (task 11) =================================
     # Diagnostic tempo-cave variants stamp the panel name so the running
     # firmware is unmistakable (the R48/R49 isolation, 24 Aug 2026).
+    # 11 chars + a 2-char tag is 13, which FILLS the 13-byte field and leaves
+    # no NUL -- the defect Bryan T's HELLO WORLD contribution found on the
+    # abbr field (5 chars in 5 bytes, crash on LFO modulation). Bounded to 10
+    # so the tagged name still terminates. The check below enforces it for
+    # every arm that writes a name, not just these two.
     if os.environ.get("TEMPOCAVE") == "replay":
-        FULLNAME["DELAY SERVER"] = b"BongDlyRPLY" + BUILD_TAG
+        FULLNAME["DELAY SERVER"] = b"BongDlyRPL" + BUILD_TAG
     elif os.environ.get("NOTEMPO") == "1":
-        FULLNAME["DELAY SERVER"] = b"BongDlyNOCF" + BUILD_TAG
+        FULLNAME["DELAY SERVER"] = b"BongDlyNOC" + BUILD_TAG
     cave_end = CLONE_BASE + CLONE_STRIDE * len(CLONED_ORDER)
     if any(img[NEW_LIST - BASE:cave_end - BASE]):
         sys.exit("menu cave not free")
+
+    # ---- both name fields are NUL-TERMINATED --------------------------------
+    # The schema checks what a MANIFEST declares; this checks what the build
+    # actually writes, which is not the same string -- the panel name is
+    # rewritten from six different places depending on the flags, and the
+    # build tag is appended after all of them. A name that exactly fills its
+    # field leaves no terminator, and the firmware's string read runs off the
+    # end of it: 5 chars in the 5-byte abbr crashed a real unit on LFO
+    # modulation (2 Sep 2026, Bryan T -- schema.MenuEntry has the writeup).
+    # Two diagnostic delay names had been doing it to the 13-byte fullname
+    # since 24 Aug 2026, found by that contribution and shortened above.
+    for name in CLONED_ORDER:
+        if len(ABBR[name]) > 4:
+            sys.exit(f"abbr {ABBR[name]!r} for {name} is {len(ABBR[name])} "
+                     f"characters -- the field is 5 bytes NUL-terminated, so "
+                     f"4 is the maximum")
+        if len(FULLNAME[name]) > 12:
+            sys.exit(f"panel name {FULLNAME[name]!r} for {name} is "
+                     f"{len(FULLNAME[name])} characters (build tag included) "
+                     f"-- the field is 13 bytes NUL-terminated, so 12 is the "
+                     f"maximum")
 
     clone_addr = {}
     print("=== ColdFire: three cloned descriptors (task 11) ===")

--- a/tools/dsp_host/dsp_host.cpp
+++ b/tools/dsp_host/dsp_host.cpp
@@ -642,6 +642,33 @@ int main(int argc, char** argv) {
                             t, a.fxid, incoming ? a.prevfx : a.fxid,
                             incoming ? a.split : 0, incoming ? "   <- BEING ADDED" : "");
         }
+        // ---- drain the host transmit FIFO -------------------------------
+        // FAITHFUL MODE RUNS THE FIRMWARE'S OWN HOST WRITES, and we model no
+        // ColdFire to read them. HDI08's TX ring is 8192 words and BLOCKING:
+        // once it fills, `movep a,x:<<M_HTX` parks inside HDI08::writeTX on a
+        // condition variable and never returns. It is not a hang in the DSP
+        // code and the 400,000-step ceiling below cannot catch it -- the
+        // process sits at 0% CPU inside ONE instruction, which is why it
+        // reads as a wedge rather than an error. Block 0 fits in the ring;
+        // block 1 does not, so `-dispatch` looked broken on every image
+        // (reported 2 Sep 2026 with the HELLO WORLD contribution, diagnosed
+        // by stack sample). Reading the words back is what the hardware host
+        // does, so this is more faithful than blocking, not less.
+        // periphX is the 56362, which is the one carrying the HDI08 here;
+        // the 56367 (periphY) has only the ESAI.
+        //
+        // Draining between instructions is NOT enough on its own: the stack
+        // sample puts the writes inside DSP::do_exec, a hardware DO loop the
+        // emulator runs to completion in ONE execInterpreter() call, so it
+        // pushes past 8192 without ever giving the harness a turn. The flag
+        // is what actually unblocks it -- with it clear, writeTX overwrites
+        // the head and returns instead of calling waitNotFull(). We keep the
+        // drain as well so `hasTX()` stays a useful thing to inspect.
+        periphX.getHDI08().setTransmitDataAlwaysEmpty(false);
+        auto drainHostTX = [&]() {
+            auto& h = periphX.getHDI08();
+            while (h.hasTX()) h.readTX();
+        };
         for (int b = 0; b < a.blocks; ++b) {
             dsp.setPC(0x372);
             bool ok = false;
@@ -653,8 +680,12 @@ int main(int argc, char** argv) {
                     recent.push_back(pc);
                     if (recent.size() > 40) recent.erase(recent.begin());
                 }
+                // Cheap enough at 1/1024 instructions, and it has to be
+                // INSIDE the block: the ring can fill mid-block.
+                if ((i & 0x3ff) == 0) drainHostTX();
                 dsp.execInterpreter();
             }
+            drainHostTX();
             if (!ok && a.trace && !recent.empty()) {
                 std::printf("  last 40 PCs: ");
                 for (TWord q : recent) std::printf("%05x ", q);

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -159,8 +159,13 @@ class MenuEntry:
 
     fx2_id: int
     donor_desc: int                    # E address of the stock donor
-    abbr: bytes                        # 5-byte short name
-    fullname: bytes                    # 13-byte panel name, before any tag
+    # BOTH NAME FIELDS ARE NUL-TERMINATED, so their usable length is one less
+    # than the field: abbr is 5 bytes = FOUR characters, fullname 13 bytes =
+    # TWELVE (docs/PARAM_PAGES.md section 2). Filling a field exactly leaves
+    # no terminator and the firmware's string read runs off the end of it --
+    # see __post_init__.
+    abbr: bytes                        # <=4 chars, in a 5-byte field
+    fullname: bytes                    # <=12 chars, in a 13-byte field
     build_tag: bool = False            # append the image's build tag
 
     def __post_init__(self):
@@ -170,10 +175,42 @@ class MenuEntry:
         if not 0x04 <= self.fx2_id <= 0x1f:
             raise ValueError(f"fx2 id 0x{self.fx2_id:02x} is out of range "
                              f"(0x00-0x03 are stock's 'no effect' synonyms)")
-        if len(self.abbr) > 5:
-            raise ValueError(f"abbr {self.abbr!r} exceeds 5 bytes")
-        if len(self.fullname) > 13:
-            raise ValueError(f"fullname {self.fullname!r} exceeds 13 bytes")
+        # ⚠️ FOUR, not five. The abbr field is 5 bytes NUL-TERMINATED, so a
+        # 5-character abbreviation fills it with no terminator and whatever
+        # reads the abbreviation as a C string runs past it into `fullname`.
+        # Found on hardware 2 Sep 2026 by Bryan T, contributing the HELLO
+        # WORLD module: `abbr=b"HELLO"` drew correctly and behaved normally
+        # under manual knob use, and threw a line-F exception the moment a
+        # parameter was LFO-MODULATED -- faulting PC 0x48454C4C, which is
+        # "HELL". It presented as "custom effects cannot be modulated".
+        #
+        # A faulting PC made of the field's own ASCII is the signature of a
+        # SMASHED RETURN ADDRESS, not merely a long read: something copies
+        # the abbreviation into a fixed 5-byte destination, and the extra
+        # characters land past it. INFERRED -- the copy has not been located
+        # in the disassembly. Falsifier: a 5-char abbr whose overrun stays
+        # printable but does not fault.
+        #
+        # What is MEASURED is the rule: all 30 of the firmware's own page
+        # descriptors carry an abbr of 4 characters or fewer with byte 5
+        # zero, every shipping module already did (WFLD, BODE, RPPL, RNGS,
+        # STRM, ...), and hello at 5 was the sole crash. The build used to
+        # accept it and silently overrun -- one evening to find, so it is a
+        # refusal now.
+        if len(self.abbr) > 4:
+            raise ValueError(
+                f"abbr {self.abbr!r} is {len(self.abbr)} characters -- the "
+                f"field is 5 bytes NUL-TERMINATED, so 4 is the maximum. A "
+                f"5th character leaves no terminator and the panel's string "
+                f"read runs into fullname (crashes on LFO modulation).")
+        # Same field shape, same reasoning: 13 bytes NUL-terminated. The
+        # build tag is appended LATER, in build_bus.py, which is where the
+        # tagged length is checked -- this cannot see it.
+        if len(self.fullname) > 12:
+            raise ValueError(
+                f"fullname {self.fullname!r} is {len(self.fullname)} "
+                f"characters -- the field is 13 bytes NUL-TERMINATED, so 12 "
+                f"is the maximum.")
 
 
 @dataclass(frozen=True)

--- a/tools/verify_hello.py
+++ b/tools/verify_hello.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""HELLO WORLD render gates, at the raw Q23 level.
+
+Input: a full-scale bipolar ramp -- every magnitude, both signs, so a silent
+mpysu mis-encoding (wrong on negative samples) cannot hide.
+
+Gates:
+  GAIN=127 -> output bit-exact vs input (both channels)
+  GAIN=0   -> output all-zero
+  GAIN in {32,64,96,126} -> per-sample |out - (in*g)>>23| <= 1 LSB
+     (also reports the factor-2 alternative, settling the mpy-scaling question)
+
+The dump comes from the audition, which builds a scratch image that really
+contains this insert:
+
+    python3 tools/remix/audition.py hello out/dry/drums_110.wav
+    python3 tools/verify_hello.py
+
+⚠️ NOTHING HERE IS HARDCODED ABOUT WHICH EFFECT IS MEASURED. The id and the
+GAIN slot come from the manifest, and the resolved entry points are checked
+against SEND's, because an id this image does not implement ALIASES TO THE
+FALLBACK and dsp_host then renders a perfectly plausible dry passthrough
+(CLAUDE.md, 12 Aug 2026). That is not hypothetical here: this file shipped
+with `FXID = 0x17` after hello moved to 0x1b, ran SEND for all six gains,
+and the GAIN=127 bit-exact gate PASSED -- because a dry passthrough is
+exactly what unity gain looks like. Only the gain-law gates dissented.
+"""
+import pathlib, struct, subprocess, sys
+
+sys.path.insert(0, "tools")
+import send_probe  # reuse its dispatch-table entry resolution
+from remix import registry
+
+MOD = registry.by_name("hello")
+SEND = registry.by_name("send")
+GAIN_SLOT = MOD.knob_map()["GAIN"]
+NSLOTS = 6                              # page 1: r6+0..5
+
+MEM = f"out/dsp/_audition_{MOD.name}_A.mem"
+HOST = "vendor/dsp56300/build/source/dsp_host/dsp_host"
+FXID = MOD.menu.fx2_id
+FRAMES, N = 15, 4200
+
+if not pathlib.Path(MEM).exists():
+    sys.exit(f"no {MEM} -- build it first:\n"
+             f"  python3 tools/remix/audition.py {MOD.name} out/dry/drums_110.wav")
+
+init, proc = send_probe.entry_points(MEM, FXID)
+print(f"entries from dispatch tables: init=P:0x{init:04x} proc=P:0x{proc:04x} "
+      f"(fx id 0x{FXID:02x}, GAIN at r6+${GAIN_SLOT:x})")
+
+# The SEND-alias guard. An absent id resolves to the fallback and renders a
+# dry pass; measuring that and calling it a null gate is the failure this
+# tool exists to avoid.
+if (init, proc) == send_probe.entry_points(MEM, SEND.menu.fx2_id):
+    sys.exit(f"fx id 0x{FXID:02x} resolves to the SAME entry points as SEND "
+             f"(0x{SEND.menu.fx2_id:02x}) -- {MOD.name} is NOT in this dump, "
+             f"so every gate below would measure the send client. Rebuild:\n"
+             f"  python3 tools/remix/audition.py {MOD.name} out/dry/drums_110.wav")
+
+# full-scale bipolar ramp, exact endpoints
+ramp = [int(round(-8388607 + (2 * 8388607) * i / (N - 1))) for i in range(N)]
+assert min(ramp) == -8388607 and max(ramp) == 8388607
+pathlib.Path("/tmp/ramp.raw").write_bytes(b"".join(struct.pack("<i", s) for s in ramp))
+
+def render(gain):
+    out = f"/tmp/hello_g{gain}.raw"
+    cmd = [HOST, "-mem", MEM, "-init", f"{init:x}", "-proc", f"{proc:x}",
+           "-inst", "1", "-r7", "2", "-alloc", "1", "-inmask", "1",
+           "-frames", str(FRAMES), "-blocks", str(N // FRAMES),
+           "-in", "/tmp/ramp.raw", "-out", out,
+           "-params", ",".join(str(gain if i == GAIN_SLOT else 0)
+                                for i in range(NSLOTS))]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        sys.exit(f"dsp_host failed for GAIN={gain}:\n{r.stdout}\n{r.stderr}")
+    d = pathlib.Path(out).read_bytes()
+    w = struct.unpack(f"<{len(d)//4}i", d)
+    L, R = w[0::2], w[1::2]
+    return L[:N], R[:N]
+
+fails = 0
+def gate(name, ok, detail=""):
+    global fails
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f"  {detail}" if detail else ""))
+    if not ok: fails += 1
+
+# --- GAIN=127: bit-exact null ---------------------------------------------
+L, R = render(127)
+same = all(L[i] == ramp[i] and R[i] == ramp[i] for i in range(N))
+gate("GAIN=127 bit-exact passthrough", same,
+     "" if same else f"first diff at {next(i for i in range(N) if L[i]!=ramp[i] or R[i]!=ramp[i])}")
+
+# --- GAIN=0: exact silence -------------------------------------------------
+L, R = render(0)
+gate("GAIN=0 exact silence", all(v == 0 for v in L + R))
+
+# --- gain law --------------------------------------------------------------
+for g in (32, 64, 96, 126):
+    L, R = render(g)
+    gq = g << 16
+    exp  = [(s * gq) >> 23 for s in ramp]          # engine as written (no asl)
+    exp2 = [(s * gq) >> 24 for s in ramp]          # the factor-2 alternative
+    err  = max(abs(L[i] - exp[i])  for i in range(N))
+    err2 = max(abs(L[i] - exp2[i]) for i in range(N))
+    lr   = max(abs(L[i] - R[i]) for i in range(N))
+    ok = err <= 1 and lr == 0
+    gate(f"GAIN={g:3d} law (in*g)>>23", ok,
+         f"max|err|={err} LSB (factor-2 alt: {err2})  L/R match: {lr==0}")
+    # negative-sample spot check: worst error on the negative half alone
+    neg = [i for i in range(N) if ramp[i] < 0]
+    errn = max(abs(L[i] - exp[i]) for i in neg)
+    gate(f"GAIN={g:3d} negative-sample half", errn <= 1, f"max|err|={errn} LSB")
+
+print("\nALL GATES PASSED" if fails == 0 else f"\n{fails} GATE(S) FAILED")
+sys.exit(1 if fails else 0)


### PR DESCRIPTION
Integrates the hello-world module Bryan T shared, and closes out three
defects it surfaced on the way in — two of them ours.

## The module

`modules/hello/` — a linear volume knob. One page-1 knob, 27 words of DSP,
no state, no bus role, no shared window. It fills the gap the module docs
left (`_template` had a manifest skeleton and no engine; the smallest
shipping insert was ~300 lines) and stays permanently buildable as a
pipeline canary. `docs/MODULES.md` and the README now send a new
contributor here first.

```bash
make check REMIX=hello
python3 tools/remix/audition.py hello out/dry/drums_110.wav GAIN=64
python3 tools/verify_hello.py            # ALL GATES PASSED, 0 LSB
```

Reproduced the author's numbers exactly: GAIN=127 bit-exact passthrough,
GAIN=0 exact silence, GAIN 32/64/96/126 all `(in*g)>>23` to **0 LSB**
including the negative half. Plus the disassembly audit CLAUDE.md requires —
the compare encodes `cmp` and not `max`, both multiplies encode `mpy` and
not `mpysu`.

### Changed on integration

- **fx2 id 0x17 -> 0x1b.** 0x17 was free when the module was written and
  became Rungs's on 2 Sep; the registry refuses a duplicate at import, so
  every build would have died.
- **`verify_hello.py` now derives the id and the GAIN slot from the
  manifest, and refuses when they resolve to SEND's entry points.** As
  contributed it hardcoded 0x17, so after the move it measured the *send
  client* for all six gains — and its "GAIN=127 bit-exact passthrough" gate
  PASSED, because a dry pass is exactly what unity gain looks like. Only the
  gain-law gates dissented. Same family as the 12 Aug "BongDelay outputs
  nothing" session.

## Descriptor names must leave room for the NUL

`abbr` is a 5-byte field holding **four** characters plus a terminator;
`fullname` is 13 bytes holding **twelve**, and the build tag is appended
after your string. Filling a field exactly leaves no terminator.

Bryan found this on hardware: `abbr=b"HELLO"` assembled, built, drew
correctly and behaved normally under manual knob use, then threw a line-F
exception the moment a parameter was **LFO-modulated** — faulting PC
`0x48454C4C`, "HELL". It presented as "custom effects can't be modulated".
The build had accepted it silently.

- MEASURED: all 30 of the firmware's own page descriptors are <=4 chars with
  byte 5 zero; every shipping module already was; hello at 5 was the sole
  crash.
- INFERRED: a faulting PC made of the field's own ASCII is a smashed return
  address, so the copy destination is fixed-size rather than the read merely
  running long. The copy is not located in the disassembly. Falsifier: a
  5-char abbr whose overrun stays printable and does not fault.

`schema.MenuEntry` refuses both over-lengths, and `build_bus.py` re-checks
the string it *actually writes* — the panel name is rewritten from six
places depending on the flags and the schema cannot see any of them. That
second check immediately caught **two of our own** diagnostic delay names,
`BongDlyRPLY` and `BongDlyNOCF`, which with the build tag have been filling
all 13 bytes with no terminator since 24 Aug. Shortened.

## dsp_host `-dispatch` was never broken the way it looked

Reported with the module as "wedges with wild memory reads on any image, on
two machines". Reproduced and taken apart: block 0 always completes, block 1
never does, at **0% CPU**. A stack sample lands in `HDI08::writeTX` ->
`ConditionVariable::wait`. Faithful mode runs the firmware's own host
writes; the emulator's TX ring is 8192 words and **blocking**; dsp_host
models no ColdFire to read them. Once it fills, `movep a,x:<<M_HTX` parks
forever inside a single instruction — which is why the 400,000-step hang
ceiling never fires.

Draining between instructions does **not** fix it: the writes happen inside
a hardware DO loop the emulator runs to completion in one
`execInterpreter()` call. Clearing the transmit-always-empty flag does.
Scoped to dispatch mode; every other path is unaffected.

⚠️ **Faithful mode is still broken** — with the wedge gone it SIGSEGVs on
block 1, the "wild memory reads" half, a second defect the hang was masking.
The register-file explanation is **falsified**: restoring the entire `SRegs`
struct before each block changes nothing, at 1 track and at 4. So the state
that kills it is in memory. Next falsifier is written down in
`modules/hello/README.md`.

## Gates

- `make check` green on `chongbong`, `hello` and `mutables`.
- `tools/verify_hello.py`: all gates, 0 LSB.
- **refhash:** the schema change is byte-neutral — all 26 cases bit-identical
  with `modules/hello` held aside. Adding the module itself aliases its id to
  the fallback in every remix, so all 26 gain 13 bytes; that is the
  module-addition path, not a build change.
- ⚠️ **The `build_bus.py` name fix deliberately moves two cases**, `notempo`
  and `tempocave-replay`, and only those two. **Re-save the baseline.**

## Not done

Hello World is hardware-confirmed **by its author, on his unit, not this
project's** — the only module here in that position. One anomaly on record
and not reproduced: the first flash froze the sequencer ~2 steps after play,
a reflash of the byte-identical image ran clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)