### PR TITLE
The remixer goes global: FX1 rows, dynamic donor regions, and a deterministic test project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ modmap: ## DSP module load map — which bytes land at which P address
 verify: ## Verify the ColdFire menu edits, module ledger (+ burn probe when it fits; it currently SKIPS)
 	python3 tools/remix/selftest.py
 	python3 tools/verify_slots.py
+	python3 tools/verify_replaces.py
 	REMIX=$(REMIX) python3 tools/verify_menu.py
 	python3 tools/verify_burn.py
 

--- a/Makefile
+++ b/Makefile
@@ -163,13 +163,13 @@ modules: ## List the module index and the available remixes
 	python3 tools/remix/index.py
 
 .PHONY: remix
-remix: ## The workbench: 8 tracks, dial + hear effects, compose + build the image
+remix: ## The remixer: swap effects in and out, dial + hear them, build the image
 	$(PY) tools/remix/app.py
 
 .PHONY: emu-setup
-emu-setup: ## Provision the workbench deps (unicorn + textual) into .venv via uv
+emu-setup: ## Provision the remixer deps (unicorn + textual) into .venv via uv
 	uv sync --extra emu
-	@echo "workbench ready — 'make remix' (docs/EMU.md for the emulator view)"
+	@echo "remixer ready — 'make remix' (docs/EMU.md for the emulator view)"
 
 # -------------------------------------------------------------------- misc --
 

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,9 @@ verify: ## Verify the ColdFire menu edits, module ledger (+ burn probe when it f
 	python3 tools/remix/selftest.py
 	python3 tools/verify_slots.py
 	python3 tools/verify_replaces.py
+	python3 tools/label_fmt.py
+	@$(PY) tools/verify_labels.py $(REMIX) 2>/dev/null || \
+	  echo "  [SKIP] label check against the firmware: no .venv (make emu-setup)"
 	REMIX=$(REMIX) python3 tools/verify_menu.py
 	python3 tools/verify_burn.py
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -68,7 +68,7 @@ twelve parameter slots, its DSP source, its ColdFire caves — and
 image and the reference every refactor proves itself against.
 
 ```sh
-make remix                # the workbench: compose a selection interactively
+make remix                # the remixer: compose a selection interactively
 make modules              # the module index and the available remixes
 make bus REMIX=<name>     # build a selection (default: chongbong)
 ```
@@ -448,7 +448,7 @@ parameter slot to put a delay control on. Treat a first result of "it makes
 delayed sound at some arbitrary time" as success for the experiment and a
 separate problem for the design.
 
-### 5. The workbench: remix TUI + a local ColdFire emulator (decided 31 Aug 2026)
+### 5. The remixer: remix TUI + a local ColdFire emulator (decided 31 Aug 2026)
 
 **The aim is an iterate-with-a-cycle loop for ColdFire/UI work** — the class
 of change that today costs a flash per attempt. Two backlog items merge into
@@ -494,7 +494,7 @@ the TUI is a shell around it.**
    list drawer `FUN_40037590`, sprintf `0x40013a08`) into a windows+strings
    model; inject keys at the software layer (the `[PAGE]` keycode-`0x1b`
    precedent). Not pixel-faithful — menu-walking faithful.
-3. **TUI shell** (upgrades the `make remix` workbench): remix pane + build
+3. **TUI shell** (upgrades the `make remix` remixer): remix pane + build
    pane land first and are useful with no emulator; the emu pane plugs in
    when Tier 1 does. Schedules deliberately uncoupled.
 4. **Audio stays out.** The voicing loop (render → afplay → ear) is already
@@ -517,7 +517,7 @@ through all early hardware init, and stops exactly at the RTOS handoff
 completion-flag spins are auto-satisfied.
 
 **Milestone 1 is shipped**: the emulator is a library (`boot()` +
-`read_menu_tree()`), wired into the remix workbench — `make remix`, press
+`read_menu_tree()`), wired into the remixer — `make remix`, press
 **`e`** to boot the *built* image, confirm it reaches the handoff with no
 fault, and see the MAIN MENU walked from RAM with any patched-in entry
 highlighted. That is the crow-flies no-flash gate: a cave that breaks early
@@ -535,7 +535,7 @@ The **FX2 dials page** renders too (`e` → `f`): the EFFECT 2 SETUP window,
 listing the built remix's own effects (`ChonVerb77`, `BongDelay77`, `Send`)
 and the param row.
 
-**Milestone 3 is shipped (31 Aug 2026): the track-centric workbench.** The
+**Milestone 3 is shipped (31 Aug 2026): the track-centric remixer.** The
 curses TUI is retired; `make remix` now runs `tools/remix/app.py` (Textual,
 in the same `.venv` extra as unicorn), organized the way an Octatrack user
 thinks. Home is a RIG of eight tracks: assign any effect the track can host
@@ -554,7 +554,7 @@ image changes and follows the rig's selected track. Follow-ups landed the
 same day: esc stops audio, Rich-markup escaping, per-knob docs + select
 labels in the manifests with `?` help overlays, the audition journal
 (`out/_audition/log.jsonl`), and the terminal-ANSI theme. The manual is
-`docs/WORKBENCH.md`.
+`docs/REMIXER.md`.
 
 Remaining toward full fidelity: item-level menu descent and live dial *values*
 (same detour shape — drive the real key handler `FUN_40064e64`, capture the
@@ -633,7 +633,7 @@ those, and reports which: `donor ids taken (PLATE) ... KEPT STOCK:
 SPRING/DARK`.
 
 The three reverbs are now ordinary listable stock rows (`tools/remix/
-stock.py`), so the workbench offers them like any other effect. Two guards
+stock.py`), so the remixer offers them like any other effect. Two guards
 make that safe:
 
 - the **build** refuses a donor row whose words this selection took, by name
@@ -677,8 +677,8 @@ worth keeping.
   then verified the v6 seam-click fix. (The old blocker stands for a
   freeze toggled MID-render more than once; one engage per render is what
   the hook does.)
-- **BACKLOG (Sam, 3 Sep 2026): "workbench" is a name nobody reviewed.** It
-  arrived with the 31 Aug redesign and spread to `docs/WORKBENCH.md`, the
+- **BACKLOG (Sam, 3 Sep 2026): "remixer" is a name nobody reviewed.** It
+  arrived with the 31 Aug redesign and spread to `docs/REMIXER.md`, the
   pane copy, the `?` overlay and a dozen comments without anyone deciding it
   was the right word. The thing is a **remixer** — that is what the project
   calls the concept everywhere else (`make remix`, `remixes/`,

--- a/PLAN.md
+++ b/PLAN.md
@@ -385,11 +385,30 @@ different bases (`P:0x00591..0x01d9f`, the same 6,158 words); ✅ per-effect
 spans in `stock.p_spans()`, *derived* from the module map by record-size
 fingerprint rather than written down, so a firmware whose layout differs
 raises instead of being written over; ✅ `Remix.harvest`, defaulting to the
-three reverbs; ✅ `build_bus.py` places into the harvested run, refusing a
-non-contiguous set by name; ✅ every harvested effect the cursor reached is
-nulled and the survivors keep their algorithm, by SPAN rather than by a
-hand-written donor list; ✅ selftest asserts contiguity in both payloads and
-that every shipped remix harvests a run; ✅ **refhash 26/26 bit-identical**.
+three reverbs; ✅ `build_bus.py` places into the harvested run; ✅ every
+harvested effect the placer reached is nulled and the survivors keep their
+algorithm, by SPAN rather than by a hand-written donor list; ✅ selftest
+asserts contiguity in both payloads and that every shipped remix harvests a
+run; ✅ **refhash 26/26 bit-identical**.
+
+✅ **EVERY RUN IS PLACEABLE, not just the largest** (3 Sep 2026). The build
+refused a non-contiguous harvest, so `stock.region_of` handed it the biggest
+run alone and every other run was given up and then left empty — Sam, from
+the budget map: *"when I remove the modulation it shows free space. But when
+I remove some reverb it only shows the free reverb space."* Two adjacent
+effects (EQ+PHASER, 489 words) simply vanished behind the reverbs' 2,724.
+Now `stock.regions_of()` groups the harvest into runs and the placer
+first-fits each module into a run it fits — assembling once per candidate,
+since a module's origin is an argument. Proven: STREAMZ placed into
+SPATIALIZER's isolated 261-word opening renders **bit-identical** to the
+same module in a single 2,724-word run. `bothslots` goes 3,342 → 3,880
+usable words. ⚠️ The residual cost of a gap is **fragmentation** — a module
+is one code stream and must fit ONE run — so the budget names the largest
+opening beside the total, the map draws a bracket per run instead of one
+across the wall, and `consumed_at`'s single-stream arithmetic is gated to
+the one-run case rather than left to be quietly wrong. ✅ refhash 26/26
+bit-identical (the single-run report wording, failure text included, is
+frozen for exactly this reason).
 
 ✅ **And the remixer composes it.** `h` harvests the highlighted stock
 effect, `⌁` marks it, `consumed_at`/`region_words`/`placeable` all take the

--- a/PLAN.md
+++ b/PLAN.md
@@ -448,7 +448,7 @@ parameter slot to put a delay control on. Treat a first result of "it makes
 delayed sound at some arbitrary time" as success for the experiment and a
 separate problem for the design.
 
-### 5. The remixer: remix TUI + a local ColdFire emulator (decided 31 Aug 2026)
+### 5. The remixer and a local ColdFire emulator (decided 31 Aug 2026)
 
 **The aim is an iterate-with-a-cycle loop for ColdFire/UI work** — the class
 of change that today costs a flash per attempt. Two backlog items merge into
@@ -494,7 +494,7 @@ the TUI is a shell around it.**
    list drawer `FUN_40037590`, sprintf `0x40013a08`) into a windows+strings
    model; inject keys at the software layer (the `[PAGE]` keycode-`0x1b`
    precedent). Not pixel-faithful — menu-walking faithful.
-3. **TUI shell** (upgrades the `make remix` remixer): remix pane + build
+3. **TUI shell** (upgrades the `make remix` composer): remix pane + build
    pane land first and are useful with no emulator; the emu pane plugs in
    when Tier 1 does. Schedules deliberately uncoupled.
 4. **Audio stays out.** The voicing loop (render → afplay → ear) is already
@@ -677,14 +677,18 @@ worth keeping.
   then verified the v6 seam-click fix. (The old blocker stands for a
   freeze toggled MID-render more than once; one engage per render is what
   the hook does.)
-- **BACKLOG (Sam, 3 Sep 2026): "remixer" is a name nobody reviewed.** It
-  arrived with the 31 Aug redesign and spread to `docs/REMIXER.md`, the
-  pane copy, the `?` overlay and a dozen comments without anyone deciding it
-  was the right word. The thing is a **remixer** — that is what the project
-  calls the concept everywhere else (`make remix`, `remixes/`,
-  `tools/remix/`), and the entry point is already `make remix`. Renaming is
-  cheap in the UI copy and the doc, and it removes a second vocabulary for
-  one tool. Decide the name first; the rename is mechanical after that.
+- ✅ **"the workbench" was a name nobody reviewed, and it is now "the
+  remixer"** (Sam raised it 3 Sep 2026; done the same day). It had arrived
+  with the 31 Aug redesign and spread to the doc, the pane copy, the `?`
+  overlay and about eighty comments — a second vocabulary for a tool the
+  project already calls a remix everywhere else (`make remix`, `remixes/`,
+  `tools/remix/`, the `Remix` dataclass). `docs/REMIXER.md` is the manual.
+  `WORKBENCH_SOURCES`, `WORKBENCH_THEME` and `out/_audition/workbench.json`
+  are still read, so nobody's shell profile or sample folder silently stops
+  working. ⚠️ The blanket substitution rewrote *this entry* into "'remixer'
+  is a name nobody reviewed ... the thing is a remixer" — a rename cannot be
+  applied to the text discussing the rename, and that is the one place to
+  check by hand afterwards.
 - **BACKLOG (Sam, 3 Sep 2026): a freshly flashed unit keeps drawing the
   effect you had before.** After a flash the track still shows the PREVIOUS
   effect's controls, and only selecting SEND (or anything else) redraws it.

--- a/PLAN.md
+++ b/PLAN.md
@@ -379,16 +379,29 @@ having two states and gains three — **listed** / **unlisted but intact** /
 **harvested** — and the remixer has to make that choice legible, because it
 is the first one in this tool that actually takes something away.
 
-**The work, in order:** ⬜ re-run the containment sweep on payload B (same
-code, other payload, unmeasured); ⬜ per-effect spans into `stock.py` beside
-`WORDS`; ⬜ `build_bus.py` places into a computed run of harvested effects
-rather than the fixed region, packing from the lowest freed address (the
-`consumed_at` ladder generalises to "which effect does the cursor reach");
-⬜ null the dispatch of anything harvested, which the donor path already
-does; ⬜ `verify_menu`/`verify_slots` assert the harvested set matches what
-was placed; ⬜ the remixer's third state and the Budget's words row.
-⬜ **`refhash` is the gate** — a selection harvesting only the three reverbs
-must stay bit-identical to today.
+**The work, in order:** ✅ containment sweep on payload B — **all twelve
+self-contained there too**, and B carries the same thirteen effects at
+different bases (`P:0x00591..0x01d9f`, the same 6,158 words); ✅ per-effect
+spans in `stock.p_spans()`, *derived* from the module map by record-size
+fingerprint rather than written down, so a firmware whose layout differs
+raises instead of being written over; ✅ `Remix.harvest`, defaulting to the
+three reverbs; ✅ `build_bus.py` places into the harvested run, refusing a
+non-contiguous set by name; ✅ every harvested effect the cursor reached is
+nulled and the survivors keep their algorithm, by SPAN rather than by a
+hand-written donor list; ✅ selftest asserts contiguity in both payloads and
+that every shipped remix harvests a run; ✅ **refhash 26/26 bit-identical**.
+
+⬜ **Left:** `stock.consumed_at()` still walks the three reverbs rather than
+the selection's own harvest order; the remixer's `DONOR_WORDS = 2724` is
+still a constant; and the **third state** — a stock effect is listed /
+unlisted / harvested, and only the first two are expressible in the UI.
+
+⚠️ **One constraint found the hard way: the build report's donor names must
+be ONE WORD.** `state.measure()` reads `KEPT STOCK: (\S+)` and splits on
+`/`, so `PLATE REV/SPRING REV/DARK REV` truncates the whole list at the
+first space. The report is API — refhash hashes it and three verifiers parse
+it — so the first word is emitted, exactly as the old lowercase donor keys
+produced.
 
 ### 2. FX1 consolidation — turning the stranded pool into capability
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -349,11 +349,13 @@ feedback. **FILTER is the outlier**: 727 words, the default FX1 effect, ~260
 cycles. Highest value, highest risk. ✅ Taking the three reverbs cost FX1
 nothing — they were never on its menu; FX1's ten effects are the whole pool.
 
-✅ **A module can be listed on FX1 since 3 Sep 2026** — `Remix.fx1`, the
-chooser list relocated into the cave with its three `lea` refs repointed and
-FX1's own id and cursor tables written (`docs/MODULES.md`). It costs no
-words; the bill is cycles, and `make cycles` now prices FX1's four slots, so
-the trade is visible before it is made. Emulator-verified, **unflashed**;
+✅ **FX1's chooser is COMPOSED since 3 Sep 2026** — `Remix.fx1` is FX1's row
+list exactly as `modules` is FX2's: list, unlist, reorder, stock effects and
+ours alike. The list is rebuilt in the cave with its three `lea` refs
+repointed, the viewport literal at `0x40059be6` sized to it, and FX1's own
+id and cursor tables written (`docs/MODULES.md`). It costs no words; the
+bill is cycles, and `make cycles` prices FX1's four slots, so the trade is
+visible before it is made. Emulator-verified, **unflashed**;
 `remixes/bothslots.py` is the worked example. That is orthogonal to the
 consolidation below, which is about freeing FX1's own words.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -349,6 +349,14 @@ feedback. **FILTER is the outlier**: 727 words, the default FX1 effect, ~260
 cycles. Highest value, highest risk. ✅ Taking the three reverbs cost FX1
 nothing — they were never on its menu; FX1's ten effects are the whole pool.
 
+✅ **A module can be listed on FX1 since 3 Sep 2026** — `Remix.fx1`, the
+chooser list relocated into the cave with its three `lea` refs repointed and
+FX1's own id and cursor tables written (`docs/MODULES.md`). It costs no
+words; the bill is cycles, and `make cycles` now prices FX1's four slots, so
+the trade is visible before it is made. Emulator-verified, **unflashed**;
+`remixes/bothslots.py` is the worked example. That is orthogonal to the
+consolidation below, which is about freeing FX1's own words.
+
 ⚠️ Sequence FX1 ambition after the burn sweep (§3) — its real ceiling is
 cycles ×4. Note the spare HAS been measured per core since 23 Aug 2026
 (704 with the reverb + 4× FILTER, 1,088 with 2×, one FILTER = 192 —
@@ -669,6 +677,27 @@ worth keeping.
   then verified the v6 seam-click fix. (The old blocker stands for a
   freeze toggled MID-render more than once; one engage per render is what
   the hook does.)
+- **BACKLOG (Sam, 3 Sep 2026): "workbench" is a name nobody reviewed.** It
+  arrived with the 31 Aug redesign and spread to `docs/WORKBENCH.md`, the
+  pane copy, the `?` overlay and a dozen comments without anyone deciding it
+  was the right word. The thing is a **remixer** — that is what the project
+  calls the concept everywhere else (`make remix`, `remixes/`,
+  `tools/remix/`), and the entry point is already `make remix`. Renaming is
+  cheap in the UI copy and the doc, and it removes a second vocabulary for
+  one tool. Decide the name first; the rename is mechanical after that.
+- **BACKLOG (Sam, 3 Sep 2026): a freshly flashed unit keeps drawing the
+  effect you had before.** After a flash the track still shows the PREVIOUS
+  effect's controls, and only selecting SEND (or anything else) redraws it.
+  Not yet investigated. The shape to check first: the stored per-part `fx2_id`
+  survives the flash (it lives in the project, not the OS), so the id resolves
+  through the NEW image's tables — a remix that dropped that module aliases it
+  to the fallback, and one that kept it on a different row draws the right
+  page but from a stale cursor. Either way, what is on screen is a page
+  STAGED at part-load time and not re-staged when the image under it changed.
+  Adjacent to "a slot can draw a knob and publish nothing" and to the
+  `ID2POS`/`FX2_IDS` pair that `verify_menu` already checks agree. **Polish
+  round, not a defect hunt** — decide what a flashed unit SHOULD show before
+  deciding what to change.
 - **Duplicate instances of one effect corrupt audio after ~5.45 s**, any
   address, mechanism unestablished. One server per bank is the design rule;
   no product configuration has this.

--- a/PLAN.md
+++ b/PLAN.md
@@ -561,82 +561,54 @@ is the slice of that road worth having.
 
 ---
 
-### 6. On-device labels for the mode selects (backlogged 2 Sep 2026)
+### 6. On-device labels for the mode selects — DONE 2 Sep 2026
 
-**Today every stepped select on the unit reads as a NUMBER.** WarpFold's MODE
-draws `1 2 3` where the manifest already says `FOLD RING BOTH`; the operator
-has to remember which is which, on all twelve of them:
+**Every stepped select now prints its words on the unit.** WarpFold's MODE
+draws `FOLD RING BOTH` where it drew `1 2 3`; the twelve labelled selects the
+manifests had authored all along are load-bearing at last.
 
-| module | slot | select | labels already authored |
-|---|---|---|---|
-| REVERB SERVER | 7 / 9 / 11 | MODE / SHFT / RATE | ROOM PLATE BIG · +12 +19 +7 −12 · 0.5x 1x 2x 4x |
-| DELAY SERVER | 7 / 9 / 11 | MODE / PTCH / FRZE | CLEAN PITCH (CLEAN) GRAIN REVRS · +12 +7 −12 det · RUN HOLD |
-| WARPFOLD / RIPPLE / RUNGS / STREAMZ / BODESHIFT | 7 | MODE | FOLD RING BOTH · LP BP HP · STRING BELL GLASS · LPG VCF VCA · UP DOWN WIDE |
-| NIMBUS | 7 | FRZE | RUN HOLD |
+`Param.labels` was written, schema-checked against `count`, and then never
+read by the build — the refhash gate *proved* it was never read. This is the
+pass that changed that (`tools/build_bus.py`, the section after the cave
+patches).
 
-**Every piece already exists**, which is why this is a wiring job and not a
-project:
+**How.** Every per-slot "A" formatter (`P+0x0ca`) has one signature —
+`void fmt(char *buf, int value)` — and `0x4003c14c` (ON/OFF) proves the shape
+that matters: **the label IS the format string**. So a labelled select is a
+small cave: bounds-check the value, index a `.word` offset table, overwrite
+the value slot with the pointer, and tail-`jmp` into `sprintf`. 40 bytes of
+code plus 2 bytes and a string per label — 54 to 82 bytes each, **386 bytes
+for the shipping remix's six**, with 2,330 bytes of cave left.
 
-- `docs/PARAM_PAGES.md` §7 has the ABI and the design: `void fmt(char *buf,
-  int value)`, every stock formatter a thin `sprintf` wrapper, and **"a
-  labelled select is a ~20-byte code cave"** — index a pointer table by
-  value, put the pointer where the format string goes, `jmp sprintf`. The
-  `0x4003c14c` (`ON`/`OFF`) formatter proves the shape: *the label IS the
-  format string.*
-- `CavePatch(registers_formatter=FormatterReg(module=..., slot=...))` is the
-  installer, and it is **hardware-proven** — `modules/tempo-sync/time_fmt.s`
-  has been drawing BongDelay's TIME as a tempo division since R56 (24 Aug,
-  confirmed on the unit).
-- `Param.labels` is **already authored and schema-validated** against
-  `count` in all twelve slots. The build never reads it (the refhash gate
-  proves that); this is the change that makes it load-bearing.
+**Only "A" moves.** B stays `0x40047254`, the CHORUS.TAPS tick widget the
+clone pass already chose, so this changes *what is printed*, not *how it is
+drawn*. `verify_menu` used to pin A to stock's `0x4003c718`; it now requires
+B and `0x12a` (the invariant it was actually written for, 17 Aug 2026) and
+allows A to be stock's or a cave address.
 
-**What is NEW since §7 was written on 24 Aug, and why it is worth another
-look now rather than then:**
+**The bytes are emitted, not assembled** (`tools/label_fmt.py`). A CavePatch
+carries *pinned* bytes so the build needs no m68k toolchain, and twelve caves
+whose contents vary with the labels cannot be hand-pinned — so `emit()`
+produces them and `verify()` re-derives them through `m68k-elf-as -mcpu=5407`
+whenever one is on PATH. All twelve match byte-for-byte.
 
-1. **§7 was derived with r2, and r2 cannot decode this CPU.** 6,757
-   instructions it mis-decodes, and it *invents plausible code* rather than
-   failing (`docs/EXTERNAL.md`, 30 Aug). The 90-address re-check found
-   nothing broken, but every formatter address in that table should be
-   re-read with `scripts/disasm.sh emac` before a byte is pinned against it.
-2. **We can now RUN a formatter and read what it prints.**
-   `tools/stock_labels.py` (2 Sep) drives every stock formatter for every
-   value on the emulated ColdFire and checks the words in. That is an
-   empirical oracle for the ABI *and* a ready-made harness for testing ours
-   against stock's before it ever reaches a unit.
-3. **The emulator draws the FX2 page.** `emu_bringup.render_fx2()` renders
-   EFFECT 2 SETUP from the built image. A new formatter can be seen working,
-   locally, with no flash — which was impossible in August and is the whole
-   reason this is cheap now.
-4. **The space is measured.** 2,612 B free in the cave region for
-   `chongbong`, 1,756 B for `mutables` (−416 B per additional cloned
-   effect). At ~20 bytes of code plus a pointer table plus the strings, all
-   twelve fit comfortably — but `mutables` carries five of them and is the
-   tightest remix, so cost it there, not on chongbong.
+**Verified without a flash.** `tools/verify_labels.py` (in `make check`)
+*calls* each formatter on the emulated ColdFire and compares what it printed
+with the manifest — the same method `stock_labels.py` uses, and the only
+honest one, because the words are printed rather than stored. It also feeds
+each select an **out-of-range** value: a part stores the raw byte, so a saved
+project can hand a select a value past its count, and the formatter clamps to
+label 0 rather than indexing off the end of its table (value 200 → `ROOM`).
 
-**⚠️ Labels do not fix the WIDGET.** The "B" array is a separate drawer with
-its position count HARD-CODED (`0x40047254` is 5-tick, `0x40047424` is
-3-position), which is why BongDelay's 4-value PTCH sits on a 5-tick widget.
-A labelled select still draws on whatever tick count its donor's B callback
-has. Setting `B = 0` gives the plain dial that prints whatever A wrote —
-possibly the better answer for a 4- or 5-value select, and it is what stock
-DELAY TIME does. Decide that per slot; `verify_menu` already checks the
-renderer against the count and will refuse a mismatch.
+⚠️ **The page render cannot show this** — knob *values* draw as dial graphics
+the string-capture hook cannot read (`docs/EMU.md`), so the emulator proves
+it by calling the formatter, not by photographing the screen. Still
+**UNFLASHED**: what is unverified on hardware is the buffer length behind
+`buf` (our longest label is 5 chars, `1/16T`; stock's longest is 4) and
+whether anything else consults A where the B widget's count matters.
 
-**Shape of the work**, smallest first: one generic cave that takes a table
-address, then one table per select generated from `Param.labels`, then a
-manifest field so a module asks for it declaratively rather than hand-writing
-a `CavePatch`. First customer should be a 3-value MODE whose donor widget
-already has three positions, so nothing about the widget is in play.
-
-**The payoff this makes concrete — BongDelay's dead MODE position.** MODE
-counts five, and position 2 is the retired TAPE slot: it falls through to
-CLEAN. That is deliberate and the numbering is load-bearing — a part stores
-the raw value, so closing the gap would turn every saved GRAIN (3) into
-REVERSE. It cannot be renumbered, so the operator is left with a five-way
-select where one position silently does nothing, drawn as a bare `3`. With
-labels it draws `CLEAN` and the mystery is gone. This is the case that shows
-why numbers are not good enough: the select is CORRECT and still unusable.
+Confinement, measured on the shipping build: **296 bytes differ from the
+pre-§6 image, all of them inside the cave region — zero anywhere else.**
 
 ### 7. Putting the unit back — CLOSED 2 Sep 2026
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -391,10 +391,21 @@ nulled and the survivors keep their algorithm, by SPAN rather than by a
 hand-written donor list; ✅ selftest asserts contiguity in both payloads and
 that every shipped remix harvests a run; ✅ **refhash 26/26 bit-identical**.
 
-⬜ **Left:** `stock.consumed_at()` still walks the three reverbs rather than
-the selection's own harvest order; the remixer's `DONOR_WORDS = 2724` is
-still a constant; and the **third state** — a stock effect is listed /
-unlisted / harvested, and only the first two are expressible in the UI.
+✅ **And the remixer composes it.** `h` harvests the highlighted stock
+effect, `⌁` marks it, `consumed_at`/`region_words`/`placeable` all take the
+selection's own harvest, and the Budget's `held by` row follows
+(`Chorus, Plate, Spring, Dark — 3,053 words; drop Chorus for 329 more`). The
+run is kept contiguous at the KEYSTROKE, naming what is in the way, and the
+resource line offers `h harvests them` only on the two effects that could
+legally join.
+
+⬜ **Left, and it is the interesting half now:** nothing has been *flashed*,
+and harvesting a non-reverb has never run on hardware. The measurement says
+each effect is self-contained; what it cannot say is whether anything
+outside the DSP — a ColdFire path, a descriptor, the allocator table — cares
+that CHORUS's algorithm is gone. The cheapest real test is a card with
+`harvest=("CHORUS", ...)` and CHORUS left off both choosers, listening for
+anything but silence on its id.
 
 ⚠️ **One constraint found the hard way: the build report's donor names must
 be ONE WORD.** `state.measure()` reads `KEPT STOCK: (\S+)` and splits on

--- a/PLAN.md
+++ b/PLAN.md
@@ -742,6 +742,19 @@ official installer does, and it is simpler. This is the same image with our
 chooser edits reverted, which is only interesting if some ColdFire cave is
 worth keeping.
 
+## The flash backlog
+
+**What is on the unit is tag 77 / R58, 24 August 2026** — 134 commits ago.
+Everything since is unflashed: the delay's R59–R62 quality pass, the
+stepped-select labels, stock effects listable beside ours, the insert card,
+a module on FX1, and a donor region beyond the three reverbs.
+
+**`docs/FLASHPLAN.md` is the schedule** — three images, ordered so the
+cheapest and safest goes first, each shaped to stack independent claims whose
+failures stay distinguishable, and each with what would falsify it. The
+platform work needs no flash at all: refhash proves a default selection is
+bit-identical, which is what that gate is for.
+
 ## Open items and standing caveats
 
 - **Cross-core bus: three defects found and fixed, all hardware-confirmed**

--- a/PLAN.md
+++ b/PLAN.md
@@ -793,19 +793,22 @@ bit-identical, which is what that gate is for.
   "the OS is the same, so it should run" (inferred) rather than "verified on
   MK1" (not measured). Sweep `README.md` and `docs/` and say it once, in the
   right place, instead of hedging in a dozen.
-- **BACKLOG (Sam, 3 Sep 2026): a freshly flashed unit keeps drawing the
-  effect you had before.** After a flash the track still shows the PREVIOUS
-  effect's controls, and only selecting SEND (or anything else) redraws it.
-  Not yet investigated. The shape to check first: the stored per-part `fx2_id`
-  survives the flash (it lives in the project, not the OS), so the id resolves
-  through the NEW image's tables — a remix that dropped that module aliases it
-  to the fallback, and one that kept it on a different row draws the right
-  page but from a stale cursor. Either way, what is on screen is a page
-  STAGED at part-load time and not re-staged when the image under it changed.
-  Adjacent to "a slot can draw a knob and publish nothing" and to the
-  `ID2POS`/`FX2_IDS` pair that `verify_menu` already checks agree. **Polish
-  round, not a defect hunt** — decide what a flashed unit SHOULD show before
-  deciding what to change.
+- ✅ **A freshly flashed unit keeps drawing the PREVIOUS effect's controls —
+  CAUSE FOUND, 3 Sep 2026, and it is not a defect.** The per-part FX1/FX2 ids
+  live in the PROJECT (`bank##.work`, `PART+0x009` and `PART+0x011`, eight
+  bytes each — one per track), not in the OS, so they survive a flash and
+  resolve against the new image's tables. The unit is faithfully drawing the
+  effect the project still asks for; what changed underneath it is which
+  effect that id names. ⚠️ **Which also means a flash test that starts from
+  an old project is not a test of anything** — half the tracks are running
+  whatever the last image left there.
+  `tools/ot_project.py testproj SRC DEST REMIX` copies a project and stamps
+  every bank, part and track with an id the image implements, current parts
+  **and** their saved copies, checksums recomputed and read back.
+  `docs/FLASHPLAN.md` step 0b.
+  ⬜ Still open, and a smaller question than it looked: whether the panel
+  should RE-STAGE a page when the image under it changed, or whether "the
+  project asked for id 0x12 and got what 0x12 now is" is the right answer.
 - **Duplicate instances of one effect corrupt audio after ~5.45 s**, any
   address, mechanism unestablished. One server per bank is the design rule;
   no product configuration has this.

--- a/PLAN.md
+++ b/PLAN.md
@@ -689,6 +689,15 @@ worth keeping.
   is a name nobody reviewed ... the thing is a remixer" — a rename cannot be
   applied to the text discussing the rename, and that is the one place to
   check by hand afterwards.
+- **BACKLOG (Sam, 3 Sep 2026): the docs over-name the MKII and it reads as a
+  restriction.** Sam: it works on MK1 and MK2 — they are the same machine
+  apart from a few buttons, and `docs/` already records that both run the
+  **same 1.40C image, hash-verified**. So every "MKII" that is really just
+  "the Octatrack" should say so. ⚠️ Keep the one distinction that is honest:
+  everything here has only ever been *tested* on an MKII, so the claim is
+  "the OS is the same, so it should run" (inferred) rather than "verified on
+  MK1" (not measured). Sweep `README.md` and `docs/` and say it once, in the
+  right place, instead of hedging in a dozen.
 - **BACKLOG (Sam, 3 Sep 2026): a freshly flashed unit keeps drawing the
   effect you had before.** After a flash the track still shows the PREVIOUS
   effect's controls, and only selecting SEND (or anything else) redraws it.

--- a/PLAN.md
+++ b/PLAN.md
@@ -638,6 +638,37 @@ select where one position silently does nothing, drawn as a bare `3`. With
 labels it draws `CLEAN` and the mystery is gone. This is the case that shows
 why numbers are not good enough: the select is CORRECT and still unusable.
 
+### 7. A stock-only build: "put my unit back" (backlogged 2 Sep 2026)
+
+The workbench opens on **stock** — the chooser an unmodified unit shows — and
+that selection **cannot be built**, which makes the default state a view
+rather than a starting point. Two things stand in the way, and neither is
+hardware:
+
+1. **A remix must name a fallback** (`schema.Remix`), and no stock effect is
+   a safe one: the fallback is what unimplemented ids alias to, and a real
+   effect would *process* the unknown id. `auto_fallback()` returns None and
+   `problems()` refuses. A selection with no modules of ours has nothing to
+   alias, so the requirement should be conditional rather than absolute.
+2. **`DONOR_IDS` (PLATE/SPRING/DARK REV) are repointed to the null stub
+   unconditionally** in `build_bus.py`, so even a build that placed no code
+   would silence the three reverbs. That is defensive, not necessary — and
+   there is a precedent for making it conditional: **CHORUS was a donor until
+   v98 and got its stock dispatch back the moment we stopped taking its
+   code.** The three reverbs are consumed because every buildable selection
+   so far contains at least SEND; they are not consumed by nature.
+
+Worth having because it is the honest bottom of the range: an image that
+restores an unmodified chooser, including the three reverbs, is *"undo my
+mods"* — the thing to flash before selling the box, or when a remix turns out
+badly. It also makes the workbench's default state buildable, which is what
+a person expects from a thing they are looking at.
+
+⚠️ It is NOT "flash the stock OS back" — that is what the official installer
+does, and it is simpler. This is the same image with our chooser edits
+reverted, which is only interesting if some ColdFire cave is worth keeping.
+If nothing is, say so and close this rather than building it.
+
 ## Open items and standing caveats
 
 - **Cross-core bus: three defects found and fixed, all hardware-confirmed**

--- a/PLAN.md
+++ b/PLAN.md
@@ -570,7 +570,7 @@ has to remember which is which, on all twelve of them:
 | module | slot | select | labels already authored |
 |---|---|---|---|
 | REVERB SERVER | 7 / 9 / 11 | MODE / SHFT / RATE | ROOM PLATE BIG · +12 +19 +7 −12 · 0.5x 1x 2x 4x |
-| DELAY SERVER | 7 / 9 / 11 | MODE / PTCH / FRZE | CLEAN PITCH (tape) GRAIN REVRS · +12 +7 −12 det · RUN HOLD |
+| DELAY SERVER | 7 / 9 / 11 | MODE / PTCH / FRZE | CLEAN PITCH (CLEAN) GRAIN REVRS · +12 +7 −12 det · RUN HOLD |
 | WARPFOLD / RIPPLE / RUNGS / STREAMZ / BODESHIFT | 7 | MODE | FOLD RING BOTH · LP BP HP · STRING BELL GLASS · LPG VCF VCA · UP DOWN WIDE |
 | NIMBUS | 7 | FRZE | RUN HOLD |
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -561,6 +561,74 @@ is the slice of that road worth having.
 
 ---
 
+### 6. On-device labels for the mode selects (backlogged 2 Sep 2026)
+
+**Today every stepped select on the unit reads as a NUMBER.** WarpFold's MODE
+draws `1 2 3` where the manifest already says `FOLD RING BOTH`; the operator
+has to remember which is which, on all twelve of them:
+
+| module | slot | select | labels already authored |
+|---|---|---|---|
+| REVERB SERVER | 7 / 9 / 11 | MODE / SHFT / RATE | ROOM PLATE BIG · +12 +19 +7 −12 · 0.5x 1x 2x 4x |
+| DELAY SERVER | 7 / 9 / 11 | MODE / PTCH / FRZE | CLEAN PITCH (tape) GRAIN REVRS · +12 +7 −12 det · RUN HOLD |
+| WARPFOLD / RIPPLE / RUNGS / STREAMZ / BODESHIFT | 7 | MODE | FOLD RING BOTH · LP BP HP · STRING BELL GLASS · LPG VCF VCA · UP DOWN WIDE |
+| NIMBUS | 7 | FRZE | RUN HOLD |
+
+**Every piece already exists**, which is why this is a wiring job and not a
+project:
+
+- `docs/PARAM_PAGES.md` §7 has the ABI and the design: `void fmt(char *buf,
+  int value)`, every stock formatter a thin `sprintf` wrapper, and **"a
+  labelled select is a ~20-byte code cave"** — index a pointer table by
+  value, put the pointer where the format string goes, `jmp sprintf`. The
+  `0x4003c14c` (`ON`/`OFF`) formatter proves the shape: *the label IS the
+  format string.*
+- `CavePatch(registers_formatter=FormatterReg(module=..., slot=...))` is the
+  installer, and it is **hardware-proven** — `modules/tempo-sync/time_fmt.s`
+  has been drawing BongDelay's TIME as a tempo division since R56 (24 Aug,
+  confirmed on the unit).
+- `Param.labels` is **already authored and schema-validated** against
+  `count` in all twelve slots. The build never reads it (the refhash gate
+  proves that); this is the change that makes it load-bearing.
+
+**What is NEW since §7 was written on 24 Aug, and why it is worth another
+look now rather than then:**
+
+1. **§7 was derived with r2, and r2 cannot decode this CPU.** 6,757
+   instructions it mis-decodes, and it *invents plausible code* rather than
+   failing (`docs/EXTERNAL.md`, 30 Aug). The 90-address re-check found
+   nothing broken, but every formatter address in that table should be
+   re-read with `scripts/disasm.sh emac` before a byte is pinned against it.
+2. **We can now RUN a formatter and read what it prints.**
+   `tools/stock_labels.py` (2 Sep) drives every stock formatter for every
+   value on the emulated ColdFire and checks the words in. That is an
+   empirical oracle for the ABI *and* a ready-made harness for testing ours
+   against stock's before it ever reaches a unit.
+3. **The emulator draws the FX2 page.** `emu_bringup.render_fx2()` renders
+   EFFECT 2 SETUP from the built image. A new formatter can be seen working,
+   locally, with no flash — which was impossible in August and is the whole
+   reason this is cheap now.
+4. **The space is measured.** 2,612 B free in the cave region for
+   `chongbong`, 1,756 B for `mutables` (−416 B per additional cloned
+   effect). At ~20 bytes of code plus a pointer table plus the strings, all
+   twelve fit comfortably — but `mutables` carries five of them and is the
+   tightest remix, so cost it there, not on chongbong.
+
+**⚠️ Labels do not fix the WIDGET.** The "B" array is a separate drawer with
+its position count HARD-CODED (`0x40047254` is 5-tick, `0x40047424` is
+3-position), which is why BongDelay's 4-value PTCH sits on a 5-tick widget.
+A labelled select still draws on whatever tick count its donor's B callback
+has. Setting `B = 0` gives the plain dial that prints whatever A wrote —
+possibly the better answer for a 4- or 5-value select, and it is what stock
+DELAY TIME does. Decide that per slot; `verify_menu` already checks the
+renderer against the count and will refuse a mismatch.
+
+**Shape of the work**, smallest first: one generic cave that takes a table
+address, then one table per select generated from `Param.labels`, then a
+manifest field so a module asks for it declaratively rather than hand-writing
+a `CavePatch`. First customer should be a 3-value MODE whose donor widget
+already has three positions, so nothing about the widget is in play.
+
 ## Open items and standing caveats
 
 - **Cross-core bus: three defects found and fixed, all hardware-confirmed**

--- a/PLAN.md
+++ b/PLAN.md
@@ -629,6 +629,15 @@ manifest field so a module asks for it declaratively rather than hand-writing
 a `CavePatch`. First customer should be a 3-value MODE whose donor widget
 already has three positions, so nothing about the widget is in play.
 
+**The payoff this makes concrete — BongDelay's dead MODE position.** MODE
+counts five, and position 2 is the retired TAPE slot: it falls through to
+CLEAN. That is deliberate and the numbering is load-bearing — a part stores
+the raw value, so closing the gap would turn every saved GRAIN (3) into
+REVERSE. It cannot be renumbered, so the operator is left with a five-way
+select where one position silently does nothing, drawn as a bare `3`. With
+labels it draws `CLEAN` and the mystery is gone. This is the case that shows
+why numbers are not good enough: the select is CORRECT and still unusable.
+
 ## Open items and standing caveats
 
 - **Cross-core bus: three defects found and fixed, all hardware-confirmed**

--- a/PLAN.md
+++ b/PLAN.md
@@ -334,6 +334,62 @@ capability: 70 ms lines per track — doublers, short slaps, wide chorus.
   costs level (the reference manages loud AND sparse). Needs makeup gain on
   the surviving grains, which does not exist yet.
 
+### 1b. DYNAMIC DONOR REGIONS — measured feasible, 3 Sep 2026
+
+**Sam's framing, and it is the right one: if the goal is to mix and match all
+effects freely, dropping any stock effect should give you its words.** Today
+only three can be harvested — the donor region is exactly PLATE + SPRING +
+DARK REV — and every other stock effect answers "what does this cost?" with a
+number you cannot spend. That is a property of THIS BUILD, not of the
+machine, and the difference had been showing up as UI copy nobody could make
+read straight ("dropping it frees none").
+
+**The two facts that make it possible are measured** (`tools/dsp_reach.py`
+disassembly of payload A, against the module records and the spans in
+`docs/DSP.md` §8):
+
+- **The thirteen DSP effects are CONTIGUOUS**, `P:0x007d1..0x01fdf`, **6,158
+  words**, with no other module between them:
+
+  | | | | | |
+  |---|---|---|---|---|
+  | `007d1` FILTER 727 | `00aa8` SPATIALIZER 261 | `00bad` EQUALIZER 282 | `00cc7` PHASER 157+41 | `00d96` FLANGER 289 |
+  | `00eb7` CHORUS 329 | `01000` PLATE 594 | `01252` SPRING 1063 | `01679` DARK 1067 | `01aa4` COMPRESSOR 180 |
+  | `01b58` LO-FI 537 | `01d71` DJ EQ 345 | `01eca` COMB 277 | | |
+
+  The current 2,724-word donor region is the middle third of that run.
+- **Every one is SELF-CONTAINED.** No control flow leaves an effect's own
+  span, and nothing enters one but its own dispatch entry. The single
+  apparent exception is PLATE's `do #<$6,>$1267` — a loop END address, which
+  is exclusive, so it is its own boundary rather than a jump into SPRING.
+  (⚠️ PHASER is the known irregular one: its true extent runs 41 words past
+  its record into four small blocks, `docs/DSP.md` §8. Its span is the true
+  one above.)
+
+**So the ceiling is 6,158 words against today's 2,724 — 2.26×** — and
+anything between: drop CHORUS and the region grows *downward* from PLATE
+because CHORUS is its neighbour.
+
+**What it costs, and this is the new decision it forces.** Today an unlisted
+stock effect keeps working — its code, descriptor and dispatch stay stock, so
+an old project that selects it still runs it, and leaving it out costs only a
+chooser row. A stock effect *harvested for its words* is gone: its dispatch
+must go to the null stub, exactly as the donors' do. So a stock effect stops
+having two states and gains three — **listed** / **unlisted but intact** /
+**harvested** — and the remixer has to make that choice legible, because it
+is the first one in this tool that actually takes something away.
+
+**The work, in order:** ⬜ re-run the containment sweep on payload B (same
+code, other payload, unmeasured); ⬜ per-effect spans into `stock.py` beside
+`WORDS`; ⬜ `build_bus.py` places into a computed run of harvested effects
+rather than the fixed region, packing from the lowest freed address (the
+`consumed_at` ladder generalises to "which effect does the cursor reach");
+⬜ null the dispatch of anything harvested, which the donor path already
+does; ⬜ `verify_menu`/`verify_slots` assert the harvested set matches what
+was placed; ⬜ the remixer's third state and the Budget's words row.
+⬜ **`refhash` is the gate** — a selection harvesting only the three reverbs
+must stay bit-identical to today.
+
 ### 2. FX1 consolidation — turning the stranded pool into capability
 
 The trick ChonVerb already ran: replace near-duplicates with one engine plus

--- a/PLAN.md
+++ b/PLAN.md
@@ -638,36 +638,47 @@ select where one position silently does nothing, drawn as a bare `3`. With
 labels it draws `CLEAN` and the mystery is gone. This is the case that shows
 why numbers are not good enough: the select is CORRECT and still unusable.
 
-### 7. A stock-only build: "put my unit back" (backlogged 2 Sep 2026)
+### 7. Putting the unit back — CLOSED 2 Sep 2026
 
-The workbench opens on **stock** — the chooser an unmodified unit shows — and
-that selection **cannot be built**, which makes the default state a view
-rather than a starting point. Two things stand in the way, and neither is
-hardware:
+**Item 2 is done and item 1 is moot.** `restock` is the remix: thirteen of
+the fourteen stock effects, **including SPRING REV and DARK REV**, plus SEND.
 
-1. **A remix must name a fallback** (`schema.Remix`), and no stock effect is
-   a safe one: the fallback is what unimplemented ids alias to, and a real
-   effect would *process* the unknown id. `auto_fallback()` returns None and
-   `problems()` refuses. A selection with no modules of ours has nothing to
-   alias, so the requirement should be conditional rather than absolute.
-2. **`DONOR_IDS` (PLATE/SPRING/DARK REV) are repointed to the null stub
-   unconditionally** in `build_bus.py`, so even a build that placed no code
-   would silence the three reverbs. That is defensive, not necessary — and
-   there is a precedent for making it conditional: **CHORUS was a donor until
-   v98 and got its stock dispatch back the moment we stopped taking its
-   code.** The three reverbs are consumed because every buildable selection
-   so far contains at least SEND; they are not consumed by nature.
+What was wrong: `build_bus.py` repointed all three donor ids to the null stub
+**unconditionally**, so a build that placed 250 words silenced 2,724 words'
+worth of reverb, and the answer to *"why can I never get the stock verbs
+back?"* was "you cannot, ever". The code stream is contiguous from PLATE
+upward, so the written span is `[base_a, cursor)` and a donor whose record
+starts at or after the cursor **still holds its own code**. It now keeps
+those, and reports which: `donor ids taken (PLATE) ... KEPT STOCK:
+SPRING/DARK`.
 
-Worth having because it is the honest bottom of the range: an image that
-restores an unmodified chooser, including the three reverbs, is *"undo my
-mods"* — the thing to flash before selling the box, or when a remix turns out
-badly. It also makes the workbench's default state buildable, which is what
-a person expects from a thing they are looking at.
+The three reverbs are now ordinary listable stock rows (`tools/remix/
+stock.py`), so the workbench offers them like any other effect. Two guards
+make that safe:
 
-⚠️ It is NOT "flash the stock OS back" — that is what the official installer
-does, and it is simpler. This is the same image with our chooser edits
-reverted, which is only interesting if some ColdFire cave is worth keeping.
-If nothing is, say so and close this rather than building it.
+- the **build** refuses a donor row whose words this selection took, by name
+  — only the placement knows where the cursor stopped, so nothing predicts
+  it; and
+- the **ledger** refuses a reverb beside a module with fixed Y buffers.
+  `buffer=True` on all three is **measured, not assumed**: each reads
+  `x:>$213` — the host's bump allocator — within ~25 words of its entry
+  (PLATE `0x01018`, SPRING `0x01267`, DARK `0x01692`; payload A
+  disassembly), exactly like the four stock effects already flagged.
+
+Item 1 (the fallback requirement) was never the real blocker: SEND costs one
+row and 215 words, which only ever takes PLATE — the *smallest* reverb,
+because the region packs from PLATE upward. So the minimum image costs one
+reverb, not three, and no schema change was needed.
+
+Bit-identity: the two shipping layouts (`bus`, `plain`) are **unchanged**.
+Four of the 26 refhash cases moved — `render` and the three `xbus-*probe`
+diagnostics — and every diff is the intended one: a build that placed few
+words no longer silences reverbs it never touched.
+
+⚠️ **UNFLASHED**, and it is NOT "flash the stock OS back" — that is what the
+official installer does, and it is simpler. This is the same image with our
+chooser edits reverted, which is only interesting if some ColdFire cave is
+worth keeping.
 
 ## Open items and standing caveats
 

--- a/README.md
+++ b/README.md
@@ -55,19 +55,19 @@ real budget decision, not a label.
 | **`hello`** | HELLO WORLD + send | the reference minimal build, and the worked example to read first |
 
 ```bash
-make remix                  # the workbench: 8 tracks, hear effects, compose
+make remix                  # the remixer: 8 tracks, hear effects, compose
 make modules                # the index of what exists
 make bus REMIX=<name>       # build a selection
 ```
 
-`make remix` is the workbench, organized like the unit: eight tracks, an
+`make remix` is the remixer, organized like the unit: eight tracks, an
 effect on each, its real knobs to dial and render and hear (every effect
 renders locally). Its composer view shows what would collide, what the FX2
 chooser ends up looking like on the panel — including which **stock**
 effects the image keeps, hides or consumes (only the three reverbs are
 consumed; the rest can be kept for free) — and what the selection costs
 against the donor region — then builds or saves it.
-**[docs/WORKBENCH.md](docs/WORKBENCH.md)** is the manual.
+**[docs/REMIXER.md](docs/REMIXER.md)** is the manual.
 
 See **[docs/MODULES.md](docs/MODULES.md)** to write a module.
 
@@ -278,11 +278,11 @@ make bus       # build the effects into it
 make image     # repack as a card-flashable .bin
 ```
 
-`make remix` opens the workbench (`make emu-setup` provisions it): a rig of
+`make remix` opens the remixer (`make emu-setup` provisions it): a rig of
 eight tracks to trial effects on by ear, a composer showing collisions, the
 panel your choice produces and its word cost against the donor region, and
 the built image booted in the local ColdFire emulator — the manual is
-**[docs/WORKBENCH.md](docs/WORKBENCH.md)**.
+**[docs/REMIXER.md](docs/REMIXER.md)**.
 
 `make help` lists everything. The setup script assumes **macOS + Homebrew**;
 on Linux the substitutions are the obvious ones (the DSP toolchain itself is

--- a/README.md
+++ b/README.md
@@ -55,18 +55,21 @@ real budget decision, not a label.
 | **`hello`** | HELLO WORLD + send | the reference minimal build, and the worked example to read first |
 
 ```bash
-make remix                  # the remixer: 8 tracks, hear effects, compose
+make remix                  # the remixer: swap effects, hear them, compose
 make modules                # the index of what exists
 make bus REMIX=<name>       # build a selection
 ```
 
-`make remix` is the remixer, organized like the unit: eight tracks, an
-effect on each, its real knobs to dial and render and hear (every effect
-renders locally). Its composer view shows what would collide, what the FX2
+`make remix` is the remixer: one page holding the library of everything that
+could be in an image, the image you are composing, and the selected effect —
+its real knobs to dial, render and hear (every effect renders locally), and
+the firmware's own draw of its page. It shows what would collide, what the
 chooser ends up looking like on the panel — including which **stock**
 effects the image keeps, hides or consumes (only the three reverbs are
 consumed; the rest can be kept for free) — and what the selection costs
-against the donor region — then builds or saves it.
+against the five scarce things: the two donor regions, the FX2 buffer slots,
+the per-core cycles, the chooser rows and the ColdFire cave. Then it builds
+or saves it.
 **[docs/REMIXER.md](docs/REMIXER.md)** is the manual.
 
 See **[docs/MODULES.md](docs/MODULES.md)** to write a module.
@@ -278,10 +281,10 @@ make bus       # build the effects into it
 make image     # repack as a card-flashable .bin
 ```
 
-`make remix` opens the remixer (`make emu-setup` provisions it): a rig of
-eight tracks to trial effects on by ear, a composer showing collisions, the
-panel your choice produces and its word cost against the donor region, and
-the built image booted in the local ColdFire emulator — the manual is
+`make remix` opens the remixer (`make emu-setup` provisions it): every
+effect auditionable by ear, a composer showing collisions, the panel your
+choice produces and what it costs against each scarce resource, and the
+built image booted in the local ColdFire emulator — the manual is
 **[docs/REMIXER.md](docs/REMIXER.md)**.
 
 `make help` lists everything. The setup script assumes **macOS + Homebrew**;

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -1,6 +1,6 @@
 # Local ColdFire emulator — Tier-0 bring-up
 
-The workbench emu of `PLAN.md` §5. Goal: an iterate-with-a-cycle loop for
+The remixer emu of `PLAN.md` §5. Goal: an iterate-with-a-cycle loop for
 ColdFire/UI work (a menu patch, a cave) without a flash. This page is the
 Tier-0 record — how far the real firmware boots under emulation and what it
 needs on the way. `tools/emu_bringup.py` is the harness; re-run it to
@@ -89,20 +89,20 @@ Two facts for whoever crosses it:
   `0x40000d74` written to every slot). So the vector base is known at run
   time from that variable, which sidesteps the no-op register read.
 
-## Milestone 1 — boot-and-inspect, wired into the workbench ✅
+## Milestone 1 — boot-and-inspect, wired into the remixer ✅
 
 `emu_bringup.boot(image)` returns a warm machine; `read_menu_tree(uc)` walks
 the MAIN MENU tables (`docs/MAINMENU.md`) out of its RAM. `make remix`
-(the workbench, `tools/remix/app.py` — manual in `docs/WORKBENCH.md`; the
+(the remixer, `tools/remix/app.py` — manual in `docs/REMIXER.md`; the
 curses `tui.py` is retired, in history) has an **`e`** view: it boots the *built* image
 (`out/mainos_bus.bin` — byte-compatible with the raw section), confirms it
 reaches the RTOS handoff with no fault, and shows the firmware's own screens
 with any patched-in entry highlighted. This is the crow-flies form of the
 no-flash gate: a cave that breaks early init **faults here instead of on the
 unit**, and a menu-table patch is visible before a flash. It needs `unicorn`
-in the interpreter that runs the workbench; without it the view degrades to
-an "unavailable" message and the rest of the workbench is unaffected. The
-workbench caches one `BootResult` and re-boots only when the image's mtime
+in the interpreter that runs the remixer; without it the view degrades to
+an "unavailable" message and the rest of the remixer is unaffected. The
+remixer caches one `BootResult` and re-boots only when the image's mtime
 changes, so re-entering the view is instant; the FX2 page follows the rig's
 selected track (1-8) rather than a hardcoded track 5.
 
@@ -178,7 +178,7 @@ highlight is the next increment.
 
 `render_fx2(r, track, effect_id)` and `render_fx1(r, track, effect_id)` render
 the real FX2 / FX1 parameter pages — the effect's actual knob rows, not a
-default. In the workbench's emu view: `f` (FX2 — follows the rig's selected
+default. In the remixer's emu view: `f` (FX2 — follows the rig's selected
 track and its assigned effect) / `o` (FX1; left/right cycle the effect). FX2 with `0x07` shows ChonVerb's knobs (SHMR/MODE/DIFF/SHFT/GATE/RATE/
 HP/LP/IN); FX1 shows the stock effects (FILTER's BASE/WDTH/ENV/ATK/DEC/…, EQ's
 FRQ/GN/…) — our inserts are all FX2, so the FX1 tables are stock.
@@ -215,7 +215,7 @@ text is the remaining nicety.
 
 ## The RTOS fork — still open, still not forced
 
-Milestone 2 took route **B** (detour) and it carries the workbench: a menu- or
+Milestone 2 took route **B** (detour) and it carries the remixer: a menu- or
 cave-patch is visible and walkable without a flash. Route **A** (emulate the
 RTOS — dispatch `trap #0` via VBR `[0x400b9668]`, drive a timer tick, run the
 real scheduler) remains the later fidelity upgrade, the only one that could
@@ -234,9 +234,9 @@ The emulator's one dependency (`unicorn`, with QEMU's CFV4E core — the DEFAULT
 m68k core is plain-68k and cannot decode this CPU) lives in the uv-managed
 `.venv` as the optional `emu` extra (`pyproject.toml`). `make remix` prefers
 `.venv/bin/python3` and falls back to bare `python3`, where the emulator view
-reports itself unavailable and the rest of the workbench is unaffected.
+reports itself unavailable and the rest of the remixer is unaffected.
 
 The CLI prints the boot outcome (the `trap #0` boundary), the auto-pokes, the
 MAIN MENU walked from booted RAM, and the peripheral boot map. In the
-workbench, `e` does the same against `out/mainos_bus.bin` and highlights what
+remixer, `e` does the same against `out/mainos_bus.bin` and highlights what
 the selection's patches added.

--- a/docs/FLASHPLAN.md
+++ b/docs/FLASHPLAN.md
@@ -1,0 +1,235 @@
+# The flash plan — clearing the backlog on hardware
+
+**What is on the unit today: tag 77 / R58, flashed 24 August 2026.** Since
+then, 134 commits on `main` plus the current branch. None of it has been on
+Sam's Octatrack.
+
+This page is the plan for putting it there: what is untested, which flashes
+prove which claims, what to listen for, and — the part that matters — **what
+would falsify each claim.** Flash cycles are the expensive resource here
+(each one is a manual firmware write), so the images are shaped to stack as
+many independent claims as possible *while keeping their failures
+distinguishable*. `docs/FLASHING.md` is the procedure; this is the schedule.
+
+---
+
+## 0. What is actually unflashed
+
+Three classes, and only two of them need hardware.
+
+### A. Proven not to change the image — no flash needed
+
+The modules/remixes platform, the remixer, the ColdFire emulator, the FX1
+plumbing at its default, and the dynamic-donor refactor at its default are
+all **bit-identical** to what they replaced: `scripts/refhash.sh check`, 26
+configurations, artifacts *and* build reports. That is the whole point of
+that gate. Nothing below tests them, because there is nothing to test.
+
+⚠️ What refhash proves is that a *default* selection is unchanged. It says
+nothing about a selection that uses the new capability — which is what
+flashes 2 and 3 are for.
+
+### B. Changes the shipping image — flash 1
+
+| | what it changes | first flashed |
+|---|---|---|
+| BongDelay R59–R62 | GRAIN density was a 2-position switch (now a full dial) + makeup gain; REVERSE default = 93 ms segment; the −19 interval swap | never |
+| Stepped-select labels (PLAN §6) | twelve selects print words instead of `1 2 3` — `Param.labels` was authored, schema-checked and never read until 2 Sep | never |
+
+### C. New capability, never on hardware at all — flashes 2 and 3
+
+| | claim | evidence so far |
+|---|---|---|
+| Stock effects listable | our servers and stock effects coexist on one chooser; the reverbs come back where the placement never reached them | build + ledger only |
+| The insert card | five inserts of ours stack, and four copies of the dearest fit one core's cycle budget | `cycle_count` is a **floor**, not a measurement |
+| A module on FX1 | FX1's chooser relocated into the cave, its three `lea` refs repointed, its own id **and cursor** tables written | ColdFire emulator only |
+| A donor region beyond the reverbs | any stock effect's words can be taken; every one is self-contained | `dsp_reach` over both payloads — **static** |
+| Hello World (Bryan T) | builds and runs | flashed on **his** unit, not Sam's |
+
+---
+
+## Flash 1 — the accumulated shipping build
+
+**Image:** `chongbong`, the shipping remix, at HEAD. Bump `BUILD` to 79.
+
+```bash
+make check && scripts/refhash.sh check     # both must be green
+BUILD=79 make image
+```
+
+**Why first, and alone.** It is the same *shape* as what is on the unit —
+three modules, the same donor region, the same chooser — so it is the lowest
+risk of anything here, and it is the gate: if the accumulated tree does not
+work, nothing after it is worth flashing. It proves class B and, incidentally,
+that the platform refactor really was inert.
+
+**Checks, in order:**
+
+1. **It boots.** Anything else is moot. The emulator has already reached the
+   RTOS handoff on this image (`make remix`, the CHOOSERS line ends `boots`),
+   so a failure here means something the emulator cannot see.
+2. **The chooser reads `ChonVerb79 / BongDelay79 / Send`.** The tag is how you
+   know which build is running — three rounds were lost to not being able to
+   tell "the change did not work" from "the flash did not apply".
+3. **Every stepped select prints words.** WarpFold is not in this image;
+   check BongDelay's `MODE`, `RATE`, `FRZE` and ChonVerb's `MODE`, `SHFT`,
+   `RATE`. ⚠️ **Falsifier: a select still showing `1 2 3`.** That is the
+   formatter not taking, and it is a descriptor field a clone inherits from
+   its donor — the 17 Aug class of bug.
+4. **BongDelay GRAIN `DENS` sweeps.** It behaved as a two-position switch
+   before R61. Turn it slowly across the full range and listen for continuous
+   change. ⚠️ **Falsifier: it still jumps between two densities.**
+5. **Levels.** R61 added makeup gain to keep GRAIN level-flat (±1.2 dB
+   measured locally). Sweep DENS with a steady source and listen for a level
+   jump. ⚠️ **Falsifier: an audible level step across the sweep.**
+6. **REVERSE default.** R62 set it to the 93 ms segment. Check it sounds like
+   a segment reverse, not a whole-buffer one.
+7. **Test the reverb on TRACK 5, not track 1.** Payload A serves tracks 5–8.
+   This has cost a session before.
+
+**Stop condition:** if it does not boot, or if the reverb or delay is
+audibly broken on its own track, **stop and do not flash 2**. Recover with
+`downloads/extracted/OCTATRACK_OS1.40C.syx` and bisect locally — 134 commits
+is a wide net, but `git bisect` with `make render` is cheap.
+
+---
+
+## Flash 2 — stock effects beside ours
+
+**Image:** `restored` — chongbong plus the seven stock effects that can
+coexist with the servers. Bump `BUILD` to 80.
+
+**What it proves.** That a stock effect and one of ours can share a chooser
+and a bank at all. Everything about that is currently build-time reasoning:
+the ledger refuses the pairs it believes collide and permits these seven, and
+nothing has ever checked the permission on hardware.
+
+**Checks:**
+
+1. **The chooser lists both.** Seven stock rows plus ChonVerb / BongDelay /
+   Send, in the order `restored` declares.
+2. **Each stock row actually runs.** Select FILTER, EQUALIZER, DJ EQ, PHASER,
+   COMPRESSOR, LO-FI and DELAY in turn on **tracks 1–4** and confirm each is
+   its own effect and not silence, noise, or another effect's algorithm.
+   ⚠️ **Falsifier: a listed stock effect that is silent** — that is its
+   dispatch pointing at the null stub, i.e. the build nulled something it
+   should not have.
+3. **A stock effect on tracks 1–4 while ChonVerb runs on 5–8.** This is the
+   coexistence claim in the shape that matters. Play both. ⚠️ **Falsifier:
+   tank corruption on the reverb** — a rising, grainy or metallic tail that
+   is not there when tracks 1–4 are silent. That is the buffer collision the
+   ledger exists to prevent, appearing on a pair it believed safe.
+4. **Which reverbs survived.** The build report names them (`KEPT STOCK:`).
+   If any survived, select it and confirm it is the real reverb.
+
+**Stop condition:** tank corruption in (3) invalidates the ledger's
+coexistence table, which is upstream of a lot. Stop, and record exactly which
+pair and which tracks.
+
+---
+
+## Flash 3 — the field test: inserts, FX1, and a donor beyond the reverbs
+
+**Image:** `remixes/fieldtest.py`. Bump `BUILD` to 81.
+
+Three never-flashed claims in one image, shaped so a failure says which one
+broke:
+
+```
+ region P:0x00d96..0x01aa4 (3342 words)  used 2195  FREE 1147
+ donor ids taken (FLANGER/CHORUS/PLATE/SPRING) ... KEPT STOCK: DARK
+ FX1 chooser = 10 rows (NONE + … + WARPFOLD), 3 refs repointed
+```
+
+**1. The insert card.** Five inserts on the FX2 chooser. Put **BodeShift on
+all four tracks of one core** (5–8) — `cycle_count` says that plus four
+WarpFolds on FX1 is the worst case at 1,780 of the 3,120 usable, but that
+figure is a *floor*: exact for the code, optimistic about memory contention,
+and it does not count stock's own FX1 load at all.
+⚠️ **Falsifier: the unit wedges or the audio stops.** PLAN §2 says the wall
+is a **cliff**, not a slope — +200 cycles was a hard hang with no warning.
+If it wedges, that is the first real cycle measurement since 23 August and
+worth more than the test that failed.
+
+**2. WarpFold on FX1.** It is row 9 of a ten-row FX1 chooser.
+- The row is **there** and reads `WarpFold81`.
+- Selecting it draws **its own** knob names (`DRV FREQ TONE MODE MIX`), not
+  the previous effect's.
+- The cursor opens **on its row**, not row 0. ⚠️ That is `FX1_ID2POS`, which
+  `tools/build_fx1.py`'s original experiment never wrote — the one thing in
+  the FX1 path with no precedent at all.
+- It **processes audio** on an FX1 slot.
+⚠️ **Falsifier: a garbled FX1 chooser** — rows of symbols past the end of the
+list. That is the viewport literal at `0x40059be6` not taking, and it is the
+"bunch of symbols" failure FX2 had on hardware test 1.
+
+**3. A donor region beyond the reverbs.** CHORUS and FLANGER are on neither
+chooser, so their words are the region and our code sits at FLANGER's
+address. **Nothing has ever overwritten a non-reverb stock effect on
+hardware.** The static evidence is good — every effect is self-contained in
+both payloads, no control flow leaves its span, nothing enters it but its own
+dispatch entry — but static reachability cannot follow a computed jump or the
+DSP's own self-modification (`dsp_reach.py` says so itself).
+⚠️ **Falsifier: anything ELSE misbehaving** — an unrelated stock effect
+wrong, a crash on part load, noise that does not follow a track. Check
+FILTER, EQUALIZER, DJ EQ, PHASER, COMPRESSOR and LO-FI still sound right;
+they are the neighbours whose code sits either side of the region.
+- Also select CHORUS and FLANGER **from an old project** that has them
+  stored. They have no row, and their id should resolve to **silence**, not
+  noise. That is the null stub doing its job.
+
+⚠️ **Why CHORUS and FLANGER and not FILTER.** FILTER is the default FX1
+effect — every project touches it — so taking its words first would make any
+failure maximally confusing and maximally destructive. These two are the
+cheapest non-reverbs to be wrong about.
+
+**Stop condition:** a wedge in (1) is *information*, not a failure to hide
+from — record the exact configuration. Anything in (3) stops the dynamic
+donor work until it is understood.
+
+---
+
+## Before every flash
+
+From `docs/FLASHING.md` and the card workflow this project already uses:
+
+- [ ] `make check` and `scripts/refhash.sh check` both green.
+- [ ] **Bump `BUILD`.** The tag is stamped into the effect name; a unit whose
+      version you cannot map to a commit is a unit you are guessing about.
+- [ ] `make image` — `.bin` for the CF-card path (recommended), `.syx` for MIDI.
+- [ ] The rescue firmware to hand: `downloads/extracted/OCTATRACK_OS1.40C.syx`,
+      and a **DIN** MIDI path for it. USB-MIDI does not work for the upgrade.
+- [ ] Card: copy, `cmp` against the source, remove the old image, `sync`,
+      eject. Kill any `._` sidecars.
+- [ ] Stable power.
+- [ ] **A capture rig ready before the flash, not after** — `tools/rec.swift`
+      via the MicroBook, never `ffmpeg avfoundation` (it drops samples).
+- [ ] ⚠️ A capture inherits every stored knob on the part. **Re-select the
+      effect** for fresh defaults before judging it.
+
+## After every flash
+
+Write the result down the same evening, in the repo, beside the claim it
+tests — that habit is why this page could be written at all. A pass is one
+line; a failure is the configuration, the track, and what it sounded like.
+
+Mark each item in §0 as ✅ measured or ❌ falsified. **Do not leave a claim
+in the "flashed, seemed fine" state** — that is how a stale confident number
+gets written down, which this project has been burned by more than once.
+
+---
+
+## What is deliberately not in this plan
+
+- **The main-menu shortcut** (PLAN §5) — not built, so nothing to flash.
+- **An FX1 chooser SHORTER than the viewport.** `fieldtest` lists ten, above
+  the seven-row window, so the shrink path is exercised but not the extreme.
+  A three-row FX1 list is the interesting case for the viewport literal and
+  is worth its own flash later, not a shared one.
+- **The cross-core bus residual** (T4 + delay MODE 1). Standing open item;
+  it needs a track × mode sweep, which is a listening session rather than a
+  flash test.
+- **MK1.** Every flash here has been on an MKII. The OS is the same
+  hash-identical 1.40C image on both marks, so an octabam image is
+  *plausibly* MK1-compatible 🟡 — but that remains inferred, and an MK1 owner
+  flashing it is the test pilot.

--- a/docs/FLASHPLAN.md
+++ b/docs/FLASHPLAN.md
@@ -48,6 +48,60 @@ flashes 2 and 3 are for.
 
 ---
 
+## Step 0b — a project whose effects are actually set
+
+⚠️ **The effect ids live in the PROJECT, not the OS.** They survive a flash,
+so a freshly flashed unit opens every track still holding the id it had
+before — which in the new image may be a different effect, or one the image
+does not implement (and so resolves to the fallback). That is why a flashed
+unit *"keeps the old effect graphics"* until you select something, and it is
+why **a flash test that starts from an old project is not a test of
+anything**: half the tracks are running whatever the last image left there.
+
+So before flash 1, make a project whose every bank, part and track is stamped
+with an id this image implements:
+
+```bash
+python3 tools/ot_project.py testproj \
+    ~/octa/backups/<a project you trust> /Volumes/<card>/OCTABAM_T1 chongbong
+```
+
+It copies (never edits the source), lays out **one effect per part on all
+eight tracks**, writes both the current parts and their saved copies,
+recomputes each bank's checksum, reads everything back, and drops
+`OCTABAM_TEST_MAP.txt` in the project so you can see at the unit what each
+part is:
+
+```
+bank A  part 1   FX1 0x00  FX2 0x0a   WARPFOLD on FX2
+bank B  part 2   FX1 0x04  FX2 0x00   FILTER on FX1
+bank D  part 3   FX1 0x0a  FX2 0x0f   WORST by cycles: BODESHIFT on FX2 + WARPFOLD on FX1
+```
+
+One effect per part **on all eight tracks** is deliberate: selecting a part
+then auditions that effect across both cores at once, which is the shape the
+cycle test wants and the shape that shows a payload asymmetry immediately —
+tracks 5–8 are payload A, 1–4 are payload B. Parts past the end of the plan
+are NONE on both slots, which is the silent control.
+
+⚠️ **Both the current parts and the saved copies.** A bank holds eight PART
+records: 1–4 current, 5–8 the copies the unit restores on RELOAD PART.
+Writing only the first four leaves the old assignment one keypress away.
+(Verified against 80 bank files: 5–8 are byte-identical to 1–4 in every one.)
+
+⚠️ **The checksum is not optional** — the last `u16` BE is an additive sum
+over `bytes[0x10:-2]` and the unit rejects a bank whose sum does not match.
+The tool recomputes it and then reads the file back; a mismatch aborts rather
+than handing you a card that fails on load.
+
+Measured on a real project: **1,968 bytes changed across sixteen banks, none
+of them outside the FX id fields**, and no other file touched.
+
+Make a fresh one per flash — `chongbong`, then `restored`, then `fieldtest` —
+because each image implements a different set of ids.
+
+---
+
 ## Flash 1 — the accumulated shipping build
 
 **Image:** `chongbong`, the shipping remix, at HEAD. Bump `BUILD` to 79.
@@ -194,6 +248,8 @@ donor work until it is understood.
 From `docs/FLASHING.md` and the card workflow this project already uses:
 
 - [ ] `make check` and `scripts/refhash.sh check` both green.
+- [ ] **A test project stamped for THIS image** (step 0b). Without it you are
+      testing whatever ids the last image left in the parts.
 - [ ] **Bump `BUILD`.** The tag is stamped into the effect name; a unit whose
       version you cannot map to a commit is a unit you are guessing about.
 - [ ] `make image` — `.bin` for the CF-card path (recommended), `.syx` for MIDI.

--- a/docs/MAINMENU.md
+++ b/docs/MAINMENU.md
@@ -144,7 +144,7 @@ the viable designs all reuse the existing descriptor pipeline
   navigation jank goes away. ✅ **Traced end to end, 31 Aug 2026 — see §7**
   for the decoded open path, the handler, and the residual risks. (Still
   never executed: the Unicorn ColdFire harness was pruned, so a menu patch
-  goes static-verify → flash until the workbench emu of `PLAN.md` §5
+  goes static-verify → flash until the remixer emu of `PLAN.md` §5
   exists.)
 - **A bespoke PERSONALIZE-style list screen** whose setters call the stock
   parameter writer `FUN_40054cd8(track, flat, value)` for the host track, so

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -474,3 +474,58 @@ renders with no hatch at all.
 believe the hardware and go looking for what the harness cannot see. A
 measurement can be structurally blind to the thing you are using it to rule
 out — `CLAUDE.md` has two instances that each cost hours.
+
+## Replacing a stock effect
+
+A module normally takes a **free** FX2 id and appears as an extra row. If
+instead you are writing an **upgraded version of a stock effect** — a better
+LO-FI, say — you want the stock effect's own id, so that FX1, FX2 and every
+saved project that already selected it get yours. Declare it:
+
+```python
+menu=MenuEntry(
+    fx2_id=0x1c,              # LO-FI's
+    replaces="LO-FI",         # ...and say so
+    ...
+)
+```
+
+Without `replaces`, a stock id is **refused** — that is the default and it is
+the safe one.
+
+**What you are asking for.** The DSP dispatch tables are indexed by the raw id
+and shared by both menus, so your code runs wherever that id is selected. That
+is the point, and it is also the whole hazard: Rungs sat on EQUALIZER's `0x0c`
+and Nimbus on DJ EQ's `0x0d` from 29 Aug to 2 Sep 2026, in every local image,
+and the remixes *without* them aliased those ids to SEND — which took FX1's
+EQUALIZER away in the shipping image too. Every existing check passed, because
+each module was individually correct.
+
+**What the build guarantees now.** A remix that omits your replacement leaves
+the stock effect **byte-identical to stock** — descriptor and dispatch, both
+payloads — rather than aliasing its id to the fallback. The build says so:
+`not in this remix, LEFT STOCK: <KEY>`. `tools/verify_replaces.py` (in `make
+check`) proves the property for every remix: every stock id is either stock's
+own or claimed by a module that declared it. The four cases it and the schema
+between them refuse:
+
+| you wrote | what happens |
+|---|---|
+| a stock id, no `replaces` | refused at import — the Rungs/Nimbus shape |
+| `replaces="PHASER"` on LO-FI's id | refused: the declaration must name the effect whose id you carry |
+| a remix with both LO-FI and your replacement | refused: `fx2 id: hijack and lofi both claim 0x1c` |
+| a remix with neither | LO-FI stays stock, untouched |
+
+⚠️ **FX1's descriptor is NOT repointed.** `FX1_IDS` (`0x400d5f58`) and
+`FX2_IDS` (`0x400d5fdc`) are separate tables, so your *code* runs from FX1
+while FX1's *page* still draws the stock effect's knob names. Same family as
+"a slot can draw a knob and publish nothing" — the panel and the DSP are
+separate mechanisms and neither validates the other. Either match the stock
+knob layout, or accept that FX1 mislabels it. (`tools/build_fx1.py` knows how
+to write that table if repointing it is ever wanted.)
+
+**Words.** Taking a stock effect's *id* does not give you its *code space* —
+you spend from the same 2,724-word donor region as every other module. The
+region has to be physically contiguous and the build asserts it, so only a
+module adjacent to it could ever join; `DEV=1`'s fourth donor is CHORUS
+specifically because it "sits immediately BELOW PLATE".

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -253,6 +253,9 @@ selects it still runs it, it just has no row — which is what keeps FX1
 whole. `remixes/restored.py` is chongbong plus the seven that can sit
 beside the servers.
 
+`remixes/restock.py` is all fourteen and nothing else: zero words placed,
+all three reverbs alive — the unit's own chooser, rebuilt from our tables.
+
 Two rules, both enforced:
 
 - **Four stock effects allocate an instance buffer** — SPATIALIZER,
@@ -327,6 +330,53 @@ stock effect that sounds wrong locally is evidence about the **harness or
 emulator** before it is evidence about the effect — twice now.
 
 ---
+
+## What an unimplemented id falls back to
+
+The build rewrites the FX2 dispatch tables wholesale, so every one of the 32
+ids has to point at a descriptor and a DSP entry — including **id 0, which
+is what a fresh part's FX2 slot holds**. `Remix.fallback` names where they
+go, and there are two answers.
+
+**`fallback="SEND"` — for a remix with a bus.** The send client passes the
+audio through and only taps it, so an id aliased to it degrades in the
+useful direction: a track that selects a missing effect becomes a send, not
+silence and not noise. No *stock* effect is a safe target — it would
+PROCESS the unknown id on whatever knobs the part holds — and the target
+must be a module of ours anyway: it needs a cloned descriptor, a cursor
+position in the list, and placed code.
+
+**`fallback="NONE"` — for a remix with no bus.** Unimplemented ids resolve
+to the **firmware's own NONE**: the descriptor a stock chooser carries at
+list row 0 (which our rebuilt list otherwise drops) and, on the DSP side,
+the per-payload null stub the build already points silenced donor ids at.
+It costs one chooser row — four bytes of cave — and **not one word**.
+
+That matters more than it sounds. Every insert-only remix used to carry
+SEND purely to satisfy the rule, at 215–250 words, for a bus client nothing
+in the image reads: with no server, nothing ever consumes the accumulators
+it writes. On `restock` those words landed on PLATE REV's, which is the only
+reason the stock chooser was ever thirteen effects instead of fourteen.
+
+⚠️ **`NONE` is refused beside any bus participant**, and that refusal is the
+whole safety argument. Housekeeping — flipping the rotation word and
+clearing the accumulators, once per block — is gated to payload A and done
+by the first core-0 participant dispatched that block (`send_client.asm`'s
+`bus_seen` election). With SEND on every unassigned track, core 0 always has
+one. Under `NONE` an unassigned track runs *nothing*, so a project with
+tracks 5–8 all unassigned would have no housekeeper, and a server on the
+other core would read an accumulator that is never rotated and never
+cleared. With no server and no SEND in the image there is no bus, no
+rotation and nothing to clear, so the question does not arise — and that is
+the only case this is allowed in. `registry.remix()` enforces it.
+
+⚠️ And it could not be settled by measurement either way: `dsp_host` is
+single-core, so **no local test can reproduce a bus timing defect**. The
+refusal keeps the question off the table rather than answered by inference.
+
+Declare `bus_client=True` in a module's `Harness` if it writes the shared
+accumulators, the way `modules/send` does; `is_server=True` is the other
+half. Those two are what `schema.on_the_bus()` reads.
 
 ## Declaring DSP code
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -98,15 +98,15 @@ what keeps `modules/_template/` out of every build.
 short, and its comments carry the reasoning behind each field.
 
 Copy `modules/_template/` to start (and read `modules/hello/` for a
-finished one), and `make remix` opens the workbench
+finished one), and `make remix` opens the remixer
 (`tools/remix/app.py`, Textual — provisioned by `make emu-setup`; the full
-manual is `docs/WORKBENCH.md`). Its home
+manual is `docs/REMIXER.md`). Its home
 view is a RIG of eight tracks: assign effects, dial their manifest-named
 knobs, render and hear them. Its REMIX view is the composer: collisions, the
 FX2 menu your selection produces, its word cost against the donor region,
 save/load, build and check.
 
-The workbench derives a **category** and a **track range** for every module
+The remixer derives a **category** and a **track range** for every module
 (`tools/remix/rig.py`) rather than asking for new declarations:
 
 - **bus effect** (`harness.is_server`) — lives in ONE payload, which the
@@ -126,7 +126,7 @@ and A/B mark is journalled to `out/_audition/log.jsonl` (track, effect,
 source, every knob), so a listening note like "this sounds boxy" plus the
 journal tail is a full repro.
 
-Two `Param` fields exist purely for the workbench (the build never reads
+Two `Param` fields exist purely for the remixer (the build never reads
 them — the refhash gate proves it): **`doc`**, one line saying what the knob
 does, shown under the knob cursor; and **`labels`**, one short label per
 value of a stepped select (the schema pins the length to `count`). The
@@ -277,7 +277,7 @@ Two rules, both enforced:
   yet measured — `restored` is the first image with more than seven rows
   and is unflashed.
 
-Stock rows appear in the workbench (a STOCK FX2 group in the composer, any
+Stock rows appear in the remixer (a STOCK FX2 group in the composer, any
 track in the rig) **with their real knobs**: `stock.py` reads each
 descriptor's names, defaults, value counts and enable bitmap out of the
 pristine image (`out/raw/section_3_MAIN_OS.bin`), so `knob_map()`,

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -580,17 +580,34 @@ see below.
 The build asserts the tables hold stock's descriptor before touching them,
 and that the chooser list contains it exactly once.
 
-### An FX1 row without taking a stock id: `Remix.fx1`
+### The FX1 chooser: `Remix.fx1`
 
-A module on its own id can be listed on FX1 as well, and the remix says so —
-which menu an effect appears on is a composition choice, like the chooser
-order, not a property of the code:
+`modules` is the FX2 chooser in its own row order; `fx1` is the FX1 chooser
+in its own. Both hold the same kind of keys — stock effects and modules of
+ours — because which menu an effect appears on is a composition choice, not
+a property of the code. **Empty means unchanged**: FX1 keeps stock's own ten
+and the build writes not one byte, which is what keeps every remix that
+predates this byte-identical.
 
 ```python
 REMIX = Remix(name="bothslots", doc="…",
               modules=("WARPFOLD",), fallback="NONE",
-              fx1=("WARPFOLD",))          # also on the FX1 chooser
+              # FX1's chooser, in its own row order. Six of stock's ten,
+              # WarpFold among them; FLANGER, CHORUS, SPATIALIZER and COMB
+              # lose their FX1 row and nothing else.
+              fx1=("FILTER", "EQUALIZER", "DJ EQ", "PHASER", "WARPFOLD",
+                   "COMPRESSOR", "LO-FI"))
 ```
+
+⚠️ **NONE is not listed and cannot be lost.** FX1 row 0 is the firmware's own
+NONE — how the slot is turned off — and the build always emits it first.
+
+⚠️ **A list SHORTER than stock's needs the viewport shrunk**, or the draw
+loop iterates its hard-coded row count past the terminator and renders raw
+memory as text (the "bunch of symbols" of hardware test 1, on FX2). FX1's
+literal is at `0x40059be6`, located 3 Sep 2026: FX1's setup function is
+**byte-identical to FX2's apart from the list address**, and this sits at
+the identical offset (+0x14) from FX1's own list reference.
 
 The DSP side needs nothing: the dispatch table is indexed by the raw id and
 shared, so the code already ran from FX1 the moment FX1 selected the id. The
@@ -600,9 +617,10 @@ id lookup and its cursor table. The build does all four:
 
 | table | what it gets |
 |---|---|
-| the chooser list | rebuilt in the cave, stock's eleven rows first, then yours; its three `lea` references (`0x40037990`, `0x40052706`, `0x40059bd2`) repointed |
+| the chooser list | rebuilt in the cave — NONE, then exactly what `fx1` names; its three `lea` references (`0x40037990`, `0x40052706`, `0x40059bd2`) repointed |
+| the viewport `0x40059be6` | `min(7, rows)`, so a list shorter than the screen has no rows left to pad |
 | `FX1_IDS` `0x400d5f58` | your descriptor clone — the **same** one FX2 resolves, as stock does for the ten shared effects |
-| `FX1_ID2POS` `0x400d60d0` | the row your id opens on. ⚠️ `tools/build_fx1.py`'s experiment never wrote this; without it the chooser opens on row 0 |
+| `FX1_ID2POS` `0x400d60d0` | the row each listed id opens on, and **0 for every id the list drops** — a shorter list would otherwise seed the cursor past the end for an old project holding a dropped id. ⚠️ `tools/build_fx1.py`'s experiment never wrote this table at all |
 | `FX2_IDS` / `ID2POS` | untouched by this — the FX2 row is the ordinary one |
 
 **It costs no words** — the code is placed either way — and it is not free:
@@ -619,6 +637,7 @@ classes are refused:
 
 | refused | why |
 |---|---|
+| a **stock** effect FX1 does not already list | DELAY and the three reverbs do not fit a 3,072-word FX1 allocation either — that is *why* stock keeps them off it |
 | a module that reads the allocator (`x:>$213`) | it sizes its buffer for an **FX2** slot, 16,384 words; an **FX1** slot is **3,072** |
 | a module with **fixed** buffers in the FX2 region | an FX1 instance still writes to `Y:0x4000`+, i.e. into another track's FX2 buffer |
 | a bus **server** | one per core by design; an FX1 row is a second instance on the same core |

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -540,6 +540,16 @@ forgotten", which is the shape this half exists to prevent.
 reverbs are not on FX1 (their `FX1_IDS` slots are NONE), so there is nothing
 to repoint; the build says so rather than silently doing nothing.
 
+⚠️ **If your replacement allocates a buffer, size it for FX1.** The
+allocator keeps separate tables and they are not the same size (measured,
+`X:0x255` in both payloads): an **FX2 slot is 16,384 words, an FX1 slot is
+3,072**. Your code runs from *both* menus the moment it takes a stock id, so
+an effect that asks for a buffer and assumes the FX2 size overruns its
+allocation by 13,312 words the first time somebody selects it on FX1. Same
+class as the stock reverbs being FX2-only — they do not fit an FX1
+allocation either. **Nothing checks this**: a buffer size is not visible to
+the schema.
+
 **Words.** Taking a stock effect's *id* does not give you its *code space* —
 you spend from the same 2,724-word donor region as every other module. The
 region has to be physically contiguous and the build asserts it, so only a

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -573,11 +573,52 @@ FX1 under the stock effect's knob names. Both FX1 tables are therefore
 repointed as well: the id-indexed lookup, and the row the encoder scrolls.
 
 Both writes are **in place**, because a replacement's effect is already on
-FX1 — there is no list to grow and no cave to relocate into. (That is what
-`tools/build_fx1.py`'s experiment needed, because it *adds* entries: the list
-ends at `0x400d608c` and the FX2 list starts at `0x400d6090`.) The build
-asserts the tables hold stock's descriptor before touching them, and that the
-chooser list contains it exactly once.
+FX1 — there is no list to grow and no cave to relocate into. Adding a row for
+a module on a *new* id does need both, and that is the other way onto FX1:
+see below.
+
+The build asserts the tables hold stock's descriptor before touching them,
+and that the chooser list contains it exactly once.
+
+### An FX1 row without taking a stock id: `Remix.fx1`
+
+A module on its own id can be listed on FX1 as well, and the remix says so —
+which menu an effect appears on is a composition choice, like the chooser
+order, not a property of the code:
+
+```python
+REMIX = Remix(name="bothslots", doc="…",
+              modules=("WARPFOLD",), fallback="NONE",
+              fx1=("WARPFOLD",))          # also on the FX1 chooser
+```
+
+The DSP side needs nothing: the dispatch table is indexed by the raw id and
+shared, so the code already ran from FX1 the moment FX1 selected the id. The
+panel side needs the list **relocated** — FX1's ends at `0x400d608c` and
+FX2's begins at `0x400d6090`, so it cannot grow in place — plus FX1's own
+id lookup and its cursor table. The build does all four:
+
+| table | what it gets |
+|---|---|
+| the chooser list | rebuilt in the cave, stock's eleven rows first, then yours; its three `lea` references (`0x40037990`, `0x40052706`, `0x40059bd2`) repointed |
+| `FX1_IDS` `0x400d5f58` | your descriptor clone — the **same** one FX2 resolves, as stock does for the ten shared effects |
+| `FX1_ID2POS` `0x400d60d0` | the row your id opens on. ⚠️ `tools/build_fx1.py`'s experiment never wrote this; without it the chooser opens on row 0 |
+| `FX2_IDS` / `ID2POS` | untouched by this — the FX2 row is the ordinary one |
+
+**It costs no words** — the code is placed either way — and it is not free:
+FX1 is four more slots on the same four tracks, so listing an effect on both
+menus can double the worst per-core load (`make cycles` prices it; WarpFold
+goes 4× → 8×, 404 → 808 of the 3,120 our code may spend).
+
+Refused rather than allowed to go wrong: a `replaces` module (it already has
+that effect's FX1 row — a second would list it twice), a stock effect (its
+FX1 row is stock's own business), and a key with no FX2 chooser row of its
+own (nothing for FX1's list to point at). `verify_menu.py` proves the rest,
+and asserts FX1 is byte-identical to stock in every remix that asks for
+nothing.
+
+⚠️ Seen in the emulator, not on hardware: the firmware's own draw puts
+`WarpFold78` on row 11 of a twelve-entry FX1 chooser with its own knob names.
 
 Confirmed without a flash: with a throwaway module on LO-FI's id, the
 emulated firmware draws `HIJACK` in LO-FI's slot on the **FX1** chooser and

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -610,12 +610,61 @@ FX1 is four more slots on the same four tracks, so listing an effect on both
 menus can double the worst per-core load (`make cycles` prices it; WarpFold
 goes 4× → 8×, 404 → 808 of the 3,120 our code may spend).
 
-Refused rather than allowed to go wrong: a `replaces` module (it already has
-that effect's FX1 row — a second would list it twice), a stock effect (its
-FX1 row is stock's own business), and a key with no FX2 chooser row of its
-own (nothing for FX1's list to point at). `verify_menu.py` proves the rest,
-and asserts FX1 is byte-identical to stock in every remix that asks for
-nothing.
+#### Only a buffer-free INSERT may take one
+
+`state.fx1_hazard()` is the single statement of the rule — read by both the
+remixer, at the keystroke, and `build_bus.py`, at the build, because those
+two drifting apart is how a UI comes to offer what the build refuses. Three
+classes are refused:
+
+| refused | why |
+|---|---|
+| a module that reads the allocator (`x:>$213`) | it sizes its buffer for an **FX2** slot, 16,384 words; an **FX1** slot is **3,072** |
+| a module with **fixed** buffers in the FX2 region | an FX1 instance still writes to `Y:0x4000`+, i.e. into another track's FX2 buffer |
+| a bus **server** | one per core by design; an FX1 row is a second instance on the same core |
+
+⚠️ **The first is measured, not reasoned.** It is `docs/DSP.md`'s "wrong
+claim 1", bisected on hardware: a 16K layout placed at an FX1 base "runs to
+`0x53ff`, through the other FX1 buffers and into FX2 slot 0". **NIMBUS LITE
+reads the allocator and is exposed** — the first draft of the schema comment
+claimed nothing of ours was, having checked only the fixed-base modules.
+
+The second is not a *new* hazard: Nimbus is already documented "one per
+core" because its buffers are fixed rather than per-instance. An FX1 row
+doubles the slots it can be reached from, a second instance on the **same
+track** included.
+
+What is left is exactly the INSERT class — WarpFold, Ripple, Rungs, Streamz,
+BodeShift, Hello World — plus SEND, which is buffer-free (untested there,
+but nothing measured argues against it). Those keep **all** their state in
+their own `r7` block, which the dispatcher hands out **per instance**, not
+per track: FX1 instance *k* and FX2 instance *k* get different blocks, so the
+same effect on both slots of one track is two independent instances that
+happen to run in series.
+
+Also refused: a `replaces` module (it already has that effect's FX1 row — a
+second would list it twice), a stock effect (its FX1 row is stock's own
+business), and a key with no FX2 chooser row of its own (nothing for FX1's
+list to point at). `verify_menu.py` proves the rest, and asserts FX1 is
+byte-identical to stock in every remix that asks for nothing.
+
+#### What is actually different about FX1
+
+For an eligible module: **the slot size, the state block, and nothing else.**
+The DSP dispatch is one shared table, the entry point is the same code, and
+`r0`/`r6`/`r7` are set the same way — so there is no separate FX1 build, no
+separate render, and locally nothing to test that the FX2 render does not
+already cover. The differences that exist are all about memory and order:
+
+| | FX1 | FX2 |
+|---|---|---|
+| buffer slot | `0x1000 0x1c00 0x2800 0x3400`, **3,072 words** each | `0x4000 0x8000` + the shared-window pair, **16,384** |
+| state block (`r7`) | instance *k* → `0x6000 + (1 + 2k) * 0x100` | instance *k* → `0x6000 + (2 + 2k) * 0x100` |
+| in the chain | first | second — it processes what FX1 produced |
+| cycles | 4 slots per core | 4 slots per core; both are paid |
+
+The last row is the one that bites, and it is why `make cycles` prices FX1's
+four slots: an effect on both menus can double the worst per-core load.
 
 ⚠️ Seen in the emulator, not on hardware: the firmware's own draw puts
 `WarpFold78` on row 11 of a twelve-entry FX1 chooser with its own knob names.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -516,13 +516,29 @@ between them refuse:
 | a remix with both LO-FI and your replacement | refused: `fx2 id: hijack and lofi both claim 0x1c` |
 | a remix with neither | LO-FI stays stock, untouched |
 
-⚠️ **FX1's descriptor is NOT repointed.** `FX1_IDS` (`0x400d5f58`) and
-`FX2_IDS` (`0x400d5fdc`) are separate tables, so your *code* runs from FX1
-while FX1's *page* still draws the stock effect's knob names. Same family as
-"a slot can draw a knob and publish nothing" — the panel and the DSP are
-separate mechanisms and neither validates the other. Either match the stock
-knob layout, or accept that FX1 mislabels it. (`tools/build_fx1.py` knows how
-to write that table if repointing it is ever wanted.)
+**FX1 is taken over too.** `FX1_IDS` (`0x400d5f58`) and `FX2_IDS`
+(`0x400d5fdc`) are separate tables — the DSP dispatch is shared, the
+descriptors are not — so a replacement that only took FX2 would *run* from
+FX1 under the stock effect's knob names. Both FX1 tables are therefore
+repointed as well: the id-indexed lookup, and the row the encoder scrolls.
+
+Both writes are **in place**, because a replacement's effect is already on
+FX1 — there is no list to grow and no cave to relocate into. (That is what
+`tools/build_fx1.py`'s experiment needed, because it *adds* entries: the list
+ends at `0x400d608c` and the FX2 list starts at `0x400d6090`.) The build
+asserts the tables hold stock's descriptor before touching them, and that the
+chooser list contains it exactly once.
+
+Confirmed without a flash: with a throwaway module on LO-FI's id, the
+emulated firmware draws `HIJACK` in LO-FI's slot on the **FX1** chooser and
+its own `GAIN` knob on the page. `verify_replaces.py` checks both tables in
+both directions, and was itself negative-tested by restoring FX1's two
+entries to stock in a built image — it catches "FX2 repointed, FX1
+forgotten", which is the shape this half exists to prevent.
+
+⚠️ **Replacing an FX2-ONLY effect leaves FX1 alone.** DELAY and the three
+reverbs are not on FX1 (their `FX1_IDS` slots are NONE), so there is nothing
+to repoint; the build says so rather than silently doing nothing.
 
 **Words.** Taking a stock effect's *id* does not give you its *code space* —
 you spend from the same 2,724-word donor region as every other module. The

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -670,6 +670,130 @@ Not the page title, which the LCD draws itself two lines down; the FX pages
 all open with the same title and the same chooser column, so saying it twice
 is how the caption came to say nothing.
 
+#### What it is for
+
+It is the only way to see the **panel** side of an image without flashing
+one. The remixer's own panes say what you asked for; this says what the
+firmware will actually draw from the tables the build wrote — the knob
+labels the page puts under each encoder, and the effect names on the chooser
+rows. That is a real bug class: a cloned descriptor inherits its donor's
+display formatter, so a slot can carry the right count, default, name and
+enable bit and still draw as something else entirely, or as nothing at all
+(17 Aug 2026 — three of six page-2 slots drew wrong on a flash, and every
+check passed because every field they checked was right).
+
+#### An FX page is read, not photographed
+
+```
+ Filter's page, in the unit's own words
+  page 1 LEV   BASE  WDTH  Q       DPTH  ATK   DEC
+  page 2       HP    LP    ENV     HOLD  Q     DIST
+               12dB  12dB  BASE    OFF   NONE
+  FX2 rows on screen  NONE · ▸FILTER · EQUALIZER · DJ EQUALIZER
+                      PHASER · FLANGER · CHORUS
+```
+
+⚠️ **A picture of that screen is not available, and three rounds of column
+work went into finding that out.** The chooser list and the parameter block
+are two overlaid **windows** whose coordinates are not comparable. Measured
+on one FX page, the text baselines top to bottom:
+
+| | | | |
+|---|---|---|---|
+| 57 title | 56 param | 48 param | 47 **list** |
+| 40 **list** | 33 **list** | 30 param | 28 param |
+| 26 **list** | 21 param | 19 **list** | 12 **list** |
+| 5 **list** | 3 param | | |
+
+The list steps exactly 7 px and is internally consistent; the parameter
+block has its own lines, falling 1–3 px from it. **Fourteen baselines in 64
+pixels with a 7 px font are not fourteen lines** — they are two windows, the
+same thing `Pt:1 PART 1` shows in x (its coordinates put the PART window's
+text in the middle of the effect list, where it fused into `DJ EQUALIZER1`).
+Flattening them into nine rows interleaves them and reads as a mapping from
+each chooser row to the labels beside it, which is not what any of it means:
+the labels belong to the effect the **track** has selected.
+
+So the strings are sorted into what they *are*. Which page a row belongs to
+is decided against the effect's **own** parameters, not against pixel
+columns, and by **majority** — a select's value can coincide with a
+parameter's name (`BASE` is both one of FILTER's page-1 knobs and what its
+page-2 `ENV` prints). `LEV` gets its own column rather than being a fourth
+entry in the first bank, which knocked every column after it out of step.
+
+**MAIN MENU stays a picture**, because it is one window of two plain lists
+and flattening loses nothing — and seeing a patched-in top-level row drawn
+where it will be is the whole reason that view exists. Its geometry is
+measured too: the character cell is **4 pixels**, so the LCD is **32**
+characters wide, and a list is left-aligned while parameter labels are
+centred on fixed anchors (`emu_bringup.layout_screen` has both, and tells
+them apart by whether one x carries several label lengths).
+
+⚠️ **A short pane says so rather than cutting the box.** It is the tallest
+thing here and it is last, so it used to lose its bottom border and its last
+rows with nothing saying anything was missing. Trailing and leading blank
+rows go first, then it clips deliberately and prints `7 more rows — the pane
+is short` where the bottom edge would be; below four rows it draws no box at
+all, because a sliver of one costs the lines it would need to explain itself.
+
+Knob **values** draw as dial graphics the string capture cannot read, so only
+a stepped select prints one; the numbers in the pane above are the truth for
+values.
+
+### A / B compares two EFFECTS
+
+Not "two renders ago against now", which is what the marks used to hold. `r`
+hears the effect the cursor is on, `a` parks it as A, then point at the rival
+and `b` — which **re-renders it on the same source** — and `,` / `.` flip
+between them. That is the question a remixer exists to answer: *is mine
+better than the one the box came with?* It is also exactly the question an
+upgraded stock effect asks, which is why the pair is two effects rather than
+two accidents of history.
+
+**`SOURCE` is the first row**: `left`/`right` cycles the wavs in the source
+folder, so choosing what you audition on is one keypress from the knobs. `r`
+renders the effect over it and plays it; `space` replays.
+
+**`d` points the source folder somewhere else** and remembers it in
+`out/_audition/remixer.json`; `REMIXER_SOURCES` overrides both. The
+default is `out/dry/`, the curated dry set — a good default, not a permanent
+one, since a bench gets used on whatever material is to hand. A path that is
+not a directory, or holds no wavs, is refused and the old one stands.
+
+⚠️ **Six of the eleven stock effects render DRY at their defaults** —
+PHASER, FLANGER, CHORUS and COMB sit at `MIX 0`, SPATIALIZER and DELAY at
+`SEND 0` — so pressing `r` on one plays the source back unchanged, which
+reads as "this effect does nothing" (it cost a report on 2 Sep 2026). **That
+is faithful and is not fixed by seeding a different value**: stock defaults
+are read from the firmware's own descriptor (`tools/remix/stock.py`), an
+unmodified unit really does start them fully dry, and inventing a value here
+would make the remixer lie about the page it draws beside. The UNIT pane says
+`⚠ MIX is 0 — this renders DRY` instead. None of *our* modules default this
+way.
+
+**Stepping knobs**: `left`/`right` is ±1 and **`shift`+`left`/`right` is
+±10**. Holding the key runs; ~280 steps/second is sustainable (below), so
+key repeat is the limit, not the remixer.
+
+⚠️ **Holding an arrow key used to lag, and the cause was the emulated
+panel.** `rerender()` called `render_fx2` on *every* keystroke — 15–96 ms,
+mean 32 (`render_fx1` 16, `render_menu` 8; measured 2 Sep 2026) — plus three
+independent `problems()` calls at 2.4 ms each. Under key repeat the work per
+key exceeded the repeat interval, so the UI fell behind the held key and kept
+stepping after release; single presses always felt fine, which is why it
+presented as "slow when holding" rather than as latency. **Nothing a keystroke
+does can change that picture** — knob *values* draw as dial graphics the
+string-capture hook cannot read — so the panel is now cached on (page,
+effect id, build) and `problems()` is computed once per pass. Measured
+A/B: **18.1 ms → 3.6 ms per step, 55/s → 281/s.**
+
+Below that, `p` cycles the **preview** in the unit's own order — `FX1`,
+`FX2`, then `MENU` — showing the firmware's own draw of that page, under a
+caption saying **what** it is: `ChonVerb on track 5, as the unit draws it`.
+Not the page title, which the LCD draws itself two lines down; the FX pages
+all open with the same title and the same chooser column, so saying it twice
+is how the caption came to say nothing.
+
 #### What it is for, and why two things share the page
 
 It is the only way to see the **panel** side of an image without flashing

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -442,12 +442,19 @@ ChonVerb, BongDelay and Send, so every stock effect is off FX2. Taking them
 off FX1 with it would leave the unit with **no FX1 effects at all** and hand
 the modules all 6,158 words they did not ask for.
 
-⚠️ **It only costs where your code reaches.** Modules go in the **largest
-unbroken run** of what you gave up, packed from its lowest address; anything
-the placer never gets to keeps its algorithm and its dispatch and simply has
-no chooser row — which is exactly what unlisting a stock effect has always
-done. So a non-contiguous set is not a refusal any more: the leftovers are
-just unlisted.
+⚠️ **It only costs where your code reaches.** What you gave up becomes one or
+more unbroken **runs**, and each module is packed into a run it fits, from
+that run's lowest address; anything the placer never reaches keeps its
+algorithm and its dispatch and simply has no chooser row — which is exactly
+what unlisting a stock effect has always done.
+
+⚠️ **A gap is a wall, not a loss.** A module is one code stream, so it must
+fit inside a **single** run: two runs of 1,500 words will not take a
+2,000-word module, which is why the budget names the **largest opening**
+beside the total. Harvesting an effect that sits *between* two runs joins
+them into one. Until 3 Sep 2026 only the largest run was placeable at all
+and every other run was given up for nothing — visible in the remixer as
+"drop two effects and the free space does not move".
 
 ⚠️ **`remixes/bothslots.py` gives up four more than it used to.** Its curated
 FX1 chooser drops FLANGER, CHORUS, SPATIALIZER and COMB, and its FX2 chooser

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -1,9 +1,19 @@
-# The workbench — `make remix`
+# The remixer — `make remix`
 
 The interactive front end of the project, organized the way an Octatrack
-user thinks: **tracks and effects**, not modules and payloads. Shipped
-31 Aug 2026 (PRs #40–#44), replacing the curses composer; PLAN.md §5 is the
-decision record, this page is the manual.
+user thinks: **effects**, not modules and payloads. Shipped 31 Aug 2026
+(PRs #40–#44), replacing the curses composer; PLAN.md §5 is the decision
+record, this page is the manual.
+
+⚠️ **It was called "the workbench" until 3 Sep 2026**, and that name arrived
+with the 31 Aug redesign without anyone deciding on it. The project calls
+the concept a **remix** everywhere else — `make remix`, `remixes/`,
+`tools/remix/` — so a second vocabulary for one tool was pure cost. Two
+things keep their old names working rather than silently reverting somebody's
+setup: `WORKBENCH_SOURCES` / `WORKBENCH_THEME` are still honoured (an env var
+lives in a shell profile, where a rename is not a rename but a stop working),
+and `out/_audition/workbench.json` is read as a fallback for the sample
+folder until the next save writes `remixer.json`.
 
 What it is for, in priority order (Sam's, stated when the redesign was
 commissioned):
@@ -17,20 +27,20 @@ commissioned):
 
 Audio comes from the local DSP emulator (~6× real time, `docs/HARNESS.md`);
 the ColdFire emulator (`docs/EMU.md`) provides the screens. Nothing in the
-workbench touches hardware.
+remixer touches hardware.
 
 ## Setup
 
 ```bash
 make emu-setup      # uv provisions .venv with unicorn + textual
-make remix          # the workbench (make bus first if out/mainos_bus.bin
+make remix          # the remixer (make bus first if out/mainos_bus.bin
                     # doesn't exist yet — the EMU view boots it)
 ```
 
 The frontend is `tools/remix/app.py` (Textual). `make remix` prefers
 `.venv/bin/python3`; on bare `python3` it exits with the setup hint. The
 build and every check remain dependency-free — only the interactive
-workbench lives in the venv.
+remixer lives in the venv.
 
 Playback is `afplay`, so hearing renders is macOS-only; everything else
 works anywhere the DSP toolchain does.
@@ -545,7 +555,7 @@ folder, so choosing what you audition on is one keypress from the knobs. `r`
 renders the effect over it and plays it; `space` replays.
 
 **`d` points the source folder somewhere else** and remembers it in
-`out/_audition/workbench.json`; `WORKBENCH_SOURCES` overrides both. The
+`out/_audition/remixer.json`; `REMIXER_SOURCES` overrides both. The
 default is `out/dry/`, the curated dry set — a good default, not a permanent
 one, since a bench gets used on whatever material is to hand. A path that is
 not a directory, or holds no wavs, is refused and the old one stands.
@@ -557,13 +567,13 @@ reads as "this effect does nothing" (it cost a report on 2 Sep 2026). **That
 is faithful and is not fixed by seeding a different value**: stock defaults
 are read from the firmware's own descriptor (`tools/remix/stock.py`), an
 unmodified unit really does start them fully dry, and inventing a value here
-would make the bench lie about the page it draws beside. The UNIT pane says
+would make the remixer lie about the page it draws beside. The UNIT pane says
 `⚠ MIX is 0 — this renders DRY` instead. None of *our* modules default this
 way.
 
 **Stepping knobs**: `left`/`right` is ±1 and **`shift`+`left`/`right` is
 ±10**. Holding the key runs; ~280 steps/second is sustainable (below), so
-key repeat is the limit, not the workbench.
+key repeat is the limit, not the remixer.
 
 ⚠️ **Holding an arrow key used to lag, and the cause was the emulated
 panel.** `rerender()` called `render_fx2` on *every* keystroke — 15–96 ms,
@@ -582,7 +592,7 @@ Below that, `p` cycles the **preview** in the unit's own order — `FX1`,
 
 ⚠️ **The FX and MENU page entry points TOGGLE**: calling one opens the page,
 calling it again closes it, so consecutive renders used to alternate between
-a full screen and an empty one (26 draws, 0, 26, 0). A workbench that
+a full screen and an empty one (26 draws, 0, 26, 0). A remixer that
 re-renders on every keystroke therefore showed a blank LCD about half the
 time, and the MAIN MENU never drew at all — FX2 is the default view, so the
 menu render was always the second call and an FX page had already taken the
@@ -634,7 +644,7 @@ staleness gate coming back.** It genuinely cannot build: a remix must name a
 fallback for the ids it does not implement, and no stock effect is a safe one
 (it would *process* the unknown id) — `state.load_stock` is explicit that it
 "should not pretend to". So the launch state says `stock — swap a module in
-to build it` rather than `⚠`, because it is where the bench opens, not a
+to build it` rather than `⚠`, because it is where the remixer opens, not a
 mistake. One swap resolves it: SEND comes with the first module of ours.
 
 Honest limits (`docs/EMU.md`): no audio and no key matrix in the emulator —
@@ -732,7 +742,7 @@ what makes them worth colouring at all.
 
 ## Editing in another window
 
-**The bench follows the source.** Edit a module's `.asm` or manifest in your
+**The remixer follows the source.** Edit a module's `.asm` or manifest in your
 editor, or build in another terminal, and the image rebuilds and the panel
 re-boots on its own — the status line says `module source changed —
 rebuilding`. Polled, not watched: one stat sweep of `modules/` is **0.7 ms**,
@@ -747,7 +757,7 @@ firing on every save would be intolerable. The image and the panel refresh;
 
 The app renders in the **terminal's own 16-color ANSI palette** (Textual's
 `ansi-dark` theme), so it wears whatever colorscheme the terminal wears,
-background included. `WORKBENCH_THEME=<name> make remix` picks any
+background included. `REMIXER_THEME=<name> make remix` picks any
 built-in Textual theme (`gruvbox`, `nord`, `tokyo-night`, `textual-dark`
 for Textual's stock look, …); unknown names fall back to `ansi-dark`.
 
@@ -769,7 +779,7 @@ SERVER/T5-8 or T1-4; `DSP_EFFECT` with a menu → INSERT/any track;
 `Kind.STOCK` → STOCK/any track (no knobs, no render); everything else →
 SYSTEM/no track.
 
-Three `Param` fields exist purely for the workbench and are **proven
+Three `Param` fields exist purely for the remixer and are **proven
 display-only** — `scripts/refhash.sh check` ran bit-identical (26/26)
 after each manifest change that introduced them:
 

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -582,6 +582,40 @@ and only four — the **two donor regions** (one per payload), the **FX2 buffer
 slots** per core, the **chooser rows**, and the **ColdFire cave**. Everything
 else is unbounded in practice.
 
+### The map, and what each row is
+
+Every row carries a phrase saying what it *is*, in a column placed once every
+row's real width is known — a fixed column either collides with the longest
+row or leaves a canyon after the shortest, and which is longest changes with
+the selection. Under 100 columns or so the phrases drop rather than wrap.
+
+```
+ words A     403 free of 3,053 · 2,650 loaded          where your modules' code goes, core 0
+ words B   2,803 free of 3,053 · 250 loaded            the same on core 1
+ cycles    1,676 free of 3,120 · worst core: 1× ChonVerb …   DSP time, per core per sample
+        FILT   SPAT  EQ  PHSR FLNG  CHOR    PLATE       SPRING        DARK      COMP  LOFI DJEQ COMB
+ A ──────────────────────────────────#################################################.......────────────
+ B ──────────────────────────────────#####...................................................────────────
+                                     └──────────── harvested, 3,053 words ───────────┘
+```
+
+**And a MAP of the payload's effect code**, to scale from `stock.p_spans` so
+it cannot drift from what the build places: thirteen segments, one per stock
+effect, `─` for the ones this selection keeps, `.` for the harvested run,
+`#` for how far your code reached into it. One bar per payload — the layout
+is identical in both and only the fill differs.
+
+⚠️ It replaced the twenty-glyph `words` bar, which needed a legend to decode
+and still said neither **where** in the payload the region is nor **which**
+effects it costs. Once the region became a choice (`h`), those were the only
+two questions it was being asked.
+
+Widths are **cumulative-rounded** so they sum exactly and no segment is
+starved by the ones before it — rounding each on its own and giving the
+remainder to the last left COMB with two columns and its label cut to `CO`.
+Below four columns a segment cannot hold a name, so the label row drops and
+the bar and its footer carry on.
+
 ⚠️ **Every row here follows the selection's own harvest.** The `words` rows'
 total is `stock.region_words(harvest)` — 2,724 for the default three, 3,053
 with CHORUS — and once a build lands they are the build's own figures, so

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -371,6 +371,39 @@ defaults (a stale default polluted every shimmer measurement until Round 12).
 The UNIT pane carries a resource line under the doc, and the status line
 carries the same facts while you scroll (`rig.resources()`):
 
+### The donor region is a CHOICE, not a place
+
+`h` harvests the highlighted stock effect's words for your modules; `⌁` marks
+it in the library. The thirteen DSP effects are laid out **contiguously** —
+6,158 words in each payload — and every one is **self-contained**, so any
+unbroken run of them is ground a module can be placed into (`docs/MODULES.md`
+has the measurement). The three reverbs are only the **default**: they are
+the biggest and FX2-only, so taking them costs FX1 nothing.
+
+```
+ ✓⌁ Chorus        FX1+FX2          library: listed AND harvested
+    329 words — harvested, so they are yours to place into
+    yours overwrite it first
+ held by  Chorus, Plate, Spring, Dark — 3,053 words; drop Chorus for 329 more
+```
+
+⚠️ **The run has to stay contiguous** — a module of ours is one code stream,
+so a gap is not a smaller region, it is two, and nothing chooses between
+them. Only the effect just below the bottom of the run or just above its top
+can join it; `h` names what is in the way rather than letting the build
+refuse later, and the resource line offers `h harvests them` only where it
+would work.
+
+⚠️ **Harvested is not the same as unlisted, and it is the one thing here that
+takes something away.** Leaving a stock effect off a chooser costs it that
+row and nothing else — code, descriptor and dispatch stay stock, so an old
+project that selects it still runs it. Harvesting *offers* its words to the
+placer, and it loses its algorithm only where your code actually **reached**:
+the region packs from the lowest address upward and the build reports which
+survived. So an effect can be `✓⌁` — listed and harvested — right up until
+something is placed over it. That is exactly what the three reverbs have
+always done (`remixes/restock.py` keeps two of them), generalised.
+
 ⚠️ **A stock effect says what it USES, like everything else here.** It used
 to say **"free"**, which is a *marginal* cost worn as an absolute: listing it
 costs no donor words because its code is already placed, and that is true —

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -371,6 +371,32 @@ defaults (a stale default polluted every shimmer measurement until Round 12).
 The UNIT pane carries a resource line under the doc, and the status line
 carries the same facts while you scroll (`rig.resources()`):
 
+⚠️ **A stock effect says what it USES, like everything else here.** It used
+to say **"free"**, which is a *marginal* cost worn as an absolute: listing it
+costs no donor words because its code is already placed, and that is true —
+but in a remixer whose whole point is mixing stock and ours freely, one kind
+of effect answering "how much does this use?" with `free` and the other with
+`2,411 of 2,724 words` makes them look like different **kinds** of thing.
+They are not. Every effect occupies words, a buffer slot and cycles.
+
+| | says |
+|---|---|
+| an ordinary stock effect | `727 words, already placed — listing it costs none and dropping it frees none` |
+| a donor reverb | `594 words — and they are the donor region` / `yours overwrite it first` |
+| DELAY | `no DSP words — it runs on the ColdFire side` |
+| one of ours | `2,411 of 2,724 words` |
+
+The three reverbs are the exception that proves it: their words **are** the
+donor region, so they are the only stock effects whose words are yours to
+take.
+
+⚠️ **Stock rows are not in the cycles figure**, and on a card that mixes
+stock and ours freely that is a real hole — a stock effect costs cycles when
+it is selected like any other. Only FILTER's has ever been measured
+(192/instance, `docs/CHIP.md`), so the row says what is missing rather than
+inventing the rest: `cycles  3,120 free of 3,120 · worst core: nothing of
+ours · 14 stock rows not counted`.
+
 ```
 ChonVerb   — bus · id 0x07 · 2411 of 2,724 words ·
              needs the whole FX2 buffer region (blocks 7 stock effects) ·
@@ -1192,6 +1218,14 @@ adding to a venv that already carries unicorn and textual.
 Audio is **not** re-rendered on a source change — it plays out loud, and
 firing on every save would be intolerable. The image and the panel refresh;
 `r` is one key.
+
+## No command palette
+
+Textual's `^p` palette is off. It advertised itself permanently in the footer
+and offered five things, none of them ours: **Quit** and **Keys** duplicate
+`q` and `?`, **Maximize** does nothing useful to a pane that is not a
+focusable widget, and **Theme** and **Screenshot** are worth less than the
+footer space and the "what is that?" it cost. `ENABLE_COMMAND_PALETTE`.
 
 ## Theming
 

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -670,7 +670,60 @@ Not the page title, which the LCD draws itself two lines down; the FX pages
 all open with the same title and the same chooser column, so saying it twice
 is how the caption came to say nothing.
 
-⚠️ **Three things the capture does that a character grid does not** (all
+#### What it is for, and why two things share the page
+
+It is the only way to see the **panel** side of an image without flashing
+one. The remixer's own panes say what you asked for; this says what the
+firmware will actually draw from the tables the build wrote — the effect
+names on the chooser rows, in the order they will scroll, and the knob
+labels the page puts under each encoder. That is a real class of bug: a
+cloned descriptor inherits its donor's display formatter, so a slot can
+carry the right count, default, name and enable bit and still draw as
+something else entirely, or as nothing at all (17 Aug 2026 — three of six
+page-2 slots drew wrong on a flash, and every check passed because every
+field they checked was right).
+
+⚠️ **The columns beside a chooser row are not that row's.** Two independent
+things share the page, exactly as they do on the unit: the chooser list
+scrolls down the left, and the knob names belong to whichever effect the
+**track** has selected — the one the caption names, marked `▸` when its row
+is on screen. `ChonVerb78    SHMR MODE DIFF` is not a mapping.
+
+Knob **values** draw as dial graphics the string capture cannot read, so the
+numbers in the pane above are the truth for values and the picture is the
+truth for names.
+
+#### Reading the pixels as characters
+
+⚠️ **The cell is FOUR pixels, so the LCD is 32 characters wide** — not the 42
+this assumed until 3 Sep 2026, which is what made the page look ragged. The
+measurement falls out of the capture: the same column drawn with labels of
+different length starts at a different x, and the shift is 2 px per
+character, so the firmware **centres** each label on a fixed anchor.
+
+| | 4 chars | 3 | 2 | 1 | centre |
+|---|---|---|---|---|---|
+| page-2 col 1 | `12dB` 55 | `LOW` 57 | `HP` 59 | | **63** |
+| page-1 col 1 | `BASE` 62 | `ATK` 64 | `FB` 66 | | **70** |
+| page-2 col 2 | `NONE` 75 | `NUM` 77 | `LP` 79 | `Q` 81 | **83** |
+| page-1 col 2 | `WDTH` 82 | `GN1` 84 | | | **90** |
+| page-2 col 3 | `BASE` 95 | `ENV` 97 | | | **103** |
+| page-1 col 3 | `RTIM` 102 | `MIX` 104 | `Q1` 106 | `Q` 108 | **110** |
+
+Three parameter columns, each drawn twice 7 px apart. At 4 px per character
+that is under two characters, so preserving it buys a ragged indent and
+nothing else — the pair is **snapped to one column**, which is the whole
+point of a column. The anchors are clustered out of each screen's own draws,
+so a page laid out differently gets its own.
+
+⚠️ **Not every column is centred.** A LIST is left-aligned, and
+centre-snapping the MAIN MENU shuffled `PROJECT` / `SYSTEM` / `CONTROL` /
+`MIDI` into three different indents. The two are told apart by what
+distinguishes them in the capture: a centred column's x shifts with the
+label's length, so one x carries one length; a left-aligned one carries
+several.
+
+⚠️ **Two more things the capture does that a character grid does not** (all
 fixed 3 Sep 2026 — the page had become hard to read and, worse, wrong):
 
 - **A later draw over the same pixels WINS.** The firmware repaints a

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -408,6 +408,11 @@ works perfectly alone, which is the worst shape a defect can have.
 
 ### One line per menu
 
+**And one LINE per menu.** They are returned as separate strings and printed
+as separate rows; joining them with ` · ` made one long sentence that Textual
+then flowed, so the FX1 and FX2 answers broke across lines mid-phrase — which
+is the exact mistake that split them apart in the first place.
+
 FX1 and FX2 have **separate allocator tables**, so a cost on one is not a cost
 on the other — and saying that in a subordinate clause ("FX2 rows only, FX1
 keeps its 4") made a simple fact read as a caveat. There is a line each:
@@ -568,6 +573,30 @@ The four slots are drawn as four groups so the picture and the number agree,
 and the number says what it counts: `0 pinned of 4`. Two earlier forms were
 worse — `4 of 4` against an empty bar says "all four used" and meant the
 opposite, and `4 of 4 free` still invited "free for *what*?".
+
+⚠️ **There is no glyph legend, and no status line repeating this pane.**
+Both were removed 3 Sep 2026 for the same reason: they said again what was
+already on screen beside them.
+
+- The legend sat at the bottom of the strip labelled **`bar`** — in the same
+  label column as `words A`, `cycles` and `cave`, so it read as a fifth
+  scarce thing called "bar" whose value was "held by a reverb you kept
+  listed". Moving it under the bars it decodes fixed the mislabelling and
+  left the better question standing: every row already says in **words** what
+  its bar says in glyphs (`0 free of 2,724 · 0 loaded`, `held by Plate,
+  Spring, Dark`), so it was decoding a picture of a sentence printed beside
+  it.
+- The **status line** wrote the selected effect's category, id, resource
+  sentence and membership on every cursor move — word for word what the UNIT
+  pane prints under the effect's name, except that the pane wraps and the
+  status bar was one row, so the copy that got truncated mid-sentence was the
+  redundant one. ⚠️ Deleted rather than moved into the strip: a column there
+  is 62 characters against the 138 the status line already had, so "give it
+  more room" and "put it in the strip" pull opposite ways. What remains is
+  the right half of the old behaviour — moving the cursor **clears** it, so
+  an action message ("added Nimbus · added Send as the fallback") cannot sit
+  there describing a row you have since left — and the row collapses to
+  nothing when there is nothing to say.
 
 ⚠️ **A stock chooser reports its real figures, not `????`.** A stock row
 places no code — no clone, no words, its dispatch is already in the image —

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -664,7 +664,31 @@ effect id, build) and `problems()` is computed once per pass. Measured
 A/B: **18.1 ms → 3.6 ms per step, 55/s → 281/s.**
 
 Below that, `p` cycles the **preview** in the unit's own order — `FX1`,
-`FX2`, then `MENU` — showing the firmware's own draw of that page.
+`FX2`, then `MENU` — showing the firmware's own draw of that page, under a
+caption saying **what** it is: `ChonVerb on track 5, as the unit draws it`.
+Not the page title, which the LCD draws itself two lines down; the FX pages
+all open with the same title and the same chooser column, so saying it twice
+is how the caption came to say nothing.
+
+⚠️ **Three things the capture does that a character grid does not** (all
+fixed 3 Sep 2026 — the page had become hard to read and, worse, wrong):
+
+- **A later draw over the same pixels WINS.** The firmware repaints a
+  parameter row in place, so the capture holds the label that *was* there and
+  then the one that is — `PTCH` then `FRQ1` at the same x. Overlapping spans
+  are replaced. Left side by side, the page showed `LEV FRQ1 PTCH STRT GN1
+  LEN Q1` and read as an effect with seven parameters where the unit draws
+  four.
+- **Two strings that do not overlap are never fused.** Writing character by
+  character let a label whose cell was taken run into its neighbour, and the
+  result is a word that does not exist on the unit: **`DJ EQUALIZER1`**,
+  `COMPRESSORT 1`, `SMOD` (which is `SIZE`'s row eating ChonVerb's `MOD`). A
+  label pushed one column right is legible and obviously two things.
+- **The PART window's text is a caption, not a row.** `Pt:1 PART 1` comes
+  with both FX pages and its coordinates belong to a *different* window's
+  space, so it lands in the middle of the effect list — it is the `1` in `DJ
+  EQUALIZER1`. `part_label()` lifts it out; the caption says `on track 5`
+  instead, which is the same fact in words.
 
 ⚠️ **The FX and MENU page entry points TOGGLE**: calling one opens the page,
 calling it again closes it, so consecutive renders used to alternate between

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -610,6 +610,21 @@ and still said neither **where** in the payload the region is nor **which**
 effects it costs. Once the region became a choice (`h`), those were the only
 two questions it was being asked.
 
+⚠️ **`.` is "offered", not "lost", and the footer says which.** On a stock
+chooser the whole run is dotted and **nothing has been overwritten** — every
+one of those effects still works — so reading the dots as sacrifice is the
+obvious mistake, and the footer used to invite it by saying "harvested"
+whether or not a word had been placed:
+
+```
+ nothing placed   └─ 2,724 words yours to place into — none taken yet ─┘
+ ChonVerb placed  └──── harvested, 2,724 words — 3 overwritten ────────┘
+```
+
+The sentence steps down to a shorter form rather than overflowing: a footer
+wider than the run it brackets puts `┘` past the last harvested segment and
+claims ground it does not mean.
+
 Widths are **cumulative-rounded** so they sum exactly and no segment is
 starved by the ones before it — rounding each on its own and giving the
 remainder to the last left COMB with two columns and its label cut to `CO`.

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -418,7 +418,29 @@ three. Every shipped remix comes out identical, asserted in the selftest.
 
 ⚠️ **BOTH menus.** An effect off FX2 but still on FX1 is still wanted, and
 the DSP dispatch is one table shared by them — overwriting its code would
-take it off FX1 too.
+take it off FX1 too. A removal says which happened, because otherwise taking
+something off one list frees nothing and does not say why:
+
+```
+ removed Chorus from the FX2 chooser — still on FX1, so its 329 words
+   stay its own; take it off there too to free them
+ Chorus is off the FX1 chooser — off both menus now, so its 329 words
+   join the region (329 total)
+```
+
+⚠️ **The two lists stay independent, and they have to.** "Off one is off
+both" would be simpler to operate and would make the shipping remix
+impossible — measured:
+
+| | today | if off-one-is-off-both |
+|---|---|---|
+| **chongbong** | region 2,724 · FX1 keeps **10 of 10** | region 6,158 · FX1 keeps **0 of 10** |
+| restored | 2,724 · 10 of 10 | 3,342 · 6 of 10 |
+
+chongbong's whole shape is *FX2 is mine, FX1 stays stock*: its FX2 chooser is
+ChonVerb, BongDelay and Send, so every stock effect is off FX2. Taking them
+off FX1 with it would leave the unit with **no FX1 effects at all** and hand
+the modules all 6,158 words they did not ask for.
 
 ⚠️ **It only costs where your code reaches.** Modules go in the **largest
 unbroken run** of what you gave up, packed from its lowest address; anything

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -682,6 +682,33 @@ enable bit and still draw as something else entirely, or as nothing at all
 (17 Aug 2026 — three of six page-2 slots drew wrong on a flash, and every
 check passed because every field they checked was right).
 
+#### Both menus at once, docked, no switcher
+
+The block sits at the **bottom** of the UNIT pane and stays there: it used to
+follow the knob rows, so it moved up and down with the number of knobs — five
+for WarpFold, thirteen for Filter — and the thing you were reading was never
+in the same place twice.
+
+⚠️ **There was a `p` key cycling FX1 / FX2 / MENU, and all three of its
+problems were the switcher.** FX1 and FX2 resolve the **same descriptor** for
+anything listed on both — the build points both id tables at one clone and
+`verify_menu` asserts it — so switching between them showed the same knob
+names twice, and only the chooser rows differed, which is the one thing worth
+seeing side by side. And the **MAIN MENU is the same picture in every remix
+that exists**: a selection changes it only by writing the tables at
+`0x400cbc00`, and every remix so far changes **zero** bytes of them
+(`rig.menu_patched()` — a byte diff against the pristine image, no boot). So
+it is a line, `menu unchanged by this selection`, and it becomes a picture on
+the day something patches it, which is the day that view was built for.
+
+⚠️ **The Budget strip changes the panes' HEIGHT.** It is `height: auto`, so a
+row appearing there — the `cycles` row arriving when a build lands — steals a
+row from the three panes above. Nothing *resized*, so `on_resize` does not
+fire and `_paint` sees unchanged text, and the panes went on laying out
+against a height they no longer had. It is painted first now and invalidates
+them; and because `content_size` read **during** a render is the previous
+layout's, the pane works to one row of slack rather than to the row.
+
 #### An FX page is read, not photographed
 
 ```

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -371,7 +371,39 @@ defaults (a stale default polluted every shimmer measurement until Round 12).
 The UNIT pane carries a resource line under the doc, and the status line
 carries the same facts while you scroll (`rig.resources()`):
 
-### The donor region is a CHOICE, not a place
+### On an unmodified unit, every word is allocated
+
+⚠️ **The remixer opens with NOTHING harvested** (3 Sep 2026). All 6,158 words
+of the payload's effect code belong to a stock effect that is using them, and
+a stock chooser has to say so:
+
+```
+ words A   no region — every word is a stock effect's
+ A ────────────────────────────────────────────────────────────────────────
+   └─────────────── all 6,158 words allocated — h harvests one ───────────┘
+```
+
+It used to open with the three reverbs already harvested, because that is
+what the build had always done — so the map dotted them and the budget said
+`0 free of 2,724` on a selection where **nothing had been given up**. Sam,
+twice: *"why does it show verb on full stock? nothing is sacrificed?"* and
+*"a stock firmware should show everything as allocated, that the stock
+effects use. harvesting should be free choose."*
+
+Adding a module before harvesting anything is now a ⚠ with a one-key fix —
+`nothing is harvested, so there is nowhere to place your modules — x takes
+the three reverbs (2,724 words), or h takes whichever you would rather
+lose`. It is the only ⚠ whose fix **adds** rather than removes, so it
+outranks the others: an ⚠ reading "x removes Flanger…" while `x` actually
+harvested the reverbs is the worst kind of wrong.
+
+⚠️ **`Remix.harvest` still defaults to the three reverbs**, and that is
+deliberate: every remix that predates this needs its region, and refhash is
+26/26 on that default. `harvest=()` is legal — a remix of nothing but stock
+rows needs no region at all — and `build_bus.py` refuses it only when there
+is code to place.
+
+### The harvest itself
 
 `h` harvests the highlighted stock effect's words for your modules; `⌁` marks
 it in the library. The thirteen DSP effects are laid out **contiguously** —

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -229,6 +229,40 @@ with the firmware's own code — `WarpFold78` as row 11 of a twelve-entry list,
 its own knob names on the page, the cursor opening on that row — which is the
 no-flash gate, not a hardware result.
 
+### The two menus are not the same shape
+
+This is the thing that was unclear while FX1 was a tag in a column. Every
+track has **two** effect slots, FX1 then FX2, and each has its own chooser
+list:
+
+| | FX2 | FX1 |
+|---|---|---|
+| who composes it | **you** — LOADED is that list | stock's own **ten**, and no image shortens it |
+| what a remix can do | list, unlist, reorder | **append only** (`1`) |
+| leaving a stock effect out | takes its FX2 row | takes nothing — it is still on FX1 |
+| an effect FX2 alone listed (DELAY, the reverbs) | takes its only row | — |
+
+So LOADED is titled **`FX2 chooser`** — its rows are FX2 rows, its numbers
+are FX2 row numbers, and `←→` reorders FX2 — and it closes with one line for
+the other list: `FX1 chooser  stock's 10 + WarpFold`, or `stock's 10,
+unchanged`.
+
+**`p` → FX1 draws that chooser as the firmware would**, with your effect on
+it if it is there. ⚠️ It used to draw `effect_id 0x04` unconditionally, so it
+showed the stock FILTER's page whatever the cursor was on — harmless while
+nothing of ours could be on FX1, actively misleading the moment one could
+(fixed 3 Sep 2026). When the selected effect has no FX1 row it says so
+rather than letting stock's chooser look like that effect's page.
+
+⚠️ **The `FX1+FX2` column is CAPABILITY, not current rows** — which menus an
+effect *can* appear on. The `✓` beside it is what says whether it is in the
+image. Gating the FX2 half on the selection was tried the same day and
+reverted: it is more literally true, and it made the library read `—` against
+every module you had not added yet, which the missing `✓` already said, in
+place of the one thing the library is for. What leaving a stock effect out
+costs is on its resource line instead, in words: `not listed — it keeps its
+FX1 row; only the FX2 one is lost`.
+
 ### LOADED — the image being composed
 
 The selection, **in chooser order** — the order here *is* the order of rows

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -47,21 +47,24 @@ works anywhere the DSP toolchain does.
 
 ## One page, three panes
 
-`make remix` opens a single screen. `tab` moves between panes, `up`/`down`
+`make remix` opens a single screen: **AVAILABLE** (everything that could be
+in an image), **CHOOSERS** (the unit's two effect menus, both being composed)
+and **UNIT** (the selected effect). `tab` moves between panes, `up`/`down`
 moves within one, `?` opens this page's short form, `esc` stops audio, `q`
 quits. **There is no per-track view** — the eight-track rig was retired 2 Sep
 2026 because it was a second place to say what a remix already says, and
 knob values belong to the effect rather than to a track.
 
 ```
-┌ AVAILABLE ───────┬ LOADED · chongbong ────┬ ChonVerb ────────────────────┐
-│ ── server ──     │ ▸1 ChonVerb  FX2  2411w│ server · id 0x07 · tracks 5-8│
-│    BongDelay FX2 │  2 BongDelay FX2  2469w│ TIME  64  [######......] p1  │
-│    ChonVerb  FX2 │  3 Send      FX2   250w│ MOD   30  [###.........] p1  │
-│ ── insert ──     │  · tempo-sync −     ◀fb│ …                            │
-│    WarpFold  FX2 │ —  PLATE, SPRING, DARK │ preview  FX1 FX2 MENU        │
-│ ── stock ──      │                        │ .--------------------------. │
-│  ✓ FILTER FX1+FX2│ A 74 free · B 5 free   │ | EFFECT 2 SETUP           | │
+┌ Available ───────┬ Choosers · chongbong ──┬ ChonVerb ────────────────────┐
+│ ── Bus ──        │ FX1  10 rows           │ Bus · id 0x07 · tracks 5-8   │
+│    BongDelay FX2 │   1 Filter             │ TIME  64  [######......] p1  │
+│  ✓ ChonVerb  FX2 │   2 Equalizer          │ MOD   30  [###.........] p1  │
+│ ── Insert ──     │   … 8 more             │ …                            │
+│    WarpFold  FX2 │ FX2  4 rows            │ preview  FX1 FX2 MENU        │
+│ ── Stock ──      │   1 ChonVerb    2411w  │ .--------------------------. │
+│  ✓ Filter FX1+FX2│   2 BongDelay   2469w  │ | EFFECT 2 SETUP           | │
+│                  │ A 74 free · B 5 free   │                              │
 └──────────────────┴────────────────────────┴──────────────────────────────┘
 ```
 
@@ -72,8 +75,8 @@ Everything that *could* be in an image: your modules grouped **server** /
 marks what the current selection holds.
 
 **`enter` ADDS the highlighted module to the image.** It displaces nothing.
-`left`/`right` in LOADED moves a row afterwards; `enter` in LOADED removes
-the row you are on. The library only ever adds — `enter` on something already
+`left`/`right` in CHOOSERS moves a row afterwards; `enter` there removes the
+row you are on, from its own list. The library only ever adds — `enter` on something already
 in the image just points at its row.
 
 ⚠️ **`enter` used to SWAP** (2 Sep 2026, reverted the same day): the module
@@ -168,7 +171,7 @@ near-identical walls of text; the pane aggregates them into the sentence
 above. What you are left with — ChonVerb, the seven stock effects that can
 coexist, and Send — *is* `remixes/restored.py`.
 
-The three stock **reverbs** are not here — they are in LOADED, because they
+The three stock **reverbs** are not here — they are in CHOOSERS, because they
 are part of a stock chooser. See below.
 
 The `FX1+FX2` column is which **chooser** the effect has a row on, derived
@@ -229,46 +232,77 @@ with the firmware's own code — `WarpFold78` as row 11 of a twelve-entry list,
 its own knob names on the page, the cursor opening on that row — which is the
 no-flash gate, not a hardware result.
 
-### The two menus are not the same shape
+### CHOOSERS — the unit's two effect menus, both composable
 
-This is the thing that was unclear while FX1 was a tag in a column. Every
-track has **two** effect slots, FX1 then FX2, and each has its own chooser
-list:
+Every track has **two** effect slots — FX1 then FX2, in that order through
+the audio — and each has its own chooser list. The middle pane holds **both,
+stacked**, and every gesture applies to the list you are standing in:
+`enter` removes from it, `←→` reorders within it (a row cannot cross from
+one list to the other by being nudged off the end), `1` puts the highlighted
+effect on FX1 or takes it off.
+
+They start from opposite places, and that is the only asymmetry left:
 
 | | FX2 | FX1 |
 |---|---|---|
-| who composes it | **you** — LOADED is that list | stock's own **ten**, and no image shortens it |
-| what a remix can do | list, unlist, reorder | **append only** (`1`) |
-| leaving a stock effect out | takes its FX2 row | takes nothing — it is still on FX1 |
-| an effect FX2 alone listed (DELAY, the reverbs) | takes its only row | — |
+| starts as | **nothing** — every row is one this remix listed | the **ten** stock ships, because that is what the box does |
+| what a remix can do | list, unlist, reorder | list, unlist, reorder |
+| leaving an effect off | takes that row, nothing else | takes that row, nothing else |
+| row 0 | none | the firmware's own **NONE**, always, not shown and not losable |
 
-So LOADED is titled **`FX2 chooser`** — its rows are FX2 rows, its numbers
-are FX2 row numbers, and `←→` reorders FX2 — and it closes with one line for
-the other list: `FX1 chooser  stock's 10 + WarpFold`, or `stock's 10,
-unchanged`.
+Leaving an effect off a chooser takes that **row** and nothing else — its
+code, descriptor and dispatch stay stock, so an old project that selects it
+still runs it, and dropping FLANGER from FX1 does not touch its FX2 row.
 
-**`p` → FX1 draws that chooser as the firmware would**, with your effect on
-it if it is there. ⚠️ It used to draw `effect_id 0x04` unconditionally, so it
-showed the stock FILTER's page whatever the cursor was on — harmless while
-nothing of ours could be on FX1, actively misleading the moment one could
-(fixed 3 Sep 2026). When the selected effect has no FX1 row it says so
-rather than letting stock's chooser look like that effect's page.
+`p` → **FX1** draws the chooser you composed, as the firmware draws it.
 
-⚠️ **The `FX1+FX2` column is CAPABILITY, not current rows** — which menus an
-effect *can* appear on. The `✓` beside it is what says whether it is in the
-image. Gating the FX2 half on the selection was tried the same day and
-reverted: it is more literally true, and it made the library read `—` against
-every module you had not added yet, which the missing `✓` already said, in
-place of the one thing the library is for. What leaving a stock effect out
-costs is on its resource line instead, in words: `not listed — it keeps its
-FX1 row; only the FX2 one is lost`.
+⚠️ **It was "append only" for one day** (3 Sep 2026), and that was this
+build's limitation stated as if it were the machine's — the pane said "FX1
+chooser: stock's 10 + WarpFold" and the docs said FX1's rows were "not ours
+to move". The list is rebuilt from scratch in the cave, so its contents were
+always ours to choose. What was actually missing was the **viewport
+literal** that lets a list get *shorter* without the draw loop reading past
+the terminator, and it is at `0x40059be6`: the exact analogue of FX2's, at
+the identical offset (+0x14) from FX1's own list reference, with identical
+bytes. FX1's setup function differs from FX2's **only in the list address**.
 
-### LOADED — the image being composed
+#### What an FX1 row costs
 
-The selection, **in chooser order** — the order here *is* the order of rows
-on the panel, so `left`/`right` is a real edit, not a view preference. The
-number column is the panel row; `·` means no chooser row at all (a ColdFire
-patch). `◀fb` marks the fallback. Each module's word cost comes from the real
+**No words.** The DSP dispatch table is indexed by the raw id and shared by
+both menus, so an effect's code already ran from FX1 the moment FX1 selected
+its id. Four bytes of cave per row, plus the relocated list.
+
+**Cycles.** FX1 is four more slots on the same four tracks, so an effect on
+both menus can double the worst per-core load — WarpFold 4× → 8×, 404 → 808
+of the 3,120 our code may spend. The Budget's `cycles` row prices it.
+
+**Only a buffer-free INSERT of ours can take one**, and the UNIT pane says
+which cannot and why: `FX1  no row — and cannot take one: it sizes its
+buffer for an FX2 slot (16,384 words) and an FX1 slot is 3,072`. The three
+classes are in `docs/MODULES.md`, with the measured reason. The same
+arithmetic is why stock keeps DELAY and the three reverbs off FX1 — they do
+not fit either, and the remixer refuses to list them there.
+
+⚠️ **Every id the list drops has its cursor row clamped to 0.** The FX2 path
+does not do this and does not need to — it has only ever been able to *grow*
+its list from three rows, so a stale position could not point past the end.
+FX1 can now be made shorter than stock's eleven, and an old project holding
+a dropped id would otherwise seed the chooser past the last row.
+
+⚠️ **The `FX1+FX2` column in the library is CAPABILITY, not current rows** —
+which menus an effect *can* appear on. The `✓` beside it is what says
+whether it is in the image. Gating it on the selection was tried on 3 Sep
+2026 and reverted: it is more literally true, and it made the library read
+`—` against every module you had not added yet, which the missing `✓`
+already said, in place of the one thing the library is for. What leaving a
+stock effect out costs is on its resource line instead, in words.
+
+### The FX2 list
+
+**In chooser order** — the order here *is* the order of rows on the panel,
+so `left`/`right` is a real edit, not a view preference. The number column
+is the panel row; `·` means no chooser row at all (a ColdFire patch). `◀fb`
+marks the fallback. Each module's word cost comes from the real
 assembly the background rebuild runs, so it is always filled in.
 
 **The three reverbs live here, and you can keep them.** An unmodified unit
@@ -398,7 +432,7 @@ neither line.
 that is deliberate: it is the same seven for every pinner, so printing it per
 module made ChonVerb and BongDelay show identical lists and read as two bills
 for one debt. It belongs to the **image** — the ledger refuses an allocating
-stock effect beside *any* pinner — so the LOADED pane says it once:
+stock effect beside *any* pinner — so the CHOOSERS pane says it once:
 
 ```
 no room for Flanger, Chorus, Spatializer, Comb Filter and the 3 reverbs
@@ -484,7 +518,7 @@ and only four — the **two donor regions** (one per payload), the **FX2 buffer
 slots** per core, the **chooser rows**, and the **ColdFire cave**. Everything
 else is unbounded in practice.
 
-⚠️ **A listed reverb is LOADED.** The build reports the whole 2,724 as free
+⚠️ **A listed reverb is loaded.** The build reports the whole 2,724 as free
 because nothing of *ours* is placed yet — but PLATE, SPRING and DARK REV's
 code is what occupies the region, so a reverb you keep in the chooser is
 spending its own words. A stock chooser holding all three therefore has **0
@@ -644,14 +678,14 @@ four times in a row and counting the draws.
 
 **The image follows the selection.** Every selection change rebuilds and
 re-boots on a worker thread after a 0.35 s debounce, so the preview always
-draws what LOADED says. There is no build key and no staleness to reason
+draws what CHOOSERS says. There is no build key and no staleness to reason
 about.
 
 ⚠️ This replaced a `stale()` gate that refused to draw when the image on disk
 was not the selection, printing a bold `the image on disk is not this
 selection / b builds it`. The gate's *reasoning* was right — the FX2 page
 includes the firmware's own chooser list, so a stale image puts a different
-set of effects on screen beside LOADED and reads as "why are those loaded?"
+set of effects on screen beside CHOOSERS and reads as "why are those loaded?"
 — but **every fresh launch is stale**, so the headline feature opened showing
 a disclaimer, and what it was guarding is a **0.26 s build** plus a 4.6 s
 ColdFire boot, both already on a worker thread (measured 2 Sep 2026). Changed

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -448,6 +448,12 @@ that run's lowest address; anything the placer never reaches keeps its
 algorithm and its dispatch and simply has no chooser row — which is exactly
 what unlisting a stock effect has always done.
 
+`remixes/scattered.py` is the worked example: it gives up three separate runs
+(261 / 3,342 / 277 words) and the placer fills two of them — Streamz's 255
+words into Spatializer's 261-word opening, WarpFold's 322 into the big run.
+The map draws a bracket per run, so the stock effects between them read as
+what they are: the wall.
+
 ⚠️ **A gap is a wall, not a loss.** A module is one code stream, so it must
 fit inside a **single** run: two runs of 1,500 words will not take a
 2,000-word module, which is why the budget names the **largest opening**

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -403,10 +403,35 @@ deliberate: every remix that predates this needs its region, and refhash is
 rows needs no region at all — and `build_bus.py` refuses it only when there
 is code to place.
 
-### The harvest itself
+### Taking an effect off BOTH menus is that decision
 
-`h` harvests the highlighted stock effect's words for your modules; `⌁` marks
-it in the library. The thirteen DSP effects are laid out **contiguously** —
+⚠️ **There is no separate harvest gesture** (3 Sep 2026), because there was
+never a separate choice. Sam: *"harvest and remove from chooser should be
+same logic, not a new h click."* An effect on **neither** chooser is one you
+do not want, so its words are where your modules go — derived from the two
+lists rather than held as a third thing. `⌁` marks it in the library.
+
+It reproduces what the build has always done, which is why removing the
+explicit field was safe: FX1 lists ten of the thirteen and the reverbs are
+FX2-only, so a remix listing none of them on FX2 gives up exactly those
+three. Every shipped remix comes out identical, asserted in the selftest.
+
+⚠️ **BOTH menus.** An effect off FX2 but still on FX1 is still wanted, and
+the DSP dispatch is one table shared by them — overwriting its code would
+take it off FX1 too.
+
+⚠️ **It only costs where your code reaches.** Modules go in the **largest
+unbroken run** of what you gave up, packed from its lowest address; anything
+the placer never gets to keeps its algorithm and its dispatch and simply has
+no chooser row — which is exactly what unlisting a stock effect has always
+done. So a non-contiguous set is not a refusal any more: the leftovers are
+just unlisted.
+
+⚠️ **`remixes/bothslots.py` gives up four more than it used to.** Its curated
+FX1 chooser drops FLANGER, CHORUS, SPATIALIZER and COMB, and its FX2 chooser
+lists only WarpFold — so those four are on no menu at all, genuinely
+unreachable, and their words are free. `verify_replaces` had assumed only the
+three reverbs could ever be nulled. The thirteen DSP effects are laid out **contiguously** —
 6,158 words in each payload — and every one is **self-contained**, so any
 unbroken run of them is ground a module can be placed into (`docs/MODULES.md`
 has the measurement). The three reverbs are only the **default**: they are

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -201,7 +201,15 @@ menus can double the worst per-core load — WarpFold goes from `4×` to `8×`,
 it, which is why that row exists (`PLAN.md` §2 called this "the real ceiling
 is cycles ×4").
 
-Two things are refused rather than allowed to go wrong: a module that
+**Only a buffer-free INSERT may take one**, and the UNIT pane says so where
+it applies rather than letting you find out from a refusal: `FX1  no row —
+and cannot take one: it sizes its buffer for an FX2 slot (16,384 words)`.
+An FX1 slot is **3,072** words; a module with **fixed** FX2 buffers would
+write into another track's; and a bus **server** is one per core. See
+`docs/MODULES.md` for the measured reason — it is `docs/DSP.md`'s "wrong
+claim 1", bisected on hardware.
+
+Two more things are refused rather than allowed to go wrong: a module that
 `replaces` a stock effect **already** has that effect's FX1 row (the build
 repoints both of FX1's tables in place), so asking for a second would list it
 twice; and a stock effect's FX1 row is stock's own business. `verify_menu`

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -670,6 +670,113 @@ Not the page title, which the LCD draws itself two lines down; the FX pages
 all open with the same title and the same chooser column, so saying it twice
 is how the caption came to say nothing.
 
+### The no-flash gate
+
+The CHOOSERS line ends in **`boots`** when the built image reaches the RTOS
+handoff in the local ColdFire emulator. That is the whole of it, and it is
+worth having: a cave that breaks early init faults there instead of on the
+unit. It is a fact about the **image**, so it sits on the image's own line.
+
+If a selection ever patches the unit's top-level menu, the MAIN MENU appears
+under CHOOSERS as the firmware draws it. **None do yet** — a selection
+changes it only by writing the tables at `0x400cbc00`, and every remix so far
+changes **zero** bytes of them (`rig.menu_patched()`, a byte diff against the
+pristine image, no boot).
+
+### ⚠️ The per-effect preview is gone, and why
+
+The UNIT pane used to close with the firmware's own draw of that effect's
+page. Sam asked what it was for four times on 3 Sep 2026 and the honest
+answer, arrived at far too slowly, was **nothing this pane should do**:
+
+- The rows above it **already list every drawn parameter with its page
+  number**, from the same descriptor. The picture said it again.
+- The CHOOSERS pane already lists the chooser rows — and the capture only
+  ever held the **seven** the screen shows, so that half could never show all
+  ten of FX1's or all fourteen of FX2's anyway.
+- **A picture of that screen is not possible.** The chooser list and the
+  parameter block are two overlaid windows whose coordinates are not
+  comparable — fourteen text baselines in 64 pixels with a 7 px font; the
+  list steps exactly 7 and the parameter block falls 1–3 px off it. Three
+  rounds of column work went into finding that out.
+- The MAIN MENU view was the same picture every time.
+
+What it was really being squinted at for is whether the descriptor the build
+**wrote** matches the manifest that **asked for it** — a clone inherits its
+donor's name fields and slot names, so it can carry the right count, default
+and enable bit and still be labelled as the effect it was copied from. Three
+of six page-2 slots drew wrong on the 17 Aug 2026 flash and every check then
+in place passed, because every field they checked was right.
+
+**That is a check, and it now lives in `verify_menu.py`**, read straight out
+of the built image with no emulator involved:
+
+```
+ok   REVERB SERVER: the panel prints 'ChonVerb78', which starts with the
+     declared 'ChonVerb' (the build tag follows it)
+ok   REVERB SERVER: its abbreviation is 'CVRB' == 'CVRB'
+ok   REVERB SERVER: its 12 drawn slot names are the manifest's, in order
+```
+
+A mismatch now **fails `make check`** instead of having to be noticed in the
+corner of a pane. That is the general lesson and it is worth writing down: a
+fact you have to look at is not a check, and dressing it up better does not
+make it one.
+
+### A / B compares two EFFECTS
+
+Not "two renders ago against now", which is what the marks used to hold. `r`
+hears the effect the cursor is on, `a` parks it as A, then point at the rival
+and `b` — which **re-renders it on the same source** — and `,` / `.` flip
+between them. That is the question a remixer exists to answer: *is mine
+better than the one the box came with?* It is also exactly the question an
+upgraded stock effect asks, which is why the pair is two effects rather than
+two accidents of history.
+
+**`SOURCE` is the first row**: `left`/`right` cycles the wavs in the source
+folder, so choosing what you audition on is one keypress from the knobs. `r`
+renders the effect over it and plays it; `space` replays.
+
+**`d` points the source folder somewhere else** and remembers it in
+`out/_audition/remixer.json`; `REMIXER_SOURCES` overrides both. The
+default is `out/dry/`, the curated dry set — a good default, not a permanent
+one, since a bench gets used on whatever material is to hand. A path that is
+not a directory, or holds no wavs, is refused and the old one stands.
+
+⚠️ **Six of the eleven stock effects render DRY at their defaults** —
+PHASER, FLANGER, CHORUS and COMB sit at `MIX 0`, SPATIALIZER and DELAY at
+`SEND 0` — so pressing `r` on one plays the source back unchanged, which
+reads as "this effect does nothing" (it cost a report on 2 Sep 2026). **That
+is faithful and is not fixed by seeding a different value**: stock defaults
+are read from the firmware's own descriptor (`tools/remix/stock.py`), an
+unmodified unit really does start them fully dry, and inventing a value here
+would make the remixer lie about the page it draws beside. The UNIT pane says
+`⚠ MIX is 0 — this renders DRY` instead. None of *our* modules default this
+way.
+
+**Stepping knobs**: `left`/`right` is ±1 and **`shift`+`left`/`right` is
+±10**. Holding the key runs; ~280 steps/second is sustainable (below), so
+key repeat is the limit, not the remixer.
+
+⚠️ **Holding an arrow key used to lag, and the cause was the emulated
+panel.** `rerender()` called `render_fx2` on *every* keystroke — 15–96 ms,
+mean 32 (`render_fx1` 16, `render_menu` 8; measured 2 Sep 2026) — plus three
+independent `problems()` calls at 2.4 ms each. Under key repeat the work per
+key exceeded the repeat interval, so the UI fell behind the held key and kept
+stepping after release; single presses always felt fine, which is why it
+presented as "slow when holding" rather than as latency. **Nothing a keystroke
+does can change that picture** — knob *values* draw as dial graphics the
+string-capture hook cannot read — so the panel is now cached on (page,
+effect id, build) and `problems()` is computed once per pass. Measured
+A/B: **18.1 ms → 3.6 ms per step, 55/s → 281/s.**
+
+Below that, `p` cycles the **preview** in the unit's own order — `FX1`,
+`FX2`, then `MENU` — showing the firmware's own draw of that page, under a
+caption saying **what** it is: `ChonVerb on track 5, as the unit draws it`.
+Not the page title, which the LCD draws itself two lines down; the FX pages
+all open with the same title and the same chooser column, so saying it twice
+is how the caption came to say nothing.
+
 #### What it is for
 
 It is the only way to see the **panel** side of an image without flashing

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -582,6 +582,14 @@ and only four — the **two donor regions** (one per payload), the **FX2 buffer
 slots** per core, the **chooser rows**, and the **ColdFire cave**. Everything
 else is unbounded in practice.
 
+⚠️ **Every row here follows the selection's own harvest.** The `words` rows'
+total is `stock.region_words(harvest)` — 2,724 for the default three, 3,053
+with CHORUS — and once a build lands they are the build's own figures, so
+they cannot drift from it. `held by` names whatever harvested effects are
+still listed and what dropping the lowest buys. The `cycles` row's `N stock
+rows not counted` excludes any the placer reached, because their code is gone
+and nothing can select them.
+
 ⚠️ **A listed reverb is loaded.** The build reports the whole 2,724 as free
 because nothing of *ours* is placed yet — but PLATE, SPRING and DARK REV's
 code is what occupies the region, so a reverb you keep in the chooser is

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -38,7 +38,7 @@ ones — the DSP toolchain itself is plain CMake). It builds:
 |---|---|---|
 | `dsp_asm` | `vendor/dsp56300` | the DSP56300 assembler. ⚠️ It **mis-encodes some instructions silently** — `CLAUDE.md`'s trap list is required reading before trusting it |
 | `dsp_host` | `tools/dsp_host/` (staged into `vendor/dsp56300` and built there) | this project's emulator harness: runs assembled effects on the dsp56300 emulator core. `docs/HARNESS.md` |
-| `emu_bringup.py` | `tools/` | Tier-0 ColdFire bring-up: boots the real MAIN OS image on Unicorn's CFV4E core to the RTOS handoff (the workbench emu, `PLAN.md` §5). Needs `unicorn` — `make emu-setup` (uv, the `emu` extra). `docs/EMU.md` |
+| `emu_bringup.py` | `tools/` | Tier-0 ColdFire bring-up: boots the real MAIN OS image on Unicorn's CFV4E core to the RTOS handoff (the remixer emu, `PLAN.md` §5). Needs `unicorn` — `make emu-setup` (uv, the `emu` extra). `docs/EMU.md` |
 | `elektron-firmware-tool` | `vendor/elektron-firmware-tool` (patched) | packs/unpacks Elektron's OS container formats |
 
 The disassembler from the same dsp56300 project is the other half of the

--- a/docs/VOICING.md
+++ b/docs/VOICING.md
@@ -1947,7 +1947,7 @@ queued but the sound itself passes. Focus moves to the delay.
 
 ## R60 — REVERSE diagnosed: the ring is the segment comb (31 Aug 2026)
 
-Sam, from the workbench (piano_chords, TIME 68 FDBK 79 PING 16 -VRB 61
+Sam, from the remixer (piano_chords, TIME 68 FDBK 79 PING 16 -VRB 61
 DPTH 48 RATE 18 PTCH 1 DRV 55): REVERSE "sounds not great ... a fast
 metallicy ringing that seems to be specific to reverse."
 

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -94,11 +94,21 @@ Nimbus 500, Rungs 880, Send 215, ChonVerb 2,411 (+24 LFO table), BongDelay
 **One trade is often not enough**, and the status line names the next one
 rather than leaving it to the build to refuse:
 
-| after the swap | what it says |
+| after the swap | what happens |
 |---|---|
-| the first module of ours, no SEND | `now needs Send — swap another row for it` |
+| no safe fallback | **SEND is added** — `added Send too (the only safe fallback)`. A row is free, so sacrificing an effect for it would be this UI's invention, not the image's constraint |
+| a buffer clash | `needs the FX2 buffer region — also swap out FLANGER, CHORUS, SPATIALIZER, COMB` |
 | past the donor region (after `w`) | `N words exceeds … ; swap something else out too` |
-| a pair the ledger refuses | the ledger's own sentence, naming both |
+
+**The buffer clash is the expensive one, and it is why adding ChonVerb to a
+stock chooser costs four effects.** FLANGER, CHORUS, SPATIALIZER and COMB
+each take a per-track instance buffer from the host's bump allocator, at
+exactly the addresses ChonVerb's tank hardcodes — so the ledger refuses each
+pair, and the chooser is one list for all eight tracks so the image cannot
+keep them apart. The ledger states it one PAIR at a time, which is four
+near-identical walls of text; the pane aggregates them into the sentence
+above. What you are left with — ChonVerb, the seven stock effects that can
+coexist, and Send — *is* `remixes/restored.py`.
 
 The three stock **reverbs** are not here — they are in LOADED, because they
 are part of a stock chooser. See below.

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -69,19 +69,8 @@ on it is no help when you are adding from the library. It can sit one past
 the last row — that position is `(end)`, and it is how you append.
 `left`/`right` in LOADED moves a row afterwards.
 
-The three stock **reverbs** are listed last and cannot be selected: PLATE,
-SPRING and DARK REV are the 2,724-word donor region our modules are written
-over. They are shown rather than omitted because an effect that is simply
-absent reads as a bug.
-
-**Whether they are consumed depends on the selection**, and the pane says
-which: a selection carrying modules of ours names one of them ("their code
-is the region WarpFold sits in"); a selection carrying none says so instead.
-The precedent is CHORUS, which was a donor until v98 and got its stock
-dispatch back the moment the build stopped taking its code. ⚠️ A stock-only
-image would therefore keep all three — but cannot be built yet, because a
-remix must name a fallback and no stock effect is a safe one. `PLAN.md` §7
-backlogs it.
+The three stock **reverbs** are not here — they are in LOADED, because they
+are part of a stock chooser. See below.
 
 The `FX1+FX2` column is which **chooser** the effect has a row on, derived
 from the pristine image rather than written down (`stock.fx1_ids()`). Stock
@@ -102,6 +91,19 @@ on the panel, so `left`/`right` is a real edit, not a view preference. The
 number column is the panel row; `·` means no chooser row at all (a ColdFire
 patch). `●` means the effect resolves in the image on disk. `◀fb` marks the
 fallback. `w` fills in each module's word cost by running a real assembly.
+
+**The three reverbs live here.** An unmodified unit shows **fourteen** FX2
+effects, and PLATE, SPRING and DARK REV are three of them — so a stock
+selection lists all fourteen. They leave when something takes their space:
+their code *is* the 2,724-word donor region our modules are written over, so
+adding one drops them in place with the reason (`– PLATE REV taken by
+WarpFold`). That is the trade, shown where it happens rather than as a rule
+you have to know. The precedent is CHORUS, which was a donor until v98 and
+got its stock dispatch back the moment the build stopped taking its code.
+
+⚠️ A stock selection that keeps all three **cannot be built yet** — a remix
+must name a fallback and no stock effect is a safe one. `PLAN.md` §7 has the
+two changes that would fix it, and the argument for closing it instead.
 
 **You start at `stock`** — the chooser an unmodified unit shows, no modules
 of ours. You add to what the box already does rather than to somebody else's

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -157,14 +157,33 @@ number column is the panel row; `·` means no chooser row at all (a ColdFire
 patch). `◀fb` marks the fallback. Each module's word cost comes from the real
 assembly the background rebuild runs, so it is always filled in.
 
-**The three reverbs live here.** An unmodified unit shows **fourteen** FX2
-effects, and PLATE, SPRING and DARK REV are three of them — so a stock
-selection lists all fourteen. They leave when something takes their space:
-their code *is* the 2,724-word donor region our modules are written over, so
-adding one drops them to a single dim line, `— PLATE, SPRING, DARK REV
-(donors)`. That is the trade, shown where it happens rather than as a rule
-you have to know. The precedent is CHORUS, which was a donor until v98 and
-got its stock dispatch back the moment the build stopped taking its code.
+**The three reverbs live here, and you can keep them.** An unmodified unit
+shows **fourteen** FX2 effects and PLATE, SPRING and DARK REV are three of
+them, so a stock selection lists all fourteen. Their code *is* the donor
+region — but the build packs it **from PLATE upward**, so a selection only
+loses the reverbs it actually reached, and the pane shows which
+(`— Plate Rev   donor, taken`), read from the build's own report rather than
+assumed.
+
+The smallest buildable image is `remixes/restock.py`: **thirteen** stock
+effects including SPRING and DARK REV, plus SEND. SEND's 215 words land on
+the first 215 of PLATE's 594, so the minimum costs the *smallest* reverb and
+nothing else.
+
+⚠️ Until 2 Sep 2026 all three were nulled **unconditionally** — a build that
+placed 250 words silenced 2,724 words' worth of reverb — so the honest answer
+to "why can I never get the stock verbs back?" was "you cannot, ever". PLAN
+§7, now closed. The precedent was CHORUS, a donor until v98, which got its
+stock dispatch back the moment the build stopped taking its code.
+
+**Two guards make listing them safe.** The **build** refuses a donor row
+whose words this selection took, naming it — only the placement knows where
+the cursor stopped, so nothing predicts it, and `x` applies the fix. The
+**ledger** refuses a reverb beside a module with fixed Y buffers: all three
+take a per-track instance buffer, which is **measured** — each reads
+`x:>$213`, the host's bump allocator, within ~25 words of its entry (PLATE
+`0x01018`, SPRING `0x01267`, DARK `0x01692`) — exactly like SPATIALIZER,
+FLANGER, CHORUS and COMB.
 
 ⚠️ It used to be three lines, one per reverb, each reading `– PLATE REV
 taken by BongDelay +1`. That said one thing three times; it named an
@@ -172,10 +191,6 @@ arbitrary module as the taker (`eats[0]` is just the first selection with DSP
 code — **nothing computes a per-reverb attribution**, and the `+1` was SEND);
 and at 40 columns the ` +1` wrapped onto its own line, so it read as a fourth
 mystery row. Corrected 2 Sep 2026.
-
-⚠️ A stock selection that keeps all three **cannot be built yet** — a remix
-must name a fallback and no stock effect is a safe one. `PLAN.md` §7 has the
-two changes that would fix it, and the argument for closing it instead.
 
 **You start at `stock`** — the chooser an unmodified unit shows, no modules
 of ours. You add to what the box already does rather than to somebody else's

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -271,6 +271,28 @@ slot 3 or 4 — which depends on how many FX2 effects the dispatcher has
 already walked this block. **Unpredictable is still a refusal**, and each
 works perfectly alone, which is the worst shape a defect can have.
 
+### One line per menu
+
+FX1 and FX2 have **separate allocator tables**, so a cost on one is not a cost
+on the other — and saying that in a subordinate clause ("FX2 rows only, FX1
+keeps its 4") made a simple fact read as a caveat. There is a line each:
+
+```
+Nimbus          500 of 2,724 words
+                FX1  no row — takes nothing
+                FX2  pins 2 core-private slots — costs the rows of
+                     Flanger, Chorus, Spatializer, Comb Filter and the 3 reverbs
+
+Flanger         free — already in the image
+                FX1  takes 1 of the 4 slots (3,072 words each)
+                FX2  takes 1 of the 4 slots (16,384 words each)
+```
+
+**Nothing of ours takes an FX1 slot.** Our modules have no FX1 row, so the FX1
+allocator never hands them anything; FX1 slots go to stock effects only. A
+module with no chooser row at all (a ColdFire patch like tempo-sync) shows
+neither line.
+
 ### It costs the FX2 ROW, not the effect
 
 **FLANGER, CHORUS, SPATIALIZER and COMB are still on FX1, and still work.**

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -61,15 +61,27 @@ Everything that *could* be in an image: your modules grouped **server** /
 **insert** / **system**, then the stock effects the unit already ships. `✓`
 marks what the current selection holds.
 
-**`enter` adds at the LOADED pane's cursor**, not at the end — chooser order
-*is* the panel's row order, so "which slot" is the question, and the status
-line answers it ("added ChonVerb at chooser row 3"). `left`/`right` in LOADED
-moves a row afterwards.
+**`enter` adds at the `▸` in the LOADED pane**, not at the end — chooser
+order *is* the panel's row order, so "which slot" is the question, and the
+status line answers it ("added ChonVerb at chooser row 3"). The `▸` is drawn
+from either pane, because an insertion point you can only see while standing
+on it is no help when you are adding from the library. It can sit one past
+the last row — that position is `(end)`, and it is how you append.
+`left`/`right` in LOADED moves a row afterwards.
 
-The three stock **reverbs** are listed last under `consumed` and cannot be
-selected: PLATE, SPRING and DARK REV are the 2,724-word donor region every
-module packs into. They are shown rather than omitted because an effect that
-is simply absent reads as a bug.
+The three stock **reverbs** are listed last and cannot be selected: PLATE,
+SPRING and DARK REV are the 2,724-word donor region our modules are written
+over. They are shown rather than omitted because an effect that is simply
+absent reads as a bug.
+
+**Whether they are consumed depends on the selection**, and the pane says
+which: a selection carrying modules of ours names one of them ("their code
+is the region WarpFold sits in"); a selection carrying none says so instead.
+The precedent is CHORUS, which was a donor until v98 and got its stock
+dispatch back the moment the build stopped taking its code. ⚠️ A stock-only
+image would therefore keep all three — but cannot be built yet, because a
+remix must name a fallback and no stock effect is a safe one. `PLAN.md` §7
+backlogs it.
 
 The `FX1+FX2` column is which **chooser** the effect has a row on, derived
 from the pristine image rather than written down (`stock.fx1_ids()`). Stock

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -35,170 +35,97 @@ workbench lives in the venv.
 Playback is `afplay`, so hearing renders is macOS-only; everything else
 works anywhere the DSP toolchain does.
 
-## The three views
+## One page, three panes
 
-`x` / `v` / `e` move between them; `?` on any view opens an overlay with
-this page's short form; `esc` stops audio from anywhere; `q` quits (from
-EMU, `q` returns to the rig).
+`make remix` opens a single screen. `tab` moves between panes, `up`/`down`
+moves within one, `?` opens this page's short form, `esc` stops audio, `q`
+quits. **There is no per-track view** — the eight-track rig was retired 2 Sep
+2026 because it was a second place to say what a remix already says, and
+knob values belong to the effect rather than to a track.
 
-### RIG — the home view
+```
+┌ AVAILABLE ───────┬ LOADED · stock ────────┬ FILTER ──────────────────────┐
+│ ── server ──     │  1 ● FILTER    FX1+FX2 │ stock · id 0x04 · FX1+FX2    │
+│    BongDelay FX2 │  2 ● EQUALIZER FX1+FX2 │ BASE   0  [............] p1  │
+│    ChonVerb  FX2 │  3 ● DJ EQ     FX1+FX2 │ WDTH 127  [############] p1  │
+│ ── insert ──     │  …                     │ …                            │
+│    WarpFold  FX2 │ 11 ● DELAY     FX2     │ preview: FX2 MENU FX1        │
+│ ── stock ──      │                        │ .--------------------------. │
+│  ✓ FILTER FX1+FX2│ ● = in the built image │ | EFFECT 2 SETUP           | │
+└──────────────────┴────────────────────────┴──────────────────────────────┘
+```
 
-Eight tracks across the top, an effect assigned to each, the selected
-track's controls below. This is the trial-a-sound loop.
+### AVAILABLE — the library
 
-![The RIG view: Nimbus on T6, its page-1 knobs and FRZE select, the
-per-knob help line, and the render history](img/workbench-rig.png)
+Everything that *could* be in an image: your modules grouped **server** /
+**insert** / **system**, then the stock effects the unit already ships. `✓`
+marks what the current selection holds; `enter` adds or removes.
 
-| key | action |
-|---|---|
-| `1`–`8` | select track |
-| `enter` | pick the track's effect (only effects that can run there) |
-| `backspace` | clear the track's effect |
-| `up/down` (`j/k`) | move between rows: SOURCE, RENDER, then the knobs |
-| `left/right` (`h/l`) | adjust the row; `shift` steps by 10 |
-| `r` | render the track's effect over the source, then play it |
-| `space` | replay the last render |
-| `a` / `b` | mark the last render as A / B |
-| `,` / `.` | replay mark A / mark B |
-| `esc` | stop playback |
+The `FX1+FX2` column is which **chooser** the effect has a row on, derived
+from the pristine image rather than written down (`stock.fx1_ids()`). Stock
+gives the two slots different lists: ten effects on FX1, those ten plus
+DELAY and the three reverbs on FX2 — which is why taking the reverbs as
+donors cost FX1 nothing. **Our own modules are FX2-only, and that is a build
+limit, not a hardware one**: the DSP dispatch tables are indexed by the raw
+id and shared between the menus, so a module's code already runs from FX1
+the moment FX1 selects its id. What is missing is the panel side — FX1's
+15-entry chooser cannot grow in place and must be relocated to a cave
+(`tools/build_fx1.py` proved it can be), and no manifest field asks for a
+row. The real ceiling is cycles ×4 (`PLAN.md` §2).
 
-Row notes:
+### LOADED — the image being composed
 
-- **SOURCE** cycles every `.wav` in `out/dry/` — the curated DRY set
-  (31 Aug 2026; the old `out/test_audio/` + `out/demo_sources/` browse
-  mixed ~50 processed renders in with the dozen dry sources). Drop files
-  in `out/dry/` and restart. If `out/dry/` is missing or empty the old
-  two-directory browse comes back as the fallback. (No browse-anywhere
-  picker yet.)
-- **RENDER wet/full** applies to ChonVerb only (`render_reverb --wet`, an
-  exact dry subtraction). Other effects always render their normal output.
-- **Knob rows** carry the manifest's names in the unit's own page layout:
-  slots 0–5 = page 1, encoders A–F; slots 6–11 = page 2, knob/select
-  alternation. Selects show their manifest labels (the delay's MODE reads
-  CLEAN/PITCH/(tape)/GRAIN/REVRS, not 0–4). The dim `?` line under the
-  rows explains whichever row the cursor is on — the text comes from
-  `Param.doc` in the effect's manifest.
-- ChonVerb's MODE renders as its own image, cached per mode
-  (`render_reverb`'s engine cache) — the first render after a MODE flip
-  pays a build, later ones don't.
+The selection, **in chooser order** — the order here *is* the order of rows
+on the panel, so `left`/`right` is a real edit, not a view preference. The
+number column is the panel row; `·` means no chooser row at all (a ColdFire
+patch). `●` means the effect resolves in the image on disk. `◀fb` marks the
+fallback. `w` fills in each module's word cost by running a real assembly.
 
-The RENDERS panel lists recent renders with the knobs that differed from
-defaults; `[A]`/`[B]` show where the marks sit. Marks always attach to the
-**most recent** render — walk-the-history marking is a known gap.
+**You start at `stock`** — the chooser an unmodified unit shows, no modules
+of ours. You add to what the box already does rather than to somebody else's
+remix. That selection deliberately cannot build as it stands: a remix must
+name a fallback for the ids it does not implement, and no stock effect is a
+safe one (it would *process* the unknown id), so the moment you add a module
+you add SEND too. The pane says so.
 
-**Why some effects are missing on some tracks:** the two bus servers each
-live on one DSP core, and the cores serve fixed track halves — ChonVerb
-(payload A) on **tracks 5–8**, BongDelay (payload B) on **tracks 1–4** —
-the measured 10 Aug 2026 track↔core inversion. Inserts run anywhere.
-SYSTEM modules (SEND, tempo-sync) are plumbing and never appear in the
-picker.
+`l` loads a remix (or `stock`), `s` saves the selection as one, `k` resets to
+stock, `f` picks the fallback explicitly, `b` builds, `c` runs `make check`.
 
-### REMIX — the composer
+### UNIT — the selected effect
 
-The old workbench's job, reframed. Left: the modules, grouped **BUS
-EFFECTS** (with track range) / **INSERTS** (any track) / **STOCK FX2** /
-**SYSTEM**, with the cursored module's one-line doc below. Right: what the
-selection *is* — the FX2 chooser exactly as the unit will show it, in
-**selection order** (`[` / `]` move the cursored module; a saved remix
-keeps that order), the program-fit bar against the donor region, and the
-ledger's collision verdict (the same `ledger.check` the build runs, not a
-reimplementation).
+Follows the cursor, so pointing at something in the library previews it
+before you add it. Shows its kind, id, menus and track range, its one-line
+doc, and its drawn parameters with values — `left`/`right` adjusts,
+`shift` for ×10. **Values live per module**, seeded from the manifest
+defaults (a stale default polluted every shimmer measurement until Round 12).
 
-**STOCK FX2** (since 2 Sep 2026) is the eleven stock effects the image
-would otherwise hide: every image replaces the whole chooser, but only
-PLATE/SPRING/DARK REV are actually consumed (their code is the donor
-region), and the panel now says so. Toggling a stock row costs nothing —
-no code, no words, no clone; the row is the only edit. The four that
-allocate a per-track buffer (SPAT, FLNG, CHOR, COMB) are refused beside
-ChonVerb, Nimbus or BongDelay, with the reason. Past seven rows the panel
-scrolls, and the composer says that too. `docs/MODULES.md` has the rules.
+`r` renders the effect over the selected source and plays it; `space`
+replays. Below that, `p` cycles the **preview**: the firmware's own draw of
+the effect's FX2 page, the MAIN MENU, or the FX1 page, from the built image
+in the Tier-0 ColdFire emulator.
 
-In the RIG a stock effect shows its **real knobs** — names, defaults and
-value counts read from the stock descriptor in the pristine image, and a
-select shows the **words the unit draws** ("12dB|24dB", "NONE|HP|LP|BOTH",
-the comb's note names), asked of the firmware's own display formatters on
-the emulated ColdFire (`make stock-labels`) — and **renders** like
-an insert, from a one-time dump of the stock image's payload A
-(`out/dsp/_stock_A.mem`), so nothing about the currently built remix
-matters. Ten of the eleven render (2 Sep 2026): FILTER, EQ, DJ EQ,
-PHASER, FLANGER, CHORUS, SPATIALIZER, COMB, COMPRESSOR, LO-FI — every one
-a bit-exact dry pass at its neutral settings, LO-FI at +6 dB (open) and
-after an emulator patch (`tools/dsp56300.patch`, `mpyri`). **DELAY** runs
-on the ColdFire, so there is no DSP code to render and the audition says
-so. `docs/MODULES.md` has the measurements and the harness lesson (the
-audio block sits at X:0 for a stock render, as on hardware).
+- **MAIN MENU** is the no-flash gate for ColdFire cave work — a patched-in
+  top-level row draws here exactly as the unit would draw it.
+- **FX1** shows that chooser as stock ships it, which is what FX1 rows would
+  have to be added to.
+- **FX2** draws the selected effect's page — *unless it is one of ours that
+  has not been built*, in which case it is deliberately not drawn. An id the
+  image does not implement resolves to the fallback and the firmware would
+  draw a convincing picture of the wrong effect (`CLAUDE.md`, 12 Aug 2026).
+  A **stock** effect always draws: a remix that leaves one out does not
+  remove it — its code, descriptor and dispatch stay stock and an old
+  project that selects it still runs it; it only loses its chooser row.
 
-![The REMIX view: modules grouped by category with track ranges, the FX2
-menu as the unit will draw it, and the ledger's verdict —
-chongbong loaded](img/workbench-remix.png)
+The boot (~4 s) is cached and repeats only when the image changes.
 
-| key | action |
-|---|---|
-| `space` | toggle the module under the cursor |
-| `[` / `]` | move it earlier / later in the chooser |
-| `f` | make it the fallback (absent ids alias to the fallback — normally SEND, so a stale project degrades to a send, not noise; `*` explicit, `~` auto) |
-| `w` | assemble the selection and keep the real word counts |
-| `b` / `c` | `make bus` / `make check` on the **live** selection (via the scratch-remix mechanism — no save needed) |
-| `l` / `s` | load / save a remix file |
-
-A successful `b`/`c` invalidates the EMU view's cached boot, so `e` shows
-the image you just built.
-
-The panel's "no LEDGER collisions" deliberately names what is *not*
-checked (the shared 64K window) and which selected module owns the
-per-core FX2 buffer region — see CLAUDE.md for why that caveat is written
-out each time.
-
-### EMU — the emulated unit
-
-The built image (`out/mainos_bus.bin`) booted in the Tier-0 ColdFire
-emulator, drawing **its own screens**: the MAIN MENU (patched-in entries
-render as the firmware would draw them), FX2/FX1 SETUP, and the PLAYBACK
-page. Booting is itself the no-flash gate — a cave that breaks early init
-faults here, not on the unit.
-
-| key | action |
-|---|---|
-| `m` | main menu (`up/down` moves the cursor) |
-| `f` | FX2 SETUP — `left/right` cycles effects, the rig follows |
-| `o` | FX1 SETUP (stock effects; `left/right` cycles the id) |
-| `p` | PLAYBACK page (`left/right` cycles FLEX/STATIC/THRU/NEIGHBOR) |
-| `a` | stage the cycled-to effect in the composer (FX2 view) |
-| `b` | build the composer's live selection and re-boot |
-| `1`–`8` | change track |
-
-The boot (~4 s) is cached at app level and repeats only when the image's
-mtime changes.
-
-**The FX2 view closes the loop.** `left/right` cycles two groups: the rows
-the built image actually offers (read from the image on disk, in the panel's
-own order — `rig.built_chooser()`), then every other module that *could*
-have a row, marked as not built.
-
-- Landing on a **built** row draws the firmware's own EFFECT 2 SETUP and
-  **assigns it to the track** — the rig and this view are one selection, not
-  two. Where the rig cannot hold it the view says what the *unit* would do
-  instead: a server picked on the wrong core's tracks aliases to the
-  fallback and the track becomes a send; SEND is plumbing the chooser lists
-  and the rig does not hold.
-- Landing on a **pending** row is deliberately **not drawn**. An id the
-  image does not implement resolves to the fallback, and the firmware would
-  draw a convincing picture of the wrong effect — the 12 Aug 2026 trap in
-  panel form. `a` stages it in the composer, `b` builds and re-boots.
-  Cycling past several unbuilt effects costs nothing; only `b` builds.
-
-Changing track **follows** that track's assignment and never writes: an
-empty track would otherwise silently inherit whatever row was showing. The
-cursor also stays on the same *effect* across a rebuild, so staging one and
-pressing `b` leaves you looking at it, now built.
-
-Honest limits (all recorded in `docs/EMU.md`): no audio, no key matrix —
-navigation is done by poking state and re-calling draw functions. Knob
-**values** draw as dial graphics the string-capture hook cannot read, so
-the rig's numbers are always the truth for values. In a SPEC image the
-delay's DSP in payload A is the SEND alias, so its FX2 page can draw
-empty. Item-level menu descent needs the real key handler
-(`FUN_40064e64`) and is not built.
+Honest limits (`docs/EMU.md`): no audio and no key matrix in the emulator —
+navigation is poking state and re-calling draw functions. Knob **values**
+draw as dial graphics the string-capture hook cannot read, so the numbers in
+this pane are the truth for values, not the picture. In a SPEC image the
+delay's DSP in payload A is the SEND alias, so its page can draw empty.
+Item-level menu descent needs the real key handler (`FUN_40064e64`) and is
+not built. The PLAYBACK page render was dropped with the rig — it proved the
+detour could draw a non-FX page and had no role in composing an image.
 
 ## The audition backend
 
@@ -240,14 +167,19 @@ That makes a listening session addressable: "this sounds boxy" plus the
 journal tail is a full repro — track, effect, source, every knob. It is
 also how demo takes get captioned after the fact.
 
-## The rig file
+## Knob values
 
-`out/_rig.json` persists the per-track assignments and knob values across
-restarts. It is a **bench fixture, not a firmware statement** — remix
-files say what the image contains; the rig says what the operator was
-listening to. Loading validates against the current manifests: a renamed
-knob does not resurrect a stale value under its old meaning, and an
-assignment a module can no longer honour is dropped.
+Values live **per module**, in the session, seeded from that module's
+manifest defaults the first time you look at it. They are a bench fixture,
+not a firmware statement: a remix file says what the image *contains*, never
+what the operator had a knob set to. Nothing about them is written into the
+image, and a render is the only thing that consumes them.
+
+⚠️ `out/_rig.json` and the per-track rig it persisted are **gone** (2 Sep
+2026). Eight tracks with an effect on each was a second place to say what a
+remix already says, and it forced a knob set per track when what an operator
+actually tunes is an effect. An old `_rig.json` on disk is inert and can be
+deleted.
 
 ## Theming
 

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -271,6 +271,28 @@ slot 3 or 4 — which depends on how many FX2 effects the dispatcher has
 already walked this block. **Unpredictable is still a refusal**, and each
 works perfectly alone, which is the worst shape a defect can have.
 
+### It costs the FX2 ROW, not the effect
+
+**FLANGER, CHORUS, SPATIALIZER and COMB are still on FX1, and still work.**
+Leaving a stock effect out of a remix takes its FX2 chooser row and nothing
+else — its code, descriptor and dispatch stay stock on both cores, which
+`verify_menu` and `verify_replaces` both assert.
+
+**And the collision cannot follow them to FX1.** The allocator keeps two
+separate tables, and the FX1 one is nowhere near a module's buffers:
+
+| | bases | each | tops out at |
+|---|---|---|---|
+| FX1 | `0x1000 0x1c00 0x2800 0x3400` | 3,072 words | `0x3fff` |
+| FX2 | `0x4000 0x8000` + the shared-window pair | 16,384 words | — |
+
+Every FX2 buffer a module of ours pins starts at `0x4000` or in the shared
+window, so an FX1 allocation **physically cannot reach one**. (It is also why
+the reverbs are FX2-only in stock: they do not fit in an FX1 allocation.)
+
+So of the seven, four cost you a row on one menu and the three reverbs are
+lost outright — and only because FX1 never listed them in the first place.
+
 A donor reverb states the budget you have left before it goes, because that
 is arithmetic rather than a rule: the region is packed from PLATE upward, so
 PLATE goes first and DARK survives while your modules stay under 1,657 words.

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -394,18 +394,28 @@ else gets any:
 
 | what | colour | why |
 |---|---|---|
-| **whose it is** | cyan = one of *ours*, plain = the box's own | in a remixer this is what you scan for, and nothing carried it |
-| **state** | green fits · yellow is a trade or a caution · red blocks | the free-word count is coloured by its own answer |
-| **one-of-a-kind** | magenta | `◀fb`, the fallback |
-| **the panel** | blue frame | chrome, so the firmware's own words stay plain |
+| **whose it is** | aqua `#8ec07c` = one of *ours*, plain = the box's own | in a remixer this is what you scan for, and nothing carried it |
+| **state** | green `#b8bb26` fits · ochre `#d79921` is a trade or caution · red `#fb4934` blocks | the free-word count is coloured by its own answer |
+| **a knob's level** | a warm ramp, green → ochre → orange `#fe8019`, by where the value sits in its own range | the variety comes from the values, so a row's colour means something |
+| **the source wav** | muted blue `#83a598` | what you are auditioning on, distinct from what you are auditioning |
+| **one-of-a-kind** | soft purple `#d3869b` | `◀fb`, the fallback |
+| **the panel** | grey `#665c54` frame | chrome, so the firmware's own words stay plain |
 
 The free-word thresholds come from what this project actually lives with:
 payload A has shipped at `FREE 4` and B at `FREE 5`, so **double digits is
 already spent** and gets the alarm colour; over 400 is comfortable.
 
-Colours are **ANSI names, not hex** — the workbench runs Textual's
-`ansi-dark`, so it wears your terminal's own sixteen colours and a hex triple
-would fight whatever palette the terminal is set to.
+⚠️ **These were ANSI names first, and that was wrong twice over.** `cyan`
+rendered as `#00ffff` and `yellow` as `#ffff00` — Rich resolves a colour NAME
+to its standard value rather than delegating to the terminal, so the "it
+wears your palette" reasoning did not hold, and against a warm dark ground it
+read as a wall of electric blue. They are gruvbox's own tones now.
+
+**No red in the knob ramp**, deliberately: a filter cutoff at full is not an
+alarm. And the bars were briefly *neutral* — one flat tint across twelve rows
+made the accent the largest thing on screen and told you nothing, but taking
+the colour out entirely went too far the other way. Grading them by value is
+what makes them worth colouring at all.
 
 ## Editing in another window
 

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -416,9 +416,21 @@ track's** buffer, and the row names the tracks still free — those are exactly
 the ones that can host an allocating stock effect:
 
 ```
- FX2 buf A #### #### #### ####  4 of 4  none free
- FX2 buf B .... .... #### ####  2 of 4  free on 1, 2
+ FX2 buf A #### #### #### ####  ChonVerb has 5,6,7,8
+ FX2 buf B .... .... #### ####  BongDelay has 3,4 · 1,2 keep theirs
 ```
+
+⚠️ **"Free" was the wrong word and kept being read as "unused".** A track
+whose buffer no module has claimed still *has* that buffer, ready for
+whatever is selected there — so the row says `keep theirs`. That is the whole
+answer to *"the stock reverbs don't use it?"*: they use **their own track's**,
+when you select them on it, and merely listing one in the chooser claims
+nothing. Only a **module** claims a buffer for the life of the image, which
+is why only modules appear in this row.
+
+The two panes are consistent once the timing is clear: the library says
+`Plate Rev … FX2 takes 1 of the 4 slots` (what it does *when selected on a
+track*), and the budget says what is claimed *by the image*.
 
 With `chongbong`, ChonVerb holds all four of core 0's (tracks 5–8) and
 BongDelay tracks 3–4's on core 1 — so **FLANGER on track 1 or 2 would be

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -249,10 +249,27 @@ being asked, and every answer used to arrive only as a **refusal after adding
 it**.
 
 **It says the CONSEQUENCE, not the address.** `pins Y:0x4000-0xBFFF` is where
-a buffer lives; what you are deciding is what it costs you, which is the
-seven stock effects it cannot sit beside. The addresses are in `docs/DSP.md`
-§10 and belong there — **the pane carries consequences, the docs carry
-mechanism.**
+a buffer lives; what you are deciding is what it costs you — and because that
+set is FIXED, it names them: `pins all 4 FX2 buffer slots — costs Flanger,
+Chorus, Spatializer, Comb Filter and the 3 reverbs`. A count ("blocks 7
+stock effects") just makes you go and find out which seven, and the answer
+never changes. The addresses are in `docs/DSP.md` §10 and belong there —
+**the pane carries consequences, the docs carry mechanism.**
+
+How many slots differs by module, and it is **measured** — `X:0x255` read
+from both payloads:
+
+| | core 0 FX2 | core 1 FX2 |
+|---|---|---|
+| allocator hands out | `0x4000 0x8000 0x30000 0x34000` | `0x4000 0x8000 0x38000 0x3c000` |
+
+ChonVerb is **all four** of core 0's — tank in the core-private pair,
+relocated buffers in the shared-window pair. Nimbus is the core-private pair
+only. BongDelay is core 1's shared-window pair only (its lines are based at
+`0x38000`), so a stock effect there collides *only if* the allocator hands it
+slot 3 or 4 — which depends on how many FX2 effects the dispatcher has
+already walked this block. **Unpredictable is still a refusal**, and each
+works perfectly alone, which is the worst shape a defect can have.
 
 A donor reverb states the budget you have left before it goes, because that
 is arithmetic rather than a rule: the region is packed from PLATE upward, so

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -165,13 +165,51 @@ The `FX1+FX2` column is which **chooser** the effect has a row on, derived
 from the pristine image rather than written down (`stock.fx1_ids()`). Stock
 gives the two slots different lists: ten effects on FX1, those ten plus
 DELAY and the three reverbs on FX2 — which is why taking the reverbs as
-donors cost FX1 nothing. **Our own modules are FX2-only, and that is a build
-limit, not a hardware one**: the DSP dispatch tables are indexed by the raw
-id and shared between the menus, so a module's code already runs from FX1
-the moment FX1 selects its id. What is missing is the panel side — FX1's
-15-entry chooser cannot grow in place and must be relocated to a cave
-(`tools/build_fx1.py` proved it can be), and no manifest field asks for a
-row. The real ceiling is cycles ×4 (`PLAN.md` §2).
+donors cost FX1 nothing.
+
+**`1` gives the highlighted effect a row on FX1 too** (3 Sep 2026), and the
+column follows. Our modules were FX2-only until then, and it was never a
+hardware limit: the DSP dispatch tables are indexed by the raw id and shared
+between the menus, so a module's code already ran from FX1 the moment FX1
+selected its id. What was missing was the panel side, for one mechanical
+reason — FX1's chooser list ends at `0x400d608c` and FX2's begins at
+`0x400d6090`, so it cannot grow where it sits. It is relocated into the cave
+instead, exactly as the FX2 list already is when it outgrows its own, and
+FX1's three `lea` references are repointed (`tools/build_fx1.py` proved that
+move standalone against the pristine image; `build_bus.py` does it now).
+
+It belongs to the **remix**, not to the module — which menu an effect appears
+on is a composition choice, like the chooser order beside it — so it is
+`Remix.fx1`, a tuple of module keys, written by `s` and read by `l`.
+`remixes/bothslots.py` is the worked example.
+
+**It costs no words and it is not free.** The code is placed either way; the
+bill is four bytes of cave per row plus the relocated list, and **cycles**.
+FX1 is four more slots on the same four tracks, so listing an effect on both
+menus can double the worst per-core load — WarpFold goes from `4×` to `8×`,
+404 to 808 of the 3,120 our code may spend. The Budget's `cycles` row prices
+it, which is why that row exists (`PLAN.md` §2 called this "the real ceiling
+is cycles ×4").
+
+Two things are refused rather than allowed to go wrong: a module that
+`replaces` a stock effect **already** has that effect's FX1 row (the build
+repoints both of FX1's tables in place), so asking for a second would list it
+twice; and a stock effect's FX1 row is stock's own business. `verify_menu`
+proves the rest — the list relocated, its three refs in agreement, stock's
+eleven rows unchanged and still first, FX1's id lookup and its **cursor**
+table written, and FX1 and FX2 resolving the id to the *same* descriptor.
+
+⚠️ **`tools/build_fx1.py`'s experiment never wrote FX1's cursor table** and
+that is a real gap, not a cosmetic one: `FX1_ID2POS` at `0x400d60d0` is the
+exact analogue of FX2's `ID2POS`, found 3 Sep 2026 by reading the four tables
+in address order (it is FX1's because DELAY and the three reverbs are zero
+there where `ID2POS` gives them rows). Without it a project with one of our
+effects stored on FX1 opens the chooser with the cursor on row 0.
+
+⚠️ **Seen only in the emulator.** The ColdFire emulator draws the FX1 chooser
+with the firmware's own code — `WarpFold78` as row 11 of a twelve-entry list,
+its own knob names on the page, the cursor opening on that row — which is the
+no-flash gate, not a hardware result.
 
 ### LOADED — the image being composed
 
@@ -224,7 +262,8 @@ safe one (it would *process* the unknown id), so the moment you add a module
 you add SEND too. The pane says so.
 
 `l` loads a remix (or `stock`), `s` saves the selection as one, `k` resets to
-stock, `f` picks the fallback explicitly, `c` runs `make check`. **There is no
+stock, `f` picks the fallback explicitly, `1` toggles the highlighted
+effect's FX1 row, `c` runs `make check`. **There is no
 build key** — see below.
 
 **The pane closes with ONE line**, which is either the per-payload budget, a

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -114,9 +114,23 @@ rather than leaving it to the build to refuse:
 | a buffer clash | the ⚠ line reads `x removes Flanger, Chorus, Spatializer, Comb Filter — they need the same buffer`, and **`x` does it** |
 | past a payload's region | the build refuses and names it: `payload B: RUNGS overruns the region (3599 > 2724 words)` |
 
-**The ⚠ offers its own fix.** Naming the four effects that have to go was
-already better than four walls of text, but it still handed you a chore —
-find four rows, remove each. `x` applies whatever the ⚠ just advised.
+**The ⚠ offers its own fix.** `x` applies whatever it just advised.
+
+It names the **cause and the count**, not the list: `Nimbus pins the buffer 7
+stock effects allocate — x removes them`. Naming all seven took four wrapped
+lines of a 40-column pane and still said neither *which* module was doing it
+nor *why*, which is exactly the question it produced ("why did adding nimbus
+remove so many?"). The list is one keystroke away; the reason is what you
+actually want.
+
+⚠️ **Seven, not four, since the reverbs became listable.** PLATE, SPRING and
+DARK REV take a per-track instance buffer like FLANGER, CHORUS, SPATIALIZER
+and COMB — measured, they read `x:>$213`. **The image you end up with is
+unchanged**: Nimbus plus the seven stock effects that allocate nothing, plus
+SEND. The trade only *looks* bigger because the chooser now starts at
+fourteen rows instead of eleven. And two of the three would have gone anyway
+on words — Nimbus (500) + SEND (215) reaches into SPRING, so only DARK REV is
+refused purely for the buffer.
 
 **The consequence goes on the ⚠ line, not in the status bar.** Appending it
 to "swapped X → Y" produced a run-on the status bar then truncated — and the

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -44,14 +44,14 @@ quits. **There is no per-track view** — the eight-track rig was retired 2 Sep
 knob values belong to the effect rather than to a track.
 
 ```
-┌ AVAILABLE ───────┬ LOADED · stock ────────┬ FILTER ──────────────────────┐
-│ ── server ──     │  1 ● FILTER    FX1+FX2 │ stock · id 0x04 · FX1+FX2    │
-│    BongDelay FX2 │  2 ● EQUALIZER FX1+FX2 │ BASE   0  [............] p1  │
-│    ChonVerb  FX2 │  3 ● DJ EQ     FX1+FX2 │ WDTH 127  [############] p1  │
-│ ── insert ──     │  …                     │ …                            │
-│    WarpFold  FX2 │ 11 ● DELAY     FX2     │ preview: FX2 MENU FX1        │
+┌ AVAILABLE ───────┬ LOADED · chongbong ────┬ ChonVerb ────────────────────┐
+│ ── server ──     │ ▸1 ChonVerb  FX2  2411w│ server · id 0x07 · tracks 5-8│
+│    BongDelay FX2 │  2 BongDelay FX2  2469w│ TIME  64  [######......] p1  │
+│    ChonVerb  FX2 │  3 Send      FX2   250w│ MOD   30  [###.........] p1  │
+│ ── insert ──     │  · tempo-sync −     ◀fb│ …                            │
+│    WarpFold  FX2 │ —  PLATE, SPRING, DARK │ preview  FX1 FX2 MENU        │
 │ ── stock ──      │                        │ .--------------------------. │
-│  ✓ FILTER FX1+FX2│ ● = in the built image │ | EFFECT 2 SETUP           | │
+│  ✓ FILTER FX1+FX2│ A 74 free · B 5 free   │ | EFFECT 2 SETUP           | │
 └──────────────────┴────────────────────────┴──────────────────────────────┘
 ```
 
@@ -74,9 +74,9 @@ It can sit one past the last row: that position is `(end)`, and there `enter`
 appends instead of swapping. `left`/`right` in LOADED moves a row afterwards,
 and `enter` on an already-selected module removes it.
 
-**Rows are not the currency — words are.** The pane shows the budget
-(`donor region 2410/2724 · 314 free`) once `w` has measured, and this is the
-thing to watch, because:
+**Rows are not the currency — words are.** The pane's one status line shows
+the budget the way the build reports it — **per payload**, `A 74 free · B 5
+free` — and this is the thing to watch, because:
 
 - a **chooser row costs nothing** (seven fit in place, up to 32 in the long
   cave), and
@@ -84,7 +84,17 @@ thing to watch, because:
   whether or not it has a row. **Swapping a stock effect out frees zero
   words.** The swap gesture is about the panel SLOT, not about space.
 
-So the 2,724 words are spent only by modules of ours, and a swap is only
+⚠️ **There are TWO 2,724-word regions, one per payload**, and `SPEC=1` puts
+each server on its own. Summing every module's words against a single region
+is wrong, and the pane used to do it: it read `chongbong`, the *shipping*
+remix, as `5130 words exceeds the 2724-word donor region by 2406` when the
+truth was A 2,650/74 free and B 2,719/5 free. Fixed 2 Sep 2026 by reporting
+the build's own per-payload figures and deleting the reimplemented check
+(`state.problems`). An overrun now arrives as the build's own refusal, which
+names the payload: `payload B: RUNGS overruns the region (3599 > 2724
+words)`.
+
+So the words are spent only by modules of ours, and a swap is only
 1-for-1 in *rows*: Nimbus (500) could equally be Streamz (255) + WarpFold
 (322), or Hello World (27) + Ripple (347). Measured costs, payload A:
 Hello World 27, Streamz 255, WarpFold 322, Ripple 347, BodeShift 391,
@@ -96,9 +106,15 @@ rather than leaving it to the build to refuse:
 
 | after the swap | what happens |
 |---|---|
-| no safe fallback | **SEND is added** — `added Send too (the only safe fallback)`. A row is free, so sacrificing an effect for it would be this UI's invention, not the image's constraint |
-| a buffer clash | `needs the FX2 buffer region — also swap out FLANGER, CHORUS, SPATIALIZER, COMB` |
-| past the donor region (after `w`) | `N words exceeds … ; swap something else out too` |
+| no safe fallback | **SEND is added** — the status line says `added Send as the fallback`. A row is free, so sacrificing an effect for it would be this UI's invention, not the image's constraint |
+| a buffer clash | the ⚠ line reads `also remove FLANGER, CHORUS, SPATIALIZER, COMB` |
+| past a payload's region | the build refuses and names it: `payload B: RUNGS overruns the region (3599 > 2724 words)` |
+
+**The consequence goes on the ⚠ line, not in the status bar.** Appending it
+to "swapped X → Y" produced a run-on the status bar then truncated — and the
+half it cut was the only actionable one. The ⚠ line sits under the rows it
+is about and is re-derived every render rather than being a snapshot of the
+moment one swap happened.
 
 **The buffer clash is the expensive one, and it is why adding ChonVerb to a
 stock chooser costs four effects.** FLANGER, CHORUS, SPATIALIZER and COMB
@@ -130,17 +146,24 @@ row. The real ceiling is cycles ×4 (`PLAN.md` §2).
 The selection, **in chooser order** — the order here *is* the order of rows
 on the panel, so `left`/`right` is a real edit, not a view preference. The
 number column is the panel row; `·` means no chooser row at all (a ColdFire
-patch). `●` means the effect resolves in the image on disk. `◀fb` marks the
-fallback. `w` fills in each module's word cost by running a real assembly.
+patch). `◀fb` marks the fallback. Each module's word cost comes from the real
+assembly the background rebuild runs, so it is always filled in.
 
 **The three reverbs live here.** An unmodified unit shows **fourteen** FX2
 effects, and PLATE, SPRING and DARK REV are three of them — so a stock
 selection lists all fourteen. They leave when something takes their space:
 their code *is* the 2,724-word donor region our modules are written over, so
-adding one drops them in place with the reason (`– PLATE REV taken by
-WarpFold`). That is the trade, shown where it happens rather than as a rule
+adding one drops them to a single dim line, `— PLATE, SPRING, DARK REV
+(donors)`. That is the trade, shown where it happens rather than as a rule
 you have to know. The precedent is CHORUS, which was a donor until v98 and
 got its stock dispatch back the moment the build stopped taking its code.
+
+⚠️ It used to be three lines, one per reverb, each reading `– PLATE REV
+taken by BongDelay +1`. That said one thing three times; it named an
+arbitrary module as the taker (`eats[0]` is just the first selection with DSP
+code — **nothing computes a per-reverb attribution**, and the `+1` was SEND);
+and at 40 columns the ` +1` wrapped onto its own line, so it read as a fourth
+mystery row. Corrected 2 Sep 2026.
 
 ⚠️ A stock selection that keeps all three **cannot be built yet** — a remix
 must name a fallback and no stock effect is a safe one. `PLAN.md` §7 has the
@@ -154,7 +177,14 @@ safe one (it would *process* the unknown id), so the moment you add a module
 you add SEND too. The pane says so.
 
 `l` loads a remix (or `stock`), `s` saves the selection as one, `k` resets to
-stock, `f` picks the fallback explicitly, `b` builds, `c` runs `make check`.
+stock, `f` picks the fallback explicitly, `c` runs `make check`. **There is no
+build key** — see below.
+
+**The pane closes with ONE line**, which is either the per-payload budget, a
+`⚠` naming what to remove, or `building…`. It used to close with five — a
+budget, a `●` legend, a "dim = stock" legend, a keys hint and a `⚠` — which
+was roughly half the pane's height spent explaining constraints rather than
+showing the image. The explanations are in `?`.
 
 ### UNIT — the selected effect
 
@@ -181,25 +211,52 @@ window. `emu_bringup` now re-issues the call when nothing was captured
 (`_call_page`, `_open_menu_window`). Found 2 Sep 2026 by rendering each view
 four times in a row and counting the draws.
 
-⚠️ **The preview is a picture of the IMAGE ON DISK, not of the selection**,
-and it says so. The FX2 page includes the firmware's own chooser list, so a
-freshly launched workbench showing `stock` in LOADED while the preview lists
-`ChonVerb78 / BongDelay78 / Send` is not a bug — it is last week's build. The
-pane warns when the two disagree, and `b` rebuilds.
+**The image follows the selection.** Every selection change rebuilds and
+re-boots on a worker thread after a 0.35 s debounce, so the preview always
+draws what LOADED says. There is no build key and no staleness to reason
+about.
+
+⚠️ This replaced a `stale()` gate that refused to draw when the image on disk
+was not the selection, printing a bold `the image on disk is not this
+selection / b builds it`. The gate's *reasoning* was right — the FX2 page
+includes the firmware's own chooser list, so a stale image puts a different
+set of effects on screen beside LOADED and reads as "why are those loaded?"
+— but **every fresh launch is stale**, so the headline feature opened showing
+a disclaimer, and what it was guarding is a **0.26 s build** plus a 4.6 s
+ColdFire boot, both already on a worker thread (measured 2 Sep 2026). Changed
+the same day: rebuild instead of explaining.
+
+The build is `state.measure()`, which is the same `REMIX=x XBUS=1 SPEC=1
+build_bus.py` that `make bus` runs and which parses the per-module word
+counts out of the build report on the way past — so one call does what the
+old `b` (build) and `w` (word cost) keys did separately. A selection that
+cannot build is not drawn: the `⚠` line says why, and `c` still runs the full
+`make check` with its log.
 
 - **MAIN MENU** is the no-flash gate for ColdFire cave work — a patched-in
   top-level row draws here exactly as the unit would draw it.
 - **FX1** shows that chooser as stock ships it, which is what FX1 rows would
   have to be added to.
 - **FX2** draws the selected effect's page — *unless it is one of ours that
-  has not been built*, in which case it is deliberately not drawn. An id the
+  is not in the image*, in which case it is deliberately not drawn. An id the
   image does not implement resolves to the fallback and the firmware would
   draw a convincing picture of the wrong effect (`CLAUDE.md`, 12 Aug 2026).
-  A **stock** effect always draws: a remix that leaves one out does not
-  remove it — its code, descriptor and dispatch stay stock and an old
-  project that selects it still runs it; it only loses its chooser row.
+  Rare now that the image follows the selection, but kept: it is a real
+  safety property, not a staleness message. A **stock** effect always draws:
+  a remix that leaves one out does not remove it — its code, descriptor and
+  dispatch stay stock and an old project that selects it still runs it; it
+  only loses its chooser row.
 
-The boot (~4 s) is cached and repeats only when the image changes.
+The rebuild is 0.26 s and the boot 4.6 s (measured 2 Sep 2026), both on a
+worker thread; a run of swaps costs one rebuild, not one per keystroke.
+
+⚠️ **An untouched `stock` selection is not previewed, and that is not the
+staleness gate coming back.** It genuinely cannot build: a remix must name a
+fallback for the ids it does not implement, and no stock effect is a safe one
+(it would *process* the unknown id) — `state.load_stock` is explicit that it
+"should not pretend to". So the launch state says `stock — swap a module in
+to build it` rather than `⚠`, because it is where the bench opens, not a
+mistake. One swap resolves it: SEND comes with the first module of ours.
 
 Honest limits (`docs/EMU.md`): no audio and no key matrix in the emulator —
 navigation is poking state and re-calling draw functions. Knob **values**

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -413,12 +413,21 @@ only ever appeared there, because that is the one selection the build
 refuses:
 
 ```
- words A   ....................  2724 free  all of it
- words B   ....................  2724 free  all of it
- FX2 buf A .... .... .... ....  0 pinned of 4  tracks 5-8
+ words A   ....................  2724 free  = the 3 reverbs' code
+ words B   ....................  2724 free  = the 3 reverbs' code
+ FX2 buf A .... .... .... ....  0 pinned of 4  tracks 5-8  +7 stock share
  rows      14 of 31 (the long chooser cave)
  cave      untouched — nothing of ours is placed
 ```
+
+⚠️ **"Free" does not mean empty, and stock is not idle.** The donor region is
+never unoccupied — it holds PLATE + SPRING + DARK's own code, which is
+*why* it is the donor region. `2724 free` means "yours to overwrite", and the
+row says whose code that is. Likewise `0 pinned of 4` is true and would read
+as "nothing is using these": every allocating stock effect in the chooser
+takes a slot **at runtime**, so the row names how many are waiting. What stock
+genuinely does not touch is the **cave** (free space we found) — and it does
+use **rows**, 14 of 31.
 
 ⚠️ **A selection that cannot build reports `not built`, not the last one's
 numbers.** `State.forget_build()` drops them when the selection stops being

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -393,6 +393,18 @@ cave**. Everything else is unbounded in practice. Read from the build's own
 report wherever possible, because the build is the only thing that knows
 where the cursor actually stopped.
 
+⚠️ **The buffer rows count what a MODULE pins, not slots in use.** ChonVerb
+holds all four of its core's, BongDelay two of its core's, Nimbus two of
+whichever core hosts it. A **stock** effect never appears there: it takes a
+slot from the allocator *at runtime*, per instantiated effect per block, which
+no image can reserve — and that runtime contest is exactly what the ledger
+refuses a pinner beside an allocating stock effect for.
+
+The four slots are drawn as four groups so the picture and the number agree.
+They used to read `4 of 4` against an empty bar, which says "all four used"
+and meant the opposite; the bar shows what is **pinned**, the number what is
+**free**, and it now says `4 of 4 free`.
+
 ⚠️ **A selection that cannot build reports `not built`, not the last one's
 numbers.** `State.forget_build()` drops them when the selection stops being
 buildable — a budget that silently belongs to the image you had two edits ago

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -234,15 +234,43 @@ defaults (a stale default polluted every shimmer measurement until Round 12).
 ### What an effect COSTS, while you are choosing
 
 The UNIT pane carries a resource line under the doc, and the status line
-carries the same facts while you scroll: words, payload, whether it pins the
-FX2 buffer region or asks the allocator for a slot, core-private Y words,
-ColdFire caves. `rig.resources()`.
+carries the same facts while you scroll (`rig.resources()`):
+
+```
+ChonVerb   — bus · id 0x07 · 2411 of 2,724 words ·
+             needs the whole FX2 buffer region (blocks 7 stock effects) ·
+             2 core-private Y words · not in the image
+Dark Rev   — stock · id 0x16 · free while your modules stay under 1,657 words ·
+             takes 1 of the 4 FX2 buffer slots · in the image
+```
 
 "Will this fit beside what I already have" is what the library pane is really
-being asked, and every answer used to arrive only as a **refusal after
-adding it**. Everything there is derived where it can be — private Y is
-scanned from the source, caves and hooks counted from the manifest, words
-taken from the build — so it cannot go stale against the module it describes.
+being asked, and every answer used to arrive only as a **refusal after adding
+it**.
+
+**It says the CONSEQUENCE, not the address.** `pins Y:0x4000-0xBFFF` is where
+a buffer lives; what you are deciding is what it costs you, which is the
+seven stock effects it cannot sit beside. The addresses are in `docs/DSP.md`
+§10 and belong there — **the pane carries consequences, the docs carry
+mechanism.**
+
+A donor reverb states the budget you have left before it goes, because that
+is arithmetic rather than a rule: the region is packed from PLATE upward, so
+PLATE goes first and DARK survives while your modules stay under 1,657 words.
+The three figures sum to exactly the 2,724 the build asserts, which is the
+cross-check that keeps them honest.
+
+Everything is derived where it can be — private Y scanned from the source,
+caves and hooks counted from the manifest, the seven counted rather than
+written down (it was four until the reverbs became listable).
+
+⚠️ **Words used to read `build to measure`**, which was both jargon and
+circular: the build only reports what it PLACED, so a module you had not
+added had no number — and the cost is exactly what you want *before* adding
+it. Every module of ours is now assembled once beside SEND (0.19 s each,
+~2 s for all eleven) in a background worker at startup, cached to
+`out/_audition/words.json` against the newest module source, and re-measured
+when you edit one.
 
 ### A / B compares two EFFECTS
 

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -400,10 +400,25 @@ slot from the allocator *at runtime*, per instantiated effect per block, which
 no image can reserve — and that runtime contest is exactly what the ledger
 refuses a pinner beside an allocating stock effect for.
 
-The four slots are drawn as four groups so the picture and the number agree.
-They used to read `4 of 4` against an empty bar, which says "all four used"
-and meant the opposite; the bar shows what is **pinned**, the number what is
-**free**, and it now says `4 of 4 free`.
+The four slots are drawn as four groups so the picture and the number agree,
+and the number says what it counts: `0 pinned of 4`. Two earlier forms were
+worse — `4 of 4` against an empty bar says "all four used" and meant the
+opposite, and `4 of 4 free` still invited "free for *what*?".
+
+⚠️ **A stock chooser reports its real figures, not `????`.** A stock row
+places no code — no clone, no words, its dispatch is already in the image —
+so a selection with no modules of ours uses **zero** of either donor region
+and leaves the cave untouched, and no build is needed to say so. The `????`
+only ever appeared there, because that is the one selection the build
+refuses:
+
+```
+ words A   ....................  2724 free  all of it
+ words B   ....................  2724 free  all of it
+ FX2 buf A .... .... .... ....  0 pinned of 4  tracks 5-8
+ rows      14 of 31 (the long chooser cave)
+ cave      untouched — nothing of ours is placed
+```
 
 ⚠️ **A selection that cannot build reports `not built`, not the last one's
 numbers.** `State.forget_build()` drops them when the selection stops being

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -293,6 +293,33 @@ allocator never hands them anything; FX1 slots go to stock effects only. A
 module with no chooser row at all (a ColdFire patch like tempo-sync) shows
 neither line.
 
+⚠️ **The list of effects a pinner costs you is NOT on the module line**, and
+that is deliberate: it is the same seven for every pinner, so printing it per
+module made ChonVerb and BongDelay show identical lists and read as two bills
+for one debt. It belongs to the **image** — the ledger refuses an allocating
+stock effect beside *any* pinner — so the LOADED pane says it once:
+
+```
+no room for Flanger, Chorus, Spatializer, Comb Filter and the 3 reverbs
+— ChonVerb and BongDelay pin their slots
+```
+
+What genuinely differs per module is which slots, on which core, for which
+tracks:
+
+```
+ChonVerb   FX2  pins all 4 buffer slots on the core serving tracks 5-8
+BongDelay  FX2  pins 2 shared-window buffer slots on the core serving tracks 1-4
+Nimbus     FX2  pins 2 core-private buffer slots on whichever core hosts it
+```
+
+**They are two effects, not one.** ChonVerb serves tracks 5-8 and BongDelay
+tracks 1-4, on different cores, and each ships alone: `verbonly` is ChonVerb
+without the delay, and a delay-only remix builds too (BongDelay lands on
+payload B and its id aliases to SEND on A, so selecting it on tracks 5-8
+makes a send rather than silence). Showing them as one "bus" would hide the
+track range, which is the thing you have to know to use either.
+
 ### It costs the FX2 ROW, not the effect
 
 **FLANGER, CHORUS, SPATIALIZER and COMB are still on FX1, and still work.**

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -59,7 +59,17 @@ knob values belong to the effect rather than to a track.
 
 Everything that *could* be in an image: your modules grouped **server** /
 **insert** / **system**, then the stock effects the unit already ships. `✓`
-marks what the current selection holds; `enter` adds or removes.
+marks what the current selection holds.
+
+**`enter` adds at the LOADED pane's cursor**, not at the end — chooser order
+*is* the panel's row order, so "which slot" is the question, and the status
+line answers it ("added ChonVerb at chooser row 3"). `left`/`right` in LOADED
+moves a row afterwards.
+
+The three stock **reverbs** are listed last under `consumed` and cannot be
+selected: PLATE, SPRING and DARK REV are the 2,724-word donor region every
+module packs into. They are shown rather than omitted because an effect that
+is simply absent reads as a bug.
 
 The `FX1+FX2` column is which **chooser** the effect has a row on, derived
 from the pristine image rather than written down (`stock.fx1_ids()`). Stock
@@ -99,10 +109,18 @@ doc, and its drawn parameters with values — `left`/`right` adjusts,
 `shift` for ×10. **Values live per module**, seeded from the manifest
 defaults (a stale default polluted every shimmer measurement until Round 12).
 
-`r` renders the effect over the selected source and plays it; `space`
-replays. Below that, `p` cycles the **preview**: the firmware's own draw of
-the effect's FX2 page, the MAIN MENU, or the FX1 page, from the built image
-in the Tier-0 ColdFire emulator.
+**`SOURCE` is the first row**: `left`/`right` cycles the wavs in `out/dry/`,
+so choosing what you audition on is one keypress from the knobs. `r` renders
+the effect over it and plays it; `space` replays.
+
+Below that, `p` cycles the **preview**: the firmware's own draw of the
+effect's FX2 page, the MAIN MENU, or the FX1 page.
+
+⚠️ **The preview is a picture of the IMAGE ON DISK, not of the selection**,
+and it says so. The FX2 page includes the firmware's own chooser list, so a
+freshly launched workbench showing `stock` in LOADED while the preview lists
+`ChonVerb78 / BongDelay78 / Send` is not a bug — it is last week's build. The
+pane warns when the two disagree, and `b` rebuilds.
 
 - **MAIN MENU** is the no-flash gate for ColdFire cave work — a patched-in
   top-level row draws here exactly as the unit would draw it.

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -61,13 +61,27 @@ Everything that *could* be in an image: your modules grouped **server** /
 **insert** / **system**, then the stock effects the unit already ships. `✓`
 marks what the current selection holds.
 
-**`enter` adds at the `▸` in the LOADED pane**, not at the end — chooser
-order *is* the panel's row order, so "which slot" is the question, and the
-status line answers it ("added ChonVerb at chooser row 3"). The `▸` is drawn
-from either pane, because an insertion point you can only see while standing
-on it is no help when you are adding from the library. It can sit one past
-the last row — that position is `(end)`, and it is how you append.
-`left`/`right` in LOADED moves a row afterwards.
+**`enter` SWAPS the `▸` row in LOADED for the highlighted module.** Composing
+an image is *trading*, not accumulating: the donor region is 2,724 words and
+the chooser is a list somebody has to scroll, so putting something in
+normally means taking something out — and the new effect takes the old one's
+**slot**, because the row number *is* the panel position. The status line
+says what happened ("swapped FILTER → WarpFold at chooser row 1").
+
+The `▸` is drawn from either pane, because an insertion point you can only
+see while standing on it is no help when you are choosing from the library.
+It can sit one past the last row: that position is `(end)`, and there `enter`
+appends instead of swapping. `left`/`right` in LOADED moves a row afterwards,
+and `enter` on an already-selected module removes it.
+
+**One trade is often not enough**, and the status line names the next one
+rather than leaving it to the build to refuse:
+
+| after the swap | what it says |
+|---|---|
+| the first module of ours, no SEND | `now needs Send — swap another row for it` |
+| past the donor region (after `w`) | `N words exceeds … ; swap something else out too` |
+| a pair the ledger refuses | the ledger's own sentence, naming both |
 
 The three stock **reverbs** are not here — they are in LOADED, because they
 are part of a stock chooser. See below.

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -74,6 +74,23 @@ It can sit one past the last row: that position is `(end)`, and there `enter`
 appends instead of swapping. `left`/`right` in LOADED moves a row afterwards,
 and `enter` on an already-selected module removes it.
 
+**Rows are not the currency — words are.** The pane shows the budget
+(`donor region 2410/2724 · 314 free`) once `w` has measured, and this is the
+thing to watch, because:
+
+- a **chooser row costs nothing** (seven fit in place, up to 32 in the long
+  cave), and
+- a **stock effect costs nothing at all** — its code is already in the image
+  whether or not it has a row. **Swapping a stock effect out frees zero
+  words.** The swap gesture is about the panel SLOT, not about space.
+
+So the 2,724 words are spent only by modules of ours, and a swap is only
+1-for-1 in *rows*: Nimbus (500) could equally be Streamz (255) + WarpFold
+(322), or Hello World (27) + Ripple (347). Measured costs, payload A:
+Hello World 27, Streamz 255, WarpFold 322, Ripple 347, BodeShift 391,
+Nimbus 500, Rungs 880, Send 215, ChonVerb 2,411 (+24 LFO table), BongDelay
+2,469 (payload B).
+
 **One trade is often not enough**, and the status line names the next one
 rather than leaving it to the build to refuse:
 

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -405,12 +405,27 @@ even though it is unoccupied — keeping PLATE alone leaves 2,130 words by size
 and **0 you can actually place**. The figure shown is the placeable one; it
 equals the subtraction for every other combination (checked for all four).
 
-⚠️ **The buffer rows count what a MODULE pins, not slots in use.** ChonVerb
-holds all four of its core's, BongDelay two of its core's, Nimbus two of
-whichever core hosts it. A **stock** effect never appears there: it takes a
-slot from the allocator *at runtime*, per instantiated effect per block, which
-no image can reserve — and that runtime contest is exactly what the ledger
-refuses a pinner beside an allocating stock effect for.
+⚠️ **The FX2 buffer slots are ONE PER TRACK, not a pool.** Each track
+allocates an FX1 slot and then an FX2 slot, so track *k*'s FX2 effect always
+gets table entry `1 + 2k` — `0x4000`, `0x8000`, then the shared-window pair
+(`docs/DSP.md`, "the allocator's instance model"). Nothing is handed out
+first-come.
+
+So a slot is not "a buffer somebody might take", it is **one particular
+track's** buffer, and the row names the tracks still free — those are exactly
+the ones that can host an allocating stock effect:
+
+```
+ FX2 buf A #### #### #### ####  4 of 4  none free
+ FX2 buf B .... .... #### ####  2 of 4  free on 1, 2
+```
+
+With `chongbong`, ChonVerb holds all four of core 0's (tracks 5–8) and
+BongDelay tracks 3–4's on core 1 — so **FLANGER on track 1 or 2 would be
+fine**. The ledger still refuses it, and correctly: the FX2 chooser is one
+list for all eight tracks, so an image cannot say "FLANGER, but only on
+tracks 1–2". The refusal is the image being unable to constrain the operator,
+not a claim that every track collides.
 
 The four slots are drawn as four groups so the picture and the number agree,
 and the number says what it counts: `0 pinned of 4`. Two earlier forms were

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -425,12 +425,17 @@ only ever appeared there, because that is the one selection the build
 refuses:
 
 ```
- words A   ....................  2724 free  = the 3 reverbs' code
- words B   ....................  2724 free  = the 3 reverbs' code
+ words A   --------------------     0 free  drop Plate Rev for 594 more
+ words B   --------------------     0 free  drop Plate Rev for 594 more
  FX2 buf A .... .... .... ....  0 pinned of 4  tracks 5-8  +7 stock share
- rows      14 of 31 (the long chooser cave)
+ rows      17 free of 31 (14 loaded)
  cave      untouched — nothing of ours is placed
 ```
+
+The words row **names the next trade** rather than the state: how far you can
+go before the next reverb dies, or — at zero — what dropping it is worth. Drop
+PLATE from that chooser and the row becomes `594 free · then Spring Rev goes`,
+which is exactly the 594 it promised.
 
 ⚠️ **"Free" does not mean empty, and stock is not idle.** The donor region is
 never unoccupied — it holds PLATE + SPRING + DARK's own code, which is

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -387,6 +387,39 @@ remix already says, and it forced a knob set per track when what an operator
 actually tunes is an effect. An old `_rig.json` on disk is inert and can be
 deleted.
 
+## Colour
+
+Colour carries meaning here; it does not decorate. Three axes, and nothing
+else gets any:
+
+| what | colour | why |
+|---|---|---|
+| **whose it is** | cyan = one of *ours*, plain = the box's own | in a remixer this is what you scan for, and nothing carried it |
+| **state** | green fits · yellow is a trade or a caution · red blocks | the free-word count is coloured by its own answer |
+| **one-of-a-kind** | magenta | `◀fb`, the fallback |
+| **the panel** | blue frame | chrome, so the firmware's own words stay plain |
+
+The free-word thresholds come from what this project actually lives with:
+payload A has shipped at `FREE 4` and B at `FREE 5`, so **double digits is
+already spent** and gets the alarm colour; over 400 is comfortable.
+
+Colours are **ANSI names, not hex** — the workbench runs Textual's
+`ansi-dark`, so it wears your terminal's own sixteen colours and a hex triple
+would fight whatever palette the terminal is set to.
+
+## Editing in another window
+
+**The bench follows the source.** Edit a module's `.asm` or manifest in your
+editor, or build in another terminal, and the image rebuilds and the panel
+re-boots on its own — the status line says `module source changed —
+rebuilding`. Polled, not watched: one stat sweep of `modules/` is **0.7 ms**,
+so a 1.5 s tick costs nothing and a filesystem-event dependency is not worth
+adding to a venv that already carries unicorn and textual.
+
+Audio is **not** re-rendered on a source change — it plays out loud, and
+firing on every save would be intolerable. The image and the panel refresh;
+`r` is one key.
+
 ## Theming
 
 The app renders in the **terminal's own 16-color ANSI palette** (Textual's

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -194,9 +194,42 @@ doc, and its drawn parameters with values — `left`/`right` adjusts,
 `shift` for ×10. **Values live per module**, seeded from the manifest
 defaults (a stale default polluted every shimmer measurement until Round 12).
 
-**`SOURCE` is the first row**: `left`/`right` cycles the wavs in `out/dry/`,
-so choosing what you audition on is one keypress from the knobs. `r` renders
-the effect over it and plays it; `space` replays.
+**`SOURCE` is the first row**: `left`/`right` cycles the wavs in the source
+folder, so choosing what you audition on is one keypress from the knobs. `r`
+renders the effect over it and plays it; `space` replays.
+
+**`d` points the source folder somewhere else** and remembers it in
+`out/_audition/workbench.json`; `WORKBENCH_SOURCES` overrides both. The
+default is `out/dry/`, the curated dry set — a good default, not a permanent
+one, since a bench gets used on whatever material is to hand. A path that is
+not a directory, or holds no wavs, is refused and the old one stands.
+
+⚠️ **Six of the eleven stock effects render DRY at their defaults** —
+PHASER, FLANGER, CHORUS and COMB sit at `MIX 0`, SPATIALIZER and DELAY at
+`SEND 0` — so pressing `r` on one plays the source back unchanged, which
+reads as "this effect does nothing" (it cost a report on 2 Sep 2026). **That
+is faithful and is not fixed by seeding a different value**: stock defaults
+are read from the firmware's own descriptor (`tools/remix/stock.py`), an
+unmodified unit really does start them fully dry, and inventing a value here
+would make the bench lie about the page it draws beside. The UNIT pane says
+`⚠ MIX is 0 — this renders DRY` instead. None of *our* modules default this
+way.
+
+**Stepping knobs**: `left`/`right` is ±1 and **`shift`+`left`/`right` is
+±10**. Holding the key runs; ~280 steps/second is sustainable (below), so
+key repeat is the limit, not the workbench.
+
+⚠️ **Holding an arrow key used to lag, and the cause was the emulated
+panel.** `rerender()` called `render_fx2` on *every* keystroke — 15–96 ms,
+mean 32 (`render_fx1` 16, `render_menu` 8; measured 2 Sep 2026) — plus three
+independent `problems()` calls at 2.4 ms each. Under key repeat the work per
+key exceeded the repeat interval, so the UI fell behind the held key and kept
+stepping after release; single presses always felt fine, which is why it
+presented as "slow when holding" rather than as latency. **Nothing a keystroke
+does can change that picture** — knob *values* draw as dial graphics the
+string-capture hook cannot read — so the panel is now cached on (page,
+effect id, build) and `problems()` is computed once per pass. Measured
+A/B: **18.1 ms → 3.6 ms per step, 55/s → 281/s.**
 
 Below that, `p` cycles the **preview** in the unit's own order — `FX1`,
 `FX2`, then `MENU` — showing the firmware's own draw of that page.
@@ -374,7 +407,8 @@ through `rich.markup.escape`.
 - DELAY (stock) has no local render (ColdFire-side); LO-FI renders at
   +6 dB at zero settings (unexplained).
 - A/B marks attach only to the most recent render (no history cursor).
-- No browse-anywhere source picker (one fixed directory, `out/dry/`).
+- The source picker takes one directory at a time (`d`), not a tree —
+  no recursion into subfolders and no in-TUI file browser.
 - Wet-only rendering is ChonVerb-only.
 - The emulator limits listed above (values, key injection, delay page
   under SPEC).

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -114,7 +114,17 @@ rather than leaving it to the build to refuse:
 | a buffer clash | the ⚠ line reads `x removes Flanger, Chorus, Spatializer, Comb Filter — they need the same buffer`, and **`x` does it** |
 | past a payload's region | the build refuses and names it: `payload B: RUNGS overruns the region (3599 > 2724 words)` |
 
-**The ⚠ offers its own fix.** `x` applies whatever it just advised.
+**The ⚠ offers its own fix.** `x` applies whatever it just advised — and it
+names **every** row that has to go, not the first. The build used to `exit`
+on the first offending donor row, so clearing a selection meant iterating:
+remove PLATE, rebuild, fail on SPRING, remove that, rebuild. It knows all of
+them the moment it knows the cursor, and the one-key fix can only remove what
+the build named.
+
+⚠️ The ⚠ describes the **image**, not the cursor, so it does not change as
+you scroll. That is deliberate — it is the state of what you are composing —
+but it means a warning naming an effect you have scrolled away from is still
+current.
 
 It names the **cause and the count**, not the list: `Nimbus pins the buffer 7
 stock effects allocate — x removes them`. Naming all seven took four wrapped
@@ -388,6 +398,15 @@ numbers.** `State.forget_build()` drops them when the selection stops being
 buildable — a budget that silently belongs to the image you had two edits ago
 is worse than no budget at all. Rows are countable without a build, so they
 are still shown; the cave and the words are not.
+
+⚠️ **A build that FAILS still reports what it got to.** `measure()` used to
+return the moment the return code was non-zero, so every build-derived number
+kept the last *successful* build's value — a failed selection showed the
+budget of an image it was not. It parses the report first now, and a failure
+is usually still informative: a chooser-row refusal happens *after* the
+region line is printed, so `726 used, 1998 free` is exactly the fact that
+tells you the failure is not about space. Only the payload the build reached
+is shown.
 
 The pane dividers run the **full height** of the screen: a `Static` is only as
 tall as its text, so they used to stop wherever the shortest column ran out.

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -231,6 +231,19 @@ doc, and its drawn parameters with values — `left`/`right` adjusts,
 `shift` for ×10. **Values live per module**, seeded from the manifest
 defaults (a stale default polluted every shimmer measurement until Round 12).
 
+### What an effect COSTS, while you are choosing
+
+The UNIT pane carries a resource line under the doc, and the status line
+carries the same facts while you scroll: words, payload, whether it pins the
+FX2 buffer region or asks the allocator for a slot, core-private Y words,
+ColdFire caves. `rig.resources()`.
+
+"Will this fit beside what I already have" is what the library pane is really
+being asked, and every answer used to arrive only as a **refusal after
+adding it**. Everything there is derived where it can be — private Y is
+scanned from the source, caves and hooks counted from the manifest, words
+taken from the build — so it cannot go stale against the module it describes.
+
 ### A / B compares two EFFECTS
 
 Not "two renders ago against now", which is what the marks used to hold. `r`

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -160,13 +160,37 @@ faults here, not on the unit.
 | key | action |
 |---|---|
 | `m` | main menu (`up/down` moves the cursor) |
-| `f` | FX2 SETUP — follows the rig's selected track and its assigned effect |
+| `f` | FX2 SETUP — `left/right` cycles effects, the rig follows |
 | `o` | FX1 SETUP (stock effects; `left/right` cycles the id) |
 | `p` | PLAYBACK page (`left/right` cycles FLEX/STATIC/THRU/NEIGHBOR) |
+| `a` | stage the cycled-to effect in the composer (FX2 view) |
+| `b` | build the composer's live selection and re-boot |
 | `1`–`8` | change track |
 
 The boot (~4 s) is cached at app level and repeats only when the image's
 mtime changes.
+
+**The FX2 view closes the loop.** `left/right` cycles two groups: the rows
+the built image actually offers (read from the image on disk, in the panel's
+own order — `rig.built_chooser()`), then every other module that *could*
+have a row, marked as not built.
+
+- Landing on a **built** row draws the firmware's own EFFECT 2 SETUP and
+  **assigns it to the track** — the rig and this view are one selection, not
+  two. Where the rig cannot hold it the view says what the *unit* would do
+  instead: a server picked on the wrong core's tracks aliases to the
+  fallback and the track becomes a send; SEND is plumbing the chooser lists
+  and the rig does not hold.
+- Landing on a **pending** row is deliberately **not drawn**. An id the
+  image does not implement resolves to the fallback, and the firmware would
+  draw a convincing picture of the wrong effect — the 12 Aug 2026 trap in
+  panel form. `a` stages it in the composer, `b` builds and re-boots.
+  Cycling past several unbuilt effects costs nothing; only `b` builds.
+
+Changing track **follows** that track's assignment and never writes: an
+empty track would otherwise silently inherit whatever row was showing. The
+cursor also stays on the same *effect* across a rebuild, so staging one and
+pressing `b` leaves you looking at it, now built.
 
 Honest limits (all recorded in `docs/EMU.md`): no audio, no key matrix —
 navigation is done by poking state and re-calling draw functions. Knob

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -113,8 +113,18 @@ defaults (a stale default polluted every shimmer measurement until Round 12).
 so choosing what you audition on is one keypress from the knobs. `r` renders
 the effect over it and plays it; `space` replays.
 
-Below that, `p` cycles the **preview**: the firmware's own draw of the
-effect's FX2 page, the MAIN MENU, or the FX1 page.
+Below that, `p` cycles the **preview** in the unit's own order — `FX1`,
+`FX2`, then `MENU` — showing the firmware's own draw of that page.
+
+⚠️ **The FX and MENU page entry points TOGGLE**: calling one opens the page,
+calling it again closes it, so consecutive renders used to alternate between
+a full screen and an empty one (26 draws, 0, 26, 0). A workbench that
+re-renders on every keystroke therefore showed a blank LCD about half the
+time, and the MAIN MENU never drew at all — FX2 is the default view, so the
+menu render was always the second call and an FX page had already taken the
+window. `emu_bringup` now re-issues the call when nothing was captured
+(`_call_page`, `_open_menu_window`). Found 2 Sep 2026 by rendering each view
+four times in a row and counting the draws.
 
 ⚠️ **The preview is a picture of the IMAGE ON DISK, not of the selection**,
 and it says so. The FX2 page includes the firmware's own chooser list, so a

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -61,18 +61,22 @@ Everything that *could* be in an image: your modules grouped **server** /
 **insert** / **system**, then the stock effects the unit already ships. `✓`
 marks what the current selection holds.
 
-**`enter` SWAPS the `▸` row in LOADED for the highlighted module.** Composing
-an image is *trading*, not accumulating: the donor region is 2,724 words and
-the chooser is a list somebody has to scroll, so putting something in
-normally means taking something out — and the new effect takes the old one's
-**slot**, because the row number *is* the panel position. The status line
-says what happened ("swapped FILTER → WarpFold at chooser row 1").
+**`enter` ADDS the highlighted module to the image.** It displaces nothing.
+`left`/`right` in LOADED moves a row afterwards; `enter` in LOADED removes
+the row you are on. The library only ever adds — `enter` on something already
+in the image just points at its row.
 
-The `▸` is drawn from either pane, because an insertion point you can only
-see while standing on it is no help when you are choosing from the library.
-It can sit one past the last row: that position is `(end)`, and there `enter`
-appends instead of swapping. `left`/`right` in LOADED moves a row afterwards,
-and `enter` on an already-selected module removes it.
+⚠️ **`enter` used to SWAP** (2 Sep 2026, reverted the same day): the module
+took the highlighted row's slot and that row was dropped, with a `▸` caret
+marking where it would land. The stated justification was "an image is a
+fixed budget, so putting something in means taking something out" — which is
+**the ledger's scarcity applied to the operator's gesture, where it does not
+belong**. Rows are not the scarce thing: the long-list cave holds **31** of
+them (`build_bus.py` LONG_LIST), and a **stock row costs zero words** — no
+code placed, no descriptor cloned. Only *words* are scarce, and only for
+modules of ours. Two things went wrong in practice: a chongbong user pressed
+`enter` on a server and lost the other one (the caret had moved onto it), and
+the caret itself was a second cursor in a pane you were not standing in.
 
 **Rows are not the currency — words are.** The pane's one status line shows
 the budget the way the build reports it — **per payload**, `A 74 free · B 5
@@ -104,11 +108,15 @@ Nimbus 500, Rungs 880, Send 215, ChonVerb 2,411 (+24 LFO table), BongDelay
 **One trade is often not enough**, and the status line names the next one
 rather than leaving it to the build to refuse:
 
-| after the swap | what happens |
+| after you add | what happens |
 |---|---|
 | no safe fallback | **SEND is added** — the status line says `added Send as the fallback`. A row is free, so sacrificing an effect for it would be this UI's invention, not the image's constraint |
-| a buffer clash | the ⚠ line reads `also remove FLANGER, CHORUS, SPATIALIZER, COMB` |
+| a buffer clash | the ⚠ line reads `x removes Flanger, Chorus, Spatializer, Comb Filter — they need the same buffer`, and **`x` does it** |
 | past a payload's region | the build refuses and names it: `payload B: RUNGS overruns the region (3599 > 2724 words)` |
+
+**The ⚠ offers its own fix.** Naming the four effects that have to go was
+already better than four walls of text, but it still handed you a chore —
+find four rows, remove each. `x` applies whatever the ⚠ just advised.
 
 **The consequence goes on the ⚠ line, not in the status bar.** Appending it
 to "swapped X → Y" produced a run-on the status bar then truncated — and the
@@ -193,6 +201,16 @@ before you add it. Shows its kind, id, menus and track range, its one-line
 doc, and its drawn parameters with values — `left`/`right` adjusts,
 `shift` for ×10. **Values live per module**, seeded from the manifest
 defaults (a stale default polluted every shimmer measurement until Round 12).
+
+### A / B compares two EFFECTS
+
+Not "two renders ago against now", which is what the marks used to hold. `r`
+hears the effect the cursor is on, `a` parks it as A, then point at the rival
+and `b` — which **re-renders it on the same source** — and `,` / `.` flip
+between them. That is the question a remixer exists to answer: *is mine
+better than the one the box came with?* It is also exactly the question an
+upgraded stock effect asks, which is why the pair is two effects rather than
+two accidents of history.
 
 **`SOURCE` is the first row**: `left`/`right` cycles the wavs in the source
 folder, so choosing what you audition on is one keypress from the knobs. `r`

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -387,11 +387,23 @@ Budget
  cave      2,202 B free
 ```
 
-Four scarce things and only four: the **two donor regions** (one per payload),
-the **FX2 buffer slots** per core, the **chooser rows**, and the **ColdFire
-cave**. Everything else is unbounded in practice. Read from the build's own
-report wherever possible, because the build is the only thing that knows
-where the cursor actually stopped.
+**Every row is: what exists, minus what this selection loaded.** Nothing is a
+constant and nothing is a leftover from an earlier build. Four scarce things
+and only four — the **two donor regions** (one per payload), the **FX2 buffer
+slots** per core, the **chooser rows**, and the **ColdFire cave**. Everything
+else is unbounded in practice.
+
+⚠️ **A listed reverb is LOADED.** The build reports the whole 2,724 as free
+because nothing of *ours* is placed yet — but PLATE, SPRING and DARK REV's
+code is what occupies the region, so a reverb you keep in the chooser is
+spending its own words. A stock chooser holding all three therefore has **0
+free**, not 2,724, and the row names the one you would lose first.
+
+⚠️ **One place the plain subtraction is too generous.** The region packs from
+PLATE upward, so holding a *low* reverb makes the space above it unreachable
+even though it is unoccupied — keeping PLATE alone leaves 2,130 words by size
+and **0 you can actually place**. The figure shown is the placeable one; it
+equals the subtraction for every other combination (checked for all four).
 
 ⚠️ **The buffer rows count what a MODULE pins, not slots in use.** ChonVerb
 holds all four of its core's, BongDelay two of its core's, Nimbus two of

--- a/docs/WORKBENCH.md
+++ b/docs/WORKBENCH.md
@@ -360,6 +360,38 @@ it. Every module of ours is now assembled once beside SEND (0.19 s each,
 `out/_audition/words.json` against the newest module source, and re-measured
 when you edit one.
 
+### The budget, standing under the effect
+
+The third column is two stacked panes: the selected effect, and **what is left
+of the image** under it. Every other number is read against this one — "500
+words" means nothing without "and 313 are free" — and it used to be something
+you inferred from a refusal.
+
+```
+Budget
+ words A   ###################.    74 free
+ words B   ####################     5 free
+ FX2 buf A ####################  0 of 4  tracks 5-8
+ FX2 buf B ##########..........  2 of 4  tracks 1-4
+ rows      10 of 31 (the long chooser cave)
+ cave      2,202 B free
+```
+
+Four scarce things and only four: the **two donor regions** (one per payload),
+the **FX2 buffer slots** per core, the **chooser rows**, and the **ColdFire
+cave**. Everything else is unbounded in practice. Read from the build's own
+report wherever possible, because the build is the only thing that knows
+where the cursor actually stopped.
+
+⚠️ **A selection that cannot build reports `not built`, not the last one's
+numbers.** `State.forget_build()` drops them when the selection stops being
+buildable — a budget that silently belongs to the image you had two edits ago
+is worse than no budget at all. Rows are countable without a build, so they
+are still shown; the cave and the words are not.
+
+The pane dividers run the **full height** of the screen: a `Static` is only as
+tall as its text, so they used to stop wherever the shortest column ran out.
+
 ### A / B compares two EFFECTS
 
 Not "two renders ago against now", which is what the marks used to hold. `r`

--- a/modules/bongdelay/manifest.py
+++ b/modules/bongdelay/manifest.py
@@ -64,12 +64,17 @@ MODULE = Module(
         # TAPE was retired 18 Aug 2026 (its wow/flutter became the global
         # DPTH/RATE knobs, so TAPE was CLEAN with the knobs up) and its slot
         # was KEPT rather than closed up, because a part stores the raw value:
-        # renumbering would turn every saved GRAIN (3) into REVERSE. It is
-        # labelled for what it DOES, not for what it was -- "(tape)" read as
-        # a mode that exists, and on the unit it draws as a bare "3" today
-        # with nothing to say otherwise (PLAN §6 is the fix).
+        # renumbering would turn every saved GRAIN (3) into REVERSE.
+        #
+        # It is labelled CLEAN, plainly, because that is what it RUNS. Two
+        # earlier labels were both worse: "(tape)" named a mode that does not
+        # exist, and "(CLEAN)" carried an editorial aside in a field that can
+        # only hold a value's NAME -- the parentheses read as a defect rather
+        # than as a footnote. Since PLAN §6 the unit prints these words too,
+        # so the list reads CLEAN PITCH CLEAN GRAIN REVRS: two positions that
+        # do the same thing, which is the truth and needs no explaining.
         Param(b"MODE", 0, 5, active=True, formatter=_STEP,
-              labels=("CLEAN", "PITCH", "(CLEAN)", "GRAIN", "REVRS"),
+              labels=("CLEAN", "PITCH", "CLEAN", "GRAIN", "REVRS"),
               doc="engine select; 2 is the retired TAPE slot and runs CLEAN "
                   "(kept: parts store raw)"),
         # RATE 64 IS LOAD-BEARING: exactly 1x, the pre-knob modulation speed.

--- a/modules/bongdelay/manifest.py
+++ b/modules/bongdelay/manifest.py
@@ -70,8 +70,8 @@ MODULE = Module(
         # with nothing to say otherwise (PLAN §6 is the fix).
         Param(b"MODE", 0, 5, active=True, formatter=_STEP,
               labels=("CLEAN", "PITCH", "(CLEAN)", "GRAIN", "REVRS"),
-              doc="engine select; 2 is the retired TAPE slot, kept so stored "
-                  "TAPE parts still play, and it runs CLEAN"),
+              doc="engine select; 2 is the retired TAPE slot and runs CLEAN "
+                  "(kept: parts store raw)"),
         # RATE 64 IS LOAD-BEARING: exactly 1x, the pre-knob modulation speed.
         # The DPTH=0 bypass gate only holds with the law exact here.
         Param(b"RATE", 64, 128, active=True, formatter=_PLAIN,

--- a/modules/bongdelay/manifest.py
+++ b/modules/bongdelay/manifest.py
@@ -103,7 +103,7 @@ MODULE = Module(
                                           # the algorithm still being designed
         # Payload B -> the core serving TRACKS 1-4 (the 10 Aug 2026 track/core
         # inversion). The build's SPEC table still hardcodes this pairing;
-        # here it is stated so the workbench can derive the track range.
+        # here it is stated so the remixer can derive the track range.
         payloads=frozenset({"B"}),
         bus_role=BusRole.SERVER,
         ybase=YBase.ALWAYS,               # its 32K of lines live at the base

--- a/modules/bongdelay/manifest.py
+++ b/modules/bongdelay/manifest.py
@@ -60,9 +60,18 @@ MODULE = Module(
         Param(b"DPTH", 48, 128, active=True, formatter=_PLAIN,
               doc="tape wow depth; 0 = none - GRAIN: density, full dial, "
                   "level-flat (R61)"),
+        # ⚠️ Position 2 is DEAD ON PURPOSE, and the numbering is load-bearing.
+        # TAPE was retired 18 Aug 2026 (its wow/flutter became the global
+        # DPTH/RATE knobs, so TAPE was CLEAN with the knobs up) and its slot
+        # was KEPT rather than closed up, because a part stores the raw value:
+        # renumbering would turn every saved GRAIN (3) into REVERSE. It is
+        # labelled for what it DOES, not for what it was -- "(tape)" read as
+        # a mode that exists, and on the unit it draws as a bare "3" today
+        # with nothing to say otherwise (PLAN §6 is the fix).
         Param(b"MODE", 0, 5, active=True, formatter=_STEP,
-              labels=("CLEAN", "PITCH", "(tape)", "GRAIN", "REVRS"),
-              doc="engine select; 2 is the retired TAPE slot and runs CLEAN"),
+              labels=("CLEAN", "PITCH", "(CLEAN)", "GRAIN", "REVRS"),
+              doc="engine select; 2 is the retired TAPE slot, kept so stored "
+                  "TAPE parts still play, and it runs CLEAN"),
         # RATE 64 IS LOAD-BEARING: exactly 1x, the pre-knob modulation speed.
         # The DPTH=0 bypass gate only holds with the law exact here.
         Param(b"RATE", 64, 128, active=True, formatter=_PLAIN,

--- a/modules/chonverb/manifest.py
+++ b/modules/chonverb/manifest.py
@@ -80,7 +80,7 @@ MODULE = Module(
         priority=1,                       # after SEND, before the delay
         # Payload A -> the core serving TRACKS 5-8 (the docstring's measured
         # inversion). The build's SPEC table still hardcodes this pairing;
-        # here it is stated so the workbench can derive the track range.
+        # here it is stated so the remixer can derive the track range.
         payloads=frozenset({"A"}),
         bus_role=BusRole.SERVER,
         # Eight occurrences: the relocated tank buffers at 0x30000/0x34000.

--- a/modules/nimbuslite/manifest.py
+++ b/modules/nimbuslite/manifest.py
@@ -1,0 +1,86 @@
+"""Nimbus -- a Mutable-Instruments-Clouds-flavoured granular texture insert.
+
+A per-track INSERT with a real buffer: the track's audio records continuously
+into a 32,768-word mono line (743 ms) and four unity-rate grains read it back
+-- two per channel at half-period offsets, so each channel's triangle windows
+sum to constant power. POS reaches back into the buffer, SIZE picks the grain
+length (23/46/93/186 ms), DENS scatters each grain's start by up to ~92 ms of
+per-grain randomness (latched at the grain's own wrap, the trap GRAIN taught
+us about), and FRZE stops the write head so the last 743 ms becomes a frozen
+cloud to graze.
+
+⚠️ ONE NIMBUS PER CORE. The buffer is the fixed core-private FX2-instance
+region Y:0x4000-0xBFFF -- the same ground ChonVerb's tank uses in chongbong.
+Safe in an insert remix because every module there is zero-Y-footprint
+(exactly the argument BUS.md made for the hardcoded-base server), but two
+Nimbus instances on one core would share one buffer, and a legacy project
+putting a buffer-writing stock FX2 on the same core carries the same caveat
+PLAN.md records for the servers.
+
+MIX=0 is an exact passthrough (during warm-up the effect outputs pure dry).
+"""
+
+from remix.schema import (BusRole, Claims, DspSection, Formatter, Harness,
+                          Kind, MenuEntry, Module, Param, YBase)
+
+_PLAIN = Formatter.PLAIN
+_STEP = Formatter.STEPPED
+
+MODULE = Module(
+    name="nimbuslite",
+    key="NIMBUS LITE",
+    kind=Kind.DSP_EFFECT,
+    doc="Nimbus on one allocator buffer: 371 ms, 4 grains, freeze.",
+    menu=MenuEntry(
+        fx2_id=0x1d,
+        # ⚠️ was 0x0c/0x0d until 2 Sep 2026: STOCK ids (EQUALIZER /
+        # DJ EQ). The dispatch tables are shared with FX1, so the old
+        # id hijacked that effect on both menus. schema.STOCK_FX2_IDS
+        # now rejects it at construction.
+        donor_desc=0x400d58b8,        # DARK REV, the standing donor
+        abbr=b"NMBL",
+        fullname=b"NimbusLite",
+        build_tag=True,
+    ),
+    params=(
+        # ---- page 1 -------------------------------------------------------
+        Param(b"POS", 30, active=True, formatter=_PLAIN,
+              doc="how far back into the 743 ms buffer the grains read"),
+        Param(b"SIZE", 70, active=True, formatter=_PLAIN,
+              doc="grain length, 23/46/93/186 ms"),
+        Param(b"DENS", 40, active=True, formatter=_PLAIN,
+              doc="per-grain start scatter, up to ~92 ms -- 0 is coherent, high is cloud"),
+        Param(b"MIX", 100, active=True, formatter=_PLAIN,
+              doc="dry/wet; 0 = exact passthrough"),
+        Param(), Param(),
+        # ---- page 2 -------------------------------------------------------
+        Param(),
+        Param(b"FRZE", 0, 2, active=True, formatter=_STEP,
+              labels=("RUN", "HOLD"),
+              doc="stop the write head -- the last 743 ms becomes a frozen cloud"),
+        Param(), Param(), Param(), Param(),
+    ),
+    dsp=DspSection(
+        asm="modules/nimbuslite/nimbus_lite.asm",
+        priority=9,                   # after rungs
+        bus_role=BusRole.NONE,
+        ybase=YBase.NEVER,            # the buffer is core-private Y, no $30000
+        r7_latch_slot=None,
+        gate_label=None,
+    ),
+    # ⚠️ NO owns_fx2_buffers, and that is the whole point of this variant.
+    # Nimbus pins Y:0x4000-0xBFFF -- both core-private FX2 slots, every
+    # buffer the allocator has to hand out -- so the ledger refuses it beside
+    # the seven stock effects that need one. This ASKS the allocator for one
+    # 16,384-word slot at init (docs/DSP.md section 10) exactly as those
+    # stock effects do, so they coexist and two instances get two slots.
+    #
+    # It still cannot sit beside a module with FIXED buffers there (ChonVerb,
+    # Nimbus): two of the allocator's four FX2 bases are 0x30000/0x34000, in
+    # payload A's half of the shared window, which is where ChonVerb's
+    # relocated tank and the bus scratch live. stock_instance_buffer is the
+    # claim that says "I take an allocator slot", and the ledger already
+    # refuses that pairing.
+    claims=Claims(stock_instance_buffer=True),
+    harness=Harness(layout_char="Q", is_server=False),
+)

--- a/modules/nimbuslite/nimbus_lite.asm
+++ b/modules/nimbuslite/nimbus_lite.asm
@@ -1,0 +1,489 @@
+; ---------------------------------------------------------------------------
+; Nimbus Lite -- Nimbus's granular texture on ONE allocator buffer.
+;
+; Same insert contract as the other outsider modules (r0 frames in place,
+; knobs from r6, state in this instance's r7 block) -- plus, uniquely, a
+; real BUFFER: the mono input sum records continuously into ONE 16,384-word
+; FX2 instance slot (371 ms @44.1k) taken from the host's bump allocator, and
+; four unity-rate grains read it back.
+;
+; WHY IT EXISTS. Nimbus pins Y:0x4000..0xBFFF -- BOTH core-private FX2 slots,
+; every buffer the allocator has to give -- so the ledger refuses it beside
+; any stock effect that needs one, which today is seven of them. Half the
+; ring, asked for rather than seized, buys all seven back and lets two
+; instances run at once. What it costs is texture: 371 ms of material to
+; scatter grains through instead of 743.
+;
+; ---- structure ------------------------------------------------------------
+; * Grain g's phase is (age + g*G/4) & (G-1): ONE age serves all four (the
+;   GRAIN architecture), so a single advance moves the cloud, and the count
+;   is EVEN -- odd grain counts ripple at the grain rate (BongDelay, 12 Aug).
+;   Grains 0/2 sum to L, 1/3 to R: per channel two triangle windows at a
+;   half-period offset, which sum to constant power by construction.
+; * A grain reads W - (POSbase + s_g + G - phase): it plays FORWARD at unity
+;   rate relative to the moving write head, always at least POSbase+s_g+1
+;   behind it, so no head ever reads ahead of the write.
+; * s_g is a per-grain scatter LATCHED AT THAT GRAIN'S OWN WRAP from the
+;   xorshift PRNG (23-bit, shifts 15/15/8 -- BongDelay's, verbatim, with its
+;   A2-clean dances). The latch is a branch over two moves, so no Tcc shares
+;   condition codes with anything (the GRAIN 5d trap).
+; * FRZE=1 stops the write head (write AND advance): the last 743 ms becomes
+;   a static cloud, and every read stays behind the frozen W by construction.
+; * WARM-UP, ChonVerb's tagged-counter idiom (tag $2d0000|count at r7+$31,
+;   a garbage tag restarts at zero): the first 256 blocks clear 128 words
+;   each -- the whole buffer -- zero the states, seed the PRNG, and leave the
+;   frames untouched (pure dry out). Boot garbage is never played.
+;
+; ---- knobs ----------------------------------------------------------------
+;   p0 POS   read-back distance base = 1024 + POS*120 (23..370 ms behind W)
+;   p1 SIZE  grain length, power of two: <32: 1024  <64: 2048  <96: 4096
+;            else 8192 samples (23/46/93/186 ms). Power-of-two G is what
+;            makes every wrap a mask and the window gain one multiply.
+;   p2 DENS  scatter depth: each grain's latched start offset is
+;            prng * DENS, up to ~4064 samples (92 ms)
+;   p3 MIX   out = dry + MIX*(wet - dry); MIX=0 is an exact passthrough
+;   p7 FRZE  0 recording, 1 FROZEN (slot-7 companion, ChonVerb's decode)
+;
+; ---- r7 slots -------------------------------------------------------------
+;   $20 m        $21 scat depth Q23   $22 POSbase    $23 G-1 mask
+;   $24 G/4      $26 2^(23-k) window multiplier ($25 unused)
+;   $27 FRZE     $28 write head W (PERSISTENT, masked on load AND save)
+;   $29 age      (PERSISTENT, masked by G-1 every sample)
+;   $2a..$2d latched scatter s_0..s_3 (PERSISTENT, integers 0..4064)
+;   $2e PRNG state (PERSISTENT)       $2f wet L    $30 wet R (per sample)
+;   $31 warm tag|count (PERSISTENT)   $32 mono in  $33 scatter candidate
+;   $34 warm count stash (per call)
+;
+; ---- the window is one multiply, and a NEW TRAP: a0 IS NOT a1/2^24 -------
+; phase is a small positive INTEGER (0..G-1, G = 2^k). Multiplying it by
+; 2^(23-k) and reading the accumulator's LOW word gives a ramp that reaches
+; bit 23 exactly at phase = G/2; read back as a SIGNED 24-bit word (move
+; a0,x0 / move x0,a sign-extends, so A2 is clean) that is 0 -> +1 over the
+; first half and -1 -> 0 over the second, and `abs` folds it into a TRIANGLE
+; peaking at G/2. One multiply, one abs, no per-size shift chain.
+;
+; ⚠️ THE MULTIPLIER IS 2^(23-k) AND NOT 2^(24-k), because **a0 EXPOSES THE
+; FRACTIONAL LEFT SHIFT THAT a1 HIDES**. `mpy` aligns the Q46 product into
+; Q47, so reading a1 gives the plain fractional product -- which is why the
+; project's standing note that "mpy does not double here" is true and stays
+; true for every other module, all of which read a1. Reading a0 sees the RAW
+; 48-bit content, shift included, so the effective integer scale is 2x the
+; multiplier. Getting this wrong is invisible: 2^(24-k) assembles, renders,
+; and makes a plausible granular noise -- it just runs the window at DOUBLE
+; RATE, so the two grains of a pair land in phase instead of interleaving.
+; MEASURED, 29 Aug 2026: DC in came back with 2x-DC ripple on a DC mean
+; (the double-rate signature) and went flat when the multiplier was halved.
+; The DC gate is what pins this: two triangles a half period apart sum to
+; EXACTLY 1, so DC in must come back flat and unrippled.
+;
+; Every mpy is `mpy x0,y1` (known-signed); audited by disassembly.
+;
+; ; CYCLES_FORWARD_BRANCHES -- the five conditional branches in the sample
+; loop (the freeze gate and the four per-grain scatter latches) are all
+; FORWARD skips, so tools/cycle_count.py may price the fall-through path and
+; call the result a ceiling. It enforces the forward part rather than taking
+; this word for it.
+; ---------------------------------------------------------------------------
+
+init:
+; ---- THE DIFFERENCE FROM NIMBUS ------------------------------------------
+; Nimbus hardcodes Y:0x4000 and owns the whole 32,768-word FX2 buffer region,
+; which is why it cannot sit beside anything else that wants one. This reads
+; the host's own bump allocator instead and takes ONE 16,384-word slot, like
+; every stock effect that needs a buffer -- so it coexists with them, and two
+; instances get two slots instead of writing over each other.
+;
+; ⚠️ READ IT IN INIT AND CARRY IT (docs/DSP.md section 10). The dispatcher
+; advances the pointer once per effect, so reading it in `proc` gives two
+; loaded effects the SAME entry and one of them writes through memory it does
+; not own -- and with one effect loaded it works BY LUCK, which is the worst
+; shape a defect can have.
+        move    x:>$213,r4
+        move    x:(r4),x0
+        move    x0,x:(r7+$35)           ; this instance's buffer base
+        rts
+
+proc:
+        move    #>$ffffff,m1
+        move    #>$ffffff,m2
+
+; ---- warm-up: ChonVerb's tagged counter, buffer-sized ---------------------
+        move    x:(r7+$31),a
+        move    #>$fffe00,x0
+        and     x0,a                    ; tag field -- AND cleans A1 only
+        move    a1,x0
+        move    x0,a                    ; A2-clean before the compare
+        move    #>$2d0000,x0
+        cmp     x0,a
+        beq     nl_wtag
+        clr     a                       ; garbage tag: warm-up starts at 0
+        bra     nl_wrun
+nl_wtag:
+        move    x:(r7+$31),a
+        move    #>$1ff,x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a                    ; the count, A2-clean
+        move    #>$80,x0                ; 128 blocks x 128 words = 16,384
+        cmp     x0,a
+        bge     nl_wdone                ; warmed: run the grains
+nl_wrun:
+        move    a,x:(r7+$34)            ; count, for the save below
+        asl     #$7,a,a                 ; count*128: 128 blocks x 128 = 16,384
+        move    x:(r7+$35),x0
+        add     x0,a                    ; = the whole buffer
+        move    a,r1
+        clr     b
+        do      #128,>nl_wz
+        move    b,y:(r1)+
+nl_wz:
+        nop
+        move    b,x:(r7+$28)            ; W = 0
+        move    b,x:(r7+$29)            ; age = 0
+        move    b,x:(r7+$2a)            ; scatters = 0
+        move    b,x:(r7+$2b)
+        move    b,x:(r7+$2c)
+        move    b,x:(r7+$2d)
+        move    #>$345678,a             ; PRNG seed: any nonzero word
+        move    a,x:(r7+$2e)
+        move    x:(r7+$34),a
+        add     #>$1,a
+        add     #>$2d0000,a             ; tag | count+1
+        move    a,x:(r7+$31)
+        rts                             ; frames untouched: pure dry out
+nl_wdone:
+
+; ---- per-block knob decode ------------------------------------------------
+        move    x:(r6+$3),x0            ; m = MIX
+        move    x0,x:(r7+$20)
+        move    x:(r6+$2),x0            ; scat depth, straight Q23
+        move    x0,x:(r7+$21)
+; POSbase = 1024 + POS*120  (val*128 - val*8)
+        move    x:(r6+$0),a
+        asr     #$10,a,a                ; the integer knob value 0..127
+        move    a,b
+        asl     #$7,a,a                 ; val*128
+        asl     #$3,b,b                 ; val*8
+        sub     b,a
+        add     #>$400,a
+        move    a,x:(r7+$22)
+; SIZE -> G family: the wrap mask, G/4 (the grain-to-grain offset)
+; and the window multiplier 2^(23-k)
+        move    x:(r6+$1),a
+        asr     #$10,a,a
+        move    #>$20,x0
+        cmp     x0,a
+        blt     nl_s10
+        move    #>$40,x0
+        cmp     x0,a
+        blt     nl_s11
+        move    #>$60,x0
+        cmp     x0,a
+        blt     nl_s12
+        move    #>$1fff,x0              ; G = 8192
+        move    x0,x:(r7+$23)
+        move    #>$800,x0
+        move    x0,x:(r7+$24)
+        move    #>$400,x0              ; 2^(23-13)
+        move    x0,x:(r7+$26)
+        bra     nl_sdone
+nl_s12:
+        move    #>$fff,x0               ; G = 4096
+        move    x0,x:(r7+$23)
+        move    #>$400,x0
+        move    x0,x:(r7+$24)
+        move    #>$800,x0              ; 2^(23-12)
+        move    x0,x:(r7+$26)
+        bra     nl_sdone
+nl_s11:
+        move    #>$7ff,x0               ; G = 2048
+        move    x0,x:(r7+$23)
+        move    #>$200,x0
+        move    x0,x:(r7+$24)
+        move    #>$1000,x0             ; 2^(23-11)
+        move    x0,x:(r7+$26)
+        bra     nl_sdone
+nl_s10:
+        move    #>$3ff,x0               ; G = 1024
+        move    x0,x:(r7+$23)
+        move    #>$100,x0
+        move    x0,x:(r7+$24)
+        move    #>$2000,x0             ; 2^(23-10)
+        move    x0,x:(r7+$26)
+nl_sdone:
+; FRZE: slot-7 companion (ChonVerb's decode); any nonzero value freezes.
+; The marker is the DEV freeze hook's splice point (NFRZAT=n, build_bus.py's
+; _dev_hooks): it replaces the decoded value in `a` with a block counter's
+; verdict, so a render can capture real material and THEN freeze it. A
+; static freeze can only ever hold the silence the warm-up just cleared.
+        move    x:(r6+$c),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+; NFRZ_OVERRIDE
+        move    a,x:(r7+$27)
+
+; ---- per-sample loop ------------------------------------------------------
+        move    #>$1,n0
+        do      n7,>nl_end
+; mono in
+        move    x:(r0),a
+        move    x:(r0+n0),x0
+        add     x0,a
+        asr     #$1,a,a
+        move    a,x:(r7+$32)
+; PRNG advance (BongDelay's 23-bit xorshift 15/15/8, verbatim)
+        move    x:(r7+$2e),a
+        move    a1,x0
+        asl     #$f,a,a
+        and     #>$7fffff,a
+        eor     x0,a
+        move    a1,x0
+        move    x0,a
+        asr     #$f,a,a
+        eor     x0,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        and     #>$7fffff,a
+        eor     x0,a
+        move    a1,x0
+        move    x0,a                    ; A2 clean before the store
+        move    a,x:(r7+$2e)
+; scatter candidate = prng * DENS, scaled to 0..4064 samples
+        move    a,x0
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a                 ; fraction in [0,1)
+        asr     #$b,a,a                 ; -> integer samples, <= 4064
+        move    a1,x0
+        move    x0,a
+        and     #>$fff,a                ; belt and braces: it IS 0..4064
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$33)
+; record + advance W, unless FROZEN
+        move    x:(r7+$27),a
+        tst     a
+        bne     nl_fz
+        move    x:(r7+$28),a
+        and     #>$3fff,a               ; mask on LOAD -- boot garbage dies
+        move    a1,x0
+        move    x0,a
+        move    x:(r7+$35),x0
+        add     x0,a
+        move    a,r1
+        move    x:(r7+$32),x0
+        move    x0,y:(r1)               ; buffer[W] = mono
+        move    x:(r7+$28),a
+        add     #>$1,a
+        and     #>$3fff,a               ; mask on SAVE too
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$28)
+nl_fz:
+; age advance, masked by G-1 (also swallows size changes and boot garbage)
+        move    x:(r7+$29),a
+        add     #>$1,a
+        move    x:(r7+$23),x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$29)
+; clear the wet accumulators
+        clr     a
+        move    a,x:(r7+$2f)
+        move    a,x:(r7+$30)
+
+; ---- grain 0 (L, offset 0) ------------------------------------------------
+        move    x:(r7+$29),a            ; phase = age (already masked)
+        tst     a
+        bne     nl_g0
+        move    x:(r7+$33),x0           ; wrap: latch this grain's scatter
+        move    x0,x:(r7+$2a)
+nl_g0:
+        move    a,x1                    ; phase, kept for the dist calc
+        move    a,x0
+        move    x:(r7+$26),y1           ; 2^(23-k)
+        mpy     x0,y1,a                 ; a0 = wrap(2*phase/G), signed Q23
+        move    a0,x0
+        move    x0,a                    ; reloaded clean: A2 consistent
+        abs     a
+        move    a,y1                    ; window gain = |wrap(2*phase/G)|
+        move    x:(r7+$22),a            ; dist = POSbase + s_g + G - phase
+        move    x:(r7+$2a),x0
+        add     x0,a
+        move    x:(r7+$23),x0
+        add     x0,a
+        add     #>$1,a
+        sub     x1,a
+        move    a,x0
+        move    x:(r7+$28),a
+        sub     x0,a                    ; W - dist
+        and     #>$3fff,a
+        move    a1,x0
+        move    x0,a
+        move    x:(r7+$35),x0
+        add     x0,a
+        move    a,r2
+        move    y:(r2),x0
+        mpy     x0,y1,a                 ; grain sample * window
+        move    x:(r7+$2f),b
+        add     b,a
+        move    a,x:(r7+$2f)            ; wet L +=
+; ---- grain 1 (R, offset G/4) ----------------------------------------------
+        move    x:(r7+$29),a
+        move    x:(r7+$24),x0
+        add     x0,a
+        move    x:(r7+$23),x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a
+        tst     a
+        bne     nl_g1
+        move    x:(r7+$33),x0
+        move    x0,x:(r7+$2b)
+nl_g1:
+        move    a,x1
+        move    a,x0
+        move    x:(r7+$26),y1
+        mpy     x0,y1,a
+        move    a0,x0
+        move    x0,a
+        abs     a
+        move    a,y1
+        move    x:(r7+$22),a
+        move    x:(r7+$2b),x0
+        add     x0,a
+        move    x:(r7+$23),x0
+        add     x0,a
+        add     #>$1,a
+        sub     x1,a
+        move    a,x0
+        move    x:(r7+$28),a
+        sub     x0,a
+        and     #>$3fff,a
+        move    a1,x0
+        move    x0,a
+        move    x:(r7+$35),x0
+        add     x0,a
+        move    a,r2
+        move    y:(r2),x0
+        mpy     x0,y1,a
+        move    x:(r7+$30),b
+        add     b,a
+        move    a,x:(r7+$30)            ; wet R +=
+; ---- grain 2 (L, offset G/2) ----------------------------------------------
+        move    x:(r7+$29),a
+        move    x:(r7+$24),x0
+        add     x0,a
+        add     x0,a
+        move    x:(r7+$23),x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a
+        tst     a
+        bne     nl_g2
+        move    x:(r7+$33),x0
+        move    x0,x:(r7+$2c)
+nl_g2:
+        move    a,x1
+        move    a,x0
+        move    x:(r7+$26),y1
+        mpy     x0,y1,a
+        move    a0,x0
+        move    x0,a
+        abs     a
+        move    a,y1
+        move    x:(r7+$22),a
+        move    x:(r7+$2c),x0
+        add     x0,a
+        move    x:(r7+$23),x0
+        add     x0,a
+        add     #>$1,a
+        sub     x1,a
+        move    a,x0
+        move    x:(r7+$28),a
+        sub     x0,a
+        and     #>$3fff,a
+        move    a1,x0
+        move    x0,a
+        move    x:(r7+$35),x0
+        add     x0,a
+        move    a,r2
+        move    y:(r2),x0
+        mpy     x0,y1,a
+        move    x:(r7+$2f),b
+        add     b,a
+        move    a,x:(r7+$2f)
+; ---- grain 3 (R, offset 3G/4) ---------------------------------------------
+        move    x:(r7+$29),a
+        move    x:(r7+$24),x0
+        add     x0,a
+        add     x0,a
+        add     x0,a
+        move    x:(r7+$23),x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a
+        tst     a
+        bne     nl_g3
+        move    x:(r7+$33),x0
+        move    x0,x:(r7+$2d)
+nl_g3:
+        move    a,x1
+        move    a,x0
+        move    x:(r7+$26),y1
+        mpy     x0,y1,a
+        move    a0,x0
+        move    x0,a
+        abs     a
+        move    a,y1
+        move    x:(r7+$22),a
+        move    x:(r7+$2d),x0
+        add     x0,a
+        move    x:(r7+$23),x0
+        add     x0,a
+        add     #>$1,a
+        sub     x1,a
+        move    a,x0
+        move    x:(r7+$28),a
+        sub     x0,a
+        and     #>$3fff,a
+        move    a1,x0
+        move    x0,a
+        move    x:(r7+$35),x0
+        add     x0,a
+        move    a,r2
+        move    y:(r2),x0
+        mpy     x0,y1,a
+        move    x:(r7+$30),b
+        add     b,a
+        move    a,x:(r7+$30)
+
+; ---- mix: out = dry + m*(wet - dry), per channel --------------------------
+        move    x:(r7+$2f),a            ; wet L
+        move    x:(r0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)
+        move    x:(r7+$30),a            ; wet R
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+nl_end:
+        nop
+        rts

--- a/modules/send/manifest.py
+++ b/modules/send/manifest.py
@@ -50,5 +50,8 @@ MODULE = Module(
         r7_latch_slot=0x69,
         gate_label="notfirst",
     ),
-    harness=Harness(layout_char="S", is_server=False),
+    # bus_client: SEND writes the shared accumulators and carries the
+    # housekeeping block, so an image containing it HAS a bus. That is what
+    # forbids schema.NO_FALLBACK beside it.
+    harness=Harness(layout_char="S", is_server=False, bus_client=True),
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 # octabam is a scripts + Makefile project, not an installable package — the
 # build and analysis tools deliberately run on bare `python3` with the stdlib
-# only. This file exists for ONE reason: the interactive workbench's optional
+# only. This file exists for ONE reason: the interactive remixer's optional
 # dependencies. The local ColdFire emulator (docs/EMU.md) needs `unicorn`,
-# and the workbench frontend (`make remix`) needs `textual`; both live in
+# and the remixer frontend (`make remix`) needs `textual`; both live in
 # `.venv` as the `emu` extra (one extra on purpose — one setup command, and
-# the workbench is the only consumer of either). The tooling prefers that
+# the remixer is the only consumer of either). The tooling prefers that
 # venv and falls back to bare `python3`, where the build and every check
 # still run; only the interactive views report themselves unavailable.
 #

--- a/remixes/_fx1bad.py
+++ b/remixes/_fx1bad.py
@@ -1,0 +1,4 @@
+"""_fx1bad -- scratch."""
+from remix.schema import Remix
+REMIX = Remix(name="_fx1bad", doc="should be refused", modules=("REVERB SERVER", "SEND"),
+              fallback="SEND", fx1=("REVERB SERVER",))

--- a/remixes/_probe_stock.py
+++ b/remixes/_probe_stock.py
@@ -1,0 +1,9 @@
+"""_probe_stock -- scratch: is an all-stock selection buildable at all?"""
+from remix.schema import Remix
+REMIX = Remix(
+    name="_probe_stock",
+    doc="all eleven stock FX2 effects, no modules",
+    modules=("FILTER", "EQUALIZER", "DJ EQ", "PHASER", "FLANGER", "CHORUS",
+             "SPATIALIZER", "COMB FILTER", "COMPRESSOR", "LO-FI", "DELAY"),
+    fallback="FILTER",
+)

--- a/remixes/_probe_verbs.py
+++ b/remixes/_probe_verbs.py
@@ -1,0 +1,9 @@
+"""_probe_verbs -- scratch: the stock chooser plus a send, keeping the reverbs."""
+from remix.schema import Remix
+REMIX = Remix(
+    name="_probe_verbs",
+    doc="stock chooser plus SEND, keeping the reverbs the build never reached",
+    modules=("FILTER", "EQUALIZER", "DJ EQ", "PHASER", "COMPRESSOR", "LO-FI",
+             "DELAY", "PLATE REV", "SPRING REV", "DARK REV", "SEND"),
+    fallback="SEND",
+)

--- a/remixes/bothslots.py
+++ b/remixes/bothslots.py
@@ -1,0 +1,33 @@
+"""bothslots -- the WarpFold insert on BOTH effect slots, and nothing else.
+
+The first remix to use `Remix.fx1`, and the point of it: until 3 Sep 2026 a
+module of ours could only be reached from the FX2 slot. Not for any DSP
+reason -- the dispatch tables are indexed by the raw id and shared by both
+menus, so WarpFold's code already ran the moment FX1 selected 0x0a -- but
+because FX1's chooser list ends at 0x400d608c and FX2's begins four bytes
+later, so it could not grow where it sat. It moves into the cave instead,
+exactly as the FX2 list already does when it outgrows its own.
+
+It costs no words: 68 bytes of cave for the relocated list, and FX1's own id
+and cursor tables written for the one new row. What it DOES cost is cycles.
+FX1 is four more slots on the same four tracks, so the worst per-core load
+goes from 4x WarpFold to 8x -- 404 to 808 of the 3,120 our code may spend
+(`make cycles`). That trade is the whole reason this is a per-remix choice
+rather than a property of the module.
+
+⚠️ UNFLASHED. The FX1 chooser has been seen only in the local ColdFire
+emulator, which draws it with the firmware's own code: `WarpFold78` appears
+as row 11 of a twelve-entry list, the page draws its own knob names
+(DRV/FREQ/TONE/MODE/MIX), and the cursor opens on that row rather than on
+row 0 -- which is what FX1's cursor table being written looks like.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="bothslots",
+    doc="WarpFold, listed on FX1 as well as FX2. No bus, no servers.",
+    modules=("WARPFOLD",),
+    fallback="NONE",
+    fx1=("WARPFOLD",),
+)

--- a/remixes/bothslots.py
+++ b/remixes/bothslots.py
@@ -13,10 +13,15 @@ when it outgrows its own.
 **FX1 is COMPOSED, not just appended to.** This lists six of stock's ten and
 drops the other four, so the chooser is shorter than the one the box ships --
 which needs the viewport literal at 0x40059be6 shrunk to match, or the draw
-loop reads past the terminator and renders raw memory as text. The four that
-go (FLANGER, CHORUS, SPATIALIZER, COMB FILTER) lose their FX1 ROW and
-nothing else: their code, descriptors and dispatch stay stock, so an old
-project that selects one still runs it.
+loop reads past the terminator and renders raw memory as text.
+
+⚠️ AND THOSE FOUR ARE ON NO MENU AT ALL. FLANGER, CHORUS, SPATIALIZER and
+COMB FILTER are off this FX1 list and were never on its FX2 one, so they are
+unreachable -- and since 3 Sep 2026 that IS the decision to give up their
+words (stock.harvested). CHORUS and FLANGER sit immediately below PLATE, so
+the region runs from FLANGER: 3,342 words rather than 2,724, and WarpFold's
+322 land at FLANGER's address. Their dispatch goes to the null stub. If you
+want them kept, put them back on either chooser.
 
 It costs no words: 32 bytes of cave for the list plus FX1's id and cursor
 tables. What it DOES cost is cycles. FX1 is four more slots on the same four

--- a/remixes/bothslots.py
+++ b/remixes/bothslots.py
@@ -18,10 +18,16 @@ loop reads past the terminator and renders raw memory as text.
 ⚠️ AND THOSE FOUR ARE ON NO MENU AT ALL. FLANGER, CHORUS, SPATIALIZER and
 COMB FILTER are off this FX1 list and were never on its FX2 one, so they are
 unreachable -- and since 3 Sep 2026 that IS the decision to give up their
-words (stock.harvested). CHORUS and FLANGER sit immediately below PLATE, so
-the region runs from FLANGER: 3,342 words rather than 2,724, and WarpFold's
-322 land at FLANGER's address. Their dispatch goes to the null stub. If you
-want them kept, put them back on either chooser.
+words (stock.harvested). Their dispatch goes to the null stub. If you want
+them kept, put them back on either chooser.
+
+⚠️ AND THEY DO NOT MAKE ONE REGION. SPATIALIZER sits above FILTER, and COMB
+above DJ EQ, so this selection gives up THREE separate runs: 261 words
+(SPATIALIZER), 3,342 (FLANGER/CHORUS + the three reverbs) and 277 (COMB).
+The placer fills each one, so all 3,880 words are usable -- but a single
+module still has to fit inside ONE of them, and WarpFold's 322 therefore go
+to the big run at FLANGER's address, not to SPATIALIZER's 261-word opening.
+Until 3 Sep the smaller two were given up and then left empty.
 
 It costs no words: 32 bytes of cave for the list plus FX1's id and cursor
 tables. What it DOES cost is cycles. FX1 is four more slots on the same four

--- a/remixes/bothslots.py
+++ b/remixes/bothslots.py
@@ -1,33 +1,41 @@
-"""bothslots -- the WarpFold insert on BOTH effect slots, and nothing else.
+"""bothslots -- WarpFold on BOTH effect slots, and a curated FX1 chooser.
 
-The first remix to use `Remix.fx1`, and the point of it: until 3 Sep 2026 a
-module of ours could only be reached from the FX2 slot. Not for any DSP
-reason -- the dispatch tables are indexed by the raw id and shared by both
-menus, so WarpFold's code already ran the moment FX1 selected 0x0a -- but
-because FX1's chooser list ends at 0x400d608c and FX2's begins four bytes
-later, so it could not grow where it sat. It moves into the cave instead,
-exactly as the FX2 list already does when it outgrows its own.
+The worked example for `Remix.fx1`. Two things it demonstrates:
 
-It costs no words: 68 bytes of cave for the relocated list, and FX1's own id
-and cursor tables written for the one new row. What it DOES cost is cycles.
-FX1 is four more slots on the same four tracks, so the worst per-core load
-goes from 4x WarpFold to 8x -- 404 to 808 of the 3,120 our code may spend
-(`make cycles`). That trade is the whole reason this is a per-remix choice
-rather than a property of the module.
+**A module of ours on FX1.** Until 3 Sep 2026 an effect of ours could only be
+reached from the FX2 slot -- not for any DSP reason (the dispatch tables are
+indexed by the raw id and shared by both menus, so WarpFold's code already
+ran the moment FX1 selected 0x0a) but because FX1's chooser list ends at
+0x400d608c and FX2's begins four bytes later, so it could not grow where it
+sat. It moves into the cave instead, exactly as the FX2 list already does
+when it outgrows its own.
+
+**FX1 is COMPOSED, not just appended to.** This lists six of stock's ten and
+drops the other four, so the chooser is shorter than the one the box ships --
+which needs the viewport literal at 0x40059be6 shrunk to match, or the draw
+loop reads past the terminator and renders raw memory as text. The four that
+go (FLANGER, CHORUS, SPATIALIZER, COMB FILTER) lose their FX1 ROW and
+nothing else: their code, descriptors and dispatch stay stock, so an old
+project that selects one still runs it.
+
+It costs no words: 32 bytes of cave for the list plus FX1's id and cursor
+tables. What it DOES cost is cycles. FX1 is four more slots on the same four
+tracks, so the worst per-core load goes from 4x WarpFold to 8x -- 404 to 808
+of the 3,120 our code may spend (`make cycles`).
 
 ⚠️ UNFLASHED. The FX1 chooser has been seen only in the local ColdFire
-emulator, which draws it with the firmware's own code: `WarpFold78` appears
-as row 11 of a twelve-entry list, the page draws its own knob names
-(DRV/FREQ/TONE/MODE/MIX), and the cursor opens on that row rather than on
-row 0 -- which is what FX1's cursor table being written looks like.
+emulator, which draws it with the firmware's own code.
 """
 
 from remix.schema import Remix
 
 REMIX = Remix(
     name="bothslots",
-    doc="WarpFold, listed on FX1 as well as FX2. No bus, no servers.",
+    doc="WarpFold on FX1 and FX2, with a curated FX1 chooser.",
     modules=("WARPFOLD",),
     fallback="NONE",
-    fx1=("WARPFOLD",),
+    # The FX1 chooser, in its own row order. NONE is row 0 always and is not
+    # named here. Empty would mean "leave stock's ten alone".
+    fx1=("FILTER", "EQUALIZER", "DJ EQ", "PHASER", "WARPFOLD",
+         "COMPRESSOR", "LO-FI"),
 )

--- a/remixes/fieldtest.py
+++ b/remixes/fieldtest.py
@@ -1,0 +1,44 @@
+"""fieldtest -- one image that puts three never-flashed claims on the unit.
+
+Built to be FLASHED, and shaped so that a failure says which claim broke:
+
+1. **The insert card.** Five inserts of ours on the FX2 chooser, so four
+   copies of the dearest can be put on one core's four tracks -- the cycle
+   test `tools/cycle_count.py` can only bound. A wedge there is the cliff
+   PLAN.md section 2 describes; a wrong SOUND is a module's own bug.
+2. **A module on FX1.** WarpFold takes an FX1 row, which needs FX1's chooser
+   list relocated into the cave, its three `lea` references repointed, and
+   FX1's own id and cursor tables written. Emulator-verified only. A failure
+   here is a MENU failure -- a missing row, a wrong page, a cursor on the
+   wrong line -- and cannot be confused with (1).
+3. **A donor region beyond the three reverbs.** CHORUS and FLANGER are on
+   neither chooser, so their words join the region: 3,342 rather than 2,724,
+   and our code is placed at FLANGER's address. Nothing has EVER overwritten
+   a non-reverb stock effect on hardware. The measurement says every effect
+   is self-contained (tools/dsp_reach.py, both payloads); what it cannot say
+   is whether anything outside the DSP cares. A failure here is anything
+   ELSE misbehaving -- an unrelated stock effect, a crash on part load --
+   and is the reason CHORUS and FLANGER are dropped rather than, say, FILTER
+   (the default FX1 effect, which every project touches).
+
+⚠️ SPATIALIZER and COMB FILTER stay listed on FX1 deliberately. They
+allocate an instance buffer at the addresses our servers pin, so keeping
+them is what proves the ledger's coexistence rule the right way round -- and
+this image carries no server, so there is nothing for them to collide with.
+
+⚠️ NO SERVER, so no bus: the fallback is the firmware's own NONE, and an
+unimplemented id is silence rather than a send.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="fieldtest",
+    doc="Five inserts, one of them on FX1, placed in a region beyond the reverbs.",
+    modules=("WARPFOLD", "RIPPLE", "RUNGS", "STREAMZ", "BODESHIFT"),
+    fallback="NONE",
+    # FX1 without CHORUS or FLANGER -- with neither on the FX2 chooser
+    # either, that is what gives up their words.
+    fx1=("FILTER", "EQUALIZER", "DJ EQ", "PHASER", "SPATIALIZER",
+         "COMB FILTER", "COMPRESSOR", "LO-FI", "WARPFOLD"),
+)

--- a/remixes/hello.py
+++ b/remixes/hello.py
@@ -1,18 +1,20 @@
 """HELLO -- the reference minimal build: one gain insert, nothing else.
 
 The smallest image the module system can produce: HELLO WORLD (a linear
-volume knob) plus SEND, which every insert remix carries because the
-absent-server alias needs its entry points to exist. This remix is the
-worked example `modules/_template` points at, and doubles as a pipeline
-canary: if this stops building or stops nulling at GAIN=127, the build
-system moved under everyone.
+volume knob) and nothing else at all. It used to carry SEND as well, for
+the fallback alias -- 250 words for a bus client nothing in an insert-only
+image reads. Unimplemented ids resolve to the firmware's own NONE instead
+(schema.NO_FALLBACK), which costs one chooser row and no words. This remix
+is the worked example `modules/_template` points at, and doubles as a
+pipeline canary: if this stops building or stops nulling at GAIN=127, the
+build system moved under everyone.
 """
 
 from remix.schema import Remix
 
 REMIX = Remix(
     name="hello",
-    doc="Reference minimal build: HELLO WORLD gain insert + SEND.",
-    modules=("HELLO WORLD", "SEND"),
-    fallback="SEND",
+    doc="Reference minimal build: the HELLO WORLD gain insert, alone.",
+    modules=("HELLO WORLD",),
+    fallback="NONE",
 )

--- a/remixes/mutables.py
+++ b/remixes/mutables.py
@@ -6,8 +6,9 @@ gate) and BodeShift (a frequency shifter). Inserts stack, unlike the
 servers -- each is in both payloads, any track can host any of them, several
 at once -- so this remix carries the whole set where `warped` carries one.
 
-SEND is the fallback and the housekeeper, as everywhere; both servers' ids
-degrade to it. No ColdFire caves.
+No bus and no SEND: both servers' ids degrade to the firmware's own NONE
+(schema.NO_FALLBACK), which is what an unassigned track shows on a stock
+unit and costs no words. No ColdFire caves.
 """
 
 from remix.schema import Remix
@@ -15,6 +16,6 @@ from remix.schema import Remix
 REMIX = Remix(
     name="mutables",
     doc="Five MI-flavoured inserts: WarpFold, Ripple, Rungs, Streamz, BodeShift.",
-    modules=("WARPFOLD", "RIPPLE", "RUNGS", "STREAMZ", "BODESHIFT", "SEND"),
-    fallback="SEND",
+    modules=("WARPFOLD", "RIPPLE", "RUNGS", "STREAMZ", "BODESHIFT"),
+    fallback="NONE",
 )

--- a/remixes/nimbus.py
+++ b/remixes/nimbus.py
@@ -1,4 +1,4 @@
-"""nimbus -- the granular texture card: Nimbus alone, plus the send bus.
+"""nimbus -- the granular texture card: Nimbus alone.
 
 Nimbus owns the core-private FX2 buffer region Y:0x4000-0xBFFF, which is
 only free because every other module in an insert remix has no Y footprint
@@ -14,7 +14,7 @@ from remix.schema import Remix
 
 REMIX = Remix(
     name="nimbus",
-    doc="Nimbus granular texture + send bus. One instance per core.",
-    modules=("NIMBUS", "SEND"),
-    fallback="SEND",
+    doc="Nimbus granular texture, alone. One instance per core.",
+    modules=("NIMBUS",),
+    fallback="NONE",
 )

--- a/remixes/nimbuslite.py
+++ b/remixes/nimbuslite.py
@@ -20,9 +20,9 @@ from remix.schema import Remix
 REMIX = Remix(
     name="nimbuslite",
     doc="Nimbus Lite plus every stock effect that still fits.",
-    modules=("NIMBUS LITE", "SEND",
+    modules=("NIMBUS LITE",
              "FILTER", "EQUALIZER", "DJ EQ", "PHASER", "FLANGER", "CHORUS",
              "SPATIALIZER", "COMB FILTER", "COMPRESSOR", "LO-FI", "DELAY",
              "DARK REV"),
-    fallback="SEND",
+    fallback="NONE",
 )

--- a/remixes/nimbuslite.py
+++ b/remixes/nimbuslite.py
@@ -1,0 +1,28 @@
+"""nimbuslite -- Nimbus Lite beside the whole stock chooser.
+
+The thing Nimbus cannot do. Nimbus pins Y:0x4000-0xBFFF -- both core-private
+FX2 slots, every buffer the host's bump allocator has to give -- so the
+ledger refuses it beside the seven stock effects that need one: FLANGER,
+CHORUS, SPATIALIZER, COMB and the three reverbs. Adding it to a stock chooser
+costs all seven.
+
+Nimbus Lite asks the allocator for ONE 16,384-word slot at init instead, the
+way those stock effects do, so it sits beside every one of them. What it
+gives up is texture: 371 ms of material to scatter grains through rather than
+743.
+
+⚠️ UNFLASHED, and the ear pass is Sam's -- halving the ring is a voicing
+change, not just a resource one.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="nimbuslite",
+    doc="Nimbus Lite plus every stock effect that still fits.",
+    modules=("NIMBUS LITE", "SEND",
+             "FILTER", "EQUALIZER", "DJ EQ", "PHASER", "FLANGER", "CHORUS",
+             "SPATIALIZER", "COMB FILTER", "COMPRESSOR", "LO-FI", "DELAY",
+             "DARK REV"),
+    fallback="SEND",
+)

--- a/remixes/restock.py
+++ b/remixes/restock.py
@@ -1,0 +1,29 @@
+"""restock -- put the unit back, keeping two of the three reverbs.
+
+The honest bottom of the range: an unmodified FX2 chooser plus SEND, which
+is the one thing a buildable image cannot do without (an id this image does
+not implement has to alias SOMEWHERE, and a real effect would process the
+unknown id rather than pass it).
+
+THIRTEEN of the fourteen stock effects, including SPRING REV and DARK REV.
+Only PLATE REV is missing, and only because SEND's 215 words land on the
+first 215 of PLATE's 594 -- the donor region is packed from PLATE upward, so
+the smallest possible image costs the smallest reverb and nothing else. The
+build reports it: "donor ids taken (PLATE) ... KEPT STOCK: SPRING/DARK".
+
+⚠️ UNFLASHED. What it is for: undoing a remix without reflashing the stock
+OS, when some ColdFire cave is worth keeping -- and as the proof that the
+three reverbs are consumed by ARITHMETIC, not by nature (PLAN §7, closed
+2 Sep 2026).
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="restock",
+    doc="the stock chooser minus PLATE REV, plus SEND: put my unit back.",
+    modules=("FILTER", "EQUALIZER", "DJ EQ", "PHASER", "FLANGER", "CHORUS",
+             "SPATIALIZER", "COMB FILTER", "COMPRESSOR", "LO-FI", "DELAY",
+             "SPRING REV", "DARK REV", "SEND"),
+    fallback="SEND",
+)

--- a/remixes/restock.py
+++ b/remixes/restock.py
@@ -1,29 +1,39 @@
-"""restock -- put the unit back, keeping two of the three reverbs.
+"""restock -- put the unit back. All fourteen stock FX2 effects, no words spent.
 
-The honest bottom of the range: an unmodified FX2 chooser plus SEND, which
-is the one thing a buildable image cannot do without (an id this image does
-not implement has to alias SOMEWHERE, and a real effect would process the
-unknown id rather than pass it).
+The honest bottom of the range, and since 2 Sep 2026 it is the WHOLE stock
+chooser rather than thirteen fourteenths of it.
 
-THIRTEEN of the fourteen stock effects, including SPRING REV and DARK REV.
-Only PLATE REV is missing, and only because SEND's 215 words land on the
-first 215 of PLATE's 594 -- the donor region is packed from PLATE upward, so
-the smallest possible image costs the smallest reverb and nothing else. The
-build reports it: "donor ids taken (PLATE) ... KEPT STOCK: SPRING/DARK".
+It used to carry SEND, because an id this image does not implement has to
+alias somewhere and a real effect would PROCESS the unknown id rather than
+pass it. SEND's 215 words land on the first 215 of PLATE's 594 -- the donor
+region is packed from PLATE upward -- so the smallest possible image cost
+the smallest reverb, and PLATE REV was missing for that reason and no other.
+
+Unimplemented ids now resolve to the FIRMWARE's own NONE instead
+(schema.NO_FALLBACK): the descriptor a stock chooser carries at list row 0,
+and the per-payload null stub on the DSP side. That costs one chooser row
+and NOT ONE WORD, so nothing is placed over PLATE and all three reverbs
+survive. The build reports it: "KEPT STOCK: PLATE/SPRING/DARK".
+
+It is safe here for the reason it is refused anywhere else: with no server
+and no SEND there is no bus in this image, so there is no rotation to flip
+and no accumulator to clear, and an unassigned track running nothing costs
+nothing.
 
 ⚠️ UNFLASHED. What it is for: undoing a remix without reflashing the stock
 OS, when some ColdFire cave is worth keeping -- and as the proof that the
 three reverbs are consumed by ARITHMETIC, not by nature (PLAN §7, closed
-2 Sep 2026).
+2 Sep 2026). With nothing placed at all, that proof is now exact: the
+chooser an unmodified unit shows, rebuilt from our own tables.
 """
 
 from remix.schema import Remix
 
 REMIX = Remix(
     name="restock",
-    doc="the stock chooser minus PLATE REV, plus SEND: put my unit back.",
+    doc="every stock FX2 effect, all fourteen: put my unit back.",
     modules=("FILTER", "EQUALIZER", "DJ EQ", "PHASER", "FLANGER", "CHORUS",
              "SPATIALIZER", "COMB FILTER", "COMPRESSOR", "LO-FI", "DELAY",
-             "SPRING REV", "DARK REV", "SEND"),
-    fallback="SEND",
+             "PLATE REV", "SPRING REV", "DARK REV"),
+    fallback="NONE",
 )

--- a/remixes/scattered.py
+++ b/remixes/scattered.py
@@ -1,0 +1,51 @@
+"""scattered -- two modules in two runs that are NOT next to each other.
+
+The worked example for non-contiguous harvesting, and the reason the placer
+stopped being a single bump cursor on 3 Sep 2026.
+
+The thirteen DSP effects are laid out contiguously, but the ones you want to
+give up need not be adjacent. This remix keeps six stock effects on FX1 and
+puts Streamz and WarpFold on FX2, which leaves SPATIALIZER on no menu at all
+-- and SPATIALIZER sits between FILTER and EQUALIZER, nowhere near the
+reverbs. So what it gives up is THREE separate runs:
+
+    run 1     261 w   SPATIALIZER
+    run 2   3,342 w   FLANGER/CHORUS/PLATE REV/SPRING REV/DARK REV
+    run 3     277 w   COMB FILTER
+
+⚠️ ALL THREE ARE PLACEABLE, AND THAT IS THE POINT. Until 3 Sep the build
+wrote one contiguous stream, so `stock.region_of` handed it the largest run
+alone and runs 1 and 3 were given up and then left empty -- 538 words
+surrendered for nothing, with the budget showing no change when you dropped
+them. The placer now first-fits each module into a run it fits: Streamz's
+255 words go into SPATIALIZER's 261-word opening, WarpFold's 322 into run 2.
+
+⚠️ A GAP IS STILL A WALL. A module is ONE code stream, so it must fit inside
+a SINGLE run -- 3,880 words across three runs will not take a 3,500-word
+module, and the remixer says the largest opening beside the total for that
+reason. Harvesting an effect that sits BETWEEN two runs joins them into one.
+
+⚠️ WHY WARPFOLD IS IN RUN 2 AND NOT RUN 1: it is 322 words and run 1 holds
+261. First-fit walks the runs in address order and takes the first that
+fits, so the order modules appear in `modules` does not decide where they
+land -- their sizes do.
+
+Measured, not assumed: both modules render BIT-IDENTICAL audio here and in a
+control remix whose harvest is a single run (`tools/remix/selftest.py`).
+
+⚠️ UNFLASHED, and a demonstration rather than a voicing: Streamz and
+WarpFold are both inserts, so this image has no bus at all.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="scattered",
+    doc="Two modules placed into two non-adjacent runs of harvested code.",
+    modules=("STREAMZ", "WARPFOLD"),
+    fallback="NONE",
+    # Six of stock's ten. Dropping SPATIALIZER and COMB FILTER from FX1 is
+    # what makes the harvest non-contiguous -- put either back and its run
+    # merges away.
+    fx1=("FILTER", "EQUALIZER", "DJ EQ", "PHASER", "COMPRESSOR", "LO-FI"),
+)

--- a/remixes/warped.py
+++ b/remixes/warped.py
@@ -1,21 +1,23 @@
-"""warped -- WarpFold on every track, the send bus idle underneath.
+"""warped -- WarpFold on every track, and nothing else in the image.
 
 The first remix built around an OUTSIDER module: WarpFold is an insert with
 no bus role, placed in BOTH payloads, so any of the eight tracks can host
-one. SEND is here as the fallback (a saved project's stale id degrades to a
-send, per the standing rule) and because a remix without it would leave
-nothing to housekeep the bus scratch; nothing consumes its accumulators in
-this selection, which is harmless -- the housekeeper clears them each block.
+one. It carried SEND until 2 Sep 2026 -- as the fallback, and on the theory
+that a remix without it would leave nothing to housekeep the bus scratch.
+That theory had it backwards: with no server, nothing ever reads those
+accumulators, so there is no bus in this image to keep. Unimplemented ids
+resolve to the firmware's own NONE instead (schema.NO_FALLBACK), which is
+what an unassigned track shows on a stock unit.
 
 Neither server fits beside a new effect in one donor region, so this remix
-carries neither; their ids fall back to SEND like every other absent id.
+carries neither; their ids fall back to NONE like every other absent id.
 """
 
 from remix.schema import Remix
 
 REMIX = Remix(
     name="warped",
-    doc="WarpFold insert + send bus only. No servers, no ColdFire caves.",
-    modules=("WARPFOLD", "SEND"),
-    fallback="SEND",
+    doc="The WarpFold insert, alone. No bus, no servers, no ColdFire caves.",
+    modules=("WARPFOLD",),
+    fallback="NONE",
 )

--- a/tools/_prev_build.py
+++ b/tools/_prev_build.py
@@ -95,7 +95,6 @@ from dsp_modmap import BASE, IMG, PAYLOADS, modules  # noqa: E402
 from remix import registry as remix_registry  # noqa: E402
 from remix.registry import modules as remix_modules  # noqa: E402
 from remix.schema import YBase  # noqa: E402
-import label_fmt  # noqa: E402
 from remix import ledger  # noqa: E402
 
 OUT = pathlib.Path("out/mainos_bus.bin")
@@ -1120,48 +1119,6 @@ def main():
         print(f"  {_c.label}: {len(_b)} bytes at 0x{_c.cave_addr:08x}"
               f"{_hook}{_c.report_note}")
         _cave_top = _c.cave_addr + len(_b)
-
-    # ---- PLAN §6: the mode selects print their WORDS ---------------------
-    # Every stepped select drew as a bare number -- WarpFold's MODE as `1 2 3`
-    # where the manifest has said FOLD RING BOTH all along -- because
-    # Param.labels was authored, schema-checked against count, and then never
-    # read. This is the pass that makes it load-bearing.
-    #
-    # Only the "A" array (P+0x0ca) moves. B stays 0x40047254, the CHORUS.TAPS
-    # tick widget the clone loop already chose: the ticks are the right
-    # picture for an enumerated control, and B=0 would drop back to a plain
-    # dial. So this replaces WHAT IS PRINTED, not how it is drawn.
-    #
-    # The bytes come from tools/label_fmt.py rather than a pinned CavePatch:
-    # twelve caves whose contents vary with the labels cannot be hand-pinned,
-    # and emit() is re-derived through m68k-elf-as whenever one is on PATH.
-    _lbl_top = max(_cave_top, cave_end)
-    _lbl = []
-    for name in CLONED_ORDER:
-        for _i, _p in enumerate(_MODS[name].params):
-            if not (_p.active and _p.labels):
-                continue
-            _bytes = label_fmt.emit(_p.labels)
-            label_fmt.verify(_p.labels)
-            if _lbl_top + len(_bytes) > cave_limit:
-                sys.exit(f"label formatters do not fit: {name} slot {_i} "
-                         f"needs {len(_bytes)} B at 0x{_lbl_top:08x}, limit "
-                         f"0x{cave_limit:08x}")
-            if any(img[_lbl_top - BASE:_lbl_top - BASE + len(_bytes)]):
-                sys.exit(f"label cave at 0x{_lbl_top:08x} is not free")
-            img[_lbl_top - BASE:_lbl_top - BASE + len(_bytes)] = _bytes
-            wr32(clone_addr[name] + 0x0ca + _i * 4, _lbl_top)
-            _lbl.append((name, _i, _p.name.decode("latin1"), _lbl_top,
-                         len(_bytes), _p.labels))
-            _lbl_top += len(_bytes)
-    for _n, _i, _nm, _a, _sz, _labels in _lbl:
-        print(f"  {_n:13s} slot {_i:<2} {_nm:<5} prints "
-              f"{'|'.join(_labels)}  ({_sz} B at 0x{_a:08x})")
-    if _lbl:
-        print(f"  {len(_lbl)} label formatters, "
-              f"0x{max(_cave_top, cave_end):08x}..0x{_lbl_top:08x} "
-              f"({_lbl_top - max(_cave_top, cave_end)} B), "
-              f"{cave_limit - _lbl_top} B of cave left")
 
     # A fresh part's FX2 id is 0. Rather than hunt down the part-init template,
     # alias id 0 to SEND: its descriptor, its cursor position, and (below) its

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -1892,7 +1892,25 @@ mkgo:""",
         # contiguity assert is what proves that rather than assuming it.
         # Dev-only; the flashable build leaves CHORUS alone unless a remix
         # asks for it.
-        _harvest = list(REMIX.harvest) + (["CHORUS"] if DEV else [])
+        # ⚠️ DERIVED FROM THE TWO CHOOSERS. An effect on neither is one this
+        # remix does not want, and giving up its words is the same decision
+        # -- see stock.harvested(). The largest contiguous run of them is the
+        # region; the rest are simply unlisted and keep their code.
+        _listed = set(REMIX.modules) | set(
+            REMIX.fx1 or [k for k in stock_mod.p_spans("A")
+                          if _MODS[k].menu.fx2_id in stock_mod.fx1_ids()])
+        # ⚠️ IN ADDRESS ORDER. DEV's CHORUS sits BELOW the reverbs, and the
+        # report lists the donors in this order -- appending it put CHORUS
+        # last and changed every DEV case's report hash (refhash caught it).
+        _derived = stock_mod.region_of(stock_mod.harvested(_listed))
+        _dev_chorus = DEV and "CHORUS" not in _derived
+        _harvest = sorted(
+            set(_derived)
+            # DEV takes CHORUS whether or not a chooser lists it -- that is
+            # the hatch's whole point, and why a DEV build is never flashed
+            # ("taking CHORUS costs FX1 its chorus", the module docstring).
+            | ({"CHORUS"} if DEV else set()),
+            key=lambda k: stock_mod.p_spans(tag)[k][0])
         if not _harvest:
             # Nothing harvested is the honest default for a stock chooser --
             # every word belongs to a stock effect that is using it -- but a
@@ -1903,7 +1921,8 @@ mkgo:""",
                          f"nowhere to place "
                          f"{', '.join(sorted(m.key for m in _need))}. Name "
                          f"the stock effects whose words this remix may take "
-                         f"(schema.Remix.harvest).")
+                         f"Take one off both choosers to give up "
+                         f"its words.")
         _sp = stock_mod.p_spans(tag)
         for _k in _harvest:
             if _k not in _sp:
@@ -2397,10 +2416,14 @@ mkgo:""",
             # API (refhash hashes it, and verify_* parse it). Every shipping
             # layout packs past all three, so this is the line every existing
             # case still prints.
-            _dflt = list(REMIX.harvest) == list(DEFAULT_HARVEST)
-            _all = ("CHORUS/" if DEV else "") + (
+            # ⚠️ WORDING FROZEN for the default: the report is API (refhash
+            # hashes it verbatim). DEV's CHORUS is named by the prefix, so it
+            # must not also appear in the list behind it.
+            _rest = [k for k in _harvest if not (_dev_chorus and k == "CHORUS")]
+            _dflt = list(_rest) == list(DEFAULT_HARVEST)
+            _all = ("CHORUS/" if _dev_chorus else "") + (
                 "PLATE/SPRING/DARK REV" if _dflt
-                else "/".join(_short.values()))
+                else "/".join(_short[k] for k in _rest))
             print(f"  donor ids ({_all}) "
                   f"-> null stub P:0x{pp['nul_i']:05x}/0x{pp['nul_p']:05x} -- any "
                   f"path resolving a donor id gets silence, not our code "

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -2150,15 +2150,24 @@ mkgo:""",
         # A chooser row for a reverb whose words we just overwrote would
         # point at a live descriptor over dead code: the panel would draw
         # PLATE REV and the DSP would run ours. Refuse, loudly.
-        for _name in STOCK_ROWS:
-            _d = next((d for d, e in DONOR_IDS.items()
-                       if e == NEW_IDS[_name]), None)
-            if _d is not None and _d not in kept:
-                sys.exit(f"payload {tag}: {_name} is listed in the chooser but "
-                         f"this selection places code over it (region used "
-                         f"{cursor - base_a} words, {_d.upper()} starts at "
-                         f"{record(pp[_d])[1] - base_a}) -- remove the row or "
-                         f"free the words")
+        # ⚠️ NAME EVERY OFFENDER, NOT THE FIRST. Exiting on the first one
+        # made the operator iterate: remove PLATE, rebuild, fail on SPRING,
+        # remove that, rebuild, fail on DARK. The build knows all three the
+        # moment it knows the cursor, and the workbench's one-key fix can
+        # only remove what the build named.
+        _over = [(_name, record(pp[_d])[1] - base_a)
+                 for _name in STOCK_ROWS
+                 for _d in [next((d for d, e in DONOR_IDS.items()
+                                  if e == NEW_IDS[_name]), None)]
+                 if _d is not None and _d not in kept]
+        if _over:
+            _list = ", ".join(f"{n} (starts at {a})" for n, a in _over)
+            sys.exit(f"payload {tag}: {_list} "
+                     f"{'are' if len(_over) > 1 else 'is'} listed in the "
+                     f"chooser but this selection places code over "
+                     f"{'them' if len(_over) > 1 else 'it'} (region used "
+                     f"{cursor - base_a} words) -- remove the row"
+                     f"{'s' if len(_over) > 1 else ''} or free the words")
         if DEV:
             print(f"  *** CHORUS (id 0x12) TAKEN as a fourth donor -- FX1 loses "
                   f"its chorus. DEV builds are never flashed. ***")

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -1277,7 +1277,7 @@ def main():
 
     # ALWAYS report the headroom, even when nothing was planted. It used to
     # ride on the label-formatter line, so a remix with no labelled select
-    # (SEND alone, say) reported no cave figure at all and the workbench's
+    # (SEND alone, say) reported no cave figure at all and the remixer's
     # budget had a hole in it -- for a selection that builds perfectly well.
     print(f"  cave: 0x{_lbl_top:08x}..0x{cave_limit:08x}, "
           f"{cave_limit - _lbl_top} B of cave left")
@@ -2288,7 +2288,7 @@ mkgo:""",
         # ⚠️ NAME EVERY OFFENDER, NOT THE FIRST. Exiting on the first one
         # made the operator iterate: remove PLATE, rebuild, fail on SPRING,
         # remove that, rebuild, fail on DARK. The build knows all three the
-        # moment it knows the cursor, and the workbench's one-key fix can
+        # moment it knows the cursor, and the remixer's one-key fix can
         # only remove what the build named.
         _over = [(_name, record(pp[_d])[1] - base_a)
                  for _name in STOCK_ROWS

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -94,7 +94,8 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent))
 from dsp_modmap import BASE, IMG, PAYLOADS, modules  # noqa: E402
 from remix import registry as remix_registry  # noqa: E402
 from remix.registry import modules as remix_modules  # noqa: E402
-from remix.schema import NO_FALLBACK, BusRole, YBase  # noqa: E402
+from remix.schema import (DEFAULT_HARVEST, NO_FALLBACK, BusRole,  # noqa: E402
+                          YBase)
 from remix.state import fx1_hazard  # noqa: E402
 from remix import stock as stock_mod  # noqa: E402
 import label_fmt  # noqa: E402
@@ -1879,19 +1880,53 @@ mkgo:""",
 
         print(f"-- payload {tag} --")
 
-        # ---- all three servers pack into PLATE + SPRING + DARK ------------
-        # v98: CHORUS is not a donor any more. See the module docstring.
-        # DEV=1 takes it back as a fourth donor -- it sits immediately BELOW
-        # PLATE and the contiguity assert below is what proves that rather than
-        # assuming it. Dev-only; the flashable build still leaves CHORUS alone.
-        _donors = ("chorus", "plate", "spring", "dark") if DEV else \
-                  ("plate", "spring", "dark")
-        region = sorted((record(pp[k]) for k in _donors), key=lambda m: m[1])
+        # ---- the servers pack into the HARVESTED effects' code -----------
+        # The donor region is not a place, it is a choice: the thirteen DSP
+        # effects are contiguous and each is self-contained, so any unbroken
+        # run of them is placeable ground (schema.Remix.harvest,
+        # stock.p_spans). `DEFAULT_HARVEST` is the three reverbs, which is
+        # what every remix did before 3 Sep 2026 -- so a default selection
+        # writes the same bytes it always has (refhash).
+        #
+        # DEV=1 adds CHORUS, which sits immediately BELOW PLATE; the
+        # contiguity assert is what proves that rather than assuming it.
+        # Dev-only; the flashable build leaves CHORUS alone unless a remix
+        # asks for it.
+        _harvest = list(REMIX.harvest) + (["CHORUS"] if DEV else [])
+        _sp = stock_mod.p_spans(tag)
+        for _k in _harvest:
+            if _k not in _sp:
+                sys.exit(f"harvest={_k!r}: not a stock effect with DSP code "
+                         f"in payload {tag} (have: "
+                         f"{', '.join(sorted(_sp))})")
+        # ⚠️ EVERY RECORD INSIDE A HARVESTED SPAN, not one per effect. PHASER
+        # is FIVE records -- its true extent runs 41 words past the one that
+        # bears its name, into four small blocks it enters by falling off its
+        # own end (docs/DSP.md s8) -- so keying the region by effect would
+        # have placed 157 of its 207 words and left the rest as a hole in the
+        # middle of the stream.
+        _want = [_sp[k] for k in _harvest]
+        region = sorted((m for m in mods if m[0] == 0
+                         and any(a <= m[1] < a + n for a, n in _want)),
+                        key=lambda m: m[1])
+        _have = sum(m[2] for m in region)
+        if _have != sum(n for _a, n in _want):
+            sys.exit(f"payload {tag}: the harvested spans cover "
+                     f"{sum(n for _a, n in _want)} words but their P records "
+                     f"total {_have} -- the module map and stock.p_spans "
+                     f"disagree")
         for (_, a, cnt, _), (_, a2, _, _) in zip(region, region[1:]):
             if a + cnt != a2:
-                sys.exit(f"payload {tag}: PLATE/SPRING/DARK are not contiguous "
-                         f"(0x{a:05x}+{cnt} != 0x{a2:05x}) -- a single code "
-                         f"stream cannot span them")
+                # A module of ours is ONE code stream, so a gap is not a
+                # smaller region, it is two -- and nothing here chooses
+                # between them. Refuse and name the survivor in the way.
+                between = sorted(k for k, (ad, _n) in _sp.items()
+                                 if a + cnt <= ad < a2)
+                sys.exit(f"payload {tag}: the harvested effects are not "
+                         f"contiguous (0x{a:05x}+{cnt} != 0x{a2:05x}) -- "
+                         f"{', '.join(between) or 'something'} "
+                         f"{'sit' if len(between) != 1 else 'sits'} between "
+                         f"them and a single code stream cannot span it")
         base_a = region[0][1]
         budget = sum(m[2] for m in region)
 
@@ -2322,25 +2357,44 @@ mkgo:""",
         # The stream is contiguous from base_a, so the written span is
         # [base_a, cursor) and a donor whose record STARTS at or after the
         # cursor still holds its own code, untouched. Give it back.
-        kept = [d for d in DONOR_IDS if record(pp[d])[1] >= cursor]
-        for donor, eid in DONOR_IDS.items():
+        # ⚠️ BY SPAN, NOT BY A HAND-WRITTEN DONOR LIST. Every harvested
+        # effect whose code the stream did not reach keeps its algorithm and
+        # its dispatch; every one it did reach is silenced. That is what the
+        # three reverbs have always done, now true of whatever was harvested.
+        _hv = {k: _sp[k] for k in _harvest}
+        # ⚠️ THE REPORT NAMES ARE ONE WORD, and that is load-bearing rather
+        # than cosmetic: state.measure() reads `KEPT STOCK: (\S+)` and splits
+        # on "/", so a name with a space in it truncates the whole list at
+        # the first one. The old code took the lowercase donor keys and
+        # upper-cased them ("plate" -> "PLATE"); the module keys are "PLATE
+        # REV", so the first word is what keeps every existing report line
+        # byte-identical (refhash) and every existing parser working.
+        _short = {k: k.split()[0].upper() for k in _hv}
+        kept = [d for d, (a, _n) in _hv.items() if a >= cursor]
+        for donor, (a, _n) in _hv.items():
             if donor in kept:
                 continue
+            eid = _MODS[donor].menu.fx2_id
             wrw_p(pp["xtab"] + eid * 3, pp["nul_i"])
             wrw_p(pp["xtab"] + (32 + eid) * 3, pp["nul_p"])
         if not kept:
-            # ⚠️ WORDING FROZEN: the build report is API (refhash hashes it,
-            # and verify_* parse it). Every shipping layout packs past all
-            # three, so this is the line every existing case still prints.
-            print(f"  donor ids ({'CHORUS/' if DEV else ''}PLATE/SPRING/DARK REV) "
+            # ⚠️ WORDING FROZEN for the default harvest: the build report is
+            # API (refhash hashes it, and verify_* parse it). Every shipping
+            # layout packs past all three, so this is the line every existing
+            # case still prints.
+            _dflt = list(REMIX.harvest) == list(DEFAULT_HARVEST)
+            _all = ("CHORUS/" if DEV else "") + (
+                "PLATE/SPRING/DARK REV" if _dflt
+                else "/".join(_short.values()))
+            print(f"  donor ids ({_all}) "
                   f"-> null stub P:0x{pp['nul_i']:05x}/0x{pp['nul_p']:05x} -- any "
                   f"path resolving a donor id gets silence, not our code "
                   f"(defensive: the FX1 menu never listed the reverbs)")
         else:
-            _gone = [d for d in DONOR_IDS if d not in kept]
-            print(f"  donor ids taken ({'/'.join(_gone).upper() or 'none'}) "
+            _gone = [_short[d] for d in _hv if d not in kept]
+            print(f"  donor ids taken ({'/'.join(_gone) or 'none'}) "
                   f"-> null stub P:0x{pp['nul_i']:05x}/0x{pp['nul_p']:05x}; "
-                  f"KEPT STOCK: {'/'.join(kept).upper()} -- this selection "
+                  f"KEPT STOCK: {'/'.join(_short[k] for k in kept)} -- this selection "
                   f"stops at P:0x{cursor:05x} and never touched their code")
         # A chooser row for a reverb whose words we just overwrote would
         # point at a live descriptor over dead code: the panel would draw
@@ -2350,11 +2404,8 @@ mkgo:""",
         # remove that, rebuild, fail on DARK. The build knows all three the
         # moment it knows the cursor, and the remixer's one-key fix can
         # only remove what the build named.
-        _over = [(_name, record(pp[_d])[1] - base_a)
-                 for _name in STOCK_ROWS
-                 for _d in [next((d for d, e in DONOR_IDS.items()
-                                  if e == NEW_IDS[_name]), None)]
-                 if _d is not None and _d not in kept]
+        _over = [(_name, _hv[_name][0] - base_a) for _name in STOCK_ROWS
+                 if _name in _hv and _name not in kept]
         if _over:
             _list = ", ".join(f"{n} (starts at {a})" for n, a in _over)
             sys.exit(f"payload {tag}: {_list} "

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -1160,8 +1160,13 @@ def main():
     if _lbl:
         print(f"  {len(_lbl)} label formatters, "
               f"0x{max(_cave_top, cave_end):08x}..0x{_lbl_top:08x} "
-              f"({_lbl_top - max(_cave_top, cave_end)} B), "
-              f"{cave_limit - _lbl_top} B of cave left")
+              f"({_lbl_top - max(_cave_top, cave_end)} B)")
+    # ALWAYS report the headroom, even when nothing was planted. It used to
+    # ride on the label-formatter line, so a remix with no labelled select
+    # (SEND alone, say) reported no cave figure at all and the workbench's
+    # budget had a hole in it -- for a selection that builds perfectly well.
+    print(f"  cave: 0x{_lbl_top:08x}..0x{cave_limit:08x}, "
+          f"{cave_limit - _lbl_top} B of cave left")
 
     # A fresh part's FX2 id is 0. Rather than hunt down the part-init template,
     # alias id 0 to SEND: its descriptor, its cursor position, and (below) its

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -1893,6 +1893,17 @@ mkgo:""",
         # Dev-only; the flashable build leaves CHORUS alone unless a remix
         # asks for it.
         _harvest = list(REMIX.harvest) + (["CHORUS"] if DEV else [])
+        if not _harvest:
+            # Nothing harvested is the honest default for a stock chooser --
+            # every word belongs to a stock effect that is using it -- but a
+            # module of ours has to go somewhere.
+            _need = [m for m in _SEL if m.dsp is not None]
+            if _need:
+                sys.exit(f"payload {tag}: nothing is harvested, so there is "
+                         f"nowhere to place "
+                         f"{', '.join(sorted(m.key for m in _need))}. Name "
+                         f"the stock effects whose words this remix may take "
+                         f"(schema.Remix.harvest).")
         _sp = stock_mod.p_spans(tag)
         for _k in _harvest:
             if _k not in _sp:
@@ -1927,7 +1938,11 @@ mkgo:""",
                          f"{', '.join(between) or 'something'} "
                          f"{'sit' if len(between) != 1 else 'sits'} between "
                          f"them and a single code stream cannot span it")
-        base_a = region[0][1]
+        # With nothing harvested there is no region at all -- legal, and
+        # what a pure stock chooser is. `_need` above has already refused it
+        # if anything wanted placing, so the rest of this runs over an empty
+        # stream and writes nothing.
+        base_a = region[0][1] if region else 0
         budget = sum(m[2] for m in region)
 
         def place(words, start):

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -1088,9 +1088,22 @@ def main():
     _omitted = [m for m in remix_modules().values()
                 if m.menu is not None and m.key not in REMIX.modules
                 and not m.is_stock]
+    # ⚠️ A REPLACEMENT THAT IS NOT IN THIS REMIX LEAVES STOCK ALONE. Aliasing
+    # its id to the fallback would take the stock effect away from BOTH menus
+    # -- which is exactly what happened for four days when Rungs sat on
+    # EQUALIZER's 0x0c: the remixes without Rungs aliased 0x0c to SEND, so
+    # the shipping image had no EQUALIZER on FX1 either. The id belongs to a
+    # stock effect; absent our replacement, it goes back to being one.
+    _restored = [m for m in _omitted if m.menu.replaces]
+    _omitted = [m for m in _omitted if not m.menu.replaces]
     for _m in _omitted:
         wr32(FX2_IDS + _m.menu.fx2_id * 4, clone_addr[REMIX.fallback])
         wr32(ID2POS + _m.menu.fx2_id * 4, ORDER.index(REMIX.fallback))
+    if _restored:
+        print(f"  not in this remix, LEFT STOCK: "
+              f"{', '.join(sorted(m.key for m in _restored))} -- each replaces "
+              f"a stock effect, so its id keeps that effect's descriptor and "
+              f"dispatch on both menus")
     if _omitted:
         print(f"  not in this remix: "
               f"{', '.join(sorted(m.key for m in _omitted))} -- their ids "

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -94,7 +94,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent))
 from dsp_modmap import BASE, IMG, PAYLOADS, modules  # noqa: E402
 from remix import registry as remix_registry  # noqa: E402
 from remix.registry import modules as remix_modules  # noqa: E402
-from remix.schema import YBase  # noqa: E402
+from remix.schema import NO_FALLBACK, YBase  # noqa: E402
 import label_fmt  # noqa: E402
 from remix import ledger  # noqa: E402
 
@@ -161,6 +161,13 @@ REMIX = remix_registry.remix(os.environ.get("REMIX")
                              or remix_registry.DEFAULT_REMIX)
 ORDER = [k for k in REMIX.modules
          if remix_modules()[k].menu is not None]
+# THE FIRMWARE'S OWN NONE AS THE FALLBACK, for a remix with no bus (see
+# schema.NO_FALLBACK, which is also what refuses it beside a bus
+# participant). Unimplemented ids -- and id 0, a fresh part's -- then resolve
+# to stock's NONE descriptor and to the payload's null stub, instead of to a
+# module of ours that has to be listed and placed. The one thing it costs is
+# a chooser row, restored at position 0 where a stock unit has it.
+NO_FB = REMIX.fallback == NO_FALLBACK
 
 # BUILD TAG, stamped into the effect's displayed name. Three rounds were lost
 # to not being able to tell WHICH build was running on the unit: a symptom
@@ -1003,6 +1010,9 @@ def main():
         clone_addr[name] = stock_P
         print(f"  {name:14s} id 0x{NEW_IDS[name]:02x}  STOCK P=0x{stock_P:08x}"
               f"  (no clone, no code: the row is the only edit)")
+    if delayprobe == "send" and NO_FB:
+        sys.exit("DELAYPROBE=send reuses the SEND client, and this remix has "
+                 f"no SEND (fallback={NO_FALLBACK})")
     if delayprobe and "DELAY" in ORDER:
         sys.exit("DELAYPROBE puts stock DELAY back in the menu, but this remix "
                  "already lists it -- drop one")
@@ -1013,6 +1023,12 @@ def main():
     # making every unassigned track a SEND removes the "first track set to NONE
     # stalls the bus" hazard by construction rather than patching around it.
     real = [(n, clone_addr[n]) for n in ORDER]
+    if NO_FB:
+        # NONE goes back where stock has it: list position 0. It clones no
+        # descriptor and places no code -- FX1_NONE is the firmware's own,
+        # already in the image -- so the row is four bytes of cave and the
+        # only edit.
+        real = [("NONE", FX1_NONE)] + real
     if delayprobe:
         # Stock DELAY needs no clone -- it has its own descriptor and its own
         # FX2_IDS entry, both untouched by this build. It only needs putting
@@ -1046,8 +1062,10 @@ def main():
         if rd32(r) != FX2_LIST:
             sys.exit(f"list ref at 0x{r:08x} not stock FX2_LIST -- refusing")
         wr32(r, list_addr)
+    # The cursor position of every listed effect, past the NONE row if one
+    # was restored -- ID2POS is an index into `real`, not into ORDER.
     for pos, name in enumerate(ORDER):
-        wr32(ID2POS + NEW_IDS[name] * 4, pos)
+        wr32(ID2POS + NEW_IDS[name] * 4, pos + (1 if NO_FB else 0))
     # ==== 1b. ColdFire caves, from whichever modules carry them =============
     # A cave is how a module changes the firmware's BEHAVIOUR rather than
     # adding an effect: assert the hook site still holds the stock bytes,
@@ -1171,8 +1189,10 @@ def main():
     # A fresh part's FX2 id is 0. Rather than hunt down the part-init template,
     # alias id 0 to SEND: its descriptor, its cursor position, and (below) its
     # DSP dispatch. Every unassigned track is then a SEND automatically.
-    wr32(FX2_IDS + NONE_ID * 4, clone_addr[REMIX.fallback])
-    wr32(ID2POS + NONE_ID * 4, ORDER.index(REMIX.fallback))
+    fb_desc = FX1_NONE if NO_FB else clone_addr[REMIX.fallback]
+    fb_pos = 0 if NO_FB else ORDER.index(REMIX.fallback)
+    wr32(FX2_IDS + NONE_ID * 4, fb_desc)
+    wr32(ID2POS + NONE_ID * 4, fb_pos)
     # A module this remix leaves out still owns an id, and a saved project can
     # carry it. Alias it to the fallback for exactly the reason id 0 is
     # aliased: the alternative is a chooser entry dispatching into whatever
@@ -1195,8 +1215,8 @@ def main():
     _restored = [m for m in _omitted if m.menu.replaces]
     _omitted = [m for m in _omitted if not m.menu.replaces]
     for _m in _omitted:
-        wr32(FX2_IDS + _m.menu.fx2_id * 4, clone_addr[REMIX.fallback])
-        wr32(ID2POS + _m.menu.fx2_id * 4, ORDER.index(REMIX.fallback))
+        wr32(FX2_IDS + _m.menu.fx2_id * 4, fb_desc)
+        wr32(ID2POS + _m.menu.fx2_id * 4, fb_pos)
     if _restored:
         print(f"  not in this remix, LEFT STOCK: "
               f"{', '.join(sorted(m.key for m in _restored))} -- each replaces "
@@ -1212,14 +1232,19 @@ def main():
             sys.exit("DELAY's FX2_IDS entry is not stock -- refusing to probe")
         print(f"  *** DELAY PROBE: stock DELAY restored to the menu at "
               f"position {len(real) - 1} ***")
-    print(f"  chooser list = {len(real)} entries, no NONE, viewport shrunk to "
+    _none = "with NONE at row 0" if NO_FB else "no NONE"
+    print(f"  chooser list = {len(real)} entries, {_none}, viewport shrunk to "
           f"{len(real)} rows (no padding)" if len(real) <= CHOOSER_ROWS else
           f"  chooser list = {len(real)} entries at 0x{list_addr:08x} (the "
-          f"long list cave), no NONE, viewport {rows} rows -- it scrolls")
+          f"long list cave), {_none}, viewport {rows} rows -- it scrolls")
     if STOCK_ROWS:
         print(f"  stock rows kept: {', '.join(STOCK_ROWS)} -- descriptors, "
               f"code and dispatch untouched on both cores")
-    print(f"  id 0x00 aliased to SEND: a fresh/unassigned track is a send\n")
+    # ⚠️ WORDING FROZEN for the SEND arm: the build report is API (refhash
+    # hashes it verbatim). Only the NONE arm is new.
+    print(f"  id 0x00 aliased to NONE: a fresh/unassigned track is off, as "
+          f"on a stock unit\n" if NO_FB else
+          f"  id 0x00 aliased to SEND: a fresh/unassigned track is a send\n")
 
     # ==== 2. DSP code placement + dispatch (task 13) ========================
     print("=== DSP: code placed, dispatch wired, both payloads ===")
@@ -1979,6 +2004,15 @@ mkgo:""",
             # away, and its id is already handled by the omitted-id alias.
             if absent not in NEW_IDS:
                 absent = None
+        if NO_FB:
+            # The DSP half of the NONE fallback, and it needs no new code:
+            # the per-payload null stub is already in the image and is what
+            # the build points a silenced donor id at, described there as
+            # proven. Set before placement because nothing below assigns
+            # fb_init/fb_proc when the fallback is not a module.
+            fb_init, fb_proc = pp["nul_i"], pp["nul_p"]
+            wrw_p(pp["xtab"] + NONE_ID * 3, fb_init)
+            wrw_p(pp["xtab"] + (32 + NONE_ID) * 3, fb_proc)
         cursor = base_a
         # LFO roll table (10 Aug 2026): reverb_server.asm's rolled lines 2-7
         # read per-line [rate const, phase slot, int slot, frac slot] from a

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -2011,14 +2011,48 @@ mkgo:""",
               f"({budget} words)  used {cursor - base_a}  "
               f"FREE {base_a + budget - cursor}")
 
-        # ---- donor ids -> the proven-silent null stub, not our code ------
+        # ---- donor ids -> the null stub, BUT ONLY WHERE OUR CODE LANDED --
+        # This used to null all three unconditionally, so a build that placed
+        # 250 words silenced 2,724 words' worth of reverb -- and the answer
+        # to "why can I never get the stock verbs back?" was "you cannot,
+        # ever". PLAN §7 item 2. The precedent is CHORUS, which got its stock
+        # dispatch back the moment the build stopped taking its code.
+        #
+        # The stream is contiguous from base_a, so the written span is
+        # [base_a, cursor) and a donor whose record STARTS at or after the
+        # cursor still holds its own code, untouched. Give it back.
+        kept = [d for d in DONOR_IDS if record(pp[d])[1] >= cursor]
         for donor, eid in DONOR_IDS.items():
+            if donor in kept:
+                continue
             wrw_p(pp["xtab"] + eid * 3, pp["nul_i"])
             wrw_p(pp["xtab"] + (32 + eid) * 3, pp["nul_p"])
-        print(f"  donor ids ({'CHORUS/' if DEV else ''}PLATE/SPRING/DARK REV) "
-              f"-> null stub P:0x{pp['nul_i']:05x}/0x{pp['nul_p']:05x} -- any "
-              f"path resolving a donor id gets silence, not our code "
-              f"(defensive: the FX1 menu never listed the reverbs)")
+        if not kept:
+            # ⚠️ WORDING FROZEN: the build report is API (refhash hashes it,
+            # and verify_* parse it). Every shipping layout packs past all
+            # three, so this is the line every existing case still prints.
+            print(f"  donor ids ({'CHORUS/' if DEV else ''}PLATE/SPRING/DARK REV) "
+                  f"-> null stub P:0x{pp['nul_i']:05x}/0x{pp['nul_p']:05x} -- any "
+                  f"path resolving a donor id gets silence, not our code "
+                  f"(defensive: the FX1 menu never listed the reverbs)")
+        else:
+            _gone = [d for d in DONOR_IDS if d not in kept]
+            print(f"  donor ids taken ({'/'.join(_gone).upper() or 'none'}) "
+                  f"-> null stub P:0x{pp['nul_i']:05x}/0x{pp['nul_p']:05x}; "
+                  f"KEPT STOCK: {'/'.join(kept).upper()} -- this selection "
+                  f"stops at P:0x{cursor:05x} and never touched their code")
+        # A chooser row for a reverb whose words we just overwrote would
+        # point at a live descriptor over dead code: the panel would draw
+        # PLATE REV and the DSP would run ours. Refuse, loudly.
+        for _name in STOCK_ROWS:
+            _d = next((d for d, e in DONOR_IDS.items()
+                       if e == NEW_IDS[_name]), None)
+            if _d is not None and _d not in kept:
+                sys.exit(f"payload {tag}: {_name} is listed in the chooser but "
+                         f"this selection places code over it (region used "
+                         f"{cursor - base_a} words, {_d.upper()} starts at "
+                         f"{record(pp[_d])[1] - base_a}) -- remove the row or "
+                         f"free the words")
         if DEV:
             print(f"  *** CHORUS (id 0x12) TAKEN as a fourth donor -- FX1 loses "
                   f"its chorus. DEV builds are never flashed. ***")

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -1945,24 +1945,43 @@ mkgo:""",
                      f"{sum(n for _a, n in _want)} words but their P records "
                      f"total {_have} -- the module map and stock.p_spans "
                      f"disagree")
-        for (_, a, cnt, _), (_, a2, _, _) in zip(region, region[1:]):
-            if a + cnt != a2:
-                # A module of ours is ONE code stream, so a gap is not a
-                # smaller region, it is two -- and nothing here chooses
-                # between them. Refuse and name the survivor in the way.
-                between = sorted(k for k, (ad, _n) in _sp.items()
-                                 if a + cnt <= ad < a2)
-                sys.exit(f"payload {tag}: the harvested effects are not "
-                         f"contiguous (0x{a:05x}+{cnt} != 0x{a2:05x}) -- "
-                         f"{', '.join(between) or 'something'} "
-                         f"{'sit' if len(between) != 1 else 'sits'} between "
-                         f"them and a single code stream cannot span it")
+        # ⚠️ A GAP IS TWO RUNS, NOT A SMALLER REGION. A module of ours is one
+        # code stream, so it must fit inside a single run -- but different
+        # modules can sit in different runs, and the placer below packs them
+        # that way. Until 3 Sep 2026 this refused any gap and the caller
+        # handed us the largest run alone, so harvesting two separated groups
+        # gave up the smaller one for nothing (Sam, 3 Sep: "when I remove some
+        # reverb it only shows the free reverb space"). Splitting here is what
+        # makes every harvested word placeable; the only residual cost of a
+        # gap is FRAGMENTATION, which the placer reports by name.
+        runs = []
+        for _rec in region:
+            if runs and runs[-1]["base"] + runs[-1]["words"] == _rec[1]:
+                runs[-1]["words"] += _rec[2]
+            else:
+                runs.append({"base": _rec[1], "words": _rec[2]})
+        for _r in runs:
+            _r["cursor"] = _r["base"]
         # With nothing harvested there is no region at all -- legal, and
         # what a pure stock chooser is. `_need` above has already refused it
         # if anything wanted placing, so the rest of this runs over an empty
         # stream and writes nothing.
         base_a = region[0][1] if region else 0
         budget = sum(m[2] for m in region)
+
+        def _end_of_run(a):
+            """End address of the run containing `a` (its own value if none)."""
+            for r in runs:
+                if r["base"] <= a < r["base"] + r["words"]:
+                    return r["base"] + r["words"]
+            return a
+
+        def _written(a):
+            """Did the placed code actually reach address `a`?"""
+            for r in runs:
+                if r["base"] <= a < r["base"] + r["words"]:
+                    return a < r["cursor"]
+            return False
 
         def place(words, start):
             """Write a contiguous word stream at P address `start`.
@@ -2266,18 +2285,9 @@ mkgo:""",
         # once and compare them.
         LFO01_MARK = "LFO lines 0-1: ROLLED TOO"
         for name, src in plan:
-            if "$facade" in src:
-                if src.count("$facade") != 1:
-                    sys.exit(f"payload {tag}: {name} has multiple $facade "
-                             f"LFOTAB literals -- expected exactly one")
-                tab = (LFO01 + LFOTAB) if LFO01_MARK in src else LFOTAB
-                place(tab, cursor)
-                src = src.replace("$facade", f"${cursor:x}")
-                print(f"  LFOTAB        P:0x{cursor:05x}.."
-                      f"0x{cursor + len(tab):05x} "
-                      f"({len(tab):4d} words)  rolled LFO lines "
-                      f"{'0-7' if LFO01_MARK in src else '2-7'}")
-                cursor += len(tab)
+            if "$facade" in src and src.count("$facade") != 1:
+                sys.exit(f"payload {tag}: {name} has multiple $facade "
+                         f"LFOTAB literals -- expected exactly one")
             if DEV and name == "DELAY SERVER":
                 # DEV: the delay does NOT go in the donor region. It is
                 # assembled at DEV_DELAY_P (see that constant) and its module
@@ -2303,11 +2313,56 @@ mkgo:""",
                       f"  id 0x{NEW_IDS[name]:02x}  Y base 0x38000  "
                       f"(DEV: OUT OF REGION, code lives in the .mem dump)")
                 continue
-            words, init_a, proc_a = assemble(src, cursor)
-            if cursor + len(words) > base_a + budget:
-                sys.exit(f"payload {tag}: {name} overruns the region "
-                         f"({cursor + len(words) - base_a} > {budget} words)")
+            # ---- pick a RUN that fits, lowest address first --------------
+            # A module is one code stream, so it goes wholly inside one run.
+            # First-fit in address order: with a single run this is exactly
+            # the old bump cursor, byte for byte (refhash). The LFO table
+            # rides with its module so the address the module was assembled
+            # against is always in the same run.
+            # ⚠️ THE MODULE IS ASSEMBLED ONCE PER CANDIDATE, because its
+            # origin is an argument -- cheap (the whole build is ~0.3 s) and
+            # it keeps the length honest instead of assuming origin-invariant
+            # encoding, which is exactly the kind of assumption this codebase
+            # has been burned by.
+            _fit, _last = None, None
+            for _r in runs:
+                _c, _end = _r["cursor"], _r["base"] + _r["words"]
+                _tab, _s2 = None, src
+                if "$facade" in src:
+                    _tab = (LFO01 + LFOTAB) if LFO01_MARK in src else LFOTAB
+                    if _c + len(_tab) > _end:
+                        continue
+                    _s2 = src.replace("$facade", f"${_c:x}")
+                    _c += len(_tab)
+                _w, _ia, _pa = assemble(_s2, _c)
+                _last = (_c, len(_w))
+                if _c + len(_w) <= _end:
+                    _fit = (_r, _tab, _s2, _c, _w, _ia, _pa)
+                    break
+            if _fit is None:
+                if len(runs) < 2 and _last is not None:
+                    # ⚠️ WORDING FROZEN: the build report is API (refhash
+                    # hashes the failure text of the overrun cases too).
+                    sys.exit(f"payload {tag}: {name} overruns the region "
+                             f"({_last[0] + _last[1] - base_a} > {budget} "
+                             f"words)")
+                _big = max((r["base"] + r["words"] - r["cursor"]
+                            for r in runs), default=0)
+                _tot = sum(r["base"] + r["words"] - r["cursor"] for r in runs)
+                sys.exit(f"payload {tag}: {name} does not fit any harvested "
+                         f"run -- {_tot} words are free across {len(runs)} "
+                         f"separate runs but the largest single opening has "
+                         f"only {_big}; harvest an effect BETWEEN two runs to "
+                         f"join them into one")
+            _r, tab, src, cursor, words, init_a, proc_a = _fit
+            if tab is not None:
+                place(tab, _r["cursor"])
+                print(f"  LFOTAB        P:0x{_r['cursor']:05x}.."
+                      f"0x{_r['cursor'] + len(tab):05x} "
+                      f"({len(tab):4d} words)  rolled LFO lines "
+                      f"{'0-7' if LFO01_MARK in src else '2-7'}")
             place(words, cursor)
+            _r["cursor"] = cursor + len(words)
             wrw_p(pp["xtab"] + NEW_IDS[name] * 3, init_a)
             wrw_p(pp["xtab"] + (32 + NEW_IDS[name]) * 3, proc_a)
             if name == REMIX.fallback:
@@ -2343,7 +2398,7 @@ mkgo:""",
         if probe == "silence":
             words, init_a, proc_a = assemble(
                 pathlib.Path("dsp/silence_stub.asm").read_text(), cursor)
-            if cursor + len(words) > base_a + budget:
+            if cursor + len(words) > _end_of_run(cursor):
                 sys.exit("silence stub does not fit the region's free tail")
             place(words, cursor)
             wrw_p(pp["xtab"] + STOCK_DELAY_ID * 3, init_a)
@@ -2377,9 +2432,28 @@ mkgo:""",
             print(f"  {'SEND @ 0x08':13} P:0x{fb_init:05x} "
                   f"(reuses the SEND client)  id 0x{STOCK_DELAY_ID:02x} "
                   f"*** DELAY's slot now runs SEND; audio passes through ***")
-        print(f"  region P:0x{base_a:05x}..0x{base_a + budget:05x} "
-              f"({budget} words)  used {cursor - base_a}  "
-              f"FREE {base_a + budget - cursor}")
+        if len(runs) < 2:
+            # ⚠️ WORDING FROZEN for a single run: the build report is API
+            # (refhash hashes it verbatim, verify_* parse it).
+            print(f"  region P:0x{base_a:05x}..0x{base_a + budget:05x} "
+                  f"({budget} words)  used {cursor - base_a}  "
+                  f"FREE {base_a + budget - cursor}")
+        else:
+            # ⚠️ THE SUMMARY KEEPS THE SINGLE-RUN SHAPE `(N words) used U
+            # FREE F` -- state.measure() reads the budget off it, and there
+            # must be exactly ONE such line per payload. The per-run lines
+            # below are deliberately spelled so they do NOT match it.
+            _used = sum(r["cursor"] - r["base"] for r in runs)
+            print(f"  region {len(runs)} runs ({budget} words)  "
+                  f"used {_used}  FREE {budget - _used}")
+            for _i, _r in enumerate(runs, 1):
+                _e = _r["base"] + _r["words"]
+                _in = "/".join(k for k in _harvest
+                               if _r["base"] <= _sp[k][0] < _e)
+                print(f"    run {_i} P:0x{_r['base']:05x}..0x{_e:05x} "
+                      f"{_r['words']:5d} w  used "
+                      f"{_r['cursor'] - _r['base']:5d}  spare "
+                      f"{_e - _r['cursor']:5d}  {_in}")
 
         # ---- donor ids -> the null stub, BUT ONLY WHERE OUR CODE LANDED --
         # This used to null all three unconditionally, so a build that placed
@@ -2404,7 +2478,10 @@ mkgo:""",
         # REV", so the first word is what keeps every existing report line
         # byte-identical (refhash) and every existing parser working.
         _short = {k: k.split()[0].upper() for k in _hv}
-        kept = [d for d, (a, _n) in _hv.items() if a >= cursor]
+        # ⚠️ PER RUN. One global cursor was right only while the region was
+        # one run; with two, an effect in a run we never opened is untouched
+        # however far the other run was packed.
+        kept = [d for d, (a, _n) in _hv.items() if not _written(a)]
         for donor, (a, _n) in _hv.items():
             if donor in kept:
                 continue
@@ -2433,7 +2510,9 @@ mkgo:""",
             print(f"  donor ids taken ({'/'.join(_gone) or 'none'}) "
                   f"-> null stub P:0x{pp['nul_i']:05x}/0x{pp['nul_p']:05x}; "
                   f"KEPT STOCK: {'/'.join(_short[k] for k in kept)} -- this selection "
-                  f"stops at P:0x{cursor:05x} and never touched their code")
+                  + (f"stops at P:0x{cursor:05x} and never touched their code"
+                     if len(runs) < 2 else
+                     f"never reached into their runs"))
         # A chooser row for a reverb whose words we just overwrote would
         # point at a live descriptor over dead code: the panel would draw
         # PLATE REV and the DSP would run ours. Refuse, loudly.

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -94,7 +94,8 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent))
 from dsp_modmap import BASE, IMG, PAYLOADS, modules  # noqa: E402
 from remix import registry as remix_registry  # noqa: E402
 from remix.registry import modules as remix_modules  # noqa: E402
-from remix.schema import NO_FALLBACK, YBase  # noqa: E402
+from remix.schema import NO_FALLBACK, BusRole, YBase  # noqa: E402
+from remix.state import fx1_hazard  # noqa: E402
 import label_fmt  # noqa: E402
 from remix import ledger  # noqa: E402
 
@@ -992,6 +993,18 @@ def main():
             sys.exit(f"{name}: FX1_IDS[0x{NEW_IDS[name]:02x}] is 0x{cur:08x}, "
                      f"not stock {rep}'s 0x{stock_P:08x} -- refusing to "
                      f"repoint a table that is not where we think it is")
+        # ⚠️ AN INHERITED FX1 ROW IS STILL AN FX1 ROW. This is the path the
+        # schema's `replaces` note described as "Nothing checks this": the
+        # module lands on FX1 whether or not it can survive there, and the
+        # three ways it cannot are the same three Remix.fx1 refuses. The
+        # difference is that here the row is not asked for -- it comes with
+        # the id -- so the refusal has to name the way out.
+        _hz = fx1_hazard(_MODS[name])
+        if _hz:
+            sys.exit(f"{name}: replacing {rep} puts it on FX1 too, and "
+                     f"{_hz}. Either take an id FX1 does not list, or make "
+                     f"it buffer-free (docs/MODULES.md, 'only a buffer-free "
+                     f"insert may take an FX1 row')")
         wr32(slot, clone_addr[name])
         # ...and the row the encoder scrolls, which holds the descriptor
         # pointer directly. Exactly one entry may match, or the assumption
@@ -1227,6 +1240,42 @@ def main():
                 sys.exit(f"fx1={_n!r}: a stock effect's FX1 row is stock's "
                          f"own business; this build does not add or remove "
                          f"one")
+            # A SERVER IS ONE PER CORE by design (SPEC places one engine per
+            # payload). An FX1 row is a second instance on the same core,
+            # which is the open "duplicate instances corrupt audio after
+            # ~5.45 s" item, reachable by two keystrokes.
+            if (_MODS[_n].dsp is not None
+                    and _MODS[_n].dsp.bus_role is BusRole.SERVER):
+                sys.exit(f"fx1={_n!r}: a bus server is one per core by "
+                         f"design; an FX1 row would be a second instance on "
+                         f"the same core")
+            # ⚠️ AN FX1 SLOT IS 3,072 WORDS AND AN FX2 SLOT IS 16,384, and
+            # the trap is not theoretical -- docs/DSP.md's "wrong claim 1"
+            # is this exact failure, bisected on hardware: a 16K layout
+            # placed at table[2] = 0x1c00 "runs to 0x53ff, through the other
+            # FX1 buffers and into FX2 slot 0". A module that reads the
+            # host's allocator (x:>$213) sizes itself for the slot it
+            # expects, and on FX1 it gets a quarter of it.
+            _c = getattr(_MODS[_n], "claims", None)
+            if _c is not None and _c.stock_instance_buffer:
+                sys.exit(f"fx1={_n!r}: it takes a buffer from the host's "
+                         f"allocator, sized for an FX2 slot (16,384 words). "
+                         f"An FX1 slot is 3,072 -- the layout would run "
+                         f"through the other FX1 buffers and into FX2 slot 0 "
+                         f"(docs/DSP.md, 'wrong claim 1', bisected on "
+                         f"hardware)")
+            # And a module with FIXED buffers hardcodes FX2-region addresses,
+            # so an FX1 instance writes into some OTHER track's FX2 buffer.
+            # That hazard exists on FX2 already -- it is why Nimbus is "one
+            # per core" -- but an FX1 row doubles the slots it can be reached
+            # from, including a second instance on the SAME track.
+            if (_c is not None and _c.owns_fx2_buffers) or (
+                    _MODS[_n].dsp is not None
+                    and _MODS[_n].dsp.ybase is not YBase.NEVER):
+                sys.exit(f"fx1={_n!r}: its buffers are at FIXED addresses in "
+                         f"the FX2 region, so an FX1 instance would write "
+                         f"into another track's FX2 buffer. Only a "
+                         f"buffer-free insert can take an FX1 row")
         _old = []
         _a = FX1_LIST
         while rd32(_a):

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -117,6 +117,18 @@ FX2_IDS = 0x400d5fdc
 FX1_IDS = 0x400d5f58        # id-indexed, 32 slots; NONE for an FX2-only effect
 FX1_LIST = 0x400d6060       # the chooser list FX1 scrolls, NUL-terminated
 FX1_NONE = 0x400d4618       # the descriptor every unused id points at
+# FX1's OWN cursor-position table, the exact analogue of ID2POS below, found
+# 3 Sep 2026 by reading the four tables in address order: FX1_LIST (11
+# entries) at 0x400d6060, FX2_LIST (15) at 0x400d6090, then two 32-entry
+# id->row tables back to back. It is FX1's because its FX2-only ids are all
+# zero -- DELAY (0x08) and the three reverbs (0x14-0x16) -- where ID2POS
+# gives them rows 0x0b and 0x0c-0x0e. tools/build_fx1.py's experiment never
+# wrote it, which is a real gap: without it a project that has one of our
+# effects stored on FX1 opens the chooser with the cursor on row 0.
+FX1_ID2POS = 0x400d60d0
+# The `lea.l FX1_LIST,aN` sites, the FX1 counterparts of LIST_REFS. Measured
+# by tools/build_fx1.py, which repoints exactly these three.
+FX1_LIST_REFS = [0x40037990, 0x40052706, 0x40059bd2]
 FX2_LIST = 0x400d6090
 ID2POS = 0x400d6150
 LIST_REFS = [0x400375f4, 0x40052496, 0x40059a42]
@@ -1179,6 +1191,90 @@ def main():
         print(f"  {len(_lbl)} label formatters, "
               f"0x{max(_cave_top, cave_end):08x}..0x{_lbl_top:08x} "
               f"({_lbl_top - max(_cave_top, cave_end)} B)")
+    # ==== 1d. FX1 ROWS, for modules that asked for one =====================
+    # THE OTHER HALF OF "BOTH SLOTS". The DSP dispatch is ONE table indexed by
+    # the raw id and shared by the menus, so a module's CODE already runs from
+    # FX1 the moment FX1 selects its id -- and a REPLACEMENT already gets the
+    # row, because it inherits the stock effect's (above, in place). What was
+    # missing is a row for a module on a NEW id, and it was missing for one
+    # mechanical reason: FX1's list ends at 0x400d608c and FX2's begins at
+    # 0x400d6090, so it cannot grow where it is.
+    #
+    # So it moves, exactly as the FX2 list does when it outgrows NEW_LIST:
+    # rebuilt in the cave, three `lea` references repointed. That relocation
+    # is not new -- tools/build_fx1.py proved it standalone against the stock
+    # image (data only, 74 bytes changed) and it still applies today.
+    #
+    # It costs NO WORDS. The code is in the image either way; this is four
+    # bytes of cave per row plus the relocated list. What it does cost is
+    # CYCLES: an FX1 effect runs on a track that is already running an FX2
+    # one, so the worst per-core load can gain four more copies of it
+    # (tools/cycle_count.py, which prices FX1 slots for exactly this reason).
+    _fx1 = [n for n in ORDER if n in REMIX.fx1]
+    if _fx1:
+        # The remix names keys; only a module with a chooser row of its own
+        # has a descriptor for FX1's list to point at, and a REPLACEMENT
+        # already has FX1's tables repointed to it in place (above).
+        for _n in REMIX.fx1:
+            if _n not in ORDER:
+                sys.exit(f"fx1={_n!r}: it has no FX2 chooser row, so there "
+                         f"is no descriptor clone for FX1 to point at")
+            if _MODS[_n].menu.replaces:
+                sys.exit(f"fx1={_n!r}: it replaces stock "
+                         f"{_MODS[_n].menu.replaces}, which already gives it "
+                         f"that effect's FX1 row -- this would list it twice")
+            if _MODS[_n].is_stock:
+                sys.exit(f"fx1={_n!r}: a stock effect's FX1 row is stock's "
+                         f"own business; this build does not add or remove "
+                         f"one")
+        _old = []
+        _a = FX1_LIST
+        while rd32(_a):
+            _old.append(rd32(_a))
+            _a += 4
+            if len(_old) > 32:
+                sys.exit("FX1 chooser list has no terminator -- refusing")
+        _new = _old + [clone_addr[n] for n in _fx1] + [0]
+        _need = len(_new) * 4
+        if _lbl_top + _need > cave_limit:
+            sys.exit(f"FX1 chooser list of {len(_new) - 1} rows needs "
+                     f"{_need} B at 0x{_lbl_top:08x} and the cave ends at "
+                     f"0x{cave_limit:08x}")
+        if any(img[_lbl_top - BASE:_lbl_top - BASE + _need]):
+            sys.exit(f"FX1 chooser list cave at 0x{_lbl_top:08x} is not free")
+        _fx1_addr = _lbl_top
+        for _i, _v in enumerate(_new):
+            wr32(_fx1_addr + _i * 4, _v)
+        _lbl_top += _need
+        # REPOINT, having proved each site is what we think it is. A `lea.l
+        # <abs>.l,aN` is 0x4?f9 followed by the address, so the two bytes
+        # before the operand pin the instruction as well as the value.
+        for _r in FX1_LIST_REFS:
+            if rd32(_r) != FX1_LIST:
+                sys.exit(f"FX1 list ref at 0x{_r:08x} is 0x{rd32(_r):08x}, "
+                         f"not stock FX1_LIST -- refusing")
+            if bytes(img[_r - BASE - 2:_r - BASE]) not in (
+                    b"\x41\xf9", b"\x47\xf9", b"\x4b\xf9"):
+                sys.exit(f"FX1 list ref at 0x{_r:08x} is not preceded by a "
+                         f"lea.l opcode -- refusing")
+            wr32(_r, _fx1_addr)
+        # FX1 RESOLVES ITS OWN DESCRIPTOR AND ITS OWN CURSOR ROW. Writing
+        # only the list would draw the row and then open the stock NONE page
+        # under it -- "a slot can draw a knob and publish nothing", one table
+        # further along.
+        for _n in _fx1:
+            _slot = FX1_IDS + NEW_IDS[_n] * 4
+            if rd32(_slot) != FX1_NONE:
+                sys.exit(f"{_n}: FX1_IDS[0x{NEW_IDS[_n]:02x}] is "
+                         f"0x{rd32(_slot):08x}, not NONE -- this id is "
+                         f"already on FX1 and the row would be a duplicate")
+            wr32(_slot, clone_addr[_n])
+            wr32(FX1_ID2POS + NEW_IDS[_n] * 4, len(_old) + _fx1.index(_n))
+        print(f"  FX1 chooser = {len(_new) - 1} entries at 0x{_fx1_addr:08x} "
+              f"(stock's {len(_old)} + {', '.join(_fx1)}), "
+              f"{len(FX1_LIST_REFS)} refs repointed, id table and cursor "
+              f"rows written -- no words: the code is already placed")
+
     # ALWAYS report the headroom, even when nothing was planted. It used to
     # ride on the label-formatter line, so a remix with no labelled select
     # (SEND alone, say) reported no cave figure at all and the workbench's

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -102,6 +102,20 @@ DIS = pathlib.Path("vendor/dsp56300/build/source/dsp_host/dsp_asm")
 
 # ---- ColdFire menu tables (task 11, tools/build_menu.py, reproduced here) --
 FX2_IDS = 0x400d5fdc
+# ---- FX1's OWN descriptor tables ------------------------------------------
+# The DSP dispatch is ONE table shared by both menus, but the descriptors are
+# not: FX1 resolves its own. So a module replacing a stock effect runs from
+# FX1 the moment it takes the id, while FX1's PAGE would still draw the stock
+# effect's knob names unless these two are repointed as well -- the "a slot
+# can draw a knob and publish nothing" family, in reverse.
+#
+# For a REPLACEMENT both writes are IN PLACE, because the effect is already
+# on FX1: there is no list to grow and no cave to relocate into. (That is
+# what tools/build_fx1.py's experiment needed, because it ADDS entries --
+# the list ends at 0x400d608c and the FX2 list starts at 0x400d6090.)
+FX1_IDS = 0x400d5f58        # id-indexed, 32 slots; NONE for an FX2-only effect
+FX1_LIST = 0x400d6060       # the chooser list FX1 scrolls, NUL-terminated
+FX1_NONE = 0x400d4618       # the descriptor every unused id points at
 FX2_LIST = 0x400d6090
 ID2POS = 0x400d6150
 LIST_REFS = [0x400375f4, 0x40052496, 0x40059a42]
@@ -941,6 +955,42 @@ def main():
 
     for name in CLONED_ORDER:
         wr32(FX2_IDS + NEW_IDS[name] * 4, clone_addr[name])
+    # ---- a REPLACEMENT also takes over the stock effect's FX1 page --------
+    for name in CLONED_ORDER:
+        rep = _MODS[name].menu.replaces
+        if not rep:
+            continue
+        stock_P = _MODS[rep].menu.donor_desc + 0x38
+        slot = FX1_IDS + NEW_IDS[name] * 4
+        cur = rd32(slot)
+        if cur == FX1_NONE:
+            print(f"  {name:14s} replaces {rep}, which FX1 does not list -- "
+                  f"its FX1 page is left alone (adding a row needs the list "
+                  f"relocated; see tools/build_fx1.py)")
+            continue
+        if cur != stock_P:
+            sys.exit(f"{name}: FX1_IDS[0x{NEW_IDS[name]:02x}] is 0x{cur:08x}, "
+                     f"not stock {rep}'s 0x{stock_P:08x} -- refusing to "
+                     f"repoint a table that is not where we think it is")
+        wr32(slot, clone_addr[name])
+        # ...and the row the encoder scrolls, which holds the descriptor
+        # pointer directly. Exactly one entry may match, or the assumption
+        # about this table is wrong and nothing should be written.
+        hits = []
+        a = FX1_LIST
+        while rd32(a) != 0:
+            if rd32(a) == stock_P:
+                hits.append(a)
+            a += 4
+            if a > FX1_LIST + 32 * 4:
+                sys.exit("FX1 chooser list has no terminator")
+        if len(hits) != 1:
+            sys.exit(f"{name}: {rep} appears {len(hits)} times in the FX1 "
+                     f"chooser list -- expected exactly one")
+        wr32(hits[0], clone_addr[name])
+        print(f"  {name:14s} REPLACES stock {rep} on FX1 too: id table "
+              f"0x{slot:08x} and chooser row 0x{hits[0]:08x} -> "
+              f"0x{clone_addr[name]:08x}")
     # A stock row's descriptor is the one stock ships, at P = E + 0x38, and
     # its FX2_IDS entry must still be stock's -- the two are the same
     # pointer on a pristine image, and nothing above may have touched it.

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -96,6 +96,7 @@ from remix import registry as remix_registry  # noqa: E402
 from remix.registry import modules as remix_modules  # noqa: E402
 from remix.schema import NO_FALLBACK, BusRole, YBase  # noqa: E402
 from remix.state import fx1_hazard  # noqa: E402
+from remix import stock as stock_mod  # noqa: E402
 import label_fmt  # noqa: E402
 from remix import ledger  # noqa: E402
 
@@ -130,6 +131,13 @@ FX1_ID2POS = 0x400d60d0
 # The `lea.l FX1_LIST,aN` sites, the FX1 counterparts of LIST_REFS. Measured
 # by tools/build_fx1.py, which repoints exactly these three.
 FX1_LIST_REFS = [0x40037990, 0x40052706, 0x40059bd2]
+# FX1's viewport literal, the analogue of ROWCOUNT_AT below. Located 3 Sep
+# 2026: FX1's setup code is BYTE-IDENTICAL to FX2's apart from the list
+# address, and this sits at the identical offset (+0x14) from FX1's own list
+# reference, as `pea (0x7).w` = 4878 0007. It is what makes an FX1 list
+# SHORTER than stock's eleven safe.
+FX1_ROWCOUNT_INSN = 0x40059be4
+FX1_ROWCOUNT_AT = 0x40059be6
 FX2_LIST = 0x400d6090
 ID2POS = 0x400d6150
 LIST_REFS = [0x400375f4, 0x40052496, 0x40059a42]
@@ -1223,67 +1231,43 @@ def main():
     # CYCLES: an FX1 effect runs on a track that is already running an FX2
     # one, so the worst per-core load can gain four more copies of it
     # (tools/cycle_count.py, which prices FX1 slots for exactly this reason).
-    _fx1 = [n for n in ORDER if n in REMIX.fx1]
+    _fx1 = list(REMIX.fx1)
     if _fx1:
-        # The remix names keys; only a module with a chooser row of its own
-        # has a descriptor for FX1's list to point at, and a REPLACEMENT
-        # already has FX1's tables repointed to it in place (above).
-        for _n in REMIX.fx1:
+        # WHAT EACH ROW MAY BE. A module of ours needs an FX2 row, because
+        # that is where its descriptor CLONE comes from, and must survive on
+        # FX1 at all (state.fx1_hazard: not an allocator reader, not fixed
+        # FX2 buffers, not a bus server). A stock effect must be one FX1
+        # already lists -- DELAY and the three reverbs are FX2-only on a
+        # stock unit for exactly the reason our allocator readers are, they
+        # do not fit a 3,072-word FX1 allocation.
+        _fx1_desc = []
+        for _n in _fx1:
+            _m = _MODS.get(_n)
+            if _m is None:
+                sys.exit(f"fx1={_n!r}: no such effect")
+            if _m.is_stock:
+                if _m.menu.fx2_id not in stock_mod.fx1_ids():
+                    sys.exit(f"fx1={_n!r}: stock does not list it on FX1, "
+                             f"and it is FX2-only because it does not fit a "
+                             f"3,072-word FX1 allocation")
+                _fx1_desc.append(_m.menu.donor_desc + 0x38)
+                continue
             if _n not in ORDER:
                 sys.exit(f"fx1={_n!r}: it has no FX2 chooser row, so there "
                          f"is no descriptor clone for FX1 to point at")
-            if _MODS[_n].menu.replaces:
-                sys.exit(f"fx1={_n!r}: it replaces stock "
-                         f"{_MODS[_n].menu.replaces}, which already gives it "
-                         f"that effect's FX1 row -- this would list it twice")
-            if _MODS[_n].is_stock:
-                sys.exit(f"fx1={_n!r}: a stock effect's FX1 row is stock's "
-                         f"own business; this build does not add or remove "
-                         f"one")
-            # A SERVER IS ONE PER CORE by design (SPEC places one engine per
-            # payload). An FX1 row is a second instance on the same core,
-            # which is the open "duplicate instances corrupt audio after
-            # ~5.45 s" item, reachable by two keystrokes.
-            if (_MODS[_n].dsp is not None
-                    and _MODS[_n].dsp.bus_role is BusRole.SERVER):
-                sys.exit(f"fx1={_n!r}: a bus server is one per core by "
-                         f"design; an FX1 row would be a second instance on "
-                         f"the same core")
-            # ⚠️ AN FX1 SLOT IS 3,072 WORDS AND AN FX2 SLOT IS 16,384, and
-            # the trap is not theoretical -- docs/DSP.md's "wrong claim 1"
-            # is this exact failure, bisected on hardware: a 16K layout
-            # placed at table[2] = 0x1c00 "runs to 0x53ff, through the other
-            # FX1 buffers and into FX2 slot 0". A module that reads the
-            # host's allocator (x:>$213) sizes itself for the slot it
-            # expects, and on FX1 it gets a quarter of it.
-            _c = getattr(_MODS[_n], "claims", None)
-            if _c is not None and _c.stock_instance_buffer:
-                sys.exit(f"fx1={_n!r}: it takes a buffer from the host's "
-                         f"allocator, sized for an FX2 slot (16,384 words). "
-                         f"An FX1 slot is 3,072 -- the layout would run "
-                         f"through the other FX1 buffers and into FX2 slot 0 "
-                         f"(docs/DSP.md, 'wrong claim 1', bisected on "
-                         f"hardware)")
-            # And a module with FIXED buffers hardcodes FX2-region addresses,
-            # so an FX1 instance writes into some OTHER track's FX2 buffer.
-            # That hazard exists on FX2 already -- it is why Nimbus is "one
-            # per core" -- but an FX1 row doubles the slots it can be reached
-            # from, including a second instance on the SAME track.
-            if (_c is not None and _c.owns_fx2_buffers) or (
-                    _MODS[_n].dsp is not None
-                    and _MODS[_n].dsp.ybase is not YBase.NEVER):
-                sys.exit(f"fx1={_n!r}: its buffers are at FIXED addresses in "
-                         f"the FX2 region, so an FX1 instance would write "
-                         f"into another track's FX2 buffer. Only a "
-                         f"buffer-free insert can take an FX1 row")
-        _old = []
-        _a = FX1_LIST
-        while rd32(_a):
-            _old.append(rd32(_a))
-            _a += 4
-            if len(_old) > 32:
-                sys.exit("FX1 chooser list has no terminator -- refusing")
-        _new = _old + [clone_addr[n] for n in _fx1] + [0]
+            if _m.menu.replaces:
+                sys.exit(f"fx1={_n!r}: it replaces stock {_m.menu.replaces}, "
+                         f"which already gives it that effect's FX1 row -- "
+                         f"listing it here would show it twice")
+            _hz = fx1_hazard(_m)
+            if _hz:
+                sys.exit(f"fx1={_n!r}: {_hz}")
+            _fx1_desc.append(clone_addr[_n])
+
+        # THE FIRMWARE'S OWN NONE IS ALWAYS ROW 0. It is how the slot is
+        # turned off, stock has it there, and a remix naming effects must not
+        # be able to lose it by omission.
+        _new = [FX1_NONE] + _fx1_desc + [0]
         _need = len(_new) * 4
         if _lbl_top + _need > cave_limit:
             sys.exit(f"FX1 chooser list of {len(_new) - 1} rows needs "
@@ -1307,22 +1291,49 @@ def main():
                 sys.exit(f"FX1 list ref at 0x{_r:08x} is not preceded by a "
                          f"lea.l opcode -- refusing")
             wr32(_r, _fx1_addr)
+        # AND SIZE THE VIEWPORT, which is what makes a list SHORTER than
+        # stock's safe: the draw loop iterates this literal independently of
+        # the real length, so a short list has it reading past the terminator
+        # and rendering raw memory as text (the "bunch of symbols" of
+        # hardware test 1, on FX2). Same instruction, same offset from the
+        # list reference, same bytes -- FX1's setup function differs from
+        # FX2's only in the list address.
+        if rd32(FX1_ROWCOUNT_INSN) != 0x48780007:
+            sys.exit(f"FX1 row-count site 0x{FX1_ROWCOUNT_INSN:08x} is not "
+                     f"`pea (0x7).w` -- refusing")
+        _fx1_rows = min(CHOOSER_ROWS, len(_new) - 1)
+        img[FX1_ROWCOUNT_AT - BASE:FX1_ROWCOUNT_AT - BASE + 2] = \
+            _fx1_rows.to_bytes(2, "big")
         # FX1 RESOLVES ITS OWN DESCRIPTOR AND ITS OWN CURSOR ROW. Writing
         # only the list would draw the row and then open the stock NONE page
         # under it -- "a slot can draw a knob and publish nothing", one table
         # further along.
-        for _n in _fx1:
-            _slot = FX1_IDS + NEW_IDS[_n] * 4
-            if rd32(_slot) != FX1_NONE:
-                sys.exit(f"{_n}: FX1_IDS[0x{NEW_IDS[_n]:02x}] is "
-                         f"0x{rd32(_slot):08x}, not NONE -- this id is "
-                         f"already on FX1 and the row would be a duplicate")
-            wr32(_slot, clone_addr[_n])
-            wr32(FX1_ID2POS + NEW_IDS[_n] * 4, len(_old) + _fx1.index(_n))
-        print(f"  FX1 chooser = {len(_new) - 1} entries at 0x{_fx1_addr:08x} "
-              f"(stock's {len(_old)} + {', '.join(_fx1)}), "
-              f"{len(FX1_LIST_REFS)} refs repointed, id table and cursor "
-              f"rows written -- no words: the code is already placed")
+        #
+        # ⚠️ AND EVERY OTHER ID IS CLAMPED TO ROW 0, which the FX2 path does
+        # NOT do. FX2 has only ever been able to grow its list from three
+        # rows, so a stale position could not point past the end; FX1 can now
+        # be made SHORTER than stock's eleven, and an old project holding an
+        # id this list dropped would seed the cursor past the last row.
+        for _i in range(0x20):
+            wr32(FX1_ID2POS + _i * 4, 0)
+        for _pos, _n in enumerate(_fx1):
+            _m = _MODS[_n]
+            _eid = _m.menu.fx2_id
+            if not _m.is_stock:
+                _slot = FX1_IDS + _eid * 4
+                if rd32(_slot) != FX1_NONE:
+                    sys.exit(f"{_n}: FX1_IDS[0x{_eid:02x}] is "
+                             f"0x{rd32(_slot):08x}, not NONE -- this id is "
+                             f"already on FX1 and the row would be a "
+                             f"duplicate")
+                wr32(_slot, clone_addr[_n])
+            wr32(FX1_ID2POS + _eid * 4, _pos + 1)      # past NONE at row 0
+        _ours = [n for n in _fx1 if not _MODS[n].is_stock]
+        print(f"  FX1 chooser = {len(_new) - 1} rows at 0x{_fx1_addr:08x} "
+              f"(NONE + {', '.join(_fx1)}), {len(FX1_LIST_REFS)} refs "
+              f"repointed, viewport {_fx1_rows}, id and cursor tables "
+              f"written -- {len(_ours)} of ours, no words: their code is "
+              f"already placed")
 
     # ALWAYS report the headroom, even when nothing was planted. It used to
     # ride on the label-formatter line, so a remix with no labelled select

--- a/tools/cycle_count.py
+++ b/tools/cycle_count.py
@@ -555,8 +555,12 @@ def main():
     mix = " + ".join(f"{n}x {k}" for k, n in picks) or "(nothing of ours)"
     print(f"{'WORST ONE CORE':{w}}  {worst:>13}   {mix}")
     print(f"{'':{w}}  {'':>13}   4 FX2 slots, at most one server (the design rule)")
-    if remix.fx1:
-        print(f"{'':{w}}  {'':>13}   + 4 FX1 slots: {', '.join(remix.fx1)} "
+    # ⚠️ ONLY THE ONES PRICED. remix.fx1 is the whole FX1 chooser, stock
+    # rows included, and stock code is NOT counted here -- naming them made
+    # the line read as if FILTER's cycles were in the figure.
+    _ours = [m["key"] for m in mods if m["key"] in remix.fx1]
+    if _ours:
+        print(f"{'':{w}}  {'':>13}   + 4 FX1 slots: {', '.join(_ours)} "
               f"listed on FX1 too")
     if worst > CORE_TOTAL:
         print(f"{'':{w}}  {'':>13}   *** OVER the arithmetic ceiling ***")

--- a/tools/cycle_count.py
+++ b/tools/cycle_count.py
@@ -114,9 +114,15 @@ _ASM = registry.asm_by_stem()
 BANK = {"reverb_server": 1, "delay_server": 1, "send_client": 2}
 
 FX2_SLOTS = 4           # per core: four tracks, one FX2 each
+# AND FOUR FX1 SLOTS, on the same four tracks. Stock's own FX1 load is
+# already inside STOCK_SHARE (the 7 Aug sweep measured the spare with four
+# FILTERs running), so a module of ours listed on FX1 is charged ON TOP
+# without crediting back the stock effect it displaces. That is the
+# conservative direction, and the same one the FX2 slots are priced in.
+FX1_SLOTS = 4
 
 
-def bank_worst(rows, mods):
+def bank_worst(rows, mods, fx1=()):
     """The worst per-core load the SELECTED remix can actually be asked for.
 
     Four FX2 slots on a core, and the modules that can occupy them are the
@@ -131,6 +137,13 @@ def bank_worst(rows, mods):
         same insert, so the worst case is four copies of the dearest one --
         the number that matters for a card of inserts, and the one no
         previous version of this tool could produce.
+
+    AND FX1 IS A SECOND SET OF FOUR SLOTS on the same four tracks. A module
+    the remix lists on FX1 (Remix.fx1) can be selected there as well, on top
+    of whatever that track's FX2 slot is running -- which is why PLAN.md s2
+    puts FX1's real ceiling at "cycles x4". The dearest FX1-listed module is
+    charged four times, without crediting back the stock effect it displaces
+    (stock's own FX1 load is inside STOCK_SHARE already).
 
     Returns (total, [(name, count), ...]).
     """
@@ -149,6 +162,10 @@ def bank_worst(rows, mods):
         # anything of ours; those tracks run stock, which this tool does not
         # price. Say so rather than inventing a number for them.
         pass
+    fx1_mods = [m for m in mods if m["key"] in fx1 and m["stem"] in cyc]
+    if fx1_mods:
+        picks += [max(fx1_mods, key=lambda m: cyc[m["stem"]])["stem"]] \
+            * FX1_SLOTS
     counts = {}
     for n in picks:
         counts[n] = counts.get(n, 0) + 1
@@ -486,7 +503,7 @@ def main():
             if not ok:
                 sys.exit("marker changed codegen -- the count is not trustworthy")
 
-    worst, picks = bank_worst(rows, mods)
+    worst, picks = bank_worst(rows, mods, remix.fx1)
     # The legacy composition, and ONLY when the remix still carries the
     # modules it was measured with -- otherwise the comparison to the 7 Aug
     # hardware sweep is against a bank that shares nothing with it.
@@ -538,6 +555,9 @@ def main():
     mix = " + ".join(f"{n}x {k}" for k, n in picks) or "(nothing of ours)"
     print(f"{'WORST ONE CORE':{w}}  {worst:>13}   {mix}")
     print(f"{'':{w}}  {'':>13}   4 FX2 slots, at most one server (the design rule)")
+    if remix.fx1:
+        print(f"{'':{w}}  {'':>13}   + 4 FX1 slots: {', '.join(remix.fx1)} "
+              f"listed on FX1 too")
     if worst > CORE_TOTAL:
         print(f"{'':{w}}  {'':>13}   *** OVER the arithmetic ceiling ***")
     # The measured spare is what was left ON TOP of a full bank plus four FX1

--- a/tools/cycle_count.py
+++ b/tools/cycle_count.py
@@ -500,7 +500,21 @@ def main():
                               per_effect={m["name"]: m["cycles"] for m in rows},
                               worst_core=worst,
                               worst_core_mix=dict(picks),
+                              # The same mix keyed by MODULE KEY rather than
+                              # by asm stem, so a caller can print the name
+                              # the operator reads on the panel: `reverb
+                              # server` is a filename, `ChonVerb` is what the
+                              # workbench calls it everywhere else.
+                              worst_core_modules={
+                                  next(m["key"] for m in mods
+                                       if m["stem"] == stem): n
+                                  for stem, n in picks},
                               bank=bank, headroom=room,
+                              # What OUR code may spend, per core. The
+                              # workbench's budget row is read against this
+                              # rather than against core_total, and there
+                              # must be one source for the figure.
+                              usable=USABLE,
                               burn_spare_measured=BURN_SPARE,
                               bank_at_measure=BANK_AT_MEASURE,
                               core_total=CORE_TOTAL), indent=2))

--- a/tools/cycle_count.py
+++ b/tools/cycle_count.py
@@ -521,14 +521,14 @@ def main():
                               # by asm stem, so a caller can print the name
                               # the operator reads on the panel: `reverb
                               # server` is a filename, `ChonVerb` is what the
-                              # workbench calls it everywhere else.
+                              # remixer calls it everywhere else.
                               worst_core_modules={
                                   next(m["key"] for m in mods
                                        if m["stem"] == stem): n
                                   for stem, n in picks},
                               bank=bank, headroom=room,
                               # What OUR code may spend, per core. The
-                              # workbench's budget row is read against this
+                              # remixer's budget row is read against this
                               # rather than against core_total, and there
                               # must be one source for the figure.
                               usable=USABLE,

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -359,15 +359,30 @@ def _prime_menu(r):
     uc.hook_add(UC_HOOK_MEM_READ_UNMAPPED | UC_HOOK_MEM_WRITE_UNMAPPED
                 | UC_HOOK_MEM_FETCH_UNMAPPED, on_unmapped)
     uc.ctl_flush_tb()
-    _call(uc, MENU_OPEN)                     # allocate + set the menu window
-    uc.mem_write(MENU_STATE, (1).to_bytes(4, "big"))       # tree state
-    uc.mem_write(MENU_VIEWPORT, (6).to_bytes(4, "big"))    # visible rows
+    _open_menu_window(uc)
     # The root descriptor's rows field (0x400cbd8c+0x18) IS the MENU_ROWS
     # global that render repoints, so capture the root list ONCE now — after
     # this, reading the root descriptor gives whatever we last rendered.
     r._root_rows = _u32(uc, MENU_ROOT_DESC + 0x18)
     r._root_count = _u32(uc, MENU_ROOT_DESC)
     r._menu_ready = True
+
+
+def _open_menu_window(uc):
+    """Make the MENU the CURRENT window again.
+
+    ⚠️ Not one-time setup, though it was written as if it were. Rendering an
+    FX page (`render_fx2`/`render_fx1`) opens ITS window, and `MENU_DRAW`
+    afterwards draws for a window that is no longer the menu's -- it captures
+    NOTHING, silently, for the rest of the session. So the main-menu preview
+    worked only if it happened to be the first thing rendered, and in the
+    workbench it never was: FX2 is the default view. Found 2 Sep 2026 by
+    rendering the four views in sequence and counting the draws (12, 26, 0).
+    Re-opening is cheap and the round trip works in both directions.
+    """
+    _call(uc, MENU_OPEN)                     # allocate + set the menu window
+    uc.mem_write(MENU_STATE, (1).to_bytes(4, "big"))       # tree state
+    uc.mem_write(MENU_VIEWPORT, (6).to_bytes(4, "big"))    # visible rows
 
 
 def _list_of(r, desc):
@@ -407,9 +422,8 @@ def render_menu(r, desc=MENU_ROOT_DESC, cursor=0):
     uc = r.uc
     if uc is None or not r.reached_handoff:
         return []
-    try:
-        if not getattr(r, "_menu_ready", False):
-            _prime_menu(r)
+    def once():
+        _open_menu_window(uc)            # an FX render may own the window now
         rows, count = _list_of(r, desc)
         uc.mem_write(MENU_ROWS, rows.to_bytes(4, "big"))
         uc.mem_write(MENU_COUNT, count.to_bytes(4, "big"))
@@ -418,9 +432,32 @@ def render_menu(r, desc=MENU_ROOT_DESC, cursor=0):
         uc.mem_write(MENU_SELROW, int(cursor).to_bytes(4, "big"))
         r._draws.clear()
         _call(uc, MENU_DRAW)
+
+    try:
+        if not getattr(r, "_menu_ready", False):
+            _prime_menu(r)
+        once()
+        if not r._draws:                 # MENU_OPEN toggles, same as the FX
+            once()                       # pages -- see _call_page
     except UcError:
         pass
     return list(r._draws)
+
+
+def _call_page(uc, entry, draws):
+    """Call an FX SETUP entry point and make sure it actually DREW.
+
+    ⚠️ THESE ENTRY POINTS TOGGLE. `FX2_SETUP` opens the page on one call and
+    closes it on the next, so consecutive renders alternate 26 draws, 0, 26,
+    0 -- and a workbench that re-renders on every keystroke showed an empty
+    LCD half the time. Found 2 Sep 2026 by calling render_fx2 four times in
+    a row and counting; it reads as "the emulator is broken", which is why
+    it survived so long. A second call re-opens it.
+    """
+    draws.clear()
+    _call(uc, entry)
+    if not draws:
+        _call(uc, entry)
 
 
 def _prime_part(r):
@@ -478,8 +515,7 @@ def render_fx2(r, track=4, effect_id=0x07):
     try:
         if effect_id is not None:
             assign_fx2(r, track, effect_id)
-        r._draws.clear()
-        _call(uc, FX2_SETUP)
+        _call_page(uc, FX2_SETUP, r._draws)
     except UcError:
         pass
     return list(r._draws)
@@ -529,8 +565,7 @@ def render_fx1(r, track=4, effect_id=0x04):
             uc.mem_write(PAT_R, (0).to_bytes(1, "big"))
             uc.mem_write(_part_addr(uc, FX1_ID_OFF, track),
                          bytes([effect_id & 0xff]))
-        r._draws.clear()
-        _call(uc, FX1_SETUP)
+        _call_page(uc, FX1_SETUP, r._draws)
     except UcError:
         pass
     return list(r._draws)

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tier-0 ColdFire bring-up harness (PLAN.md §5, the workbench emu).
+"""Tier-0 ColdFire bring-up harness (PLAN.md §5, the remixer emu).
 
 Boots a MAIN OS image on Unicorn's ColdFire V4e core, modelling only as much
 of the hardware as the boot path actually touches, and stops at the RTOS
@@ -376,7 +376,7 @@ def _open_menu_window(uc):
     afterwards draws for a window that is no longer the menu's -- it captures
     NOTHING, silently, for the rest of the session. So the main-menu preview
     worked only if it happened to be the first thing rendered, and in the
-    workbench it never was: FX2 is the default view. Found 2 Sep 2026 by
+    remixer it never was: FX2 is the default view. Found 2 Sep 2026 by
     rendering the four views in sequence and counting the draws (12, 26, 0).
     Re-opening is cheap and the round trip works in both directions.
     """
@@ -449,7 +449,7 @@ def _call_page(uc, entry, draws):
 
     ⚠️ THESE ENTRY POINTS TOGGLE. `FX2_SETUP` opens the page on one call and
     closes it on the next, so consecutive renders alternate 26 draws, 0, 26,
-    0 -- and a workbench that re-renders on every keystroke showed an empty
+    0 -- and a remixer that re-renders on every keystroke showed an empty
     LCD half the time. Found 2 Sep 2026 by calling render_fx2 four times in
     a row and counting; it reads as "the emulator is broken", which is why
     it survived so long. A second call re-opens it.

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -19,6 +19,7 @@ details and the fork past the trap: docs/EMU.md.
 """
 import collections
 import os
+import re
 import sys
 
 try:
@@ -571,20 +572,76 @@ def render_fx1(r, track=4, effect_id=0x04):
     return list(r._draws)
 
 
+# The PART window's own text, which the FX pages drag in with them. Its
+# coordinates belong to a DIFFERENT window's space, so it lands in the middle
+# of the effect list and fuses with it -- "DJ EQUALIZER1" is `DJ EQUALIZER`
+# plus the trailing 1 of `Pt:1 PART 1`. It is real, and it is not this page,
+# so it comes out as a caption instead of a row (see part_label).
+_PART = re.compile(r"^Pt:\d")
+
+
+def _clean(draws):
+    """Deduped, blank-free, this-window-only draws.
+
+    The capture holds each string once per call and the page functions are
+    re-issued when nothing came back, so exact duplicates are routine.
+    """
+    seen, out = set(), []
+    for x, y, t in draws:
+        if not t.strip() or not (0 <= x <= 128 and 0 <= y <= 64):
+            continue
+        if _PART.match(t) or (x, y, t) in seen:
+            continue
+        seen.add((x, y, t))
+        out.append((x, y, t))
+    return out
+
+
+def part_label(draws):
+    """The PART window's caption, if this capture dragged one in."""
+    for _x, _y, t in draws:
+        if _PART.match(t):
+            return " ".join(t.split())
+    return None
+
+
 def layout_screen(draws, cols=42, rows=9):
     """Arrange captured (x,y,text) draws into a text grid. The LCD is 128x64
     with a bottom-left-ish origin (the list drawer steps y DOWN per row, so
-    larger y = higher on screen); map pixel x/y to character cells."""
-    grid = [[" "] * cols for _ in range(rows)]
-    for x, y, t in draws:
-        if not (0 <= x <= 128 and 0 <= y <= 64):     # skip bogus coords
-            continue
-        cx = min(cols - 1, max(0, x * cols // 128))
+    larger y = higher on screen); map pixel x/y to character cells.
+
+    Two rules, and they are the two things the LCD does that a character grid
+    does not do by itself:
+
+    ⚠️ A LATER DRAW OVER THE SAME PIXELS WINS. The firmware repaints a
+    parameter row in place, so the capture holds the label that WAS there
+    and then the one that is -- `PTCH` then `FRQ1` at the same x. Overlapping
+    spans are replaced, not shuffled aside, or the page shows both and reads
+    as an effect with seven parameters where the unit draws four.
+
+    ⚠️ TWO STRINGS THAT DO NOT OVERLAP ARE NEVER FUSED. Writing character by
+    character into a fixed grid let a label whose cell was taken run straight
+    into its neighbour, and the result is a word that does not exist on the
+    unit -- `DJ EQUALIZER1`, `COMPRESSORT 1`. A label pushed one column right
+    is legible and obviously two things; a fused one is not obviously
+    anything.
+    """
+    grid = [[] for _ in range(rows)]
+    for x, y, t in _clean(draws):
         cy = min(rows - 1, max(0, (64 - y) * rows // 64))
-        for i, ch in enumerate(t):
-            if cx + i < cols:
-                grid[cy][cx + i] = ch
-    return ["".join(row).rstrip() for row in grid]
+        cx = min(cols - 1, max(0, x * cols // 128))
+        row = grid[cy]
+        row[:] = [(s0, s1) for s0, s1 in row
+                  if s0 + len(s1) <= cx or s0 >= cx + len(t)]
+        row.append((cx, t))
+    out = []
+    for frags in grid:
+        row = ""
+        for cx, t in sorted(frags):
+            at = max(cx, len(row) + 1) if row else cx
+            row += " " * (at - len(row)) + t
+        out.append(row.rstrip())
+    return out
 
 
 def _cli():

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -605,31 +605,103 @@ def part_label(draws):
     return None
 
 
-def layout_screen(draws, cols=42, rows=9):
+# ---- the LCD's own geometry, MEASURED (3 Sep 2026) -------------------------
+# A character cell is FOUR pixels wide, so the 128 px screen is 32 characters,
+# not the 42 this used to assume. The measurement is exact and falls out of
+# the capture: the same column drawn with labels of different length starts at
+# a different x, and the shift is 2 px per character -- i.e. the firmware
+# CENTRES each label on a fixed anchor.
+#
+#   page-2 col 1   '12dB' x=55   'LOW' x=57   'HP' x=59   -> centre 63
+#   page-1 col 1   'BASE' x=62   'ATK' x=64   'FB' x=66   -> centre 70
+#   page-2 col 2   'NONE' x=75   'NUM' x=77   'LP' x=79   'Q' x=81  -> 83
+#   page-1 col 2   'WDTH' x=82   'GN1' x=84                         -> 90
+#   page-2 col 3   'BASE' x=95   'ENV' x=97                         -> 103
+#   page-1 col 3   'RTIM' x=102  'MIX' x=104  'Q1' x=106  'Q' x=108 -> 110
+#
+# Three parameter columns, each drawn twice 7 px apart (the page-1 name above
+# its dial, the page-2 name and value beside it). At 4 px per character that
+# 7 px is under two characters, so preserving it buys a ragged indent and
+# nothing else -- the columns are SNAPPED to one anchor per column instead,
+# which is the whole point of a column.
+CELL = 4                                  # px per character
+COLS = 128 // CELL
+LEFT_X = 40                               # left of this, text is left-aligned
+                                          # (the chooser list, the page title)
+
+
+def _left_aligned(items):
+    """The x positions this screen draws text LEFT-aligned at.
+
+    ⚠️ NOT EVERY COLUMN IS CENTRED. The parameter columns are; a LIST is not
+    -- the MAIN MENU's two columns are rows of different lengths sharing one
+    left edge, and centre-snapping them shuffled `PROJECT` / `SYSTEM` /
+    `CONTROL` / `MIDI` into three different indents.
+
+    The two are told apart by the thing that distinguishes them in the
+    capture: a centred column's x SHIFTS with the label's length (2 px per
+    character), so one x carries one length. A left-aligned one carries
+    several.
+    """
+    lens = collections.defaultdict(set)
+    for x, _y, t in items:
+        lens[x].add(len(t))
+    return {x for x, seen in lens.items() if len(seen) > 1}
+
+
+def _anchors(items, left, tol=8):
+    """The centres the firmware is centring parameter labels on, clustered
+    out of this screen's own draws rather than written down -- so a page laid
+    out differently gets its own columns instead of these."""
+    cs = sorted({x + CELL * len(t) / 2 for x, _y, t in items
+                 if x >= LEFT_X and x not in left})
+    groups = []
+    for c in cs:
+        if groups and c - groups[-1][-1] <= tol:
+            groups[-1].append(c)
+        else:
+            groups.append([c])
+    return [sum(g) / len(g) for g in groups]
+
+
+def layout_screen(draws, cols=COLS, rows=9):
     """Arrange captured (x,y,text) draws into a text grid. The LCD is 128x64
     with a bottom-left-ish origin (the list drawer steps y DOWN per row, so
-    larger y = higher on screen); map pixel x/y to character cells.
+    larger y = higher on screen).
 
-    Two rules, and they are the two things the LCD does that a character grid
-    does not do by itself:
+    Three rules, and they are the three things the LCD does that a character
+    grid does not do by itself:
+
+    ⚠️ PARAMETER LABELS ARE CENTRED ON COLUMNS, not placed at a left edge.
+    Scaling each label's own x into a cell put a 4-character name and a
+    2-character one in different columns, which is what made the page look
+    ragged -- they are the same column on the unit, and the shorter label
+    simply starts further into it. A LIST is left-aligned and must not be
+    snapped that way (_left_aligned tells them apart).
 
     ⚠️ A LATER DRAW OVER THE SAME PIXELS WINS. The firmware repaints a
-    parameter row in place, so the capture holds the label that WAS there
-    and then the one that is -- `PTCH` then `FRQ1` at the same x. Overlapping
-    spans are replaced, not shuffled aside, or the page shows both and reads
-    as an effect with seven parameters where the unit draws four.
+    parameter row in place, so the capture holds the label that WAS there and
+    then the one that is -- `PTCH` then `FRQ1` at the same x. Overlapping
+    spans are replaced, or the page shows both and reads as an effect with
+    seven parameters where the unit draws four.
 
     ⚠️ TWO STRINGS THAT DO NOT OVERLAP ARE NEVER FUSED. Writing character by
-    character into a fixed grid let a label whose cell was taken run straight
-    into its neighbour, and the result is a word that does not exist on the
-    unit -- `DJ EQUALIZER1`, `COMPRESSORT 1`. A label pushed one column right
-    is legible and obviously two things; a fused one is not obviously
-    anything.
+    character let a label whose cell was taken run into its neighbour, and
+    the result is a word that does not exist on the unit -- `DJ EQUALIZER1`,
+    `COMPRESSORT 1`.
     """
+    items = _clean(draws)
+    left = _left_aligned(items)
+    cols_px = _anchors(items, left)
     grid = [[] for _ in range(rows)]
-    for x, y, t in _clean(draws):
+    for x, y, t in items:
         cy = min(rows - 1, max(0, (64 - y) * rows // 64))
-        cx = min(cols - 1, max(0, x * cols // 128))
+        if x < LEFT_X or x in left or not cols_px:
+            cx = int(x / CELL + 0.5)
+        else:
+            a = min(cols_px, key=lambda c: abs(c - (x + CELL * len(t) / 2)))
+            cx = int(a / CELL - len(t) / 2 + 0.5)
+        cx = min(cols - 1, max(0, cx))
         row = grid[cy]
         row[:] = [(s0, s1) for s0, s1 in row
                   if s0 + len(s1) <= cx or s0 >= cx + len(t)]

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -650,18 +650,29 @@ def _left_aligned(items):
 
 
 def _anchors(items, left, tol=8):
-    """The centres the firmware is centring parameter labels on, clustered
-    out of this screen's own draws rather than written down -- so a page laid
-    out differently gets its own columns instead of these."""
-    cs = sorted({x + CELL * len(t) / 2 for x, _y, t in items
-                 if x >= LEFT_X and x not in left})
+    """The parameter columns: each centre the firmware centres labels on,
+    and the widest label that column carries.
+
+    Clustered out of THIS screen's own draws rather than written down, so a
+    page laid out differently gets its own columns instead of these.
+
+    -> [(centre_px, widest)], and the widest is what turns a centred column
+    into a LEFT-ALIGNED one: see layout_screen.
+    """
+    seen = {}
+    for x, _y, t in items:
+        if x < LEFT_X or x in left:
+            continue
+        c = x + CELL * len(t) / 2
+        seen[c] = max(seen.get(c, 0), len(t))
     groups = []
-    for c in cs:
-        if groups and c - groups[-1][-1] <= tol:
-            groups[-1].append(c)
+    for c in sorted(seen):
+        if groups and c - groups[-1][-1][0] <= tol:
+            groups[-1].append((c, seen[c]))
         else:
-            groups.append([c])
-    return [sum(g) / len(g) for g in groups]
+            groups.append([(c, seen[c])])
+    return [(sum(c for c, _w in g) / len(g), max(w for _c, w in g))
+            for g in groups]
 
 
 def layout_screen(draws, cols=COLS, rows=9):
@@ -672,12 +683,14 @@ def layout_screen(draws, cols=COLS, rows=9):
     Three rules, and they are the three things the LCD does that a character
     grid does not do by itself:
 
-    ⚠️ PARAMETER LABELS ARE CENTRED ON COLUMNS, not placed at a left edge.
-    Scaling each label's own x into a cell put a 4-character name and a
-    2-character one in different columns, which is what made the page look
-    ragged -- they are the same column on the unit, and the shorter label
-    simply starts further into it. A LIST is left-aligned and must not be
-    snapped that way (_left_aligned tells them apart).
+    ⚠️ PARAMETER COLUMNS ARE FOUND BY CENTRE AND DRAWN LEFT-ALIGNED. The
+    firmware centres each label on a fixed anchor, which is how the columns
+    are identified at all -- but REPRODUCING the centring is what still read
+    as ragged, because a 2-character label centred in a 4-wide column starts
+    one column in and its left edge no longer lines up with anything. So
+    each column is laid out from the left edge of its WIDEST label, which is
+    what a column of text is normally expected to do. A LIST is left-aligned
+    already and must not be snapped at all (_left_aligned tells them apart).
 
     ⚠️ A LATER DRAW OVER THE SAME PIXELS WINS. The firmware repaints a
     parameter row in place, so the capture holds the label that WAS there and
@@ -699,8 +712,9 @@ def layout_screen(draws, cols=COLS, rows=9):
         if x < LEFT_X or x in left or not cols_px:
             cx = int(x / CELL + 0.5)
         else:
-            a = min(cols_px, key=lambda c: abs(c - (x + CELL * len(t) / 2)))
-            cx = int(a / CELL - len(t) / 2 + 0.5)
+            a, w = min(cols_px,
+                       key=lambda c: abs(c[0] - (x + CELL * len(t) / 2)))
+            cx = int(a / CELL - w / 2 + 0.5)
         cx = min(cols - 1, max(0, cx))
         row = grid[cy]
         row[:] = [(s0, s1) for s0, s1 in row

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -675,6 +675,72 @@ def _anchors(items, left, tol=8):
             for g in groups]
 
 
+def _resolve(frags):
+    """One row's fragments, in draw order, with overpainted ones dropped.
+
+    ⚠️ A LATER DRAW OVER THE SAME PIXELS WINS. The firmware repaints a
+    parameter row in place, so the capture holds the label that WAS there
+    and then the one that is -- `PTCH` then `FRQ1` at the same x. Keeping
+    both makes the page read as an effect with seven parameters where the
+    unit draws four.
+    """
+    out = []
+    for x, t in frags:
+        lo, hi = x, x + CELL * len(t)
+        out = [(x0, t0) for x0, t0 in out
+               if x0 + CELL * len(t0) <= lo or x0 >= hi]
+        out.append((x, t))
+    return sorted(out)
+
+
+def read_screen(draws):
+    """The captured strings, sorted into what they ARE rather than into a
+    picture of where they were.
+
+    ⚠️ A CHARACTER GRID CANNOT BE FAITHFUL TO THIS SCREEN, which is why this
+    exists. Measured on one FX page, the text baselines top to bottom are
+
+        57 title | 56 param | 48 param | 47 LIST | 40 LIST | 33 LIST
+        30 param | 28 param | 26 LIST  | 21 param | 19 LIST | 12 LIST
+         5 LIST  |  3 param
+
+    -- the LIST steps exactly 7 px and is internally consistent, and the
+    PARAMETER block has its own lines falling 1-3 px from it. Fourteen
+    baselines in 64 pixels with a 7 px font are not fourteen lines: they are
+    two overlaid WINDOWS whose y origins are not comparable, the same thing
+    `Pt:1 PART 1` shows in x. Flattening both into nine rows interleaves them
+    and reads as a mapping from each chooser row to the labels beside it,
+    which is not what any of it means.
+
+    The STRINGS are still the firmware's own, and they are what the view is
+    for. Only their arrangement stops being a reconstruction.
+
+    -> {"title", "list": [str], "params": [[str]]}, list and params each in
+    top-to-bottom order.
+    """
+    items = _clean(draws)
+    rows = collections.defaultdict(list)
+    for x, y, t in items:
+        rows[y].append((x, t))
+    title, listed, params = None, [], []
+    for y in sorted(rows, reverse=True):
+        frags = _resolve(rows[y])
+        if all(x < LEFT_X for x, _t in frags):
+            # The topmost left-aligned row is the page's title; the rest are
+            # the chooser, which is why the title is taken before the loop
+            # settles into the list's own 7 px pitch.
+            if title is None and len(frags) == 1:
+                title = frags[0][1]
+            else:
+                listed += [t for _x, t in frags]
+            continue
+        # A row may carry a list entry AND parameters; they are separate
+        # windows and go to separate places.
+        listed += [t for x, t in frags if x < LEFT_X]
+        params.append([t for x, t in frags if x >= LEFT_X])
+    return {"title": title, "list": listed, "params": params}
+
+
 def layout_screen(draws, cols=COLS, rows=9):
     """Arrange captured (x,y,text) draws into a text grid. The LCD is 128x64
     with a bottom-left-ish origin (the list drawer steps y DOWN per row, so

--- a/tools/label_fmt.py
+++ b/tools/label_fmt.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""A ColdFire display formatter that prints a select's WORDS, not its number.
+
+PLAN §6. Every stepped select on the unit reads as a bare number today --
+WarpFold's MODE draws `1 2 3` where the manifest has said `FOLD RING BOTH`
+all along -- because `Param.labels` was authored, schema-checked against
+`count`, and then never read by the build. This is what makes it load-bearing.
+
+THE MECHANISM, from docs/PARAM_PAGES.md section 7. Every per-slot formatter
+(`P+0x0ca`, the "A" array) has one signature:
+
+    void fmt(char *buf, int value);      4(sp) = buf, 8(sp) = value
+
+and every stock one is a thin wrapper over `sprintf` (0x40013a08). The
+0x4003c14c formatter (ON/OFF) proves the shape that matters here: **the label
+IS the format string**. So a labelled select is a small cave -- index a
+pointer table by value, overwrite the value slot with the pointer, and tail
+`jmp` into sprintf, which then sees sprintf(buf, label).
+
+WHY THE BYTES ARE EMITTED HERE rather than assembled. The build deliberately
+needs no m68k toolchain: a CavePatch carries PINNED bytes and the source is
+re-assembled and compared only when `m68k-elf-as` is on PATH. Twelve caves
+whose contents vary with the labels cannot be hand-pinned, so they are
+emitted -- and `verify()` below re-derives them through the real assembler
+whenever it is available, which is the same discipline one level up.
+
+The code is a FIXED 40 bytes; only the bounds immediate varies. Verified
+against m68k-elf-as -mcpu=5407 (2 Sep 2026).
+"""
+from __future__ import annotations
+
+SPRINTF = 0x40013a08
+CODE_LEN = 40                      # the table starts here; see _CODE below
+
+
+def emit(labels: tuple[str, ...]) -> bytes:
+    """The cave for one labelled select: code, offset table, strings."""
+    n = len(labels)
+    if not 1 <= n <= 128:
+        raise ValueError(f"a select needs 1..128 labels, got {n}")
+    for s in labels:
+        # THE LABEL IS THE FORMAT STRING, so a '%' in one would be read as a
+        # conversion and sprintf would consume a garbage argument off the
+        # stack. None of the twelve authored selects contains one; refuse
+        # rather than leave it to the next person.
+        if "%" in s:
+            raise ValueError(f"label {s!r} contains '%': the label IS the "
+                             f"format string, so it would be a conversion")
+        if not s.isascii():
+            raise ValueError(f"label {s!r} is not ASCII")
+    code = bytes([
+        0x20, 0x2f, 0x00, 0x08,                          # move.l 8(sp),d0
+        0x0c, 0x80, *n.to_bytes(4, "big"),               # cmp.l  #n,d0
+        0x65, 0x02,                                      # blo.s  ok
+        0x70, 0x00,                                      # moveq  #0,d0
+        0x41, 0xfa, 0x00, 0x18,                          # lea    tab(pc),a0
+        0x32, 0x30, 0x0a, 0x00,                          # move.w (a0,d0.l*2),d1
+        0x02, 0x81, 0x00, 0x00, 0xff, 0xff,              # and.l  #0xffff,d1
+        0xd1, 0xc1,                                      # adda.l d1,a0
+        0x2f, 0x48, 0x00, 0x08,                          # move.l a0,8(sp)
+        0x4e, 0xf9, *SPRINTF.to_bytes(4, "big"),         # jmp    sprintf
+    ])
+    assert len(code) == CODE_LEN, len(code)
+    # Offsets are from the TABLE's own address, so the cave is position
+    # independent -- it is placed wherever the allocator has room.
+    tab, blob, off = b"", b"", 2 * n
+    for s in labels:
+        tab += off.to_bytes(2, "big")
+        enc = s.encode("ascii") + b"\0"
+        blob += enc
+        off += len(enc)
+    out = code + tab + blob
+    return out + b"\0" * (len(out) % 2)          # keep the next cave aligned
+
+
+def source(labels: tuple[str, ...]) -> str:
+    """The same thing as assembler, for verify() and for a human reading it."""
+    tab = ",".join(f"s{i}-tab" for i in range(len(labels)))
+    strs = "\n".join(f's{i}:     .asciz  "{s}"' for i, s in enumerate(labels))
+    return (f'        .text\n'
+            f'fmt:    move.l  8(%sp),%d0\n'
+            f'        cmp.l   #{len(labels)},%d0\n'
+            f'        blo.s   ok\n'
+            f'        moveq   #0,%d0\n'
+            f'ok:     lea     tab(%pc),%a0\n'
+            f'        move.w  (%a0,%d0.l*2),%d1\n'
+            f'        and.l   #0xffff,%d1\n'
+            f'        adda.l  %d1,%a0\n'
+            f'        move.l  %a0,8(%sp)\n'
+            f'        jmp     0x{SPRINTF:08x}\n'
+            f'tab:    .word   {tab}\n'
+            f'{strs}\n'
+            f'        .balign 2\n')
+
+
+def verify(labels: tuple[str, ...]) -> None:
+    """Re-derive emit() through the real assembler. No-op without one."""
+    import os, pathlib, shutil, subprocess, tempfile
+    if not (shutil.which("m68k-elf-as") and shutil.which("m68k-elf-objcopy")):
+        return
+    with tempfile.TemporaryDirectory() as td:
+        s = os.path.join(td, "l.s")
+        pathlib.Path(s).write_text(source(labels))
+        o, b = os.path.join(td, "l.o"), os.path.join(td, "l.bin")
+        subprocess.run(["m68k-elf-as", "-mcpu=5407", "-o", o, s], check=True)
+        subprocess.run(["m68k-elf-objcopy", "-O", "binary", "-j", ".text",
+                        o, b], check=True)
+        want = pathlib.Path(b).read_bytes()
+        got = emit(labels)
+        if got[:len(want)] != want:
+            raise SystemExit(
+                f"label_fmt.emit disagrees with m68k-elf-as for {labels}:\n"
+                f"  emitted {got.hex(' ')}\n"
+                f"  assembled {want.hex(' ')}")
+
+
+if __name__ == "__main__":
+    import sys
+    from remix import registry
+    sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent))
+    bad = 0
+    for key, m in registry.modules().items():
+        if m.is_stock:
+            continue
+        for i, p in enumerate(m.params):
+            if not (p.active and p.labels):
+                continue
+            try:
+                verify(p.labels)
+                print(f"  [PASS] {key} slot {i} {p.name.decode():<5} "
+                      f"{len(emit(p.labels)):>3} B  {' '.join(p.labels)}")
+            except SystemExit as e:
+                bad += 1
+                print(f"  [FAIL] {e}")
+    print("OK" if not bad else f"{bad} FAILED")
+    sys.exit(1 if bad else 0)

--- a/tools/ot_project.py
+++ b/tools/ot_project.py
@@ -34,7 +34,14 @@ matching /Users/sambanks/octa/backups/*pregain*.
 """
 import json, pathlib, re, sys, glob
 
-PART_BASE, PART_STRIDE, NPARTS = 0x8eed6, 0x18bb, 4
+# ⚠️ EIGHT PART RECORDS, not four: 1-4 are the CURRENT parts and 5-8 are the
+# SAVED copies the unit restores on RELOAD PART. Verified 3 Sep 2026 against
+# 80 bank files -- parts 5-8 are byte-identical to 1-4 in every one of them,
+# and part 9 lands in the name trailer (ASCII), so the count is exact. A tool
+# that writes only the first four leaves an effect assignment one RELOAD away
+# from coming back.
+PART_BASE, PART_STRIDE, NPARTS, NPARTS_ALL = 0x8eed6, 0x18bb, 4, 8
+FX1_OFF, FX2_OFF, NTRACKS = 0x009, 0x011, 8
 FX_NAMES = {0x06: "BongDelay", 0x07: "ChonVerb", 0x09: "SEND", 0x00: "-"}
 
 def read_project(pdir):
@@ -95,9 +102,16 @@ def apply_gains(pdir, changes):
     path.write_bytes(raw.encode("latin1"))
     print(f"{n} gains written to {path}")
 
-def _bank_write(pdir, banknum, mutate):
-    """Read bank, apply mutate(bytearray), fix checksum, write."""
-    guard_backup()
+def _bank_write(pdir, banknum, mutate, guard=True):
+    """Read bank, apply mutate(bytearray), fix checksum, write.
+
+    ⚠️ THE CHECKSUM IS NOT OPTIONAL. The last u16 BE is an additive sum over
+    bytes[0x10:-2]; the unit rejects a bank whose sum does not match. Verified
+    again 3 Sep 2026 across all 80 bank files in the backup set -- every one
+    agrees, so a disagreement is this tool's bug and not a format surprise.
+    """
+    if guard:
+        guard_backup()
     path = pdir / f"bank{banknum:02d}.work"
     data = bytearray(path.read_bytes())
     mutate(data)
@@ -121,6 +135,136 @@ def set_track_slot(pdir, banknum, part, track, slot_1based):
     _bank_write(pdir, banknum, mut)
     print(f"bank{banknum:02d} part{part} T{track} slot -> {slot_1based}")
 
+# ---------------------------------------------------------------------------
+# A DETERMINISTIC TEST PROJECT
+#
+# ⚠️ THE EFFECT IDS LIVE IN THE PROJECT, NOT THE OS. They survive a flash, so
+# a freshly flashed unit opens every track still holding the id it had before
+# -- which in the new image may be a different effect, or one the image does
+# not implement (and so resolves to the fallback). That is why a flashed unit
+# "keeps the old effect graphics" until you select something, and why a flash
+# test that starts from an old project is not a test of anything: half the
+# tracks are running whatever the last image put there.
+#
+# So: copy a project, and stamp EVERY bank, part and track with an id this
+# image actually implements. Nothing is left to what happened to be there.
+
+
+def fx_plan(remix_name):
+    """The layout: one effect per PART, on all eight tracks.
+
+    Selecting a part then auditions that one effect across both cores at once
+    -- which is the shape the cycle test wants and the shape that shows a
+    payload-asymmetry bug immediately (tracks 5-8 are payload A, 1-4 are B).
+
+    -> [(label, fx1_id, fx2_id)], one per part slot, in bank/part order.
+    """
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+    from remix import registry, stock
+    remix = registry.remix(remix_name)
+    mods = registry.modules()
+    out = []
+    # FX2 first: the chooser this image composes, in its own row order.
+    for k in remix.modules:
+        m = mods.get(k)
+        if m is None or m.menu is None:
+            continue
+        out.append((f"{k} on FX2", 0x00, m.menu.fx2_id))
+    # Then FX1's chooser, with FX2 silent so the FX1 effect is heard alone.
+    fx1 = remix.fx1 or tuple(
+        k for k in stock.p_spans("A")
+        if mods[k].menu.fx2_id in stock.fx1_ids())
+    for k in fx1:
+        out.append((f"{k} on FX1", mods[k].menu.fx2_id, 0x00))
+    # WARN: AND THE WORST CASE, BY CYCLES -- which is not the same as by
+    # words, and words was what a first draft sorted on: every module of ours
+    # has a word count the BUILD knows and stock.WORDS does not, so `max`
+    # silently returned the first one in the list. tools/cycle_count.py
+    # already prices each engine, so ask it rather than approximate it.
+    import json as _json, os as _os, subprocess as _sp
+    root = pathlib.Path(__file__).resolve().parent.parent
+    try:
+        r = _sp.run([sys.executable, "tools/cycle_count.py", "--json"],
+                    cwd=root, capture_output=True, text=True,
+                    env={**_os.environ, "REMIX": remix_name})
+        cyc = _json.loads(r.stdout[r.stdout.index("{"):])["per_effect"]
+    except Exception:                                # noqa: BLE001
+        cyc = {}
+    stem = {k: pathlib.Path(mods[k].dsp.asm).stem for k in remix.modules
+            if mods[k].dsp is not None}
+    cost = {k: cyc.get(v, 0) for k, v in stem.items()}
+    ours = [k for k in remix.modules
+            if mods[k].menu is not None and not mods[k].is_stock
+            and mods[k].dsp is not None]
+    if ours and cost:
+        heavy2 = max(ours, key=lambda k: cost.get(k, 0))
+        on1 = [k for k in ours if k in fx1]
+        heavy1 = max(on1, key=lambda k: cost.get(k, 0)) if on1 else None
+        out.append((f"WORST by cycles: {heavy2} on FX2"
+                    + (f" + {heavy1} on FX1" if heavy1 else ""),
+                    mods[heavy1].menu.fx2_id if heavy1 else 0x00,
+                    mods[heavy2].menu.fx2_id))
+    return out
+
+
+def make_test_project(src, dest, remix_name):
+    import shutil
+    src, dest = pathlib.Path(src), pathlib.Path(dest)
+    if dest.exists():
+        sys.exit(f"{dest} exists -- refusing to overwrite. Pick a new name.")
+    if not (src / "project.work").is_file():
+        sys.exit(f"{src} is not an Octatrack project directory")
+    plan = fx_plan(remix_name)
+    banks = sorted(src.glob("bank*.work"))
+    slots = len(banks) * NPARTS
+    if len(plan) > slots:
+        sys.exit(f"{len(plan)} assignments need {len(plan)} parts, and this "
+                 f"project has {slots} ({len(banks)} banks x {NPARTS})")
+    shutil.copytree(src, dest)
+    lines = [f"# test project for remix {remix_name!r}",
+             f"# copied from {src}",
+             "# every bank/part/track set deterministically; unused parts are",
+             "# NONE on both slots, which is the silent control.", ""]
+    for bi, bank in enumerate(sorted(dest.glob("bank*.work"))):
+        num = int(bank.name[4:6])
+
+        def mut(data, bi=bi):
+            for p in range(NPARTS_ALL):
+                # BOTH the current part and its saved copy: writing only the
+                # current one leaves the old assignment a RELOAD PART away.
+                i = bi * NPARTS + (p % NPARTS)
+                lbl, f1, f2 = plan[i] if i < len(plan) else ("-", 0x00, 0x00)
+                off = PART_BASE + p * PART_STRIDE
+                if off + FX2_OFF + NTRACKS > len(data):
+                    sys.exit(f"{bank.name}: part {p+1} runs past the file")
+                data[off + FX1_OFF:off + FX1_OFF + NTRACKS] = bytes([f1]) * NTRACKS
+                data[off + FX2_OFF:off + FX2_OFF + NTRACKS] = bytes([f2]) * NTRACKS
+
+        _bank_write(dest, num, mut, guard=False)
+        for p in range(NPARTS):
+            i = bi * NPARTS + p
+            lbl, f1, f2 = plan[i] if i < len(plan) else ("(silent)", 0, 0)
+            lines.append(f"bank {chr(64+num)}  part {p+1}   FX1 0x{f1:02x}  "
+                         f"FX2 0x{f2:02x}   {lbl}")
+    (dest / "OCTABAM_TEST_MAP.txt").write_text("\n".join(lines) + "\n")
+    # READ IT BACK. A write this tool cannot verify is a write you find out
+    # about on the unit.
+    for bi, bank in enumerate(sorted(dest.glob("bank*.work"))):
+        data = bank.read_bytes()
+        if int.from_bytes(data[-2:], "big") != (sum(data[0x10:-2]) & 0xFFFF):
+            sys.exit(f"{bank.name}: checksum did not take -- do NOT use this")
+        for p in range(NPARTS_ALL):
+            i = bi * NPARTS + (p % NPARTS)
+            _l, f1, f2 = plan[i] if i < len(plan) else ("-", 0x00, 0x00)
+            off = PART_BASE + p * PART_STRIDE
+            if set(data[off+FX1_OFF:off+FX1_OFF+NTRACKS]) != {f1} or \
+               set(data[off+FX2_OFF:off+FX2_OFF+NTRACKS]) != {f2}:
+                sys.exit(f"{bank.name} part {p+1}: read-back disagrees")
+    print("\n".join(lines))
+    print(f"\n{len(banks)} banks written and verified -> {dest}")
+    print(f"map also at {dest / 'OCTABAM_TEST_MAP.txt'}")
+
+
 if __name__ == "__main__":
     cmd = sys.argv[1]; pdir = pathlib.Path(sys.argv[2])
     if cmd == "report": cmd_report(pdir)
@@ -128,3 +272,5 @@ if __name__ == "__main__":
     elif cmd == "apply": apply_gains(pdir, json.loads(pathlib.Path(sys.argv[3]).read_text()))
     elif cmd == "part-name": set_part_name(pdir, int(sys.argv[3]), int(sys.argv[4]), sys.argv[5])
     elif cmd == "track-slot": set_track_slot(pdir, int(sys.argv[3]), int(sys.argv[4]), int(sys.argv[5]), int(sys.argv[6]))
+    elif cmd == "testproj": make_test_project(sys.argv[2], sys.argv[3], sys.argv[4])
+    else: sys.exit(f"unknown command {cmd!r}")

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -500,7 +500,13 @@ class BenchScreen(Screen):
     ]
 
     def compose(self) -> ComposeResult:
-        with Horizontal():
+        # A TAB BAR, but only when the panes are not all on screen. It names
+        # all three and marks the one you are in, so a narrow terminal reads
+        # as a workbench showing you a third at a time rather than one with
+        # two thirds missing. Full width, because the titles carry context
+        # ("Loaded · chongbong") that will not fit in a 32-column pane head.
+        yield Static(id="tabbar")
+        with Horizontal(id="panes"):
             yield Static(id="pane_avail")
             yield Static(id="pane_load")
             yield Static(id="pane_unit")
@@ -554,6 +560,79 @@ class BenchScreen(Screen):
         self.set_interval(1.5, self._poll_source)
         self.measure_all()
         self.query_one("#log", RichLog).display = False
+        self._tnames = ["Available", "Loaded", "Unit"]
+        self._vis_panes = (AVAILABLE, LOADED, UNIT)
+        self._relayout()
+        self.rerender()
+
+    # ---- fitting the terminal you actually have --------------------------
+    # THREE COLUMNS NEED 118 OF THEM: 32 for the library, 40 for the image,
+    # and the rest for a UNIT pane whose widest content is the 46-column LCD
+    # the firmware itself draws. Below that the layout did not degrade, it
+    # broke -- at 80x24 the UNIT pane was handed six columns and wrapped
+    # `Stock` / `· id` / `0x04` one word per line down the screen, both list
+    # panes were cut off mid-list, and the Budget strip took nine of the
+    # twenty-four rows. An 80x24 terminal is what a new pair of hands opens,
+    # so that was the first impression the workbench made.
+    #
+    # Below the threshold it shows ONE pane at full width and `tab` moves
+    # between them, with the titles becoming a strip naming all three so the
+    # gesture is visible rather than remembered.
+    WIDE_COLS = 118
+    # And a middle band. At 100 columns three panes do not fit but two do
+    # comfortably, and dropping straight to one pane there wasted two thirds
+    # of the width on a 40-column list. The pair SLIDES with the focus --
+    # library+image while you are choosing, image+unit while you are dialling
+    # -- so the pane you are in always has its context beside it. 92 is the
+    # floor: 40 for the image plus 50 for a UNIT pane whose widest content is
+    # the 46-column LCD.
+    TWO_UP_COLS = 92
+    # And the Budget is the one thing here that is a fixed number of LINES
+    # rather than a list you scroll, so on a short terminal it is the thing
+    # that crowds everything else out. Under this it collapses to one line
+    # carrying the same numbers.
+    TALL_ROWS = 34
+
+    @property
+    def wide_screen(self):
+        return self.app.size.width >= self.WIDE_COLS
+
+    @property
+    def tall_screen(self):
+        return self.app.size.height >= self.TALL_ROWS
+
+    def _visible_panes(self):
+        """Which panes this terminal has room for, focus included."""
+        w = self.app.size.width
+        if w >= self.WIDE_COLS:
+            return (AVAILABLE, LOADED, UNIT)
+        if w >= self.TWO_UP_COLS:
+            start = min(self.pane, LOADED)
+            return (start, start + 1)
+        return (self.pane,)
+
+    def _relayout(self):
+        """Show three panes, two or one, by what the terminal can hold."""
+        vis = self._visible_panes()
+        self._vis_panes = vis
+        # A pane's fixed width is its content's; the LAST visible one takes
+        # the rest, so nothing is left with six columns to wrap into.
+        fixed = {AVAILABLE: 32, LOADED: 40, UNIT: 46}
+        for i, wid in enumerate(("#pane_avail", "#pane_load", "#pane_unit")):
+            pane = self.query_one(wid, Static)
+            pane.display = i in vis
+            pane.styles.width = "1fr" if i == vis[-1] else fixed[i]
+            # The divider belongs BETWEEN panes: on the leftmost visible one
+            # it reads as a column that lost its neighbour.
+            pane.set_class(i == vis[0], "first")
+        self.query_one("#tabbar").display = not self.wide_screen
+
+    def on_resize(self, ev):
+        self._relayout()
+        # Every pane's text is width-dependent (the budget lays out against
+        # app.size.width), and _paint skips a repaint when the text has not
+        # changed -- so a resize has to invalidate rather than trust it.
+        self._painted.clear()
         self.rerender()
 
     # ---- the rows each pane walks ---------------------------------------
@@ -653,11 +732,52 @@ class BenchScreen(Screen):
         """
         st = self.app.state
         probs = st.problems()
+        # The three titles are needed TOGETHER by the narrow layout's strip,
+        # and each pane only knows its own -- and on a narrow screen only one
+        # pane paints at all, so they cannot be collected on the way past.
+        mod = self.selected_module()
+        self._tnames = ["Available",
+                        f"Loaded · {st.loaded_name or 'unsaved'}",
+                        disp(mod) if mod is not None else "Unit"]
         self._pane_available(st)
         self._pane_loaded(st, probs)
         self._pane_unit(st, probs)
-        self._pane_budget(st)
+        self._pane_budget(st, probs)
+        if not self.wide_screen:
+            self._paint("#tabbar", "  ".join(
+                (f"[reverse bold] {escape(t)} [/]" if i == self.pane
+                 else f"[dim]{escape(t)}[/]")
+                for i, t in enumerate(self._tnames)) + "  [dim]· tab[/]")
         self._paint("#status", f"[dim]{escape(st.msg)}[/]")
+
+    def _fit(self, wid, out, cur_line, head, tail=0):
+        """A LIST TALLER THAN THE PANE HAS TO SCROLL, or the rows past the
+        fold are unreachable -- at 80x24 the library ran out nine modules
+        short and the cursor simply walked off the bottom of the screen with
+        nothing following it.
+
+        A Static clips, it does not scroll, so the window is chosen here:
+        the title stays pinned at the top, the pane's closing lines (the ⚠,
+        the hint) at the bottom, and the rows in between follow the cursor.
+        The first and last row of a clipped window say so, because a list
+        that silently starts at item nine is worse than one that scrolls.
+        """
+        h = self.query_one(wid, Static).content_size.height
+        if h <= 0 or len(out) <= h:          # h is 0 before the first layout
+            return out
+        body = out[head:len(out) - tail] if tail else out[head:]
+        tl = out[len(out) - tail:] if tail else []
+        room = h - head - len(tl)
+        if room < 3:
+            return out[:h]
+        i = max(0, cur_line - head)
+        top = max(0, min(i - room // 2, len(body) - room))
+        win = list(body[top:top + room])
+        if top:
+            win[0] = f"[dim] ↑ {top} more[/]"
+        if top + room < len(body):
+            win[-1] = f"[dim] ↓ {len(body) - top - room} more[/]"
+        return out[:head] + win + tl
 
     def _paint(self, wid, lines):
         """Update a pane only when its TEXT changed.
@@ -672,15 +792,24 @@ class BenchScreen(Screen):
         self._painted[wid] = text
         self.query_one(wid, Static).update(text)
 
-    def _title(self, text, pane):
+    def _head(self, text, pane):
+        """A pane's opening lines: its title, or nothing.
+
+        With the tab bar on screen the title would be the same words twice,
+        one line under the other -- and a line is what a short terminal is
+        short of.
+        """
+        if not self.wide_screen:
+            return []
         on = self.pane == pane
-        return (f"[reverse bold] {escape(text)} [/]" if on
-                else f"[bold]{escape(text)}[/]")
+        return [f"[reverse bold] {escape(text)} [/]" if on
+                else f"[bold]{escape(text)}[/]", ""]
 
     def _pane_available(self, st):
         rows = self.avail_rows()
-        out = [self._title("Available", AVAILABLE), ""]
-        group = None
+        out = self._head("Available", AVAILABLE)
+        head = len(out)
+        cur_line, group = head, None
         for i, m in enumerate(rows):
             g = "Stock Effects" if m.is_stock else titlecase(rig.category(m))
             if g != group:
@@ -692,16 +821,20 @@ class BenchScreen(Screen):
             nm = disp(m) if m.is_stock else f"[{OURS}]{disp(m)}[/]"
             pad = " " * max(0, 13 - len(disp(m)))
             line = f" {mark} {nm}{pad} [dim]{menus}[/]"
+            if here:
+                cur_line = len(out)
             out.append(f"[reverse]{line}[/]" if here else line)
         out.append("")
         out.append(f"[dim]enter adds it to the image[/]")
-        self._paint("#pane_avail", out)
+        self._paint("#pane_avail", self._fit("#pane_avail", out, cur_line,
+                                             head=head, tail=2))
 
     def _pane_loaded(self, st, probs):
         rows = self.loaded_rows()
         name = st.loaded_name or "unsaved"
-        out = [self._title(f"Loaded · {name}", LOADED), ""]
-        pos = 0
+        out = self._head(f"Loaded · {name}", LOADED)
+        head = len(out)
+        cur_line, pos = head, 0
         for i, m in enumerate(rows):
             here = self.pane == LOADED and i == self.cur[LOADED]
             if m.menu is not None:
@@ -719,9 +852,12 @@ class BenchScreen(Screen):
             pad = " " * max(0, 13 - len(disp(m)))
             line = (f" [dim]{row}[/] {nm}{pad}"
                     f"[dim]{menus:<7}{cost}[/]{fb}")
+            if here:
+                cur_line = len(out)
             out.append(f"[reverse]{line}[/]" if here else line)
         if not rows:
             out.append("[dim] (empty — add from the left)[/]")
+        rows_end = len(out)
         # THE THREE REVERBS ARE PART OF A STOCK CHOOSER and belong in this
         # list, not off in the library: an unmodified unit shows fourteen FX2
         # effects, and these are three of them. They leave when something
@@ -760,9 +896,13 @@ class BenchScreen(Screen):
                        f"{escape(disp(pin[0]))}"
                        f"{' and ' + disp(pin[1]) if len(pin) > 1 else ''} "
                        f"pin their slots[/]")
+        # Everything from the notes down is the IMAGE speaking, not a row,
+        # so it stays on screen however long the list gets.
+        tail = len(out) - rows_end
         out.append("")
         out.append(self._ledger_line(st, probs))
-        self._paint("#pane_load", out)
+        self._paint("#pane_load", self._fit("#pane_load", out, cur_line,
+                                            head=head, tail=tail + 2))
 
     def _ledger_line(self, st, probs):
         """The fit, the blocker and the build state, in ONE line.
@@ -812,7 +952,7 @@ class BenchScreen(Screen):
             return "[dim]a stock chooser: 14 effects, no modules[/]"
         return "[dim]building…[/]"
 
-    def _pane_budget(self, st):
+    def _pane_budget(self, st, probs):
         """WHAT IS LEFT, standing under the effect you are looking at.
 
         Every other number in this workbench is read against this one -- "500
@@ -875,6 +1015,10 @@ class BenchScreen(Screen):
         nxt = min(held, key=stock.consumed_at) if held else None
 
         seen = set()                            # which bar glyphs are drawn
+        # THE SAME FOUR ANSWERS, for a terminal with no room for the rows.
+        # Collected as (label, coloured number) while the full rows are
+        # built, so the short form cannot drift from the long one.
+        brief = []
 
         def words_row(n, total, used):
             free, cap = placeable(st.sel, total, used)
@@ -885,6 +1029,7 @@ class BenchScreen(Screen):
             c = OK if free > 400 else WARN if free > 32 else BAD
             bar = (f"[{c}]" + "#" * fill + "[/][dim]" + "." * (edge - fill)
                    + "[/][dim red]" + "-" * (20 - edge) + "[/]")
+            brief.append((f"words {n}", f"[{c}]{free:,}[/]"))
             return (f" {'words ' + n:<{W}}{bar}  [{c}]{free:>5,}[/] free of "
                     f"{total:,} [dim]· {used:,} loaded[/]")
 
@@ -898,8 +1043,16 @@ class BenchScreen(Screen):
             for n in ("A", "B"):
                 out.append(words_row(n, DONOR_WORDS, 0))
         else:
-            out.append(f" {'words':<{W}}[dim]" + "?" * 20
-                       + "[/]  [dim]not built[/]")
+            # WHY it is not built, not just that it is not. This row is where
+            # the eye lands after the gesture that broke the selection, and
+            # `????  not built` sent you looking for a build key that does
+            # not exist. The ⚠ in LOADED holds the sentence; say which way to
+            # look and which key applies it.
+            why = ("[dim]not built — [/][bold]x[/][dim] applies the ⚠ in "
+                   "LOADED[/]" if self.blockers(probs)
+                   else "[dim]not built — see the ⚠ in LOADED[/]")
+            out.append(f" {'words':<{W}}[dim]" + "?" * 20 + f"[/]  {why}")
+            brief.append(("words", "[dim]not built[/]"))
         # THE TRADE, ONCE. It is identical for both payloads -- the same
         # three reverbs occupy both regions -- so printing it on each read as
         # two facts. NAME THE NEXT TRADE, not the state: "Plate Rev holds the
@@ -980,6 +1133,7 @@ class BenchScreen(Screen):
                 # WHICH ones are left, beside how many. The count answers
                 # "can I add another"; the list answers "where does it go".
                 bits.append(",".join(str(t) for t in free) + " free")
+            brief.append((f"buf {tag}", f"[{c}]{len(free)}/4[/]"))
             side.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{len(free):>5}[/] free "
                        f"of 4 [dim]· "
                        + (" · ".join(bits) if bits
@@ -991,6 +1145,7 @@ class BenchScreen(Screen):
         used_rows = (st.chooser_rows if st.chooser_rows is not None
                      else len(st.menu_modules))
         c = OK if 31 - used_rows > 7 else WARN if used_rows < 31 else BAD
+        brief.append(("rows", f"[{c}]{31 - used_rows}[/]"))
         side.append(f" {'rows':<{W}}[{c}]{31 - used_rows:>5}[/] free of 31 "
                    f"[dim]· {used_rows} loaded[/]")
         # And the cave. The build reports only what is LEFT, so the total
@@ -1001,13 +1156,16 @@ class BenchScreen(Screen):
         # not the wordless "untouched" this used to print.
         if st.cave_free is not None:
             c = OK if st.cave_free > 512 else WARN if st.cave_free else BAD
+            brief.append(("cave", f"[{c}]{st.cave_free:,} B[/]"))
             side.append(f" {'cave':<{W}}[{c}]{st.cave_free:>5,}[/] free of "
                        f"{CAVE_BYTES:,} B [dim]· "
                        f"{CAVE_BYTES - st.cave_free:,} loaded[/]")
         elif not [m for m in st.selected if m.dsp is not None or m.cf_patches]:
+            brief.append(("cave", f"[{OK}]{CAVE_BYTES:,} B[/]"))
             side.append(f" {'cave':<{W}}[{OK}]{CAVE_BYTES:>5,}[/] free of "
                        f"{CAVE_BYTES:,} B [dim]· nothing of ours is placed[/]")
         else:
+            brief.append(("cave", "[dim]not built[/]"))
             side.append(f" {'cave':<{W}}[dim]    ? free of {CAVE_BYTES:,} B "
                        f"· not built[/]")
         # ONE legend line, decoding the ONE thing on this pane that is not
@@ -1026,6 +1184,28 @@ class BenchScreen(Screen):
         key = [(g, w) for g, w in (("#", "loaded by a module"),
                                    ("-", "held by a reverb you kept listed"),
                                    (".", "free")) if g in seen]
+        # A SHORT TERMINAL GETS THE NUMBERS, NOT THE ROWS. Nine lines of
+        # budget out of twenty-four is the pane crowding out the thing it is
+        # supposed to be read against. One line keeps every figure and the
+        # colour that answers for it; `?` still carries what each one means.
+        # The word "free" is said ONCE, in front, because that is what every
+        # number on the line is -- repeating it six times is what made the
+        # long rows long.
+        if not self.tall_screen:
+            items = [f"[dim]{lab}[/] {val}" for lab, val in brief]
+            lines, cur = [], "[bold]Budget[/] [dim]free:[/]"
+            for it in items:
+                # Packed against the real width rather than hoped to fit: at
+                # 80 columns the one-line form wrapped mid-token, and a
+                # budget that wraps reads as a row that lost its label.
+                sep = "  [dim]·[/]  " if items.index(it) else "  "
+                if self._vis(cur + sep + it) > self.app.size.width - 2:
+                    lines.append(cur)
+                    cur = " " * 8 + it
+                else:
+                    cur += sep + it
+            self._paint("#pane_budget", lines + [cur])
+            return
         rows, wide = self._two_up(out, side)
         # THE KEY FOLLOWS THE LAYOUT. Stacked, it is one glyph per line --
         # three definitions strung along one line read as a run-on sentence,
@@ -1077,9 +1257,9 @@ class BenchScreen(Screen):
         mod = self.selected_module()
         if mod is None:
             self._paint("#pane_unit",
-                        self._title("Unit", UNIT) + "\n\n[dim]nothing selected[/]")
+                        self._head("Unit", UNIT) + ["[dim]nothing selected[/]"])
             return
-        out = [self._title(disp(mod), UNIT), ""]
+        out = self._head(disp(mod), UNIT)
         bits = [titlecase(rig.category(mod))]
         if mod.menu:
             bits.append(f"id 0x{mod.menu.fx2_id:02x}")
@@ -1097,6 +1277,8 @@ class BenchScreen(Screen):
             out.append(f"[{WARN}]{escape(' · '.join(res))}[/]")
         out.append("")
 
+        head = len(out)
+        cur_line = head
         knobs = self.unit_rows(mod)
         vals = st.knobs_for(mod)
         for i, (name, slot) in enumerate(knobs):
@@ -1105,6 +1287,8 @@ class BenchScreen(Screen):
                 src = (self.app.source.name if self.app.source
                        else f"(none — no wavs in {source_dir()})")
                 line = f" [dim]SOURCE[/] [{SRC}]{escape(src)}[/]"
+                if here:
+                    cur_line = len(out)
                 out.append(f"[reverse]{line}[/]" if here else line)
                 continue
             v = vals.get(name, 0)
@@ -1122,6 +1306,8 @@ class BenchScreen(Screen):
                        + "." * (12 - fill) + "[/]")
             page = "1" if slot < 6 else "2"
             line = f" {name:<6} {shown}[dim]\\[[/]{bar}[dim]] p{page}[/]"
+            if here:
+                cur_line = len(out)
             out.append(f"[reverse]{line}[/]" if here else line)
         if not knobs:
             out.append("[dim] (no drawn parameters)[/]")
@@ -1141,7 +1327,11 @@ class BenchScreen(Screen):
                    "[dim]tab here to change values and audition[/]")
         out.append("")
         out += self._preview(mod, probs)
-        self._paint("#pane_unit", out)
+        # No pinned tail: the knobs are what the cursor is in and the preview
+        # is what follows them, so a short pane shows as much of the page as
+        # is left over rather than reserving room for it.
+        self._paint("#pane_unit", self._fit("#pane_unit", out, cur_line,
+                                            head=head))
 
     # ---- the emulated panel ---------------------------------------------
     def _panel(self, mode, effect_id):
@@ -1337,6 +1527,7 @@ class BenchScreen(Screen):
 
     def action_pane(self, d):
         self.pane = (self.pane + d) % 3
+        self._relayout()          # on a narrow screen `tab` IS the layout
         self.rerender()
 
     def action_preview(self):
@@ -1884,8 +2075,13 @@ class Workbench(App):
                   border-left: dashed $surface; }
     #pane_unit  { width: 1fr; height: 100%; padding: 0 1;
                   border-left: dashed $surface; }
+    /* ONE PANE AT A TIME on a terminal too narrow for three columns. The
+       dividers go with them: a lone pane with a left border reads as a
+       column that lost its neighbour. */
+    #panes > Static.first { border-left: none; }
     #pane_budget { height: auto; padding: 0 1;
                    border-top: dashed $surface; }
+    #tabbar { height: 1; padding: 0 1; }
     #status { height: 1; padding: 0 1; }
     #log { height: 12; border-top: dashed $surface; }
     """

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -48,7 +48,7 @@ except ImportError:
 
 from rich.markup import escape  # noqa: E402  (rich ships with textual)
 
-from remix import audition, registry, rig  # noqa: E402
+from remix import audition, registry, rig, stock  # noqa: E402
 from remix.state import (BUILT_IMAGE, DONOR_WORDS, ROOT,  # noqa: E402
                          STOCK_ROOTS, State)
 
@@ -56,6 +56,15 @@ def step_label(mod, name, v):
     """A select's value as the manifest labels it, else the raw number."""
     lab = rig.knob_labels(mod, name)
     return lab[v] if lab and v < len(lab) else str(v)
+
+
+def disp(mod) -> str:
+    """What to CALL a module on screen: the name the panel shows, not the
+    directory slug. `warpfold` is a path; `WarpFold` is what the operator
+    reads on the unit."""
+    if mod.menu is not None:
+        return mod.menu.fullname.decode("latin1") or mod.name
+    return mod.name
 
 
 def wav_sources():
@@ -135,6 +144,31 @@ class Chooser(ModalScreen[str]):
 
 
 HELP = {
+    "bench": """[bold]THE BENCH — one page, three panes[/]
+
+[bold]AVAILABLE[/] everything that could be in an image: your modules,
+then the stock effects the unit already ships. [bold]LOADED[/] is the
+image you are composing, in CHOOSER ORDER — the order here is the order
+of rows on the panel, so left/right there is a real edit. [bold]UNIT[/]
+follows the cursor: the selected effect's knobs, and the firmware's own
+draw of its page.
+
+You start at [bold]stock[/] — the chooser an unmodified unit shows. Add
+to what the box already does. A remix must name a fallback for ids it
+does not implement (SEND is the safe one), so adding a module means
+adding SEND too; the LOADED pane says so when it matters.
+
+● in the LOADED pane means "in the image on disk". An effect that is
+loaded but not built is not previewed: its id is not in the image, so
+the firmware would draw a convincing picture of the WRONG effect.
+
+[bold]keys[/]
+  tab  pane            up/down  move
+  enter  add / remove  left/right  knob value (UNIT) or row order (LOADED)
+  p  preview mode      r  render + hear     space  play last
+  b  build             c  check             w  word cost
+  l  load remix        s  save remix        f  fallback
+  k  back to stock     ?  this""",
     "rig": """[bold]THE RIG — your bench, not the unit[/]
 
 Assign an effect to a track, dial its knobs, render a source wav through
@@ -238,222 +272,413 @@ class HelpScreen(ModalScreen[None]):
         self.dismiss(None)
 
 
-# ---- RIG -------------------------------------------------------------------
-class RigScreen(Screen):
-    """Eight tracks; the selected one shows its pages and renders."""
+# ---- THE BENCH: one page, three panes ---------------------------------------
+AVAILABLE, LOADED, UNIT = 0, 1, 2
+PREVIEWS = ("FX2", "MENU", "FX1")
+
+
+class BenchScreen(Screen):
+    """One page: the library, the image being composed, and the selected unit.
+
+    Three panes, left to right, matching how the work actually goes: what
+    COULD be in the image, what IS, and what the selected effect looks like on
+    the unit. There is no per-track view -- a remix is a statement about an
+    IMAGE, and the eight tracks were a second place to say the same thing.
+    Knob values belong to the effect, not to a track.
+
+    The default selection is STOCK: the chooser an unmodified unit shows. You
+    add to what the box already does rather than to somebody else's remix.
+    """
 
     BINDINGS = [
+        Binding("tab", "pane(1)", "pane"),
+        Binding("shift+tab", "pane(-1)", "prev pane", show=False),
+        Binding("enter", "add_remove", "add / remove"),
+        Binding("p", "preview", "preview"),
         Binding("r", "render", "render+hear"),
         Binding("space", "play", "play last"),
-        Binding("enter", "pick_effect", "effect"),
-        Binding("backspace", "clear_effect", "clear fx", show=False),
-        Binding("a", "mark('A')", "mark A"),
-        Binding("b", "mark('B')", "mark B"),
-        Binding("comma", "play_mark('A')", "play A"),
-        Binding("full_stop", "play_mark('B')", "play B"),
-        Binding("x", "app.switch_mode('remix')", "remix"),
-        Binding("e", "app.switch_mode('emu')", "emu"),
-        Binding("question_mark", "help('rig')", "what is this?"),
+        Binding("a", "mark('A')", "mark A", show=False),
+        Binding("comma", "play_mark('A')", "play A", show=False),
+        Binding("full_stop", "play_mark('B')", "play B", show=False),
+        Binding("b", "build('bus')", "build"),
+        Binding("c", "build('check')", "check", show=False),
+        Binding("w", "measure", "word cost", show=False),
+        Binding("f", "fallback", "fallback", show=False),
+        Binding("l", "load", "load remix"),
+        Binding("s", "save", "save remix"),
+        Binding("k", "stock", "reset to stock", show=False),
+        Binding("question_mark", "help", "what is this?"),
         Binding("q", "app.quit", "quit"),
     ]
 
     def compose(self) -> ComposeResult:
-        yield Static(id="strip")
-        yield Static(id="detail")
-        yield Static(id="history")
+        with Horizontal():
+            yield Static(id="pane_avail")
+            yield Static(id="pane_load")
+            yield Static(id="pane_unit")
         yield Static(id="status")
+        yield RichLog(id="log", highlight=False, markup=False)
         yield Footer()
 
     def on_mount(self):
-        self.cursor = 0                     # row in the detail list
+        self.pane = LOADED
+        self.cur = [0, 0, 0]
+        self.preview = "FX2"
+        self.booting = False
+        self.rows_mtime = None
+        self.built = []                  # (fx2_id, module) from the image
+        self.query_one("#log", RichLog).display = False
         self.rerender()
 
-    # ---- the rows the cursor walks (SOURCE, WET, then the knobs) --------
-    def rows(self):
-        app = self.app
-        mod = app.rig.effect(app.track)
-        rows = [("SOURCE", None), ("WET", None)]
-        if mod:
-            for name, slot in sorted(mod.knob_map().items(),
-                                     key=lambda kv: kv[1]):
-                if mod.params[slot].active:
-                    rows.append((name, slot))
-        return rows
+    # ---- the rows each pane walks ---------------------------------------
+    # Group order for the library pane: the way you meet them -- the two big
+    # bus effects, then the inserts that stack, then plumbing, then stock.
+    _GROUPS = (rig.SERVER, rig.INSERT, rig.SYSTEM)
 
+    def avail_rows(self):
+        """Everything that COULD be in an image: our modules, then stock."""
+        mods = [m for m in registry.modules().values() if not m.is_stock]
+        mods.sort(key=lambda m: (self._GROUPS.index(rig.category(m)),
+                                 disp(m).lower()))
+        return mods + list(stock.MODULES)
+
+    def loaded_rows(self):
+        st = self.app.state
+        return [st.mods[k] for k in st.order]
+
+    def unit_rows(self, mod):
+        """The knobs of the selected unit, in slot order."""
+        if mod is None or not mod.params:
+            return []
+        return [(n, s) for n, s in sorted(mod.knob_map().items(),
+                                          key=lambda kv: kv[1])
+                if mod.params[s].active]
+
+    def selected_module(self):
+        """The unit pane follows whichever pane the cursor is in -- point at
+        something in the library and pane 3 previews it before you add it."""
+        rows = self.avail_rows() if self.pane == AVAILABLE else self.loaded_rows()
+        if self.pane == UNIT:
+            rows = self.loaded_rows()
+        if not rows:
+            return None
+        i = min(self.cur[min(self.pane, LOADED)], len(rows) - 1)
+        return rows[i]
+
+    def image_rows(self):
+        """What the BUILT image offers -- re-read when the image changes."""
+        mt = BUILT_IMAGE.stat().st_mtime if BUILT_IMAGE.exists() else None
+        if mt != self.rows_mtime:
+            self.built, self.rows_mtime = rig.built_chooser(), mt
+        return self.built
+
+    def in_image(self, mod):
+        """Would this effect's page actually resolve in the image on disk?
+
+        A STOCK effect always does. A remix that leaves one out does not
+        REMOVE it -- its code, descriptor and dispatch entry stay stock, and
+        an old project that selects it still runs it; it only loses its
+        chooser row. So chooser membership is the wrong test for stock, and
+        using it made every effect unpreviewable on a fresh all-stock launch.
+
+        One of OURS is another matter: if it was not built, its id resolves
+        to the fallback. (The schema forbids our modules on stock ids, so
+        these two cases cannot overlap.)
+        """
+        if mod is None or mod.menu is None:
+            return False
+        if mod.is_stock:
+            return True
+        return any(m is not None and m.key == mod.key
+                   for _, m in self.image_rows())
+
+    # ---- render ----------------------------------------------------------
     def rerender(self):
-        app = self.app
-        r = app.rig
-        # -- strip ---------------------------------------------------------
-        cells = []
-        for t in rig.TRACKS:
-            mod = r.effect(t)
-            name = (mod.menu.abbr.decode("latin1") if mod and mod.menu
-                    else "--")
-            sel = "reverse bold" if t == app.track else "dim"
-            cells.append(f"[{sel}] T{t} {name:<5}[/]")
-        self.query_one("#strip", Static).update(
-            "  ".join(cells) + "\n" + "─" * 78)
+        st = self.app.state
+        self._pane_available(st)
+        self._pane_loaded(st)
+        self._pane_unit(st)
+        self.query_one("#status", Static).update(f"[dim]{escape(st.msg)}[/]")
 
-        # -- detail --------------------------------------------------------
-        mod = r.effect(app.track)
-        lines = []
-        tr = f"T{app.track}"
-        if mod:
-            full = mod.menu.fullname.decode("latin1")
-            lines.append(f"[bold]{tr} · {escape(full)}[/]   "
-                         f"(tracks {rig.track_range(mod).start}-"
-                         f"{rig.track_range(mod).stop - 1})")
-        else:
-            avail = ", ".join(m.name for m in rig.available(app.track))
-            lines.append(f"[bold]{tr} · no effect[/]   (here: {avail})")
-        lines.append("")
-        rows = self.rows()
-        for i, (name, slot) in enumerate(rows):
-            cur = i == self.cursor
-            mark = "[reverse]" if cur else ""
-            end = "[/]" if cur else ""
-            if name == "SOURCE":
-                src = app.source.name if app.source else "(none — add wavs "\
-                    "to out/dry/)"
-                lines.append(f" {mark}SOURCE  {escape(src)}{end}")
-            elif name == "WET":
-                w = "WET only (reverb render)" if app.wet else "full (dry+wet)"
-                lines.append(f" {mark}RENDER  {w}{end}")
+    def _title(self, text, pane):
+        on = self.pane == pane
+        return (f"[reverse bold] {escape(text)} [/]" if on
+                else f"[bold]{escape(text)}[/]")
+
+    def _pane_available(self, st):
+        rows = self.avail_rows()
+        out = [self._title("AVAILABLE", AVAILABLE), ""]
+        group = None
+        for i, m in enumerate(rows):
+            g = "stock effects" if m.is_stock else rig.category(m)
+            if g != group:
+                group = g
+                out.append(f"[dim]── {g} ──[/]")
+            here = self.pane == AVAILABLE and i == self.cur[AVAILABLE]
+            mark = "✓" if m.key in st.sel else " "
+            menus = "+".join(rig.menus(m)) or "—"
+            line = f" {mark} {disp(m):<13} [dim]{menus}[/]"
+            out.append(f"[reverse]{line}[/]" if here else line)
+        self.query_one("#pane_avail", Static).update("\n".join(out))
+
+    def _pane_loaded(self, st):
+        rows = self.loaded_rows()
+        name = st.loaded_name or "unsaved"
+        out = [self._title(f"LOADED · {name}", LOADED), ""]
+        pos = 0
+        for i, m in enumerate(rows):
+            here = self.pane == LOADED and i == self.cur[LOADED]
+            if m.menu is not None:
+                pos += 1
+                row = f"{pos:>2}"
             else:
-                v = r.knobs[app.track].get(name, 0)
-                hi = rig.knob_max(mod, name)
-                if hi < 8:                                # a select
-                    val = f"{step_label(mod, name, v):<6}"
-                    bar = "·" * 16
-                else:
-                    val = f"{v:>3}   "
-                    fill = round(16 * v / max(hi, 1))
-                    bar = "#" * fill + "." * (16 - fill)
-                page = "1" if slot < 6 else "2"
-                knob = "ABCDEF"[slot % 6]
-                lines.append(f" {mark}{name:<6} {val} \\[{bar}]  "
-                             f"p{page}·{knob}{end}")
-        # -- the "what is this?" line for whatever the cursor is on ------
-        name, slot = rows[self.cursor]
-        if name == "SOURCE":
-            hint = ("the wav rendered through the effect -- drop files in "
-                    "out/dry/; left/right cycles")
-        elif name == "WET":
-            hint = ("WET = the reverb's wet alone (exact dry subtraction); "
-                    "other effects always render their normal output")
-        elif mod:
-            hint = rig.knob_doc(mod, name) or "(this knob has no doc yet)"
+                row = " ·"                      # no chooser row (a CF patch)
+            menus = "+".join(rig.menus(m)) or "—"
+            words = st.words.get(m.key)
+            cost = f"[dim]{words:>5}w[/]" if words else "      "
+            built = "●" if self.in_image(m) else " "
+            fb = "◀fb" if st.eff_fallback == m.key else "   "
+            line = f" {row} {built} {disp(m):<13}[dim]{menus:<7}[/]{cost}{fb}"
+            out.append(f"[reverse]{line}[/]" if here else line)
+        if not rows:
+            out.append("[dim] (empty — add from the left)[/]")
+        probs = st.problems()
+        out.append("")
+        out.append("[dim]● = in the built image[/]")
+        if probs:
+            out.append(f"[bold]⚠ {escape(probs[0])}[/]")
+        self.query_one("#pane_load", Static).update("\n".join(out))
+
+    def _pane_unit(self, st):
+        mod = self.selected_module()
+        if mod is None:
+            self.query_one("#pane_unit", Static).update(
+                self._title("UNIT", UNIT) + "\n\n[dim]nothing selected[/]")
+            return
+        out = [self._title(disp(mod), UNIT), ""]
+        bits = [rig.category(mod)]
+        if mod.menu:
+            bits.append(f"id 0x{mod.menu.fx2_id:02x}")
+            bits.append("+".join(rig.menus(mod)))
+        tr = rig.track_range(mod)
+        if len(tr):
+            bits.append(f"tracks {tr.start}-{tr.stop - 1}")
+        out.append(f"[dim]{' · '.join(bits)}[/]")
+        out.append(f"[dim]{escape(mod.doc)}[/]")
+        out.append("")
+
+        knobs = self.unit_rows(mod)
+        vals = st.knobs_for(mod)
+        for i, (name, slot) in enumerate(knobs):
+            here = self.pane == UNIT and i == self.cur[UNIT]
+            v = vals.get(name, 0)
+            hi = rig.knob_max(mod, name)
+            if hi < 8:
+                shown = f"{step_label(mod, name, v):<7}"
+                bar = "·" * 12
+            else:
+                shown = f"{v:>3}    "
+                fill = round(12 * v / max(hi, 1))
+                bar = "#" * fill + "." * (12 - fill)
+            page = "1" if slot < 6 else "2"
+            line = f" {name:<6} {shown}\\[{bar}] [dim]p{page}[/]"
+            out.append(f"[reverse]{line}[/]" if here else line)
+        if not knobs:
+            out.append("[dim] (no drawn parameters)[/]")
+        if self.pane == UNIT and knobs:
+            name, _ = knobs[min(self.cur[UNIT], len(knobs) - 1)]
+            out.append("")
+            out.append(f"[dim]? {escape(rig.knob_doc(mod, name) or '')}[/]")
+
+        out.append("")
+        src = self.app.source.name if self.app.source else "(none)"
+        out.append(f"[dim]source {escape(src)} · r renders · space plays[/]")
+        out.append("")
+        out += self._preview(mod)
+        self.query_one("#pane_unit", Static).update("\n".join(out))
+
+    # ---- the emulated panel ---------------------------------------------
+    def _preview(self, mod):
+        modes = " ".join(f"[reverse]{m}[/]" if m == self.preview else
+                         f"[dim]{m}[/]" for m in PREVIEWS)
+        head = [f"preview: {modes}  [dim](p)[/]"]
+        r = self.app.boot
+        if r is None:
+            self.ensure_boot()
+            return head + ["[dim]booting the emulator...[/]"]
+        if not r.reached_handoff:
+            return head + ["[bold]did not reach the RTOS handoff[/] — a "
+                           "patch may have broken early init"]
+        import emu_bringup
+        if self.preview == "MENU":
+            draws = emu_bringup.render_menu(r, emu_bringup.MENU_ROOT_DESC, 0)
+        elif self.preview == "FX1":
+            draws = emu_bringup.render_fx1(r, track=4, effect_id=0x04)
         else:
-            hint = ""
-        lines.append("")
-        lines.append(f"[dim]? {escape(hint)}[/]")
-        if mod and mod.name == "chonverb":
-            lines.append("[dim]MODE renders as its own image (cached per "
-                         "mode); WET applies to the reverb only.[/]")
-        self.query_one("#detail", Static).update("\n".join(lines))
+            if mod.menu is None:
+                return head + ["[dim]no chooser row: this module patches the "
+                               "firmware rather than adding an effect[/]"]
+            if not self.in_image(mod):
+                return head + [
+                    f"[bold]not in the built image[/] — b builds the "
+                    f"selection",
+                    "[dim]the page is not drawn: an id the image does not",
+                    "implement resolves to the fallback, so the firmware",
+                    "would draw the WRONG effect (CLAUDE.md, 12 Aug).[/]"]
+            draws = emu_bringup.render_fx2(r, track=4,
+                                           effect_id=mod.menu.fx2_id)
+        grid = emu_bringup.layout_screen(draws)
+        return head + ["." + "-" * 44 + "."] + \
+            ["|" + escape(ln.ljust(44)) + "|" for ln in grid] + \
+            ["'" + "-" * 44 + "'"]
 
-        # -- history -------------------------------------------------------
-        h = ["[bold]RENDERS[/]"]
-        for i, (label, path) in enumerate(reversed(app.history[-6:])):
-            marks = "".join(m for m, p in app.marks.items() if p == path)
-            h.append(f" {('\\[' + marks + '] ') if marks else '    '}"
-                     f"{escape(label)}")
-        self.query_one("#history", Static).update(
-            "\n".join(h) if len(h) > 1 else
-            "[dim]r renders the selected track; a/b mark a render, "
-            ", . replay the marks[/]")
-        self.query_one("#status", Static).update(
-            f"[dim]{escape(app.status)}[/]")
+    def ensure_boot(self):
+        if not BUILT_IMAGE.exists() or self.booting:
+            return
+        mtime = BUILT_IMAGE.stat().st_mtime
+        if self.app.boot is not None and self.app.boot_mtime == mtime:
+            return
+        self.booting = True
+        self.boot_worker(mtime)
 
-    # ---- input ----------------------------------------------------------
-    def on_key(self, ev):
+    @work(thread=True, exclusive=True, group="boot")
+    def boot_worker(self, mtime):
         app = self.app
-        if ev.key in tuple("12345678"):
-            app.track = int(ev.key)
-            self.cursor = 0
+        try:
+            import emu_bringup
+            r = emu_bringup.boot(str(BUILT_IMAGE))
+        except Exception as e:                       # noqa: BLE001
+            r = None
+            app.state.msg = f"emulator unavailable — {e} (make emu-setup)"
+        self.booting = False
+        if r is not None:
+            app.boot, app.boot_mtime = r, mtime
+        app.call_from_thread(self.rerender)
+
+    # ---- input -----------------------------------------------------------
+    def action_pane(self, d):
+        self.pane = (self.pane + d) % 3
+        self.rerender()
+
+    def action_preview(self):
+        self.preview = PREVIEWS[(PREVIEWS.index(self.preview) + 1)
+                                % len(PREVIEWS)]
+        self.rerender()
+
+    def on_key(self, ev):
+        st = self.app.state
+        rows = (self.avail_rows() if self.pane == AVAILABLE else
+                self.loaded_rows() if self.pane == LOADED else
+                self.unit_rows(self.selected_module()))
+        n = max(len(rows), 1)
+        if ev.key in ("down", "j"):
+            self.cur[self.pane] = min(n - 1, self.cur[self.pane] + 1)
+        elif ev.key in ("up", "k"):
+            self.cur[self.pane] = max(0, self.cur[self.pane] - 1)
+        elif ev.key in ("left", "right", "h", "shift+left", "shift+right"):
+            step = 1 if ev.key in ("right", "shift+right") else -1
+            if self.pane == UNIT:
+                self.adjust(step * (10 if "shift" in ev.key else 1))
+            elif self.pane == LOADED:
+                self.move_row(step)
+            else:
+                return
+        else:
+            return
+        self.rerender()
+
+    def adjust(self, step):
+        """Change the selected knob. Values live per MODULE."""
+        st = self.app.state
+        mod = self.selected_module()
+        knobs = self.unit_rows(mod)
+        if not knobs:
+            return
+        name, _ = knobs[min(self.cur[UNIT], len(knobs) - 1)]
+        vals = st.knobs_for(mod)
+        hi = rig.knob_max(mod, name)
+        vals[name] = max(0, min(hi, vals.get(name, 0) + step))
+
+    def move_row(self, step):
+        """Reorder the loaded pane -- chooser ORDER is the panel's row order,
+        so this is a real edit, not a view preference."""
+        st = self.app.state
+        rows = self.loaded_rows()
+        if not rows:
+            return
+        i = min(self.cur[LOADED], len(rows) - 1)
+        st.move(rows[i].key, step)
+        self.cur[LOADED] = max(0, min(len(rows) - 1, i + step))
+
+    def action_add_remove(self):
+        st = self.app.state
+        if self.pane == AVAILABLE:
+            rows = self.avail_rows()
+            mod = rows[min(self.cur[AVAILABLE], len(rows) - 1)]
+            st.toggle(mod.key)
+            st.loaded_name = ""
+            st.msg = (f"added {mod.key}" if mod.key in st.sel
+                      else f"removed {mod.key}")
+        elif self.pane == LOADED:
+            rows = self.loaded_rows()
+            if not rows:
+                return
+            mod = rows[min(self.cur[LOADED], len(rows) - 1)]
+            st.toggle(mod.key)
+            st.loaded_name = ""
+            st.msg = f"removed {mod.key}"
+            self.cur[LOADED] = max(0, self.cur[LOADED] - 1)
+        self.rerender()
+
+    def action_stock(self):
+        self.app.state.load_stock()
+        self.cur = [0, 0, 0]
+        self.rerender()
+
+    def action_fallback(self):
+        st = self.app.state
+        opts = [(m.key, f"{m.name} (0x{m.menu.fx2_id:02x})")
+                for m in st.menu_modules]
+        if not opts:
+            st.msg = "nothing with a chooser row to fall back to"
             self.rerender()
             return
-        rows = self.rows()
-        if ev.key in ("down", "j"):
-            self.cursor = min(len(rows) - 1, self.cursor + 1)
-        elif ev.key in ("up", "k"):
-            self.cursor = max(0, self.cursor - 1)
-        elif ev.key in ("left", "right", "h", "l",
-                        "shift+left", "shift+right"):
-            step = 1 if ev.key in ("right", "l", "shift+right") else -1
-            if "shift" in ev.key:
-                step *= 10
-            self.adjust(rows[self.cursor], step)
-        else:
-            return
-        self.rerender()
-
-    def adjust(self, row, step):
-        app = self.app
-        name, slot = row
-        if name == "SOURCE":
-            files = wav_sources()
-            if files:
-                i = files.index(app.source) if app.source in files else 0
-                app.source = files[(i + step) % len(files)]
-        elif name == "WET":
-            app.wet = not app.wet
-        else:
-            mod = app.rig.effect(app.track)
-            hi = rig.knob_max(mod, name)
-            v = app.rig.knobs[app.track].get(name, 0)
-            app.rig.knobs[app.track][name] = max(0, min(hi, v + step))
-            app.rig.save()
-
-    def action_pick_effect(self):
-        app = self.app
-        opts = [(m.key, f"{escape(m.menu.fullname.decode('latin1')):<13} "
-                        f"\\[{rig.category(m)}]\n[dim]{escape(m.doc)}[/]")
-                for m in rig.available(app.track)] + [("__none__", "(none)")]
 
         def done(key):
             if key:
-                app.rig.set_effect(app.track,
-                                   None if key == "__none__" else key)
-                app.rig.save()
-                self.cursor = 0
-                self.rerender()
-        app.push_screen(Chooser(f"FX2 on T{app.track}:", opts), done)
+                st.fallback = key
+                st.msg = f"unimplemented ids alias to {key}"
+            self.rerender()
+        self.app.push_screen(Chooser("unimplemented ids alias to:", opts), done)
 
-    def action_clear_effect(self):
-        self.app.rig.set_effect(self.app.track, None)
-        self.app.rig.save()
-        self.cursor = 0
-        self.rerender()
+    def action_help(self):
+        self.app.push_screen(HelpScreen("bench"))
 
-    def action_help(self, view):
-        self.app.push_screen(HelpScreen(view))
-
+    # ---- audio -----------------------------------------------------------
     def action_render(self):
-        app = self.app
-        mod = app.rig.effect(app.track)
-        if mod is None:
-            app.status = "no effect on this track — enter picks one"
+        app, st = self.app, self.app.state
+        mod = self.selected_module()
+        if mod is None or rig.category(mod) == rig.SYSTEM:
+            st.msg = "that module is plumbing — nothing to hear"
         elif app.source is None:
-            app.status = "no source wav — put some in out/dry/"
+            st.msg = "no source wav — put some in out/dry/"
         elif app.rendering:
-            app.status = "a render is already running"
+            st.msg = "a render is already running"
         else:
-            self.render_worker(mod, dict(app.rig.knobs[app.track]),
-                               app.source, app.wet, app.track)
+            self.render_worker(mod, dict(st.knobs_for(mod)), app.source)
         self.rerender()
 
     @work(thread=True, exclusive=True, group="render")
-    def render_worker(self, mod, values, source, wet, track):
+    def render_worker(self, mod, values, source):
         app = self.app
 
         def log(msg):
-            app.call_from_thread(self.set_status, msg)
+            app.state.msg = msg
+            app.call_from_thread(self.rerender)
         app.rendering = True
         log(f"rendering {mod.name} on {source.name} ...")
         try:
-            path = audition.render(mod.key, values, source, wet=wet,
-                                   label=f"T{track}", log=log)
+            path = audition.render(mod.key, values, source, log=log)
         except RuntimeError as e:
             app.rendering = False
             log(str(e))
@@ -462,22 +687,19 @@ class RigScreen(Screen):
         changed = {n: v for n, v in values.items()
                    if v != rig.default_knobs(mod).get(n)}
         desc = " ".join(f"{n}={v}" for n, v in changed.items()) or "defaults"
-        app.history.append((f"T{track} {mod.name} · {desc}", path))
-        app.call_from_thread(self.set_status, f"rendered → {path.name}")
+        app.history.append((f"{mod.name} · {desc}", path))
+        app.state.msg = f"rendered → {path.name}"
         app.call_from_thread(app.play, path)
         app.call_from_thread(self.rerender)
-
-    def set_status(self, msg):
-        self.app.status = msg
-        self.rerender()
 
     def action_play(self):
         app = self.app
         if app.history:
-            app.play(app.history[-1][1])
-            app.status = f"playing {app.history[-1][1].name}"
+            label, path = app.history[-1]
+            app.play(path)
+            app.state.msg = f"playing {label}"
         else:
-            app.status = "nothing rendered yet"
+            app.state.msg = "nothing rendered yet"
         self.rerender()
 
     def action_mark(self, which):
@@ -485,7 +707,7 @@ class RigScreen(Screen):
         if app.history:
             label, path = app.history[-1]
             app.marks[which] = path
-            app.status = f"marked {which}: {label}"
+            app.state.msg = f"marked {which}: {label}"
             audition._journal({"event": "mark", "which": which,
                                "label": label, "out": path.name})
         self.rerender()
@@ -495,207 +717,22 @@ class RigScreen(Screen):
         p = app.marks.get(which)
         if p:
             app.play(p)
-            app.status = f"playing {which}: {p.name}"
+            app.state.msg = f"playing {which}: {p.name}"
         else:
-            app.status = f"no {which} mark yet — render, then press "\
-                         f"{'a' if which == 'A' else 'b'}"
+            app.state.msg = f"no {which} mark yet"
         self.rerender()
 
-
-# ---- REMIX -----------------------------------------------------------------
-class RemixScreen(Screen):
-    """The composer: what the image contains, whether it builds, what it costs.
-
-    Grouped the way an operator meets the modules -- servers with their track
-    range, inserts, then the system plumbing that never sits on a track."""
-
-    BINDINGS = [
-        Binding("space", "toggle", "toggle"),
-        Binding("f", "fallback", "fallback"),
-        Binding("w", "measure", "words"),
-        Binding("b", "build('bus')", "build"),
-        Binding("c", "build('check')", "check"),
-        Binding("l", "load", "load"),
-        Binding("s", "save", "save"),
-        Binding("v", "app.switch_mode('rig')", "rig"),
-        Binding("e", "app.switch_mode('emu')", "emu"),
-        Binding("question_mark", "help('remix')", "what is this?"),
-        Binding("q", "app.quit", "quit"),
-    ]
-
-    def compose(self) -> ComposeResult:
-        with Horizontal():
-            yield Static(id="mods")
-            yield Static(id="panel")
-        yield RichLog(id="log", max_lines=400, wrap=True)
-        yield Footer()
-
-    def on_mount(self):
-        self.cursor = 0
-        log = self.query_one("#log", RichLog)
-        log.display = False
-        self.rerender()
-
-    def grouped(self):
-        """[(key or None, line-label)] with None rows as group headers."""
-        st = self.app.state
-        cats = {rig.SERVER: [], rig.INSERT: [], rig.STOCK: [],
-                rig.SYSTEM: []}
-        for k in st.keys:
-            cats[rig.category(st.mods[k])].append(k)
-        # Stock rows in stock's own chooser order, not alphabetical.
-        from remix import stock
-        cats[rig.STOCK] = [m.key for m in stock.MODULES]
-        out = []
-        for cat, title in ((rig.SERVER, "BUS EFFECTS (one per payload)"),
-                           (rig.INSERT, "INSERTS (any track)"),
-                           (rig.STOCK, "STOCK FX2 (in every image; "
-                                       "toggle = keep its row, free)"),
-                           (rig.SYSTEM, "SYSTEM (never on a track)")):
-            if cats[cat]:
-                out.append((None, title))
-                out += [(k, "") for k in cats[cat]]
-        return out
-
-    def key_rows(self):
-        return [i for i, (k, _) in enumerate(self.grouped()) if k]
-
-    def rerender(self):
-        st = self.app.state
-        rows = self.grouped()
-        krows = self.key_rows()
-        self.cursor = min(self.cursor, len(krows) - 1)
-        lines = ["[bold]THE IMAGE[/] — modules composed into the firmware\n"]
-        for i, (k, title) in enumerate(rows):
-            if k is None:
-                lines.append(f"[bold dim]{title}[/]")
-                continue
-            m = st.mods[k]
-            on = "x" if k in st.sel else " "
-            fb = ("*" if st.fallback == k
-                  else "~" if k == st.eff_fallback else " ")
-            tr = rig.track_range(m)
-            trs = f"T{tr.start}-{tr.stop - 1}" if len(tr) else "     "
-            wd = (" stock" if m.is_stock
-                  else f"{st.words[k]:>5}w" if k in st.words else "     -")
-            cur = krows[self.cursor] == i
-            mark = "[reverse]" if cur else ("" if k in st.sel else "[dim]")
-            end = "[/]" if mark else ""
-            lines.append(f" {mark}\\[{on}]{fb} {m.name:<11}{trs} {wd}{end}")
-        lines.append("")
-        lines.append("[bold dim]REMIXES[/] [dim]" + " ".join(
-            n for n in registry.remix_names() if not n.startswith("_"))
-            + "[/]")
-        lines.append("")
-        lines.append(f"[dim]? {escape(st.mods[self.current_key()].doc)}[/]")
-        self.query_one("#mods", Static).update("\n".join(lines))
-
-        # -- right panel: the unit's FX2 menu + fit + problems --------------
-        p = ["[bold]THE FX2 MENU[/] — as the unit will show it\n"]
-        for i, m in enumerate(st.menu_modules):
-            star = ""
-            if m.key == st.eff_fallback:
-                star = (" ← fallback (auto)" if st.fallback_is_auto
-                        else " ← fallback")
-            p.append(f"  {i}. {escape(m.menu.fullname.decode('latin1')):<13} "
-                     f"0x{m.menu.fx2_id:02x}{star}")
-        from remix import stock
-        n_menu = len(st.menu_modules)
-        if n_menu > 7:
-            p.append(f"  [dim]{n_menu} rows: the panel shows 7 and scrolls[/]")
-        absent = [m for m in st.mods.values()
-                  if m.menu is not None and m.key not in st.sel
-                  and not m.is_stock]
-        if absent and st.eff_fallback:
-            p.append(f"  [dim]{len(absent)} absent module id(s) alias to "
-                     f"{st.mods[st.eff_fallback].name}[/]")
-        hidden = [m.key for m in stock.MODULES if m.key not in st.sel]
-        if hidden:
-            p.append(f"  [dim]{len(hidden)} stock effects hidden (no row; "
-                     f"still run for old projects)[/]")
-        p.append(f"  [dim]consumed by every remix: {', '.join(stock.CONSUMED)}"
-                 f" — their code is the donor region[/]")
-        p.append("")
-        dsp = [m for m in st.selected if m.dsp is not None]
-        known = [m for m in dsp if m.key in st.words]
-        if known:
-            total = sum(st.words[m.key] for m in known)
-            partial = ("" if len(known) == len(dsp)
-                       else f" ({len(known)}/{len(dsp)} measured)")
-            fill = min(30, round(30 * total / DONOR_WORDS))
-            over = total > DONOR_WORDS
-            p.append(f"program: [{'bold red' if over else 'bold'}]{total}[/] "
-                     f"of {DONOR_WORDS} words{partial}")
-            p.append("[" + "#" * fill + "." * (30 - fill) + "]")
-        else:
-            p.append("[dim]program: press w to assemble and measure[/]")
-        p.append("")
-        probs = st.problems()
-        if probs:
-            p.append(f"[bold red]WILL NOT BUILD ({len(probs)})[/]")
-            p += [f"  {escape(x)}" for x in probs]
-        else:
-            p.append("[bold green]no LEDGER collisions — this selection "
-                     "builds[/]")
-            p.append("[dim]not checked: the shared 64K window "
-                     "(see CLAUDE.md for who owns what)[/]")
-            buffered = [m for m in st.selected
-                        if m.claims is not None and m.claims.owns_fx2_buffers]
-            if buffered:
-                p.append(f"[dim]{buffered[0].name} owns Y:0x4000-0xBFFF — "
-                         f"the only such module on its core[/]")
-        p.append("")
-        p.append(f"[dim]{escape(st.msg)}[/]")
-        self.query_one("#panel", Static).update("\n".join(p))
-
-    def on_key(self, ev):
-        krows = self.key_rows()
-        if ev.key in ("down", "j"):
-            self.cursor = min(len(krows) - 1, self.cursor + 1)
-        elif ev.key in ("up", "k"):
-            self.cursor = max(0, self.cursor - 1)
-        elif ev.character in ("[", "]"):
-            self.app.state.move(self.current_key(),
-                                -1 if ev.character == "[" else +1)
-        else:
-            return
-        self.rerender()
-
-    def current_key(self):
-        return self.grouped()[self.key_rows()[self.cursor]][0]
-
-    def action_help(self, view):
-        self.app.push_screen(HelpScreen(view))
-
-    def action_toggle(self):
-        st = self.app.state
-        k = self.current_key()
-        st.toggle(k)
-        if k in st.sel and st.mods[k].is_stock:
-            st.msg = f"{k}: stock row kept -- no code, no words, no clone"
-        self.rerender()
-
-    def action_fallback(self):
-        st = self.app.state
-        k = self.current_key()
-        if k in st.sel and st.mods[k].menu is not None:
-            st.fallback = k
-            st.msg = f"fallback: {st.mods[k].name}"
-        else:
-            st.msg = "the fallback must be selected and have a menu entry"
-        self.rerender()
-
+    # ---- build, measure, load, save --------------------------------------
     def action_measure(self):
         st = self.app.state
-        st.msg = "assembling..."
+        st.msg = "assembling for word counts..."
         self.rerender()
         self.measure_worker()
 
-    @work(thread=True, exclusive=True, group="build")
+    @work(thread=True, exclusive=True, group="measure")
     def measure_worker(self):
         st = self.app.state
-        ok, msg = st.measure("this selection")
-        st.msg = msg
+        st.measure(None)
         self.app.call_from_thread(self.rerender)
 
     def action_build(self, target):
@@ -727,18 +764,23 @@ class RemixScreen(Screen):
         st.msg = (f"make {target}: {'OK' if rc == 0 else f'FAILED (rc {rc})'}"
                   f" — the built image is this selection")
         if rc == 0:
-            self.app.boot = None          # the emu view must re-boot
+            self.app.boot = None          # the preview must re-boot
+            self.rows_mtime = None        # and the ● markers re-read
         self.app.call_from_thread(self.rerender)
 
     def action_load(self):
         names = [n for n in registry.remix_names() if not n.startswith("_")]
 
         def done(name):
-            if name:
+            if name == "stock":
+                self.app.state.load_stock()
+            elif name:
                 self.app.state.load(name)
-                self.rerender()
+            self.cur = [0, 0, 0]
+            self.rerender()
         self.app.push_screen(
-            Chooser("load remix:", [(n, n) for n in names]), done)
+            Chooser("load:", [("stock", "stock (an unmodified unit)")]
+                    + [(n, n) for n in names]), done)
 
     def action_save(self):
         st = self.app.state
@@ -758,9 +800,10 @@ class RemixScreen(Screen):
                 return
 
             def documented(doc):
-                p = ROOT / f"remixes/{name}.py"
-                p.write_text(st.as_remix(
+                pth = ROOT / f"remixes/{name}.py"
+                pth.write_text(st.as_remix(
                     name, doc or "a selection composed in the workbench"))
+                st.loaded_name = name
                 st.msg = f"wrote remixes/{name}.py"
                 self.rerender()
             self.app.push_screen(TextPrompt("one-line description:"),
@@ -768,346 +811,17 @@ class RemixScreen(Screen):
         self.app.push_screen(TextPrompt("save as remix:"), named)
 
 
-# ---- EMU -------------------------------------------------------------------
-class EmuScreen(Screen):
-    """The built image, booted and drawing its own screens (docs/EMU.md)."""
-
-    BINDINGS = [
-        Binding("m", "view('menu')", "menu"),
-        Binding("f", "view('fx2')", "FX2"),
-        Binding("left,right", "noop", "cycle effect"),
-        Binding("a", "stage", "stage effect"),
-        Binding("b", "build", "build + re-boot"),
-        Binding("o", "view('fx1')", "FX1"),
-        Binding("p", "view('play')", "playback"),
-        Binding("v", "app.switch_mode('rig')", "rig"),
-        Binding("x", "app.switch_mode('remix')", "remix"),
-        Binding("question_mark", "help('emu')", "what is this?"),
-        Binding("q", "app.switch_mode('rig')", "back"),
-    ]
-
-    def compose(self) -> ComposeResult:
-        yield Static(id="emuhead")
-        yield Static(id="lcd")
-        yield Static(id="emunote")
-        yield Footer()
-
-    def on_mount(self):
-        self.view = "fx2"
-        self.cursor = 0
-        self.eff = {"fx1": 0x04, "play": 1}
-        self.rows = []                 # the built image's FX2 chooser
-        self.rowi = 0
-        self.rows_mtime = None
-        self.pending = ""               # what the last selection did
-        self.booting = False
-        self.ensure_boot()
-
-    def on_screen_resume(self):
-        # The rig's selection is this view's default subject.
-        self.view = "fx2"
-        self.sync_row()
-        self.ensure_boot()
-
-    def chooser(self):
-        """Everything this view can cycle: the rows the BUILT IMAGE offers,
-        then every other module that COULD have a row, marked as not built.
-
-        The second group is the point of the view -- "the effect I want is
-        not in this image" is the normal case, and the answer has to be
-        reachable from here rather than a trip to the composer. A pending row
-        is never RENDERED: its id is not in the image, so it would resolve to
-        the fallback and draw a convincing picture of the wrong effect. That
-        is the 12 Aug trap in panel form, so the view refuses instead.
-        """
-        # ONLY the image can change these rows. Staging changes the
-        # composer's selection, not the image, and the "STAGED" wording is
-        # read live at render time -- rebuilding here on a selection change
-        # also reset the cursor to row 0, so pressing `a` walked away from
-        # the effect you had just staged.
-        mt = BUILT_IMAGE.stat().st_mtime if BUILT_IMAGE.exists() else None
-        if mt != self.rows_mtime:
-            was = self.current_key()
-            built = [(eid, m, True) for eid, m in rig.built_chooser()]
-            have = {m.key for _, m, _ in built if m is not None}
-            pending = [(m.menu.fx2_id, m, False)
-                       for m in registry.modules().values()
-                       if m.menu is not None and m.key not in have
-                       and rig.category(m) != rig.SYSTEM]
-            pending.sort(key=lambda r: r[1].name)
-            self.rows = built + pending
-            self.rows_mtime = mt
-            self.rowi = 0
-            # Stay on the same EFFECT across a rebuild -- you stage one, press
-            # b, and want to be looking at it now that it is built, not sent
-            # back to row 0.
-            if not (was and self.goto_key(was)):
-                self.sync_row()
-        return self.rows
-
-    def current_key(self):
-        if self.rows and 0 <= self.rowi < len(self.rows):
-            _, m, _ = self.rows[self.rowi]
-            return m.key if m is not None else None
-        return None
-
-    def goto_key(self, key) -> bool:
-        for i, (_, m, _) in enumerate(self.rows):
-            if m is not None and m.key == key:
-                self.rowi = i
-                return True
-        return False
-
-    def sync_row(self):
-        """Point the cursor at whatever the rig has on this track, if the
-        image offers it -- so entering the view shows the rig's subject and
-        cycling starts from there rather than from row 0."""
-        mod = self.app.rig.effect(self.app.track)
-        if mod is None:
-            return
-        for i, (_, m, built) in enumerate(self.rows):
-            if built and m is not None and m.key == mod.key:
-                self.rowi = i
-                return
-
-    def select_row(self):
-        """Write the cycled-to effect back to the RIG, so the emu view and
-        the rig are one selection rather than two. Returns a note saying what
-        happened -- including the cases where the rig cannot hold it, which
-        are NOT errors: the unit's chooser is one list for all eight tracks
-        and will happily let you pick any row on any track.
-        """
-        app = self.app
-        if not self.rows:
-            return ""
-        eid, mod, built = self.rows[self.rowi]
-        if not built:
-            return ""                    # nothing to assign until it is built
-        if mod is None:
-            return f"id 0x{eid:02x} is in the list but no manifest claims it"
-        if rig.category(mod) == rig.SYSTEM:
-            return (f"{mod.key} is plumbing, not a track effect — the unit "
-                    f"lists it, the rig does not hold it")
-        if app.track not in rig.track_range(mod):
-            tr = rig.track_range(mod)
-            return (f"selected on the unit, but {mod.name} is a SERVER on "
-                    f"tracks {tr.start}-{tr.stop - 1} — on T{app.track} its "
-                    f"id aliases to the fallback and the track becomes a send")
-        app.rig.set_effect(app.track, mod.key)
-        app.rig.save()
-        return f"assigned {mod.key} to T{app.track} — the rig followed"
-
-    def ensure_boot(self):
-        app = self.app
-        if not BUILT_IMAGE.exists():
-            self.query_one("#emuhead", Static).update(
-                "[bold]no built image[/] — build one from the REMIX view (b)")
-            return
-        mtime = BUILT_IMAGE.stat().st_mtime
-        if app.boot is not None and app.boot_mtime == mtime:
-            self.rerender()
-            return
-        if not self.booting:
-            self.booting = True
-            self.query_one("#emuhead", Static).update(
-                f"booting {BUILT_IMAGE.name} in the Tier-0 emulator (~4 s)...")
-            self.boot_worker(mtime)
-
-    @work(thread=True, exclusive=True, group="boot")
-    def boot_worker(self, mtime):
-        app = self.app
-        try:
-            import emu_bringup
-            r = emu_bringup.boot(str(BUILT_IMAGE))
-        except Exception as e:                       # noqa: BLE001
-            r = None
-            app.call_from_thread(
-                self.query_one("#emuhead", Static).update,
-                f"[bold]emulator unavailable[/] — {e} (make emu-setup)")
-        self.booting = False
-        if r is not None:
-            app.boot, app.boot_mtime = r, mtime
-            app.call_from_thread(self.rerender)
-
-    def rerender(self):
-        app = self.app
-        r = app.boot
-        if r is None:
-            return
-        import emu_bringup
-        head = (f"[bold]{'BOOTS CLEAN' if r.clean else 'FAULT'}[/] · "
-                f"{r.instrs:,} instrs · {r.stopped} · cached until rebuilt")
-        self.query_one("#emuhead", Static).update(head)
-        note = ""
-        if not r.uc or not r.reached_handoff:
-            self.query_one("#lcd", Static).update(
-                "[bold]did not reach the RTOS handoff — a patch may have "
-                "broken early init.[/]")
-            self.query_one("#emunote", Static).update("")
-            return
-        track0 = app.track - 1               # emu_bringup tracks are 0-based
-        if self.view == "menu":
-            roots = emu_bringup.menu_children(r)
-            self.cursor %= max(len(roots), 1)
-            draws = emu_bringup.render_menu(r, emu_bringup.MENU_ROOT_DESC,
-                                            self.cursor)
-            added = [k[0] for k in roots if k[0] not in STOCK_ROOTS]
-            note = ("patched-in: " + ", ".join(added)) if added else ""
-            title = "MAIN MENU — the firmware's own render"
-        elif self.view == "fx2":
-            rows = self.chooser()
-            if not rows:
-                self.query_one("#lcd", Static).update(
-                    "[bold]the built image offers no FX2 chooser rows[/] — "
-                    "build one from the REMIX view (b)")
-                self.query_one("#emunote", Static).update("")
-                return
-            self.rowi %= len(rows)
-            eid, mod, built = rows[self.rowi]
-            name = (mod.menu.fullname.decode("latin1") if mod
-                    else f"unclaimed 0x{eid:02x}")
-            if not built:
-                staged = mod.key in app.state.sel
-                self.query_one("#lcd", Static).update(
-                    f"[bold]{escape(name)}[/] (0x{eid:02x}) is "
-                    f"{'STAGED' if staged else 'NOT'} in this image.\n\n"
-                    + ("  staged in the composer — press [bold]b[/] to build "
-                       "it and re-boot\n" if staged else
-                       "  press [bold]a[/] to stage it, then [bold]b[/] to "
-                       "build and re-boot\n")
-                    + "\n  [dim]the page is not drawn: an id this image does "
-                      "not implement resolves to\n  the fallback, so the "
-                      "firmware would draw a convincing picture of the\n"
-                      "  WRONG effect (CLAUDE.md, 12 Aug 2026).[/]")
-                self.query_one("#emunote", Static).update(
-                    f"[dim]{escape(self.pending)}[/]" if self.pending else
-                    "[dim]left/right cycles · a stages · b builds[/]")
-                return
-            draws = emu_bringup.render_fx2(r, track=track0, effect_id=eid)
-            title = (f"FX2 SETUP — T{app.track}, row {self.rowi + 1}/"
-                     f"{len(rows)}: {name} (0x{eid:02x})")
-            note = (self.pending or
-                    "left/right cycles · a stages an unbuilt effect · b "
-                    "builds · 1-8 changes track · values draw as dials the "
-                    "string hook cannot read, so the rig's numbers are true")
-            if mod and mod.name == "bongdelay":
-                note = ("a SPEC image aliases the delay's DSP to SEND on "
-                        "payload A — the page may draw empty; " + note)
-        elif self.view == "fx1":
-            draws = emu_bringup.render_fx1(r, track=track0,
-                                           effect_id=self.eff["fx1"])
-            title = (f"FX1 SETUP — T{app.track}, effect "
-                     f"0x{self.eff['fx1']:02x} (left/right cycles)")
-        else:
-            names = ["FLEX", "STATIC", "THRU", "NEIGHBOR"]
-            mi = self.eff["play"]
-            draws = emu_bringup.render_playback(r, track=track0, machine=mi)
-            title = f"PLAYBACK — T{app.track}, {names[mi]} (left/right cycles)"
-        grid = emu_bringup.layout_screen(draws)
-        lcd = "\n".join(["[bold]" + escape(title) + "[/]", "",
-                         "." + "-" * 46 + "."]
-                        + ["|" + escape(ln.ljust(46)) + "|" for ln in grid]
-                        + ["'" + "-" * 46 + "'"])
-        self.query_one("#lcd", Static).update(lcd)
-        self.query_one("#emunote", Static).update(f"[dim]{note}[/]")
-
-    def action_stage(self):
-        """Add the cycled-to module to the COMPOSER's live selection. Staging
-        only -- the image is not rebuilt until `b`, so cycling past several
-        unbuilt effects costs nothing."""
-        rows = self.chooser()
-        if self.view != "fx2" or not rows:
-            return
-        _, mod, built = rows[self.rowi]
-        if built or mod is None:
-            self.pending = "already in this image — nothing to stage"
-        elif mod.key in self.app.state.sel:
-            self.pending = f"{mod.key} is already staged — b builds it"
-        else:
-            self.app.state.toggle(mod.key)
-            probs = self.app.state.problems()
-            self.pending = (f"staged {mod.key} — b builds and re-boots"
-                            if not probs else
-                            f"staged {mod.key}, but the build would refuse: "
-                            f"{probs[0]}")
-        self.rerender()
-
-    async def action_build(self):
-        """Build the composer's live selection. The build lives on the REMIX
-        screen because that is where its log pane is, and switching there IS
-        the useful behaviour: you watch it build.
-
-        ⚠️ `await` the mode switch. Firing the build straight after
-        `switch_mode` reaches the screen before its `on_mount` has run and
-        dies on a half-built widget -- the screen exists, its state does not.
-        """
-        if self.app.state.problems():
-            self.pending = f"refusing: {self.app.state.problems()[0]}"
-            self.rerender()
-            return
-        await self.app.switch_mode("remix")
-        self.app.screen.action_build("bus")
-
-    def action_help(self, view):
-        self.app.push_screen(HelpScreen(view))
-
-    def action_view(self, v):
-        self.view = v
-        self.rerender()
-
-    def action_noop(self):
-        """left/right are handled in on_key; the binding exists so the footer
-        advertises them."""
-
-    def on_key(self, ev):
-        app = self.app
-        self.pending = ""
-        if ev.key in tuple("12345678"):
-            app.track = int(ev.key)
-            if self.view == "fx2":
-                # Follow the new track's assignment; do NOT write back.
-                # Changing track is navigation, and an empty track would
-                # otherwise silently inherit whatever row happened to show.
-                self.sync_row()
-        elif self.view == "fx2" and ev.key in ("left", "right", "h", "l"):
-            rows = self.chooser()
-            if not rows:
-                return
-            self.rowi = (self.rowi + (1 if ev.key in ("right", "l") else -1)) \
-                % len(rows)
-            self.pending = self.select_row()
-        elif self.view == "menu" and ev.key in ("down", "j"):
-            self.cursor += 1
-        elif self.view == "menu" and ev.key in ("up", "k"):
-            self.cursor -= 1
-        elif self.view == "fx1" and ev.key in ("left", "right", "h", "l"):
-            d = 1 if ev.key in ("right", "l") else -1
-            e = self.eff["fx1"] + d
-            self.eff["fx1"] = 0x04 if e > 0x0f else 0x0f if e < 0x04 else e
-        elif self.view == "play" and ev.key in ("left", "right", "h", "l"):
-            d = 1 if ev.key in ("right", "l") else -1
-            self.eff["play"] = (self.eff["play"] + d) % 4
-        else:
-            return
-        self.rerender()
-
-
 # ---- the app ---------------------------------------------------------------
 class Workbench(App):
     TITLE = "remix workbench"
     CSS = """
-    #strip { height: 2; padding: 0 1; }
-    #detail { height: 1fr; padding: 0 2; }
-    #history { height: 8; padding: 0 2; border-top: dashed $surface; }
+    #pane_avail { width: 30; padding: 0 1; }
+    #pane_load  { width: 40; padding: 0 1; border-left: dashed $surface; }
+    #pane_unit  { width: 1fr; padding: 0 1; border-left: dashed $surface; }
     #status { height: 1; padding: 0 1; }
-    #mods { width: 44; padding: 0 1; }
-    #panel { width: 1fr; padding: 0 1; border-left: dashed $surface; }
     #log { height: 12; border-top: dashed $surface; }
-    #emuhead { height: 2; padding: 0 2; }
-    #lcd { height: 1fr; padding: 0 2; }
-    #emunote { height: 2; padding: 0 2; }
     """
-    MODES = {"rig": RigScreen, "remix": RemixScreen, "emu": EmuScreen}
+    MODES = {"bench": BenchScreen}
     # App-level so it works from every view; modals handle their own escape
     # first, and no screen binds it, so escape is unambiguous.
     BINDINGS = [Binding("escape", "stop_play", "stop audio")]
@@ -1115,14 +829,10 @@ class Workbench(App):
     def __init__(self):
         super().__init__()
         self.state = State()
-        self.rig = rig.Rig()
-        self.track = 5                     # ChonVerb's home; T5 is the test track
         self.source = (wav_sources() or [None])[0]
-        self.wet = False
         self.history = []                  # [(label, path)]
         self.marks = {}                    # "A"/"B" -> path
-        self.status = ("1-8 pick a track · enter picks its effect · "
-                       "r renders · x composes the image")
+        self.status = ""                   # state.msg is the live line now
         self.rendering = False
         self.boot = None                   # cached emulator BootResult
         self.boot_mtime = None
@@ -1137,7 +847,7 @@ class Workbench(App):
         from textual.theme import BUILTIN_THEMES
         want = os.environ.get("WORKBENCH_THEME", "ansi-dark")
         self.theme = want if want in BUILTIN_THEMES else "ansi-dark"
-        self.switch_mode("rig")
+        self.switch_mode("bench")
 
     def play(self, path):
         """afplay, one at a time -- a new play stops the old."""
@@ -1157,8 +867,8 @@ class Workbench(App):
         return False
 
     def action_stop_play(self):
-        self.status = ("stopped" if self.stop_play()
-                       else "nothing playing")
+        self.state.msg = ("stopped" if self.stop_play()
+                          else "nothing playing")
         scr = self.screen
         if hasattr(scr, "rerender"):
             scr.rerender()

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -48,7 +48,7 @@ except ImportError:
 from rich.markup import escape  # noqa: E402  (rich ships with textual)
 
 from remix import audition, registry, rig, stock  # noqa: E402
-from remix.state import BUILT_IMAGE, ROOT, State  # noqa: E402
+from remix.state import BUILT_IMAGE, DONOR_WORDS, ROOT, State  # noqa: E402
 
 
 def step_label(mod, name, v):
@@ -759,6 +759,17 @@ class BenchScreen(Screen):
                 fill = min(20, round(20 * used / max(used + free, 1)))
                 c = OK if free > 400 else WARN if free > 32 else BAD
                 out.append(row(f"words {n}", fill, 20, c, f"{free:>4} free"))
+        elif not [m for m in st.selected if m.dsp is not None]:
+            # ⚠️ "????  not built" for a STOCK chooser was a non-answer to a
+            # question with an exact answer. A stock row places no code --
+            # no clone, no words, its dispatch is already in the image -- so
+            # a selection with no modules of ours uses ZERO of the donor
+            # region, on both payloads, and no build is needed to say so.
+            # The "????" only ever appeared here, because that is the one
+            # selection the build refuses.
+            for n in ("A", "B"):
+                out.append(row(f"words {n}", 0, 20, OK,
+                               f"{DONOR_WORDS:>4} free  [dim]all of it[/]"))
         else:
             out.append(f" {'words':<{W}}[dim]"
                        + "?" * 20 + "[/]  [dim]not built[/]")
@@ -785,8 +796,13 @@ class BenchScreen(Screen):
             # slots as four groups so the picture and the number agree.
             slots = " ".join("####" if i < taken else "...."
                              for i in range(4))
+            # SAY WHAT IS COUNTED IN THE NUMBER ITSELF. "N of 4 free" still
+            # invited "free for what?", and the honest answer -- slots a
+            # MODULE holds fixed -- is not what a reader assumes a budget row
+            # means. A stock effect is not in this count at all: it takes one
+            # from the allocator at runtime, which no image can reserve.
             out.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{slots}[/]  "
-                       f"{free} of 4 free  [dim]tracks {tracks}[/]")
+                       f"{taken} pinned of 4  [dim]tracks {tracks}[/]")
 
         # Rows are countable without a build; the cave is not.
         rows = (st.chooser_rows if st.chooser_rows is not None
@@ -794,17 +810,26 @@ class BenchScreen(Screen):
         c = OK if rows < 24 else WARN if rows < 31 else BAD
         out.append(f" {'rows':<{W}}[{c}]{rows}[/][dim] of 31 "
                    f"(the long chooser cave)[/]")
-        cave = (f"[{OK if st.cave_free > 512 else WARN if st.cave_free else BAD}]"
-                f"{st.cave_free:,}[/][dim] B free[/]"
-                if st.cave_free is not None else "[dim]not built[/]")
+        # Same again for the cave: a stock row clones no descriptor, plants
+        # no formatter and cuts no patch, so with no modules of ours the
+        # region is untouched. Said in words rather than a number, because
+        # the exact figure depends on where the chooser list landed and that
+        # is the build's arithmetic, not a fact to re-derive here.
+        if st.cave_free is not None:
+            c = OK if st.cave_free > 512 else WARN if st.cave_free else BAD
+            cave = f"[{c}]{st.cave_free:,}[/][dim] B free[/]"
+        elif not [m for m in st.selected if m.dsp is not None or m.cf_patches]:
+            cave = f"[{OK}]untouched[/][dim] — nothing of ours is placed[/]"
+        else:
+            cave = "[dim]not built[/]"
         out.append(f" {'cave':<{W}}{cave}")
         # What the buffer rows COUNT, because it is not "slots in use": a
         # stock effect takes one from the allocator at runtime, per
         # instantiated effect per block, which no image can reserve. These
         # are the ones a MODULE holds fixed, which is the part composing a
         # remix actually decides.
-        out.append("[dim] buffer slots = pinned by modules; stock takes "
-                   "its own at runtime[/]")
+        out.append("[dim] pinned = held by a module; stock effects take "
+                   "theirs at runtime[/]")
         self._paint("#pane_budget", out)
 
     def _pane_unit(self, st, probs):

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -142,7 +142,7 @@ def disp(mod) -> str:
     return titlecase(mod.name)
 
 
-def placeable(sel, total, used):
+def placeable(sel, total, used, harvest=None):
     """Words this selection can still PLACE in one payload's donor region.
 
     Not the build's own FREE figure, which reports the whole region as free
@@ -164,7 +164,8 @@ def placeable(sel, total, used):
     budget pane. They used to disagree on the same screen -- 2,509 there
     against 379 here -- which is a good way to make a budget unreadable.
     """
-    cap = min((stock.consumed_at(c) for c in stock.CONSUMED if c in sel),
+    hv = tuple(harvest) if harvest else stock.CONSUMED
+    cap = min((stock.consumed_at(c, hv) for c in hv if c in sel),
               default=total)
     return max(0, cap - used), cap
 
@@ -343,6 +344,7 @@ The loop is one move long: highlight one of yours in AVAILABLE and press `enter`
   r  render + hear     space  replay
   a / b  park what you just heard as A / B      , / .  play A / B
   1  put the highlighted effect on the FX1 chooser (or take it off)
+  h  harvest a stock effect's WORDS for your modules (or give them back)
   x  apply the fix the ⚠ is offering (only shown when there is one)
   d  sample folder     l  load a remix      s  save this one as a remix
   c  full check        f  choose the fallback        k  back to stock
@@ -393,6 +395,13 @@ Rows are NOT the scarce thing, which is why `enter` adds rather than swaps: 31 r
 ⚠️ TODAY THE DONOR REGION IS FIXED, and that is a property of this BUILD, not of the machine. Every effect states what it occupies — `727 words, already placed` for FILTER, `2,411 of 2,724 words` for ChonVerb — but only one region is currently harvestable: the 2,724 words PLATE, SPRING and DARK REV's code occupies, which is the only space `build_bus.py` will place a module into. So dropping FILTER frees none of its 727 *yet*.
 
 Measured 3 Sep 2026 and it says the limit is ours to lift: the thirteen DSP effects are laid out CONTIGUOUSLY in 6,158 words (`P:0x007d1..0x01fdf`, no other module between them), and every one of them is SELF-CONTAINED — no control flow leaves its own span and nothing enters it but its own dispatch entry. So any effect's words could be freed by dropping it, and a run of dropped neighbours would be one bigger region. What that costs is the effect itself: today an unlisted stock effect keeps working and only loses its row, and one harvested for its words would not.
+
+[bold]the donor region is a CHOICE, not a place[/]
+The thirteen DSP effects are laid out contiguously — 6,158 words in each payload — and every one is self-contained, so ANY unbroken run of them is ground your modules can be placed into. `h` harvests the highlighted stock effect's words and `⌁` marks it in the library. The three reverbs are only the default: they are the biggest and FX2-only, so taking them costs FX1 nothing.
+
+⚠️ The run has to stay CONTIGUOUS — a module of ours is one code stream, so a gap is not a smaller region, it is two — and only the effect just below the bottom of the run or just above its top can join it. `h` says what is in the way rather than letting the build refuse later.
+
+⚠️ HARVESTED IS NOT THE SAME AS UNLISTED, and this is the one thing here that takes something away. Leaving a stock effect off a chooser costs it that row and nothing else — its code, descriptor and dispatch stay stock, so an old project that selects it still runs it. Harvesting OFFERS its words to the placer, and it loses its algorithm only where your code actually reached: the region is packed from the lowest address upward and the build reports which survived. So an effect can be `✓⌁` — listed and harvested — right up until something is placed over it.
 
 [bold]a reverb you keep listed is spending words[/]
 PLATE, SPRING and DARK REV's code IS the donor region, so the `held by` line is the live trade: what they are holding, and what dropping the next one buys. The region packs from PLATE upward, so holding a LOW reverb also makes the space above it unreachable — keeping PLATE alone leaves 2,130 words by size and 0 you can actually place.
@@ -506,6 +515,10 @@ class RemixerScreen(Screen):
         # be reached from the FX2 slot, and only because FX1's chooser list
         # could not grow where it sits.
         Binding("1", "fx1", "FX1 row", show=False),
+        # "h" for harvest: offer a stock effect's WORDS to the placer. The
+        # third state a stock effect has -- listed, unlisted, harvested --
+        # and the only one that takes something away.
+        Binding("h", "harvest", "harvest", show=False),
         Binding("l", "load", "load"),
         Binding("s", "save", "save"),
         Binding("k", "stock", "reset to stock", show=False),
@@ -870,16 +883,21 @@ class RemixerScreen(Screen):
                 group = g
                 out.append(f"[dim {WARN}]── {g} ──[/]")
             here = self.pane == AVAILABLE and i == self.cur[AVAILABLE]
-            mark = (f"[{OK}]✓[/]" if m.key in st.sel else " ")
+            # TWO MARKS, because a stock effect has three states and they are
+            # independent: `✓` is on a chooser, `⌁` is HARVESTED -- its words
+            # offered to the placer, which is the one thing here that takes
+            # something away. An effect can be both until our code reaches it.
+            mark = ((f"[{OK}]✓[/]" if m.key in st.sel else " ")
+                    + (f"[{WARN}]⌁[/]" if m.key in st.harvest else " "))
             menus = "+".join(rig.menus(m, st.fx1)) or "—"
             nm = disp(m) if m.is_stock else f"[{OURS}]{disp(m)}[/]"
             pad = " " * max(0, 13 - len(disp(m)))
-            line = f" {mark} {nm}{pad} [dim]{menus}[/]"
+            line = f" {mark}{nm}{pad} [dim]{menus}[/]"
             if here:
                 cur_line = len(out)
             out.append(f"[reverse]{line}[/]" if here else line)
         out.append("")
-        out.append(f"[dim]enter adds it to the image[/]")
+        out.append(f"[dim]enter adds · h harvests its words (⌁)[/]")
         self._paint("#pane_avail", self._fit("#pane_avail", out, cur_line,
                                              head=head, tail=2))
 
@@ -939,10 +957,10 @@ class RemixerScreen(Screen):
         # written over -- so showing the trade where it happens is the point.
         # WHICH REVERBS ARE ACTUALLY GONE, from the build's own report --
         # not "all three, always", which is what this said before 2 Sep 2026.
-        gone = [c for c in stock.CONSUMED
+        gone = [c for c in st.harvest
                 if c.split()[0] not in st.donors_kept]
         if st.donors_kept or not gone:
-            for cname in stock.CONSUMED:
+            for cname in st.harvest:
                 if cname in st.sel or cname not in gone:
                     continue
                 out.append(f"[dim {WARN}] —  {titlecase(cname):<13}"
@@ -1024,7 +1042,7 @@ class RemixerScreen(Screen):
                     " [dim]· boots[/]" if r.reached_handoff else
                     f" [{BAD}]· DID NOT REACH THE RTOS HANDOFF[/]")
             return "[dim]" + " · ".join(
-                one(n, placeable(st.sel, t, u)[0])
+                one(n, placeable(st.sel, t, u, st.harvest)[0])
                 for n, t, u, _f in st.regions) + "[/]" + boot
         # No build has reported yet. Say which of the two reasons it is --
         # this line used to claim "a stock chooser: 14 effects, no modules"
@@ -1092,8 +1110,13 @@ class RemixerScreen(Screen):
         # all four). So `held` below is the whole tail from that reverb up,
         # not the sum of the reverbs' own sizes -- and the three numbers on
         # the row then add up exactly: loaded + held + free = total.
-        held = [c for c in stock.CONSUMED if c in st.sel]
-        nxt = min(held, key=stock.consumed_at) if held else None
+        # WHAT THIS SELECTION HARVESTS, not the three reverbs. A listed
+        # effect whose words are harvestable is spending its own words, and
+        # the region packs from the lowest upward, so the lowest one still
+        # listed is the ceiling.
+        hv = tuple(st.harvest)
+        held = [c for c in stock.harvest_order(hv) if c in st.sel]
+        nxt = min(held, key=lambda c: stock.consumed_at(c, hv)) if held else None
 
         # THE SAME FOUR ANSWERS, for a terminal with no room for the rows.
         # Collected as (label, coloured number) while the full rows are
@@ -1101,7 +1124,7 @@ class RemixerScreen(Screen):
         brief = []
 
         def words_row(n, total, used):
-            free, cap = placeable(st.sel, total, used)
+            free, cap = placeable(st.sel, total, used, st.harvest)
             fill = min(20, round(20 * used / total))
             edge = max(fill, min(20, round(20 * cap / total)))
             c = OK if free > 400 else WARN if free > 32 else BAD
@@ -1120,7 +1143,8 @@ class RemixerScreen(Screen):
             # with no module of ours has no fallback to name. The region is
             # still fully accounted for: the three reverbs are in it.
             for n in ("A", "B"):
-                out.append(words_row(n, DONOR_WORDS, 0))
+                out.append(words_row(n, stock.region_words(tuple(st.harvest)),
+                                     0))
             out.append(None)
         else:
             # WHY it is not built, not just that it is not. This row is where
@@ -1144,9 +1168,9 @@ class RemixerScreen(Screen):
             # still listed, which is NOT the reverb's own size when the one
             # above it has already gone: holding PLATE and DARK, dropping
             # PLATE opens SPRING's words too (1,657, not 594).
-            cap = stock.consumed_at(nxt)
-            rest = min((stock.consumed_at(c) for c in held if c != nxt),
-                       default=DONOR_WORDS)
+            cap = stock.consumed_at(nxt, hv)
+            rest = min((stock.consumed_at(c, hv) for c in held if c != nxt),
+                       default=stock.region_words(hv))
             # "drop Dark Rev" beside "held by Dark Rev" says the name twice
             # in eleven words; with one reverb held there is nothing to
             # disambiguate, so it is "it".
@@ -1158,7 +1182,7 @@ class RemixerScreen(Screen):
             # wrapped budget row reads as an extra mystery row.
             names = ", ".join(titlecase(c).replace(" Rev", "") for c in held)
             out.append(f" {'held by':<{W}}[dim]{names} — "
-                       f"{DONOR_WORDS - cap:,} words; "
+                       f"{stock.region_words(hv) - cap:,} words; "
                        f"drop {which} for {rest - cap:,} more[/]")
 
         # FX2 buffer slots. ONE PER TRACK, not a pool: each track allocates
@@ -1384,7 +1408,7 @@ class RemixerScreen(Screen):
         # and a simple fact read as a caveat -- which is the exact mistake
         # that split them into separate strings in the first place.
         res = rig.resources(mod, st.words.get(mod.key), st.fx1,
-                            mod.key in st.sel)
+                            mod.key in st.sel, st.harvest)
         for line in res:
             out.append(f"[{WARN}]{escape(line)}[/]")
         out.append("")
@@ -1897,6 +1921,17 @@ class RemixerScreen(Screen):
         if action == "fix":
             return bool(getattr(self, "_can_fix", False))
         return True
+
+    def action_harvest(self):
+        """Offer the highlighted stock effect's words to the placer."""
+        st = self.app.state
+        mod = self.selected_module()
+        if mod is None:
+            return
+        st.msg = st.toggle_harvest(mod.key, disp(mod))
+        st.loaded_name = ""
+        self.schedule_sync()
+        self.rerender()
 
     def action_fx1(self):
         """Give the highlighted effect a row on FX1 too, or take it away."""

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -767,9 +767,15 @@ class BenchScreen(Screen):
             # region, on both payloads, and no build is needed to say so.
             # The "????" only ever appeared here, because that is the one
             # selection the build refuses.
+            # ⚠️ "all of it" was wrong-headed: the region is never EMPTY.
+            # It holds PLATE+SPRING+DARK's own code, which is exactly why it
+            # is the donor region. "Free" here means "yours to overwrite",
+            # not "unoccupied" -- and reading it as the latter is what
+            # prompted "so the stock doesn't use any of those resources?".
             for n in ("A", "B"):
                 out.append(row(f"words {n}", 0, 20, OK,
-                               f"{DONOR_WORDS:>4} free  [dim]all of it[/]"))
+                               f"{DONOR_WORDS:>4} free  "
+                               f"[dim]= the 3 reverbs' code[/]"))
         else:
             out.append(f" {'words':<{W}}[dim]"
                        + "?" * 20 + "[/]  [dim]not built[/]")
@@ -801,8 +807,17 @@ class BenchScreen(Screen):
             # MODULE holds fixed -- is not what a reader assumes a budget row
             # means. A stock effect is not in this count at all: it takes one
             # from the allocator at runtime, which no image can reserve.
+            # AND WHO ELSE WANTS THEM. "0 pinned of 4" is true and reads as
+            # "nothing is using these", which is false: every allocating
+            # stock effect in the chooser takes one at runtime. The image
+            # cannot reserve those, so they are not part of the count -- but
+            # leaving them unmentioned made the row lie by omission.
+            share = sum(1 for m in st.selected if m.is_stock
+                        and m.claims is not None
+                        and m.claims.stock_instance_buffer)
+            also = f"  [dim]+{share} stock share[/]" if share else ""
             out.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{slots}[/]  "
-                       f"{taken} pinned of 4  [dim]tracks {tracks}[/]")
+                       f"{taken} pinned of 4  [dim]tracks {tracks}[/]{also}")
 
         # Rows are countable without a build; the cave is not.
         rows = (st.chooser_rows if st.chooser_rows is not None

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -341,7 +341,9 @@ The loop is one move long: highlight one of yours in AVAILABLE and press `enter`
 Under 118 columns the panes come in pairs that slide with the focus; under 92, one at a time. The tab bar at the top names all three and marks where you are. Lists longer than the pane scroll with the cursor and say so (`↑ 6 more`).
 
 [bold]what is actually scarce[/]
-Four things, and the Budget strip is one row for each: the two donor regions of 2,724 words (one per payload, and only YOUR modules spend them), the FX2 buffer slots (one per track, per core), the 31 chooser rows, and the ColdFire cave. Every row reads the same way — [bold]N free of TOTAL, and what took the rest[/].
+Five things, and the Budget strip is one row for each: the two donor regions of 2,724 words (one per payload, and only YOUR modules spend them), the FX2 buffer slots (one per track, per core), the per-core CYCLES, the 31 chooser rows, and the ColdFire cave. Every row reads the same way — [bold]N free of TOTAL, and what took the rest[/].
+
+CYCLES is the one that does not fail as a refusal. Over budget the DSP does not decline to build, it wedges — so the row prices the WORST core under the worst mix this selection allows, which for a card of inserts is four copies of the dearest one: nothing stops all four tracks selecting it. The budget of 3,120 is what our code may spend after stock's own share, measured 23 Aug 2026, and the count is a floor: exact for the code, optimistic about memory contention.
 
 Rows are NOT the scarce thing, which is why `enter` adds rather than swaps: 31 rows fit, and a stock effect costs zero words because its code is already in the image whether or not it has a row. Leaving a stock effect out takes its chooser row and nothing else — an old project that selects it still runs it.
 
@@ -1111,6 +1113,25 @@ class BenchScreen(Screen):
                        + (" · ".join(bits) if bits
                           else f"tracks {tracks.start}-{tracks.stop - 1}, "
                                f"no module claims one") + "[/]")
+
+        # CYCLES. The fourth scarce thing was really the fifth: over the
+        # per-core budget the DSP does not refuse the image, it WEDGES
+        # (PLAN.md s2 -- "the wall is a CLIFF", +200 cycles was a hard hang
+        # with zero warning). So it is the one resource here whose overrun
+        # you cannot discover by building, and it lived behind `c` and a
+        # full `make check`. It is the WORST core, under the worst mix of
+        # this selection's own effects across the four FX2 slots -- an image
+        # cannot stop the operator putting the heaviest one on all four.
+        if st.cycles:
+            worst, usable, mix = st.cycles
+            free = usable - worst
+            c = OK if free > 800 else WARN if free > 0 else BAD
+            how = " + ".join(
+                f"{n}× {disp(st.mods[k]) if k in st.mods else titlecase(k)}"
+                for k, n in mix.items()) or "nothing of ours"
+            brief.append(("cycles", f"[{c}]{free:,}[/]"))
+            side.append(f" {'cycles':<{W}}[{c}]{free:>5,}[/] free of "
+                        f"{usable:,} [dim]· worst core: {escape(how)}[/]")
 
         # Rows are countable without a build; the cave is not.
         # Same sentence again: 31 exist, this selection loaded N.

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -309,6 +309,18 @@ That is faithful: the defaults are read from the firmware's own
 descriptor, and an unmodified unit really does start them fully dry.
 The UNIT pane says `⚠ MIX is 0 — this renders DRY` when it applies.
 
+[bold]the Budget pane[/]
+What is LEFT of the image, under the effect you are looking at. Four
+scarce things and only four: the two donor regions (one per payload),
+the FX2 buffer slots per core, the chooser rows, and the ColdFire cave.
+
+⚠️ The buffer slots count what a MODULE pins — ChonVerb holds all four
+of its core's, BongDelay two of its core's, Nimbus two of whichever
+core hosts it. A STOCK effect does not appear there: it takes a slot
+from the allocator at runtime, per instantiated effect per block, which
+no image can reserve. That runtime contest is what the ledger refuses a
+pinner beside an allocating stock effect for.
+
 [bold]the SOURCE row[/]
 `left`/`right` cycles the wavs in the source folder; `d` points it at
 another one and remembers the choice (out/_audition/workbench.json).
@@ -766,8 +778,15 @@ class BenchScreen(Screen):
                     taken = max(taken, rig.pinned_slots(m))
             free = 4 - taken
             c = OK if free > 2 else WARN if free else BAD
-            out.append(row(f"FX2 buf {tag}", 5 * taken, 20, c,
-                           f"{free} of 4  [dim]tracks {tracks}[/]"))
+            # "4 of 4" was ambiguous and read as the opposite of what it
+            # meant: the bar shows what is PINNED and the number what is
+            # FREE, so an empty bar beside "4 of 4" looked like "all four
+            # used". Say "free", as the word rows do, and draw the four
+            # slots as four groups so the picture and the number agree.
+            slots = " ".join("####" if i < taken else "...."
+                             for i in range(4))
+            out.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{slots}[/]  "
+                       f"{free} of 4 free  [dim]tracks {tracks}[/]")
 
         # Rows are countable without a build; the cave is not.
         rows = (st.chooser_rows if st.chooser_rows is not None
@@ -779,6 +798,13 @@ class BenchScreen(Screen):
                 f"{st.cave_free:,}[/][dim] B free[/]"
                 if st.cave_free is not None else "[dim]not built[/]")
         out.append(f" {'cave':<{W}}{cave}")
+        # What the buffer rows COUNT, because it is not "slots in use": a
+        # stock effect takes one from the allocator at runtime, per
+        # instantiated effect per block, which no image can reserve. These
+        # are the ones a MODULE holds fixed, which is the part composing a
+        # remix actually decides.
+        out.append("[dim] buffer slots = pinned by modules; stock takes "
+                   "its own at runtime[/]")
         self._paint("#pane_budget", out)
 
     def _pane_unit(self, st, probs):

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -38,7 +38,7 @@ try:
     from textual import work
     from textual.app import App, ComposeResult
     from textual.binding import Binding
-    from textual.containers import Horizontal, Vertical
+    from textual.containers import Horizontal, Vertical, VerticalScroll
     from textual.screen import ModalScreen, Screen
     from textual.widgets import Footer, Input, OptionList, RichLog, Static
     from textual.widgets.option_list import Option
@@ -313,131 +313,78 @@ class Chooser(ModalScreen[str]):
 
 
 HELP = {
-    "bench": """[bold]THE BENCH — one page, three panes[/]
+    # ⚠️ PARAGRAPHS ARE ONE LINE EACH, deliberately. Rich re-wraps to the
+    # box's real width, so prose hard-wrapped in this file wrapped TWICE --
+    # every paragraph ended in an orphan ("order", "draw", "your", "a") and
+    # the page read as broken. Only the key table is hard-wrapped, and it is
+    # short enough never to be re-flowed.
+    "bench": """[bold]THE BENCH[/] — compose the effects list your unit shows, and hear each one before you commit to it.
 
-[bold]AVAILABLE[/] everything that could be in an image: your modules,
-then the stock effects the unit already ships. [bold]LOADED[/] is the
-image you are composing, in CHOOSER ORDER — the order here is the order
-of rows on the panel, so left/right there is a real edit. [bold]UNIT[/]
-follows the cursor: the selected effect's knobs, the firmware's own draw
-of its page, and `r` to hear it on the SOURCE wav.
+[bold]AVAILABLE[/] is everything that COULD be in an image: your modules, then the stock effects the box already ships. [bold]LOADED[/] is the image you are composing, in the order the unit's chooser will show it. [bold]UNIT[/] follows the cursor — the selected effect's knobs, the firmware's own draw of its page, and `r` to hear it on the SOURCE wav.
 
-The loop is one move long: point at a stock effect in LOADED, highlight
-one of yours in AVAILABLE, `enter`. The image rebuilds and re-boots by
-itself, so the panel is never showing something else.
+The loop is one move long: highlight one of yours in AVAILABLE and press `enter`. The image rebuilds and re-boots by itself, so the panel on the right is never showing something else.
 
 [bold]keys[/]
-  tab  pane            up/down  move
-  enter  in AVAILABLE: ADD it to the image. On one already in,
-         just point at its row -- THE LIBRARY ONLY ADDS.
-         in LOADED: remove the row you are on.
-  left/right  knob value (UNIT) or row order (LOADED)
-              hold to run; SHIFT+left/right steps by TEN
-  r  render + hear     space  play last    p  preview mode
-  a / b  park what you hear as A / B      , / .  play A / B
-  x  apply the ⚠'s own fix
-  d  sample folder     l  load remix       s  save remix
-  c  full check        f  fallback         k  back to stock
-  ?  this
+  tab  next pane           up/down  move the cursor
+  enter   AVAILABLE: add it to the image (it displaces nothing).
+          LOADED: remove the row you are on.
+  left/right   UNIT: the knob value, hold to run, SHIFT for ×10
+               LOADED: move the row — this is the unit's own row order
+  r  render + hear     space  replay        p  which page is previewed
+  a / b  park what you just heard as A / B      , / .  play A / B
+  x  apply the fix the ⚠ is offering (only shown when there is one)
+  d  sample folder     l  load a remix      s  save this one as a remix
+  c  full check        f  choose the fallback        k  back to stock
+  ?  this              esc  stop audio      q  quit
 
-[bold]adding does not displace anything[/]
-`enter` used to SWAP -- the new effect took the highlighted row's slot
-and that row was dropped. That was the ledger's scarcity applied to your
-gesture, where it does not belong: the chooser cave holds 31 rows and a
-STOCK row costs zero words (no code placed, no descriptor cloned). Only
-WORDS are scarce, and only for modules of ours. So `enter` adds, and the
-one line under LOADED speaks up if the budget is actually breached.
+[bold]a narrow terminal shows fewer panes[/]
+Under 118 columns the panes come in pairs that slide with the focus; under 92, one at a time. The tab bar at the top names all three and marks where you are. Lists longer than the pane scroll with the cursor and say so (`↑ 6 more`).
+
+[bold]what is actually scarce[/]
+Four things, and the Budget strip is one row for each: the two donor regions of 2,724 words (one per payload, and only YOUR modules spend them), the FX2 buffer slots (one per track, per core), the 31 chooser rows, and the ColdFire cave. Every row reads the same way — [bold]N free of TOTAL, and what took the rest[/].
+
+Rows are NOT the scarce thing, which is why `enter` adds rather than swaps: 31 rows fit, and a stock effect costs zero words because its code is already in the image whether or not it has a row. Leaving a stock effect out takes its chooser row and nothing else — an old project that selects it still runs it.
+
+[bold]a reverb you keep listed is spending words[/]
+PLATE, SPRING and DARK REV's code IS the donor region, so the `held by` line is the live trade: what they are holding, and what dropping the next one buys. The region packs from PLATE upward, so holding a LOW reverb also makes the space above it unreachable — keeping PLATE alone leaves 2,130 words by size and 0 you can actually place.
+
+You CAN keep them. The build takes only the reverbs your modules actually reach, and the pane says which went (`— Plate Rev  donor, taken`). `remixes/restock.py` is thirteen stock effects plus SEND: the smallest buildable image, costing only PLATE. (Until 2 Sep 2026 all three were nulled unconditionally and the honest answer here was "you cannot, ever". That is no longer true.)
+
+[bold]there is one FX2 buffer per track[/]
+"Free" there means "no module has pinned it", not "unused": a track whose buffer no module claims still HAS that buffer, ready for whatever is selected on it. Only a MODULE claims one for the life of the image. ChonVerb holds all four of its core's, BongDelay two of its core's, Nimbus two of whichever core hosts it — and they go in PAIRS, so "4 free" is two pairs, not four independent slots.
+
+A stock effect never appears in that row: it takes a slot from the allocator at runtime, per effect per block, only while it is selected on that track — which no image can reserve. That runtime contest is why the ledger refuses an allocating stock effect beside a pinner, and it is what the ⚠ is asking you to remove. FLANGER, CHORUS, SPATIALIZER and COMB FILTER keep their FX1 rows and still work; the three reverbs were FX2-only in stock and are lost outright.
 
 [bold]A / B compares two EFFECTS[/]
-Not two renders ago against now. `r` to hear one, `a` to park it, point
-at the rival, `b` -- which re-renders it on the SAME source -- then `,`
-and `.` to flip between them. That is the question a remixer exists to
-answer: is mine better than the one the box came with?
+Not two renders ago against now. `r` to hear one, `a` to park it, point at the rival, `b` — which re-renders it on the SAME source — then `,` and `.` to flip. That is the question a remixer exists to answer: is mine better than the one the box came with?
 
 [bold]why an effect can render DRY[/]
-SIX of the eleven stock effects ship with their wet control at zero —
-PHASER, FLANGER, CHORUS and COMB (MIX), SPATIALIZER and DELAY (SEND) —
-so `r` on one of them at its defaults plays the source back unchanged.
-That is faithful: the defaults are read from the firmware's own
-descriptor, and an unmodified unit really does start them fully dry.
-The UNIT pane says `⚠ MIX is 0 — this renders DRY` when it applies.
-
-[bold]the Budget pane[/]
-What is LEFT of the image, under the effect you are looking at. Four
-scarce things and only four: the two donor regions (one per payload),
-the FX2 buffer slots per core, the chooser rows, and the ColdFire cave.
-
-Every row is the same sentence — [bold]N free of TOTAL, and what took the
-rest[/] — so the default selection reads as what an unmodified core
-already spends rather than as a bare zero.
-
-⚠️ A REVERB YOU KEEP IN THE CHOOSER IS SPENDING WORDS. PLATE, SPRING and
-DARK REV's code IS the donor region, so the `held by` line is the trade:
-how much they are holding, and what dropping the next one buys. The
-region packs from PLATE upward, so holding a LOW reverb also makes the
-space above it unreachable — which is why keeping PLATE alone leaves
-2,130 words by size and 0 you can actually place.
-
-⚠️ THERE IS ONE FX2 BUFFER PER TRACK, and "free" there means "no module
-has pinned it" — not "unused". A track whose buffer no module claims
-still HAS that buffer, ready for whatever is selected on it.
-
-The row counts what a MODULE pins, for the life of the image — ChonVerb
-holds all four of its core's, BongDelay two of its core's, Nimbus two of
-whichever core hosts it. They go in PAIRS, so "4 free" is two pairs, not
-four independent slots: `owns_fx2_buffers` is the core-private pair
-(Y:0x4000/0x8000) and a substituted ybase is the shared-window pair
-(0x30000/0x34000 on core 0, 0x38000/0x3c000 on core 1). Two modules
-wanting the same pair is what the ledger refuses. A STOCK effect never appears there: it takes a
-slot from the allocator at runtime, per instantiated effect per block,
-and only while it is selected on that track, which no image can reserve.
-That runtime contest is what the ledger refuses a pinner beside an
-allocating stock effect for.
-
-[bold]the SOURCE row[/]
-`left`/`right` cycles the wavs in the source folder; `d` points it at
-another one and remembers the choice (out/_audition/workbench.json).
-`WORKBENCH_SOURCES` overrides both.
-
-[bold]the one line under LOADED[/]
-It says the only two things that can stop you: whether the selection
-fits the 2,724-word donor region, and — with a ⚠ — the effects you have
-to remove before it will build. Everything else the pane used to explain
-is here instead.
-
-[bold]why some stock effects go dim[/]
-Every image replaces the whole FX2 chooser, but only THREE stock effects
-are CONSUMED: PLATE, SPRING and DARK REV, whose code is the donor region
-your modules are written over. The other eleven keep their code and knobs
-in every image and only lose their chooser row — an old project that
-selects one still runs it. Four of them (SPATIALIZER, FLANGER, CHORUS,
-COMB FILTER) take a per-track instance buffer at the addresses the servers
-hardcode, so they cannot sit beside ChonVerb, Nimbus or BongDelay; that is
-what the ⚠ is telling you to remove.
+Six of the eleven stock effects ship with their wet control at zero — PHASER, FLANGER, CHORUS and COMB (MIX), SPATIALIZER and DELAY (SEND) — so `r` on one at its defaults plays the source back unchanged. That is faithful: the defaults are read from the firmware's own descriptor. The UNIT pane says `⚠ MIX is 0 — this renders DRY` when it applies.
 
 [bold]the fallback[/]
-An id the image does not implement aliases to the FALLBACK — normally
-SEND, so an old project degrades to a send instead of noise. It is added
-for you when a selection needs one; `f` chooses another. ◀fb marks it.
-
-[bold]you cannot get the three reverbs back[/]
-Not from here, and it is not the workbench refusing. Every buildable
-selection needs a fallback and SEND is the only safe one; SEND carries
-DSP code; and `build_bus.py` repoints PLATE/SPRING/DARK REV to the null
-stub UNCONDITIONALLY, whether or not code was placed over them. So every
-image loses them. PLAN.md §7 has the two build changes that would fix it
-and the argument for closing it instead.""",
+An id the image does not implement aliases to the FALLBACK — normally SEND, so an old project degrades to a send rather than to noise. It is added for you the moment a selection needs one; `f` chooses another; `◀fb` marks it. A stock chooser with no modules of ours cannot build for exactly this reason: it has no fallback to name, and no stock effect is a safe one.""",
 }
 
 
 class HelpScreen(ModalScreen[None]):
     """The ? overlay: what this view is, its keys, and the concepts."""
 
+    # ⚠️ IT WAS SILENTLY CLIPPED. A Static in an auto-height box stops at
+    # max-height with no scrollbar and no hint, so `?` showed about the
+    # first 60% of the page and the rest could not be reached at all --
+    # including every answer about the budget. It scrolls now, and the box
+    # is a PERCENTAGE so an 80-column terminal is not handed a 76-column
+    # box with two columns of padding.
     CSS = """
     HelpScreen { align: center middle; }
-    #box { width: 76; height: auto; max-height: 90%;
+    #box { width: 90%; max-width: 84; height: 90%;
            border: round $primary; padding: 1 2; }
+    #scroll { height: 1fr; }
     """
+
+    # The focused VerticalScroll already binds these; on_key must let them
+    # through rather than treating every key as "close".
+    SCROLL_KEYS = {"up", "down", "pageup", "pagedown", "home", "end"}
 
     def __init__(self, view):
         super().__init__()
@@ -445,10 +392,16 @@ class HelpScreen(ModalScreen[None]):
 
     def compose(self) -> ComposeResult:
         with Vertical(id="box"):
-            yield Static(HELP[self.view])
-            yield Static("[dim]any key closes[/]")
+            with VerticalScroll(id="scroll"):
+                yield Static(HELP[self.view])
+            yield Static("[dim]↑↓ / page  scroll  ·  any other key closes[/]")
+
+    def on_mount(self):
+        self.query_one("#scroll").focus()
 
     def on_key(self, ev):
+        if ev.key in self.SCROLL_KEYS:
+            return                       # the scroll view handles it
         ev.stop()
         self.dismiss(None)
 
@@ -489,7 +442,11 @@ class BenchScreen(Screen):
         Binding("b", "mark('B')", "B = this", show=False),
         Binding("comma", "play_mark('A')", "play A", show=False),
         Binding("full_stop", "play_mark('B')", "play B", show=False),
-        Binding("x", "fix", "apply the fix", show=False),
+        # SHOWN ONLY WHEN IT APPLIES (check_action). It is the key that
+        # gets a broken selection building again -- the one gesture the
+        # workbench is built around leaves one -- and it was the only
+        # important key hidden from the footer.
+        Binding("x", "fix", "fix it"),
         Binding("c", "build('check')", "full check", show=False),
         Binding("f", "fallback", "fallback", show=False),
         Binding("l", "load", "load"),
@@ -739,6 +696,10 @@ class BenchScreen(Screen):
         self._tnames = ["Available",
                         f"Loaded · {st.loaded_name or 'unsaved'}",
                         disp(mod) if mod is not None else "Unit"]
+        can_fix = bool(self.blockers(probs))
+        if can_fix != getattr(self, "_can_fix", None):
+            self._can_fix = can_fix
+            self.refresh_bindings()          # the footer follows it
         self._pane_available(st)
         self._pane_loaded(st, probs)
         self._pane_unit(st, probs)
@@ -890,19 +851,30 @@ class BenchScreen(Screen):
         # two bills for one debt -- ChonVerb and BongDelay showed identical
         # lists. It belongs to the image, so the image says it.
         pin = [m for m in st.selected if rig.pins_fx2(m)]
-        if pin:
-            out.append(f"[dim {WARN}]no room for "
-                       f"{escape(rig.allocating_names())} — "
-                       f"{escape(disp(pin[0]))}"
-                       f"{' and ' + disp(pin[1]) if len(pin) > 1 else ''} "
-                       f"pin their slots[/]")
+        # ⚠️ NOT WHILE THE ⚠ IS UP. The ⚠ below names the same seven effects
+        # AND the key that removes them, so both lines together spent seven
+        # of a forty-column pane's rows saying one thing twice -- and this
+        # one, phrased as "no room for", read as a second unresolved error.
+        # Once the fix has been applied it is no longer a problem, it is the
+        # shape of the image you chose, so it says that instead.
+        if pin and not probs:
+            who = " and ".join(disp(m) for m in pin)
+            out.append(f"[dim {WARN}]{escape(rig.allocating_names())} "
+                       f"cannot be listed — {escape(who)} "
+                       f"{'holds' if len(pin) == 1 else 'hold'} "
+                       f"the buffers they need[/]")
         # Everything from the notes down is the IMAGE speaking, not a row,
         # so it stays on screen however long the list gets.
         tail = len(out) - rows_end
         out.append("")
+        # THE PANE SAYS WHAT ITS KEYS DO, exactly as the library pane does.
+        # `left`/`right` here is a real edit -- the order of these rows IS
+        # the order of rows on the unit's chooser -- and it was documented
+        # only in `?`, which is the one place a newcomer looks last.
+        out.append("[dim]enter removes · ← → moves the row[/]")
         out.append(self._ledger_line(st, probs))
         self._paint("#pane_load", self._fit("#pane_load", out, cur_line,
-                                            head=head, tail=tail + 2))
+                                            head=head, tail=tail + 3))
 
     def _ledger_line(self, st, probs):
         """The fit, the blocker and the build state, in ONE line.
@@ -1286,6 +1258,13 @@ class BenchScreen(Screen):
             if name == "SOURCE":
                 src = (self.app.source.name if self.app.source
                        else f"(none — no wavs in {source_dir()})")
+                # A SAMPLE NAME IS ARBITRARILY LONG and this row is one row.
+                # Wrapped, it pushed every knob below it down the pane and
+                # read as two rows, one of them unlabelled. Trimmed from the
+                # FRONT: the end of a sample name is what distinguishes it.
+                room = self.query_one("#pane_unit", Static).size.width - 12
+                if room > 12 and len(src) > room:
+                    src = "…" + src[-(room - 1):]
                 line = f" [dim]SOURCE[/] [{SRC}]{escape(src)}[/]"
                 if here:
                     cur_line = len(out)
@@ -1622,7 +1601,11 @@ class BenchScreen(Screen):
         if not rows or self.cur[LOADED] >= len(rows):
             return
         i = self.cur[LOADED]
-        st.move(rows[i].key, step)
+        row = st.move(rows[i].key, step)
+        if row is not None:
+            st.msg = f"{disp(rows[i])} → chooser row {row}"
+        elif rows[i].key in st.sel:
+            st.msg = f"{disp(rows[i])} has no chooser row: order is moot"
         self.cur[LOADED] = max(0, min(len(rows) - 1, i + step))
         self.schedule_sync()      # placement order changes the image
 
@@ -1747,6 +1730,23 @@ class BenchScreen(Screen):
                     if m.is_stock and m.key in stock.CONSUMED
                     and m.key in self.sync_error]
         return out
+
+    def check_action(self, action, parameters):
+        """`x` is on the footer only while there is something to fix.
+
+        Recomputing it here would cost a problems() sweep (~2.4 ms) per
+        footer refresh, so rerender() -- which has already run one -- leaves
+        the answer behind in _can_fix.
+
+        ⚠️ FALSE HIDES; NONE SHOWS IT GREYED. Textual reads `is False` as
+        "disabled and not shown" and treats every other falsy value as
+        "disabled but listed", so returning None left `x fix it` on the
+        footer of a selection with nothing to fix -- which is the defect
+        this method was added to remove.
+        """
+        if action == "fix":
+            return bool(getattr(self, "_can_fix", False))
+        return True
 
     def action_fix(self):
         """Apply the ⚠'s own advice."""

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -48,6 +48,7 @@ except ImportError:
 from rich.markup import escape  # noqa: E402  (rich ships with textual)
 
 from remix import audition, registry, rig, stock  # noqa: E402
+from remix.schema import NO_FALLBACK, on_the_bus  # noqa: E402
 from remix.state import (BUILT_IMAGE, CAVE_BYTES, DONOR_WORDS, ROOT,  # noqa: E402
                          State)
 
@@ -767,8 +768,6 @@ class BenchScreen(Screen):
         Only two questions are actually live while swapping: does this fit,
         and is the panel on the right showing it yet. The rest moved to `?`.
         """
-        if self.untouched_stock(probs):
-            return "[dim]stock — swap a module in to build it[/]"
         if probs:
             return (f"[bold {BAD}]⚠ "
                     f"{escape(self._clash(probs) or probs[0])}[/]")
@@ -1134,8 +1133,6 @@ class BenchScreen(Screen):
         # in flight there is still nothing honest to show.
         self.ensure_sync(probs)
         r = self.app.boot
-        if self.untouched_stock(probs):
-            return head[:1] + ["[dim]swap a module in and this draws it[/]"]
         if probs:
             return head[:1] + ["[dim]not built — see the ⚠ in LOADED[/]"]
         if self.sync_error:
@@ -1447,14 +1444,16 @@ class BenchScreen(Screen):
         one swap happened.
         """
         st = self.app.state
-        # ⚠️ A SELECTION THAT IS STILL ALL STOCK DOES NOT WANT SEND. The
-        # "no fallback" problem is true of an untouched chooser -- that is
-        # why untouched_stock() exists to keep it off the ⚠ line -- so
-        # ensure_fallback fired on any stock ADD as well, and taking a stock
-        # reverb out and putting it back silently added Send. The rule the
-        # docstrings already state is the right one: SEND comes the moment a
-        # module of OURS goes in, and not before.
-        if not any(not m.is_stock for m in st.selected):
+        # ⚠️ A SELECTION WITH NO BUS DOES NOT NEED SEND AT ALL. Unimplemented
+        # ids resolve to the firmware's own NONE, which costs no words --
+        # see schema.NO_FALLBACK and state.auto_fallback. Conscripting SEND
+        # into an insert collection cost it 215-250 words for a client
+        # nothing in that image reads; on restock it cost PLATE REV.
+        # (This also covers the all-stock case: an untouched chooser has no
+        # bus either, and re-adding a stock reverb used to add Send because
+        # "no fallback" is true of the launch state -- which is exactly what
+        # untouched_stock() exists to keep off the ⚠ line.)
+        if not any(on_the_bus(m) for m in st.selected):
             return ""
         if not any("no fallback" in p for p in st.problems()):
             return ""
@@ -1464,20 +1463,14 @@ class BenchScreen(Screen):
         st.insert_at(send.key, len(st.order))
         return " · added Send as the fallback"
 
-    def untouched_stock(self, probs):
-        """Is this the LAUNCH state rather than a mistake?
-
-        An untouched stock chooser cannot build and is documented not to
-        pretend it can (state.load_stock): a remix must name a fallback for
-        the ids it does not implement, and no stock effect is a safe one --
-        it would PROCESS the unknown id rather than pass it. But that is the
-        state the bench OPENS in, so reporting it as ⚠ makes a fresh launch
-        look broken. Say what the next move is instead. The moment a module
-        of ours goes in, SEND comes with it and this stops applying.
-        """
-        return (bool(probs)
-                and all("no fallback" in p for p in probs)
-                and not any(not m.is_stock for m in self.app.state.selected))
+    # untouched_stock() lived here until 2 Sep 2026. THE LAUNCH STATE BUILDS
+    # NOW, so there is nothing to special-case: an untouched stock chooser
+    # falls back to the firmware's own NONE (schema.NO_FALLBACK), places no
+    # code and assembles to A 0/2724 · B 0/2724 -- the chooser an unmodified
+    # unit shows, rebuilt from our own tables. It used to be unbuildable for
+    # one reason only: the fallback had to be a module of ours, so the bench
+    # opened on a selection it had to apologise for ("stock -- swap a module
+    # in to build it") and the panel drew nothing until you did.
 
     def blockers(self, probs):
         """The modules whose removal would clear the ⚠, if that is the shape
@@ -1582,6 +1575,14 @@ class BenchScreen(Screen):
         st = self.app.state
         opts = [(m.key, f"{m.name} (0x{m.menu.fx2_id:02x})")
                 for m in st.menu_modules]
+        # The firmware's own NONE is an option whenever this selection has no
+        # bus, and the RIGHT one there: an unassigned track is off, as on a
+        # stock unit, and it costs no words. It is not offered beside a bus
+        # participant, because nothing would then flip the rotation or clear
+        # the accumulators -- see schema.NO_FALLBACK.
+        if not any(on_the_bus(m) for m in st.selected):
+            opts.insert(0, (NO_FALLBACK,
+                            "NONE -- the firmware's own, no words"))
         if not opts:
             st.msg = "nothing with a chooser row to fall back to"
             self.rerender()

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -409,7 +409,7 @@ Add a module before giving anything up and the ⚠ says so, with `x` dropping th
 
 ⚠️ THE TWO LISTS STAY INDEPENDENT, and they have to. "Off one is off both" would be simpler to operate and would make the shipping remix impossible: chongbong's FX2 chooser is ChonVerb, BongDelay and Send, so every stock effect is off FX2 — and taking them off FX1 with it would leave the unit with NO FX1 EFFECTS AT ALL and hand your modules all 6,158 words they did not ask for.
 
-⚠️ AND IT ONLY COSTS WHERE YOUR CODE REACHES. Your modules go in the largest unbroken run of what you gave up, packed from its lowest address; anything the placer never gets to keeps its algorithm and its dispatch and simply has no chooser row — which is exactly what unlisting a stock effect has always done.
+⚠️ AND IT ONLY COSTS WHERE YOUR CODE REACHES. What you gave up becomes one or more unbroken RUNS, and each module is packed into a run it fits, from that run's lowest address; anything the placer never reaches keeps its algorithm and its dispatch and simply has no chooser row — which is exactly what unlisting a stock effect has always done. A module is one code stream, so it must fit inside a SINGLE run: two runs of 1,500 words will not take a 2,000-word module, and the budget says the largest opening for that reason.
 
 [bold]a reverb you keep listed is spending words[/]
 PLATE, SPRING and DARK REV's code IS the donor region, so the `held by` line is the live trade: what they are holding, and what dropping the next one buys. The region packs from PLATE upward, so holding a LOW reverb also makes the space above it unreachable — keeping PLATE alone leaves 2,130 words by size and 0 you can actually place.
@@ -1111,19 +1111,43 @@ class RemixerScreen(Screen):
         label = ("".join(self._MAP_ABBR[k][:c].center(c)
                          for k, _a, _n, c in seg)
                  if min(c for _k, _a, _n, c in seg) >= 4 else None)
-        base = min((sp[h][0] for h in hv), default=0)
         placed = {t: u for t, _tot, u, _f in st.regions}
+        # ⚠️ THE HARVESTED EFFECTS NEED NOT BE ONE RUN, and a gap is a real
+        # wall: a module is one code stream and must fit inside a single
+        # opening. Group the columns into runs and fill each from its OWN
+        # base, or a module placed low in run 2 draws as fill across run 1.
+        runs_cols, prev = [], None
+        for k, a, n, c in seg:
+            if k not in hv:
+                prev = None
+                continue
+            if prev is not None and prev[1] == a:
+                runs_cols[-1].append((k, a, n, c))
+            else:
+                runs_cols.append([(k, a, n, c)])
+            prev = (k, a + n)
+        # Per-run usage when the build reported it; otherwise the whole
+        # region is one run and the single figure IS that run's.
+        by_run = {}
+        for tag, b, _n, u in st.runs:
+            by_run.setdefault(tag, {})[b] = u
 
         def bar(tag):
             got = placed.get(tag)
+            used = by_run.get(tag)
             out = ""
             for k, a, n, c in seg:
                 if k not in hv:
                     out += f"[dim]{'─' * c}[/]"
-                elif got is None:
+                    continue
+                grp = next(g for g in runs_cols if any(x[0] == k for x in g))
+                rbase = grp[0][1]
+                u = (used.get(rbase) if used is not None
+                     else (got if rbase == runs_cols[0][0][1] else 0))
+                if u is None or got is None:
                     out += f"[dim]{'.' * c}[/]"
                 else:
-                    fill = max(0, min(c, round((got - (a - base)) * c / n)))
+                    fill = max(0, min(c, round((u - (a - rbase)) * c / n)))
                     out += (f"[{OK}]{'#' * fill}[/][dim]{'.' * (c - fill)}[/]")
             return out
 
@@ -1160,9 +1184,32 @@ class RemixerScreen(Screen):
         # than the span pushes `┘` past the last harvested segment and the
         # footer then claims ground it does not mean, so it steps down to a
         # shorter form rather than overflowing.
-        what = next((t for t in tries if len(t) <= max(0, span - 2)),
-                    tries[-1][:max(0, span - 2)])
-        foot = (" " * lo + "└" + what.center(max(0, span - 2), "─") + "┘")[:w]
+        def bracket(text_tries, at, cols):
+            """`└──── caption ────┘` occupying `cols` columns from `at`."""
+            t = next((t for t in text_tries if len(t) <= max(0, cols - 2)),
+                     text_tries[-1][:max(0, cols - 2)])
+            return (at, "└" + t.center(max(0, cols - 2), "─") + "┘")
+        if len(runs_cols) < 2:
+            # ⚠️ ONE RUN KEEPS THE ORIGINAL SENTENCE, unchanged.
+            parts = [bracket(tries, lo, span)]
+        else:
+            # ⚠️ A BRACKET PER RUN. One spanning bracket would draw straight
+            # across the stock effects between them and say those words are
+            # yours, which is exactly backwards -- they are the wall. And the
+            # LARGEST run is the real limit on a single module, so each says
+            # its own size rather than sharing the total.
+            parts = []
+            for g in runs_cols:
+                off = sum(c for k, _a, _n, c in seg
+                          if sp[k][0] < g[0][1])
+                cols = sum(c for _k, _a, _n, c in g)
+                gw = sum(n for _k, _a, n, _c in g)
+                parts.append(bracket([f" {gw:,} words ", f" {gw:,}w ",
+                                      f"{gw:,}"], off, cols))
+        foot = ""
+        for at, txt in parts:
+            foot = foot.ljust(at) + txt
+        foot = foot[:w]
         rows = (["  " + label] if label else []) + [f"[dim]A[/] " + bar("A")]
         if len(placed) > 1 or not placed:
             rows.append(f"[dim]B[/] " + bar("B"))
@@ -1298,6 +1345,17 @@ class RemixerScreen(Screen):
         elif st.regions:
             for n, total, used, _f in st.regions:
                 out.append(words_row(n, total, used))
+            _rs = stock.regions_of(tuple(st.harvest))
+            if len(_rs) > 1:
+                # ⚠️ THE TOTAL IS NOT THE LIMIT ON ONE MODULE. A module is a
+                # single code stream, so it must fit inside ONE opening --
+                # 3,213 words across two runs will not take a 3,000-word
+                # module. Say the largest opening beside the total, or the
+                # budget promises room the placer will refuse.
+                _big = max(sum(stock.WORDS[k] for k in g) for g in _rs)
+                out.append(
+                    f" {'':<{W}}[dim]{len(_rs)} separate runs — one module "
+                    f"must fit one run, largest is {_big:,} words[/]")
             out.append(None)                # the key goes here -- see below
         elif not [m for m in st.selected if m.dsp is not None]:
             # No build to read -- and none is possible, because a selection
@@ -1327,7 +1385,13 @@ class RemixerScreen(Screen):
         # rest" was true and useless, because it says which reverb is in the
         # way without saying what dropping it buys, and at 0 free that is the
         # only live question.
-        if nxt:
+        # ⚠️ ONLY WITH ONE RUN. The arithmetic below walks the harvested
+        # effects as a single packed stream (stock.consumed_at), which is
+        # what the placer does with one opening and NOT what it does with
+        # two -- there, dropping an effect in the other run buys nothing
+        # here. Rather than print a number that is quietly wrong, say
+        # nothing; the per-run brackets in the map already carry the sizes.
+        if nxt and len(stock.regions_of(tuple(st.harvest))) < 2:
             # What dropping it actually BUYS is the gap up to the next reverb
             # still listed, which is NOT the reverb's own size when the one
             # above it has already gone: holding PLATE and DARK, dropping

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -330,7 +330,7 @@ HELP = {
     # short enough never to be re-flowed.
     "remixer": """[bold]THE REMIXER[/] — compose the effects list your unit shows, and hear each one before you commit to it.
 
-[bold]AVAILABLE[/] is everything that COULD be in an image: your modules, then the stock effects the box already ships. [bold]LOADED[/] is the image you are composing, in the order the unit's chooser will show it. [bold]UNIT[/] follows the cursor — the selected effect's knobs, the firmware's own draw of its page, and `r` to hear it on the SOURCE wav.
+[bold]AVAILABLE[/] is everything that COULD be in an image: your modules, then the stock effects the box already ships. [bold]CHOOSERS[/] is the image you are composing — the unit's two effect menus, FX1 above FX2, each in the row order the panel will show. [bold]UNIT[/] follows the cursor — the selected effect's knobs, what it costs, and `r` to hear it on the SOURCE wav.
 
 The loop is one move long: highlight one of yours in AVAILABLE and press `enter`. The image rebuilds and re-boots by itself, so the panel on the right is never showing something else.
 
@@ -360,18 +360,12 @@ Both are then equally yours. Leaving an effect off a chooser takes that ROW and 
 
 `p` → FX1 draws the chooser you composed, as the firmware draws it.
 
-[bold]what the preview is for[/]
-It is the only way to see the PANEL side of an image without flashing one. The remixer's own panes say what you asked for; this says what the firmware will actually draw from the tables the build wrote — the effect names on the chooser rows, in the order they will scroll, and the knob labels the page will put under each encoder.
+[bold]the no-flash gate[/]
+The CHOOSERS line ends in `boots` when the built image reaches the RTOS handoff in the local ColdFire emulator. That is the whole of it: a cave that breaks early init faults there instead of on your unit. It is a fact about the IMAGE, so it is on the image's line.
 
-That is a real class of bug and it has cost real days here: a cloned descriptor inherits its donor's display formatter, so a slot can carry the right count, default and name and still draw as something else entirely — or as nothing. Three of six page-2 slots drew wrong on one flash and every check passed, because every field they checked was right.
+If a selection ever patches the unit's top-level menu, the MAIN MENU appears under CHOOSERS as the firmware draws it. None do yet — a selection changes it only by writing the tables at `0x400cbc00` and every remix so far changes zero bytes of them.
 
-BOTH MENUS AT ONCE, no switcher, docked to the bottom of the pane so it does not move as you scroll between effects with different numbers of knobs. It shows the effect's knob names in the unit's own words, in the banks the encoders are in, and each chooser's rows as the firmware lists them (`▸` marks the row this effect is on).
-
-⚠️ There WAS a `p` key cycling FX1 / FX2 / MENU, and all three of its problems were the switcher. FX1 and FX2 resolve the SAME descriptor for anything listed on both — the build points both id tables at one clone — so switching showed the same knob names twice and only the chooser rows differed, which is the one thing worth seeing side by side. And the MAIN MENU is the same picture in every remix that exists: a selection changes it only by writing the tables at 0x400cbc00, and every remix so far changes ZERO bytes of them. So it is a line — `menu unchanged by this selection` — and it becomes a picture on the day something patches it, which is the day that view was built for.
-
-⚠️ A picture of an FX page is not available: the chooser list and the parameter block are two overlaid WINDOWS whose coordinates are not comparable — fourteen text baselines in 64 pixels with a 7 px font — so flattening them into one grid interleaves them and reads as a mapping from each row to the labels beside it, which is not what any of it means. The strings are still the firmware's own; only their arrangement stops being a reconstruction.
-
-Honest limits: knob VALUES draw as dial graphics the string capture cannot read, so only a stepped select prints one; the numbers in the pane above are the truth for values. Nothing here touches hardware.
+⚠️ There used to be a per-effect block here showing the firmware's own draw of the page. It is gone (3 Sep 2026) and the reason is worth knowing: the rows above already list every drawn parameter with its page number, from the same descriptor, so the picture said it again — and a picture of that screen is not even possible, because the chooser list and the parameter block are two overlaid windows whose coordinates are not comparable. What it was really being squinted at for is whether the descriptor the build WROTE matches the manifest that asked for it: a clone inherits its donor's name fields and slot names, so it can carry the right count, default and enable bit and still be labelled as the effect it was copied from. That is a CHECK, and it now lives in `verify_menu`, where a mismatch fails `make check` instead of having to be noticed in the corner of a pane.
 
 [bold]what an FX1 row costs[/]
 No words: the DSP dispatch table is indexed by the raw id and shared by both menus, so an effect's code already ran from FX1 the moment FX1 selected its id. It costs CYCLES — FX1 is four more slots on the same four tracks, so an effect on both menus can double the worst per-core load; watch the Budget's `cycles` row.
@@ -464,7 +458,8 @@ AVAILABLE, LOADED, UNIT = 0, 1, 2
 # ⚠️ THERE WAS A `p` KEY cycling FX1 / FX2 / MENU here. Both FX pages are the
 # same descriptor for anything listed on both, so it showed the same knob
 # names twice; the MAIN MENU is the same picture in every remix that exists.
-# Both are on screen at once now -- see _panel_block.
+# Neither is a per-effect view: what survives of both is in verify_menu and
+# on the CHOOSERS pane's own line -- see _ledger_line.
 
 
 class RemixerScreen(Screen):
@@ -960,6 +955,14 @@ class RemixerScreen(Screen):
                        f"cannot be listed — {escape(who)} "
                        f"{'holds' if len(pin) == 1 else 'hold'} "
                        f"the buffers they need[/]")
+        # THE MAIN MENU, only when this selection changes it -- which is
+        # never, so far. It is the image's business, not one effect's, so it
+        # sits here rather than following the cursor in the UNIT pane.
+        self.ensure_sync(probs)
+        if not probs and not self.sync_error and self.app.boot is not None:
+            n = rig.menu_patched()
+            if n:
+                out += self._menu_picture(n)
         # Everything from the notes down is the IMAGE speaking, not a row,
         # so it stays on screen however long the lists get.
         tail = len(out) - rows_end
@@ -1007,9 +1010,18 @@ class RemixerScreen(Screen):
                 # digits is already "spent" and deserves the alarm colour.
                 c = OK if f > 400 else WARN if f > 32 else BAD
                 return f"{n} [{c}]{f:,}[/] free"
+            # AND WHETHER IT BOOTS. That is the ColdFire emulator's real
+            # job here -- a cave that breaks early init faults locally
+            # instead of on the unit -- and it is a fact about the IMAGE, so
+            # it belongs on the image's own line. It spent a day in the UNIT
+            # pane, where it followed the cursor for no reason.
+            r = self.app.boot
+            boot = ("" if r is None else
+                    " [dim]· boots[/]" if r.reached_handoff else
+                    f" [{BAD}]· DID NOT REACH THE RTOS HANDOFF[/]")
             return "[dim]" + " · ".join(
                 one(n, placeable(st.sel, t, u)[0])
-                for n, t, u, _f in st.regions) + "[/]"
+                for n, t, u, _f in st.regions) + "[/]" + boot
         # No build has reported yet. Say which of the two reasons it is --
         # this line used to claim "a stock chooser: 14 effects, no modules"
         # for ANY unmeasured selection, including chongbong, which has three.
@@ -1421,36 +1433,23 @@ class RemixerScreen(Screen):
         out.append("[dim]← → change · r render + hear · space replay[/]"
                    if self.pane == UNIT else
                    "[dim]tab here to change values and audition[/]")
-        out.append("")
-        # ⚠️ DOCKED TO THE BOTTOM. The block sat straight after the knob
-        # rows, so it moved up and down the pane with the number of knobs --
-        # five for WarpFold, thirteen for Filter -- and the thing you were
-        # reading was never in the same place twice.
-        block = self._panel_block(mod, probs)
-        # ⚠️ THE ARITHMETIC IS DONE HERE, not in _fit. This pane has three
-        # parts with three different claims on the space -- a fixed head, a
-        # scrollable middle the cursor lives in, and a block that must stay
-        # docked at the bottom -- and threading that through the generic
-        # windower produced a pane whose block was sometimes simply absent.
-        # One row of slack, deliberately: content_size read DURING a render
-        # is the previous layout's and came back a row optimistic often
-        # enough to clip the block's last line away silently. Being wrong by
-        # one costs a blank row; being right to the row costs a line.
-        room = self.query_one("#pane_unit", Static).content_size.height - 1
-        # ⚠️ WHEN BOTH CANNOT FIT, THE BLOCK GOES AND SAYS SO. Windowing the
-        # knobs down to nothing to keep it would take away the thing the
-        # cursor is standing in; silently dropping it is what a docked block
-        # must never do.
-        if room > 0 and room - len(out) - len(block) < -6:
-            block = [f"[dim]what the unit will draw — the pane is "
-                     f"{len(block) + len(out) - room} rows short[/]"]
-        out += [""] * max(0, room - len(out) - len(block)) + block
+        # ⚠️ THE UNIT PANE ENDS HERE. It used to close with a block showing
+        # the firmware's own draw of this effect's page -- and the answer to
+        # "what is that for?", asked four times on 3 Sep 2026, turned out to
+        # be "nothing this pane should do". The rows above already list every
+        # drawn parameter with its page number, from the same descriptor, so
+        # the picture said it again; CHOOSERS lists the chooser rows; and
+        # what was left were two ASSERTIONS about the built descriptor and a
+        # boolean about the boot. The assertions moved to verify_menu, where
+        # a mismatch fails `make check` instead of having to be noticed in
+        # the corner of a pane; the boot is one line under CHOOSERS, where it
+        # belongs, because it is a fact about the IMAGE and not about the
+        # effect the cursor is on.
         self._paint("#pane_unit", self._fit("#pane_unit", out, cur_line,
-                                            head=head, tail=len(block),
-                                            height=room))
+                                            head=head))
 
     # ---- the emulated panel ---------------------------------------------
-    def _panel(self, mode, effect_id):
+    def _panel(self, mode, effect_id=None):
         """The firmware's own draw of one page, CACHED.
 
         ⚠️ This is what made a HELD arrow key lag. render_fx2 costs 15-96 ms
@@ -1486,153 +1485,25 @@ class RemixerScreen(Screen):
         self._panel_cache[key] = list(draws)
         return self._panel_cache[key]
 
-    def _page_rows(self, mod, draws):
-        """An FX page's knob names, in the banks the encoders are in.
+    def _menu_picture(self, n):
+        """The MAIN MENU as the firmware draws it.
 
-        ⚠️ NOT A PICTURE OF THE SCREEN. The chooser list and the parameter
-        block are two overlaid windows whose y origins are not comparable
-        (fourteen text baselines in 64 pixels with a 7 px font --
-        emu_bringup.read_screen has the measurement), so flattening them into
-        one grid interleaves them and reads as a mapping from each chooser
-        row to the labels beside it. The STRINGS are still the firmware's
-        own, which is the whole point of the view; only their arrangement
-        stops being a reconstruction.
+        ⚠️ SHOWN ONLY WHEN THE SELECTION ACTUALLY CHANGES IT, which is the
+        case this view was built for -- a patched-in top-level row
+        (PLAN.md section 5) -- and which no remix yet hits: a selection can
+        change the top-level menu only by writing the tables at 0x400cbc00,
+        and every one of them changes ZERO bytes of it. As a permanent
+        fixture it was the same picture every time.
         """
         import emu_bringup
-        scr = emu_bringup.read_screen(draws)
-        # WHICH PAGE A ROW BELONGS TO, decided against the effect's own
-        # parameters rather than against the pixel columns -- and by
-        # MAJORITY, because a select's VALUE can coincide with a parameter's
-        # name (`BASE` is both one of FILTER's page-1 knobs and what its
-        # page-2 ENV prints).
-        page = {n: ("page 1" if slot < 6 else "page 2")
-                for n, slot in self.unit_rows(mod) if n != "SOURCE"}
-        banks = {"page 1": [], "page 2": [], "": []}
-        lev = None
-        for row in scr["params"]:
-            if row and row[0] == "LEV":
-                lev, row = row[0], row[1:]
-            votes = [page.get(n, "") for n in row]
-            kind = max(set(votes), key=votes.count) if votes else ""
-            banks[kind].append(row)
-        out, w = [], 6
-        for kind in ("page 1", "page 2", ""):
-            if not banks[kind]:
-                continue
-            line = f" [dim]{kind:<7}[/]" if kind else " " * 8
-            # LEV IS ITS OWN COLUMN, not a fourth entry in the first bank:
-            # the unit puts it on the page-1 name row and the banks are
-            # threes, so folding it in knocked every column after it out of
-            # step with the rows below.
-            line += (lev or "").ljust(w)
-            for bank in banks[kind]:
-                line += "".join(escape(n).ljust(w) for n in bank).ljust(3 * w)
-                line += "  "
-            out.append(line.rstrip())
-            lev = None
-        return out or ["[dim] no parameters drawn[/]"]
-
-    def _rows_line(self, label, draws, mod):
-        """One chooser's rows as the FIRMWARE lists them, packed to the pane.
-
-        Not the same statement as the CHOOSERS pane, which shows what you
-        asked for: this is what the build actually wrote into the image, in
-        the window the screen shows. `▸` is the row this effect sits on --
-        the unit says so by XOR-highlighting it, which the string capture
-        cannot read (docs/EMU.md).
-        """
-        import emu_bringup
-        want = disp(mod).lower()
-        names = [(f"[reverse]▸{escape(n)}[/]"
-                  if n.lower().startswith(want) else escape(n))
-                 for n in emu_bringup.read_screen(draws)["list"]]
-        if not names:
-            return [f" [dim]{label:<5}no rows drawn[/]"]
-        # PACKED, not truncated: the name that gets cut is as likely to be
-        # the one you were looking for as any other.
-        # ⚠️ FLOORED AT 30. content_size read during a render is the previous
-        # layout's, and a stale narrow one packed the names ONE PER LINE --
-        # fourteen lines of chooser on a pane that had two to spare.
-        room = max(30, self.query_one("#pane_unit", Static).content_size.width
-                   - 2)
-        lead, out, cur = f" [dim]{label:<5}[/]", [], ""
-        for n in names:
-            bit = (" [dim]·[/] " if cur else "") + n
-            if cur and self._vis(lead + cur + bit) > room:
-                if len(out) == 1:               # two lines is the whole budget
-                    cur += " [dim]…[/]"
-                    break
-                out.append(lead + cur)
-                lead, cur = " " * 6, n
-            else:
-                cur += bit
-        return out + [lead + cur]
-
-    def _panel_block(self, mod, probs):
-        """WHAT THE UNIT WILL DRAW, both menus at once, no switcher.
-
-        ⚠️ THERE WAS A `p` KEY cycling FX1 / FX2 / MENU, and all three of its
-        problems were the switcher. The FX1 and FX2 pages are the SAME
-        descriptor for anything listed on both -- the build points both id
-        tables at one clone and verify_menu asserts it -- so switching
-        between them showed the same knob names twice and only the chooser
-        rows differed, which is the one thing worth seeing side by side. And
-        the MAIN MENU is the same picture in every remix that exists: a
-        selection changes it only by writing the tables at 0x400cbc00, and
-        every remix so far changes ZERO bytes of them (rig.menu_patched).
-        So it is a line, and it becomes a picture on the day something
-        patches it -- which is the day that view was built for.
-        """
-        st = self.app.state
-        head = ["[bold]what the unit will draw[/]"]
-        self.ensure_sync(probs)
-        r = self.app.boot
-        if probs:
-            return head + ["[dim]not built — see the ⚠ in CHOOSERS[/]"]
-        if self.sync_error:
-            return head + [f"[dim]build failed — {escape(self.sync_error)}[/]"]
-        if self.syncing is not None or r is None:
-            return head + ["[dim]building and booting…[/]"]
-        if not r.reached_handoff:
-            return head + ["[bold]did not reach the RTOS handoff[/] — a "
-                           "patch may have broken early init"]
-        if mod.menu is None:
-            return head + ["[dim]no chooser row: this module patches the "
-                           "firmware rather than adding an effect[/]"]
-        if not self.in_image(mod):
-            # An id the image does not implement resolves to the FALLBACK,
-            # so the firmware would draw a convincing picture of the wrong
-            # effect (CLAUDE.md, 12 Aug 2026).
-            return head + ["[dim]not in the image yet[/]"]
-        eid = mod.menu.fx2_id
-        on_fx1 = rig.FX1 in rig.menus(mod, st.fx1)
-        d2 = self._panel("FX2", eid)
-        out = head + self._page_rows(mod, d2)
-        # FX1's chooser is stock's own when this effect has no row on it, and
-        # saying so is the point: it is where an FX1 row WOULD be added.
-        out += self._rows_line("FX1", self._panel("FX1", eid if on_fx1
-                                                  else 0x04), mod)
-        out += self._rows_line("FX2", d2, mod)
-        n = rig.menu_patched()
-        out.append(f" [dim]menu [/]" + ("[dim]unchanged by this selection[/]"
-                                        if not n else
-                                        f"[{WARN}]{n} bytes patched[/]"))
-        if n:
-            out += self._menu_picture()
-        return out
-
-    def _menu_picture(self):
-        """The MAIN MENU as the firmware draws it -- shown only when the
-        selection actually changes it, which is the case that view exists
-        for (a patched-in top-level row, PLAN.md section 5)."""
-        import emu_bringup
-        grid = emu_bringup.layout_screen(self._panel("MENU", None))
+        head = [f"[{WARN}]main menu — {n} bytes patched[/]"]
+        grid = emu_bringup.layout_screen(self._panel("MENU"))
         while grid and not grid[-1].strip():
             grid.pop()
         while grid and not grid[0].strip():
             grid.pop(0)
         edge, w = f"[{LCD}]", emu_bringup.COLS
-        return [f"{edge}." + "-" * w + ".[/]"] + \
+        return head + [f"{edge}." + "-" * w + ".[/]"] + \
             [f"{edge}|[/]" + escape(ln[:w].ljust(w)) + f"{edge}|[/]"
              for ln in grid] + [f"{edge}'" + "-" * w + "'[/]"]
 

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -347,12 +347,17 @@ class BenchScreen(Screen):
         return [st.mods[k] for k in st.order]
 
     def unit_rows(self, mod):
-        """The knobs of the selected unit, in slot order."""
+        """What the UNIT cursor walks: the sample to audition, then the
+        effect's drawn knobs in slot order. SOURCE is a row rather than a
+        hidden setting because "what am I hearing this on" is the first
+        question at a bench, and it was the one thing the old per-track view
+        got right."""
+        rows = [("SOURCE", None)]
         if mod is None or not mod.params:
-            return []
-        return [(n, s) for n, s in sorted(mod.knob_map().items(),
-                                          key=lambda kv: kv[1])
-                if mod.params[s].active]
+            return rows
+        return rows + [(n, sl) for n, sl in sorted(mod.knob_map().items(),
+                                                   key=lambda kv: kv[1])
+                       if mod.params[sl].active]
 
     def selected_module(self):
         """The unit pane follows whichever pane the cursor is in -- point at
@@ -419,6 +424,15 @@ class BenchScreen(Screen):
             menus = "+".join(rig.menus(m)) or "—"
             line = f" {mark} {disp(m):<13} [dim]{menus}[/]"
             out.append(f"[reverse]{line}[/]" if here else line)
+        # The three stock REVERBS are absent from every list above, and their
+        # absence is the kind that reads as a bug. Say where they went.
+        out.append("[dim]── consumed ──[/]")
+        for name in stock.CONSUMED:
+            out.append(f"[dim]   {name:<13} —[/]")
+        out.append("[dim]   these ARE the donor region")
+        out.append("   every module packs into[/]")
+        out.append("")
+        out.append("[dim]enter adds at LOADED cursor[/]")
         self.query_one("#pane_avail", Static).update("\n".join(out))
 
     def _pane_loaded(self, st):
@@ -444,7 +458,10 @@ class BenchScreen(Screen):
             out.append("[dim] (empty — add from the left)[/]")
         probs = st.problems()
         out.append("")
-        out.append("[dim]● = in the built image[/]")
+        out.append("[dim]● = in the built image · ◀fb = fallback[/]")
+        out.append("[dim]← → moves this row (= its panel slot)[/]"
+                   if self.pane == LOADED else
+                   "[dim]tab here to reorder or remove[/]")
         if probs:
             out.append(f"[bold]⚠ {escape(probs[0])}[/]")
         self.query_one("#pane_load", Static).update("\n".join(out))
@@ -471,6 +488,12 @@ class BenchScreen(Screen):
         vals = st.knobs_for(mod)
         for i, (name, slot) in enumerate(knobs):
             here = self.pane == UNIT and i == self.cur[UNIT]
+            if name == "SOURCE":
+                src = (self.app.source.name if self.app.source
+                       else "(none — put wavs in out/dry/)")
+                line = f" SOURCE {escape(src)}"
+                out.append(f"[reverse]{line}[/]" if here else line)
+                continue
             v = vals.get(name, 0)
             hi = rig.knob_max(mod, name)
             if hi < 8:
@@ -487,21 +510,38 @@ class BenchScreen(Screen):
             out.append("[dim] (no drawn parameters)[/]")
         if self.pane == UNIT and knobs:
             name, _ = knobs[min(self.cur[UNIT], len(knobs) - 1)]
+            hint = ("the wav auditioned through this effect — left/right "
+                    "cycles what is in out/dry/" if name == "SOURCE"
+                    else rig.knob_doc(mod, name) or "")
             out.append("")
-            out.append(f"[dim]? {escape(rig.knob_doc(mod, name) or '')}[/]")
-
+            out.append(f"[dim]? {escape(hint)}[/]")
         out.append("")
-        src = self.app.source.name if self.app.source else "(none)"
-        out.append(f"[dim]source {escape(src)} · r renders · space plays[/]")
+        out.append("[dim]← → change · r render + hear · space replay[/]"
+                   if self.pane == UNIT else
+                   "[dim]tab here to change values and audition[/]")
         out.append("")
         out += self._preview(mod)
         self.query_one("#pane_unit", Static).update("\n".join(out))
 
     # ---- the emulated panel ---------------------------------------------
+    def stale(self):
+        """Does the image on disk still match the selection? The preview
+        draws the IMAGE, and when the two disagree it shows one set of
+        effects while the LOADED pane shows another -- which reads as a bug
+        rather than as staleness unless it is said out loud."""
+        want = [m.key for m in self.app.state.menu_modules if not m.is_stock]
+        got = [m.key for _, m in self.image_rows() if m is not None
+               and not m.is_stock]
+        return want != got
+
     def _preview(self, mod):
         modes = " ".join(f"[reverse]{m}[/]" if m == self.preview else
                          f"[dim]{m}[/]" for m in PREVIEWS)
-        head = [f"preview: {modes}  [dim](p)[/]"]
+        head = [f"preview {modes}  [dim](p)[/]",
+                "[dim]— drawn by the firmware, from the IMAGE ON DISK —[/]"]
+        if self.stale():
+            head.append("[bold]⚠ that image is NOT this selection[/]"
+                        "[dim] — b rebuilds[/]")
         r = self.app.boot
         if r is None:
             self.ensure_boot()
@@ -588,13 +628,20 @@ class BenchScreen(Screen):
         self.rerender()
 
     def adjust(self, step):
-        """Change the selected knob. Values live per MODULE."""
+        """Change the selected row. Knob values live per MODULE."""
         st = self.app.state
         mod = self.selected_module()
         knobs = self.unit_rows(mod)
         if not knobs:
             return
         name, _ = knobs[min(self.cur[UNIT], len(knobs) - 1)]
+        if name == "SOURCE":
+            files = wav_sources()
+            if files:
+                i = (files.index(self.app.source)
+                     if self.app.source in files else 0)
+                self.app.source = files[(i + step) % len(files)]
+            return
         vals = st.knobs_for(mod)
         hi = rig.knob_max(mod, name)
         vals[name] = max(0, min(hi, vals.get(name, 0) + step))
@@ -615,10 +662,20 @@ class BenchScreen(Screen):
         if self.pane == AVAILABLE:
             rows = self.avail_rows()
             mod = rows[min(self.cur[AVAILABLE], len(rows) - 1)]
-            st.toggle(mod.key)
+            if mod.key in st.sel:
+                st.toggle(mod.key)
+                st.msg = f"removed {disp(mod)}"
+            else:
+                # AT THE LOADED CURSOR, not appended. Chooser order is the
+                # panel's row order, so where it lands is the question.
+                at = min(self.cur[LOADED], len(st.order))
+                st.insert_at(mod.key, at)
+                rowno = len([k for k in st.order[:at + 1]
+                              if st.mods[k].menu is not None])
+                st.msg = (f"added {disp(mod)} at chooser row {rowno}"
+                          if mod.menu is not None
+                          else f"added {disp(mod)} (no chooser row)")
             st.loaded_name = ""
-            st.msg = (f"added {mod.key}" if mod.key in st.sel
-                      else f"removed {mod.key}")
         elif self.pane == LOADED:
             rows = self.loaded_rows()
             if not rows:
@@ -815,7 +872,7 @@ class BenchScreen(Screen):
 class Workbench(App):
     TITLE = "remix workbench"
     CSS = """
-    #pane_avail { width: 30; padding: 0 1; }
+    #pane_avail { width: 32; padding: 0 1; }
     #pane_load  { width: 40; padding: 0 1; border-left: dashed $surface; }
     #pane_unit  { width: 1fr; padding: 0 1; border-left: dashed $surface; }
     #status { height: 1; padding: 0 1; }

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -168,6 +168,30 @@ def placeable(sel, total, used):
     return max(0, cap - used), cap
 
 
+def chooser_slot(order, key):
+    """Where an effect goes when it is added: for a STOCK one, ITS OWN PLACE.
+
+    A stock effect has a position on the unit -- FILTER first, DARK REV
+    fourteenth -- and that order is the one the library lists it in and the
+    one an untouched chooser shows. Appending ignored it: remove PLATE REV
+    from row 12 and add it back and it landed at row 14, below DARK REV, so
+    a removal you undid left the panel reordered. Nothing warned, because
+    the order was still a legal chooser.
+
+    One of OURS has no such place -- the position is a real choice and the
+    end is the only honest default -- so it still appends, and left/right in
+    LOADED moves it.
+    """
+    seq = [m.key for m in stock.MODULES]
+    if key not in seq:
+        return len(order)
+    i = seq.index(key)
+    for j, k in enumerate(order):
+        if k in seq and seq.index(k) > i:
+            return j
+    return len(order)
+
+
 # Where the SOURCE row browses. out/dry/ is the curated dry set and stays the
 # default (31 Aug 2026: test_audio + demo_sources are full of processed
 # renders and made the browser unusable), but a bench is used on whatever
@@ -353,12 +377,17 @@ region packs from PLATE upward, so holding a LOW reverb also makes the
 space above it unreachable — which is why keeping PLATE alone leaves
 2,130 words by size and 0 you can actually place.
 
-⚠️ The buffer slots count what a MODULE pins — ChonVerb holds all four
-of its core's, BongDelay two of its core's, Nimbus two of whichever
-core hosts it. A STOCK effect does not appear there: it takes a slot
-from the allocator at runtime, per instantiated effect per block, which
-no image can reserve. That runtime contest is what the ledger refuses a
-pinner beside an allocating stock effect for.
+⚠️ THERE IS ONE FX2 BUFFER PER TRACK, and "free" there means "no module
+has pinned it" — not "unused". A track whose buffer no module claims
+still HAS that buffer, ready for whatever is selected on it.
+
+The row counts what a MODULE pins, for the life of the image — ChonVerb
+holds all four of its core's, BongDelay two of its core's, Nimbus two of
+whichever core hosts it. A STOCK effect never appears there: it takes a
+slot from the allocator at runtime, per instantiated effect per block,
+and only while it is selected on that track, which no image can reserve.
+That runtime contest is what the ledger refuses a pinner beside an
+allocating stock effect for.
 
 [bold]the SOURCE row[/]
 `left`/`right` cycles the wavs in the source folder; `d` points it at
@@ -954,17 +983,16 @@ class BenchScreen(Screen):
         else:
             out.append(f" {'cave':<{W}}[dim]    ? free of {CAVE_BYTES:,} B "
                        f"· not built[/]")
-        # What the words bar's three glyphs mean, and what a buffer count
-        # counts -- because it is not "slots in use": a stock effect takes
-        # one from the allocator at runtime, per instantiated effect per
-        # block, which no image can reserve. These are the ones a MODULE
-        # holds fixed, which is the part composing a remix actually decides.
-        out.append("[dim] words: # loaded by a module · - held by a listed "
+        # ONE legend line, decoding the ONE thing on this pane that is not
+        # already words: the bar's three glyphs. What an FX2 buffer count
+        # counts used to be spelled out here in two further lines of prose
+        # -- three of the pane's eleven lines spent on standing text -- and
+        # it read as an unexplained footnote rather than as a legend,
+        # because the rows it belonged to are two lines up and say "4 free
+        # of 4 · tracks 5-8 all keep their own" in words already. It is in
+        # `?` with the rest of the buffer story instead.
+        out.append("[dim] bar: # loaded by a module · - held by a listed "
                    "reverb · . free[/]")
-        out.append("[dim] one FX2 buffer per track. A module claims one for "
-                   "the whole image;[/]")
-        out.append("[dim] a stock effect uses its track's only while it is "
-                   "selected there.[/]")
         self._paint("#pane_budget", out)
 
     def _pane_unit(self, st, probs):
@@ -1362,7 +1390,7 @@ class BenchScreen(Screen):
                 # no descriptor cloned). Only WORDS are scarce, and only for
                 # modules of ours. So add, and let the budget speak up if it
                 # is actually breached -- which is what the ⚠ line is for.
-                st.insert_at(mod.key, len(st.order))
+                st.insert_at(mod.key, chooser_slot(st.order, mod.key))
                 st.msg = f"added {disp(mod)}"
                 st.msg += self.ensure_fallback()
             st.loaded_name = ""
@@ -1393,6 +1421,15 @@ class BenchScreen(Screen):
         one swap happened.
         """
         st = self.app.state
+        # ⚠️ A SELECTION THAT IS STILL ALL STOCK DOES NOT WANT SEND. The
+        # "no fallback" problem is true of an untouched chooser -- that is
+        # why untouched_stock() exists to keep it off the ⚠ line -- so
+        # ensure_fallback fired on any stock ADD as well, and taking a stock
+        # reverb out and putting it back silently added Send. The rule the
+        # docstrings already state is the right one: SEND comes the moment a
+        # module of OURS goes in, and not before.
+        if not any(not m.is_stock for m in st.selected):
+            return ""
         if not any("no fallback" in p for p in st.problems()):
             return ""
         send = st.mods.get("SEND")

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -766,6 +766,7 @@ class EmuScreen(Screen):
     BINDINGS = [
         Binding("m", "view('menu')", "menu"),
         Binding("f", "view('fx2')", "FX2"),
+        Binding("left,right", "noop", "cycle effect"),
         Binding("o", "view('fx1')", "FX1"),
         Binding("p", "view('play')", "playback"),
         Binding("v", "app.switch_mode('rig')", "rig"),
@@ -784,13 +785,64 @@ class EmuScreen(Screen):
         self.view = "fx2"
         self.cursor = 0
         self.eff = {"fx1": 0x04, "play": 1}
+        self.rows = []                 # the built image's FX2 chooser
+        self.rowi = 0
+        self.rows_mtime = None
+        self.pending = ""               # what the last selection did
         self.booting = False
         self.ensure_boot()
 
     def on_screen_resume(self):
         # The rig's selection is this view's default subject.
         self.view = "fx2"
+        self.sync_row()
         self.ensure_boot()
+
+    def chooser(self):
+        """The built image's FX2 rows, re-read whenever the image changes."""
+        mt = BUILT_IMAGE.stat().st_mtime if BUILT_IMAGE.exists() else None
+        if mt != self.rows_mtime:
+            self.rows, self.rows_mtime = rig.built_chooser(), mt
+            self.rowi = 0
+            self.sync_row()
+        return self.rows
+
+    def sync_row(self):
+        """Point the cursor at whatever the rig has on this track, if the
+        image offers it -- so entering the view shows the rig's subject and
+        cycling starts from there rather than from row 0."""
+        mod = self.app.rig.effect(self.app.track)
+        if mod is None:
+            return
+        for i, (_, m) in enumerate(self.rows):
+            if m is not None and m.key == mod.key:
+                self.rowi = i
+                return
+
+    def select_row(self):
+        """Write the cycled-to effect back to the RIG, so the emu view and
+        the rig are one selection rather than two. Returns a note saying what
+        happened -- including the cases where the rig cannot hold it, which
+        are NOT errors: the unit's chooser is one list for all eight tracks
+        and will happily let you pick any row on any track.
+        """
+        app = self.app
+        if not self.rows:
+            return ""
+        eid, mod = self.rows[self.rowi]
+        if mod is None:
+            return f"id 0x{eid:02x} is in the list but no manifest claims it"
+        if rig.category(mod) == rig.SYSTEM:
+            return (f"{mod.key} is plumbing, not a track effect — the unit "
+                    f"lists it, the rig does not hold it")
+        if app.track not in rig.track_range(mod):
+            tr = rig.track_range(mod)
+            return (f"selected on the unit, but {mod.name} is a SERVER on "
+                    f"tracks {tr.start}-{tr.stop - 1} — on T{app.track} its "
+                    f"id aliases to the fallback and the track becomes a send")
+        app.rig.set_effect(app.track, mod.key)
+        app.rig.save()
+        return f"assigned {mod.key} to T{app.track} — the rig followed"
 
     def ensure_boot(self):
         app = self.app
@@ -850,14 +902,24 @@ class EmuScreen(Screen):
             note = ("patched-in: " + ", ".join(added)) if added else ""
             title = "MAIN MENU — the firmware's own render"
         elif self.view == "fx2":
-            mod = app.rig.effect(app.track)
-            eid = mod.menu.fx2_id if mod else 0x07
+            rows = self.chooser()
+            if not rows:
+                self.query_one("#lcd", Static).update(
+                    "[bold]the built image offers no FX2 chooser rows[/] — "
+                    "build one from the REMIX view (b)")
+                self.query_one("#emunote", Static).update("")
+                return
+            self.rowi %= len(rows)
+            eid, mod = rows[self.rowi]
             draws = emu_bringup.render_fx2(r, track=track0, effect_id=eid)
-            title = (f"FX2 SETUP — T{app.track}, "
-                     f"{mod.menu.fullname.decode('latin1') if mod else 'stock'}"
-                     f" (0x{eid:02x})")
-            note = ("values draw as dials the string hook cannot read — "
-                    "the rig's numbers are the truth; 1-8 changes track")
+            name = (mod.menu.fullname.decode("latin1") if mod
+                    else f"unclaimed 0x{eid:02x}")
+            title = (f"FX2 SETUP — T{app.track}, row {self.rowi + 1}/"
+                     f"{len(rows)}: {name} (0x{eid:02x})")
+            note = (self.pending or
+                    "left/right cycles the image's chooser · 1-8 changes "
+                    "track · values draw as dials the string hook cannot "
+                    "read, so the rig's numbers are the truth")
             if mod and mod.name == "bongdelay":
                 note = ("a SPEC image aliases the delay's DSP to SEND on "
                         "payload A — the page may draw empty; " + note)
@@ -886,10 +948,25 @@ class EmuScreen(Screen):
         self.view = v
         self.rerender()
 
+    def action_noop(self):
+        """left/right are handled in on_key; the binding exists so the footer
+        advertises them."""
+
     def on_key(self, ev):
         app = self.app
+        self.pending = ""
         if ev.key in tuple("12345678"):
             app.track = int(ev.key)
+            if self.view == "fx2":
+                self.sync_row()
+                self.pending = self.select_row()
+        elif self.view == "fx2" and ev.key in ("left", "right", "h", "l"):
+            rows = self.chooser()
+            if not rows:
+                return
+            self.rowi = (self.rowi + (1 if ev.key in ("right", "l") else -1)) \
+                % len(rows)
+            self.pending = self.select_row()
         elif self.view == "menu" and ev.key in ("down", "j"):
             self.cursor += 1
         elif self.view == "menu" and ev.key in ("up", "k"):

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -274,7 +274,9 @@ class HelpScreen(ModalScreen[None]):
 
 # ---- THE BENCH: one page, three panes ---------------------------------------
 AVAILABLE, LOADED, UNIT = 0, 1, 2
-PREVIEWS = ("FX2", "MENU", "FX1")
+# The unit's own order: FX1 then FX2 are the two slots on a
+# track; MAIN MENU is the odd one out and goes last.
+PREVIEWS = ("FX1", "FX2", "MENU")
 
 
 class BenchScreen(Screen):
@@ -538,14 +540,24 @@ class BenchScreen(Screen):
         modes = " ".join(f"[reverse]{m}[/]" if m == self.preview else
                          f"[dim]{m}[/]" for m in PREVIEWS)
         head = [f"preview {modes}  [dim](p)[/]",
-                "[dim]— drawn by the firmware, from the IMAGE ON DISK —[/]"]
-        if self.stale():
-            head.append("[bold]⚠ that image is NOT this selection[/]"
-                        "[dim] — b rebuilds[/]")
+                "[dim]— drawn by the firmware, from the image on disk —[/]"]
+        # STALE MEANS DO NOT DRAW. Labelling it was not enough: the FX2 page
+        # includes the firmware's own chooser list, so a stale image puts a
+        # different set of effects on screen beside the LOADED pane and reads
+        # as "why are those loaded?". Same principle the unbuilt-module case
+        # already used -- do not draw a convincing picture of the wrong thing.
+        # ⚠️ Boot FIRST, then decide what to show. Returning early on stale
+        # skipped ensure_boot() entirely, so a workbench that opened stale --
+        # which is every fresh launch -- never started the emulator at all,
+        # and the preview stayed dead for the whole session.
         r = self.app.boot
         if r is None:
             self.ensure_boot()
             return head + ["[dim]booting the emulator...[/]"]
+        if self.stale():
+            return head[:1] + [
+                "[bold]the image on disk is not this selection[/]",
+                "[dim]b builds it, then this shows YOUR image[/]"]
         if not r.reached_handoff:
             return head + ["[bold]did not reach the RTOS handoff[/] — a "
                            "patch may have broken early init"]

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -57,6 +57,27 @@ def step_label(mod, name, v):
     return lab[v] if lab and v < len(lab) else str(v)
 
 
+# ---- the palette -----------------------------------------------------------
+# COLOUR CARRIES MEANING HERE, it does not decorate. Three axes, and nothing
+# else gets colour:
+#
+#   whose is it   OURS is cyan, the box's own is plain. In a remixer that is
+#                 the distinction you scan for -- "which of these did we
+#                 write" -- and it was carried by nothing at all.
+#   what state    green fits / yellow is a trade or a caution / red blocks.
+#   what is live  magenta for the one-of-a-kind markers (the fallback).
+#
+# ANSI NAMES ON PURPOSE, not hex: the workbench runs Textual's `ansi-dark`
+# so it wears the terminal's own 16 colours (WORKBENCH_THEME overrides), and
+# a hex triple would fight whatever palette Alacritty is set to.
+OURS = "cyan"          # a module from modules/
+OK = "green"           # fits, present, healthy
+WARN = "yellow"        # a trade, a caution, a knob that renders dry
+BAD = "red"            # it will not build
+MARK = "magenta"       # the fallback, and other one-of-a-kind markers
+LCD = "blue"           # the emulated panel's frame
+
+
 # Words that are acronyms, not shouting, and stay upper in a title.
 _ACRONYMS = {"DJ", "EQ", "FX", "HP", "LP", "MS", "AB"}
 
@@ -404,6 +425,15 @@ class BenchScreen(Screen):
         self._dirty = False
         self.set_interval(1 / 60, self._flush)
         self._run = (None, True, 0.0, 0)   # see _accel()
+        # EDIT THE SOURCE IN ANOTHER WINDOW AND THE BENCH FOLLOWS. The image
+        # already tracks the SELECTION; it has to track the CODE too, or the
+        # panel and every render silently describe the .asm you had a minute
+        # ago. Polled rather than watched: one stat sweep of modules/ is
+        # ~2 ms, a filesystem-event dependency is not worth adding to a venv
+        # that already carries unicorn and textual, and 1.5 s is far below
+        # the time it takes to switch windows.
+        self._src = audition._newest_input_mtime()
+        self.set_interval(1.5, self._poll_source)
         self.query_one("#log", RichLog).display = False
         self.rerender()
 
@@ -535,14 +565,16 @@ class BenchScreen(Screen):
             g = "Stock Effects" if m.is_stock else titlecase(rig.category(m))
             if g != group:
                 group = g
-                out.append(f"[dim]── {g} ──[/]")
+                out.append(f"[dim {WARN}]── {g} ──[/]")
             here = self.pane == AVAILABLE and i == self.cur[AVAILABLE]
-            mark = "✓" if m.key in st.sel else " "
+            mark = (f"[{OK}]✓[/]" if m.key in st.sel else " ")
             menus = "+".join(rig.menus(m)) or "—"
-            line = f" {mark} {disp(m):<13} [dim]{menus}[/]"
+            nm = disp(m) if m.is_stock else f"[{OURS}]{disp(m)}[/]"
+            pad = " " * max(0, 13 - len(disp(m)))
+            line = f" {mark} {nm}{pad} [dim]{menus}[/]"
             out.append(f"[reverse]{line}[/]" if here else line)
         out.append("")
-        out.append("[dim]enter adds it to the image[/]")
+        out.append(f"[dim]enter adds it to the image[/]")
         self._paint("#pane_avail", out)
 
     def _pane_loaded(self, st, probs):
@@ -560,10 +592,13 @@ class BenchScreen(Screen):
             menus = "+".join(rig.menus(m)) or "—"
             words = st.words.get(m.key)
             cost = f"{words:>5}w" if words else "      "
-            fb = "◀fb" if st.eff_fallback == m.key else ""
+            fb = f"[{MARK}]◀fb[/]" if st.eff_fallback == m.key else ""
             # No insertion caret any more: `enter` appends, so there is no
             # second cursor in another pane to keep track of.
-            line = f" {row} {disp(m):<13}[dim]{menus:<7}{cost}[/]{fb}"
+            nm = disp(m) if m.is_stock else f"[{OURS}]{disp(m)}[/]"
+            pad = " " * max(0, 13 - len(disp(m)))
+            line = (f" [dim]{row}[/] {nm}{pad}"
+                    f"[dim]{menus:<7}{cost}[/]{fb}")
             out.append(f"[reverse]{line}[/]" if here else line)
         if not rows:
             out.append("[dim] (empty — add from the left)[/]")
@@ -590,10 +625,10 @@ class BenchScreen(Screen):
             for cname in stock.CONSUMED:
                 if cname in st.sel or cname not in gone:
                     continue
-                out.append(f"[dim] —  {titlecase(cname):<13}"
+                out.append(f"[dim {WARN}] —  {titlecase(cname):<13}"
                            f"donor, taken[/]")
         elif [m for m in st.selected if m.dsp is not None]:
-            out.append("[dim] —  Plate, Spring, Dark Rev (donors)[/]")
+            out.append(f"[dim {WARN}] —  Plate, Spring, Dark Rev (donors)[/]")
         out.append("")
         out.append(self._ledger_line(st, probs))
         self._paint("#pane_load", out)
@@ -610,25 +645,34 @@ class BenchScreen(Screen):
         if self.untouched_stock(probs):
             return "[dim]stock — swap a module in to build it[/]"
         if probs:
-            return f"[bold]⚠ {escape(self._clash(probs) or probs[0])}[/]"
+            return (f"[bold {BAD}]⚠ "
+                    f"{escape(self._clash(probs) or probs[0])}[/]")
         if self.syncing is not None or self.synced != self.gen:
-            return "[dim]building…[/]"
+            return f"[dim {WARN}]building…[/]"
         if self.sync_error:
             # The build names the payload and the overrun; that IS the
             # actionable sentence, so print it rather than a pointer to it.
             gone = self.blockers([])
             if gone:
-                return ("[bold]⚠ x removes "
+                return (f"[bold {BAD}]⚠ x removes "
                         + ", ".join(disp(m) for m in gone)
                         + " — this selection needs its words[/]")
-            return f"[bold]⚠ {escape(self.sync_error)}[/]"
+            return f"[bold {BAD}]⚠ {escape(self.sync_error)}[/]"
         # THE BUILD'S OWN NUMBERS, one per payload. Not a sum of st.words
         # against DONOR_WORDS: there are TWO regions of that size and
         # SPEC=1 puts a server on each, so the sum is not a quantity
         # anything has to fit (see state.problems).
         if st.regions:
+            # The free-word count is the one number worth a glance, so let
+            # its COLOUR carry the answer: comfortable, tight, or spent.
+            def one(n, f):
+                # Thresholds from what this project actually lives with:
+                # payload A has shipped at FREE 4 and B at FREE 5, so double
+                # digits is already "spent" and deserves the alarm colour.
+                c = OK if f > 400 else WARN if f > 32 else BAD
+                return f"{n} [{c}]{f}[/] free"
             return "[dim]" + " · ".join(
-                f"{n} {f} free" for n, _u, f in st.regions) + "[/]"
+                one(n, f) for n, _u, f in st.regions) + "[/]"
         # No build has reported yet. Say which of the two reasons it is --
         # this line used to claim "a stock chooser: 14 effects, no modules"
         # for ANY unmeasured selection, including chongbong, which has three.
@@ -661,26 +705,30 @@ class BenchScreen(Screen):
             if name == "SOURCE":
                 src = (self.app.source.name if self.app.source
                        else f"(none — no wavs in {source_dir()})")
-                line = f" SOURCE {escape(src)}"
+                line = f" [dim]SOURCE[/] [{OURS}]{escape(src)}[/]"
                 out.append(f"[reverse]{line}[/]" if here else line)
                 continue
             v = vals.get(name, 0)
             hi = rig.knob_max(mod, name)
             if hi < 8:
-                shown = f"{step_label(mod, name, v):<7}"
-                bar = "·" * 12
+                # A SELECT reads as a word, not a level, so it gets the
+                # accent and a flat bar -- no fill to imply a range it does
+                # not have.
+                shown = f"[{WARN}]{step_label(mod, name, v):<7}[/]"
+                bar = "[dim]" + "·" * 12 + "[/]"
             else:
                 shown = f"{v:>3}    "
                 fill = round(12 * v / max(hi, 1))
-                bar = "#" * fill + "." * (12 - fill)
+                bar = (f"[{OURS}]" + "#" * fill + "[/][dim]"
+                       + "." * (12 - fill) + "[/]")
             page = "1" if slot < 6 else "2"
-            line = f" {name:<6} {shown}\\[{bar}] [dim]p{page}[/]"
+            line = f" {name:<6} {shown}[dim]\\[[/]{bar}[dim]] p{page}[/]"
             out.append(f"[reverse]{line}[/]" if here else line)
         if not knobs:
             out.append("[dim] (no drawn parameters)[/]")
         dry = self.dry_control(mod, vals)
         if dry:
-            out.append(f"[bold]⚠ {dry} is 0 — this renders DRY[/]")
+            out.append(f"[bold {WARN}]⚠ {dry} is 0 — this renders DRY[/]")
         if self.pane == UNIT and knobs:
             name, _ = knobs[min(self.cur[UNIT], len(knobs) - 1)]
             hint = (f"the wav auditioned through this effect — left/right "
@@ -764,9 +812,12 @@ class BenchScreen(Screen):
                 return head[:1] + ["[dim]not in the image yet[/]"]
             effect_id = mod.menu.fx2_id
         grid = self._panel(self.preview, effect_id)
-        return head + ["." + "-" * 44 + "."] + \
-            ["|" + escape(ln.ljust(44)) + "|" for ln in grid] + \
-            ["'" + "-" * 44 + "'"]
+        # The LCD frame is chrome; the firmware's own words are the content.
+        edge = f"[{LCD}]"
+        return head + [f"{edge}." + "-" * 44 + ".[/]"] + \
+            [f"{edge}|[/]" + escape(ln.ljust(44)) + f"{edge}|[/]"
+             for ln in grid] + \
+            [f"{edge}'" + "-" * 44 + "'[/]"]
 
     # ---- keeping the image equal to the selection ------------------------
     # There used to be a stale() gate here: the preview refused to draw when
@@ -828,6 +879,21 @@ class BenchScreen(Screen):
         self.app.call_from_thread(self.rerender)
 
     # ---- input -----------------------------------------------------------
+    def _poll_source(self):
+        """Rebuild when a module's source changed under us."""
+        try:
+            now = audition._newest_input_mtime()
+        except OSError:
+            return                      # mid-write; the next tick catches it
+        if now == self._src:
+            return
+        self._src = now
+        self.app.state.msg = "module source changed — rebuilding"
+        # The AUDIO is not re-rendered: it plays out loud and would fire on
+        # every save. The image and the panel refresh; `r` is one key.
+        self.schedule_sync()
+        self.rerender_soon()
+
     def rerender_soon(self):
         """Mark the screen stale; _flush draws it on the next frame."""
         self._dirty = True

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -383,7 +383,11 @@ still HAS that buffer, ready for whatever is selected on it.
 
 The row counts what a MODULE pins, for the life of the image — ChonVerb
 holds all four of its core's, BongDelay two of its core's, Nimbus two of
-whichever core hosts it. A STOCK effect never appears there: it takes a
+whichever core hosts it. They go in PAIRS, so "4 free" is two pairs, not
+four independent slots: `owns_fx2_buffers` is the core-private pair
+(Y:0x4000/0x8000) and a substituted ybase is the shared-window pair
+(0x30000/0x34000 on core 0, 0x38000/0x3c000 on core 1). Two modules
+wanting the same pair is what the ledger refuses. A STOCK effect never appears there: it takes a
 slot from the allocator at runtime, per instantiated effect per block,
 and only while it is selected on that track, which no image can reserve.
 That runtime contest is what the ledger refuses a pinner beside an
@@ -860,8 +864,12 @@ class BenchScreen(Screen):
         held = [c for c in stock.CONSUMED if c in st.sel]
         nxt = min(held, key=stock.consumed_at) if held else None
 
+        seen = set()                            # which bar glyphs are drawn
+
         def words_row(n, total, used):
             free, cap = placeable(st.sel, total, used)
+            seen.update(g for g, n in (("#", used), ("-", total - cap),
+                                       (".", free)) if n)
             fill = min(20, round(20 * used / total))
             edge = max(fill, min(20, round(20 * cap / total)))
             c = OK if free > 400 else WARN if free > 32 else BAD
@@ -953,11 +961,20 @@ class BenchScreen(Screen):
             # claims nothing. Only a MODULE claims a buffer for the life of
             # the image, which is why only modules appear here. The footnote
             # below says so, once, rather than the row fighting the word.
+            # NAME THE TRACKS FIRST. "FX2 buf A · 4 free of 4" was read as
+            # four spare buffers on an "FX2 bus"; there is no bus and they
+            # are not spare. They are the four TRACKS this payload serves,
+            # one buffer each, and the count is how many no module has
+            # pinned. Leading with the range says which four.
+            if bits and free:
+                # WHICH ones are left, beside how many. The count answers
+                # "can I add another"; the list answers "where does it go".
+                bits.append(",".join(str(t) for t in free) + " free")
             out.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{len(free):>5}[/] free "
                        f"of 4 [dim]· "
                        + (" · ".join(bits) if bits
-                          else f"tracks {tracks.start}-{tracks.stop - 1} "
-                               f"all keep their own") + "[/]")
+                          else f"tracks {tracks.start}-{tracks.stop - 1}, "
+                               f"no module claims one") + "[/]")
 
         # Rows are countable without a build; the cave is not.
         # Same sentence again: 31 exist, this selection loaded N.
@@ -991,8 +1008,17 @@ class BenchScreen(Screen):
         # because the rows it belonged to are two lines up and say "4 free
         # of 4 · tracks 5-8 all keep their own" in words already. It is in
         # `?` with the rest of the buffer story instead.
-        out.append("[dim] bar: # loaded by a module · - held by a listed "
-                   "reverb · . free[/]")
+        # A KEY, one glyph per line. Three items strung along one line with
+        # `·` separators read as a run-on sentence rather than as a legend
+        # -- which is fair, because it IS three unrelated definitions, and
+        # the only thing on the pane a reader cannot decode from the words
+        # beside it. Aligned under the label column so it reads as a key.
+        key = [(g, w) for g, w in (("#", "loaded by a module"),
+                                   ("-", "held by a reverb you kept listed"),
+                                   (".", "free")) if g in seen]
+        for i, (glyph, what) in enumerate(key):
+            out.append(f" {'bar' if not i else '':<{W}}"
+                       f"[dim]{glyph}  {what}[/]")
         self._paint("#pane_budget", out)
 
     def _pane_unit(self, st, probs):

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -807,38 +807,43 @@ class BenchScreen(Screen):
         # FX2 buffer slots. ONE PER TRACK, not a pool: each track allocates
         # FX1 then FX2, so track k's FX2 effect always gets table entry 1+2k
         # -- 0x4000, 0x8000, then the shared-window pair (docs/DSP.md, "the
-        # allocator's instance model"). So a slot is not "a buffer somebody
-        # might take", it is one particular track's buffer, and naming the
-        # tracks that are still free is the useful form: those are the ones
-        # that can still host an allocating stock effect.
-        for tag, tracks in (("A", rig.PAYLOAD_TRACKS["A"]),
-                            ("B", rig.PAYLOAD_TRACKS["B"])):
-            taken = set()
+        # allocator's instance model").
+        #
+        # So the four boxes are FOUR TRACKS, and the useful sentence is WHO
+        # has taken which and what is left. "4 of 4, none free" was accurate
+        # and told you neither.
+        for tag in ("A", "B"):
+            tracks = rig.PAYLOAD_TRACKS[tag]
+            owner = {}
             for m in st.selected:
                 if not rig.pins_fx2(m):
                     continue
                 tr = rig.track_range(m)
-                here = (not len(tr) or len(tr) == 8
-                        or tr.start == tracks.start)
-                if not here:
+                if not (not len(tr) or len(tr) == 8 or tr.start == tracks.start):
                     continue
-                # The core-private pair is tracks 1-2 of the core, the
-                # shared-window pair tracks 3-4 (rig.pinned_slots counts
-                # them; this needs to know WHICH).
                 cl = getattr(m, "claims", None)
-                if cl is not None and cl.owns_fx2_buffers:
-                    taken |= {0, 1}
                 from remix.schema import YBase
+                if cl is not None and cl.owns_fx2_buffers:
+                    owner.setdefault(0, m); owner.setdefault(1, m)
                 if m.dsp is not None and m.dsp.ybase is not YBase.NEVER:
-                    taken |= {2, 3}
-            free = [tracks.start + i for i in range(4) if i not in taken]
+                    owner.setdefault(2, m); owner.setdefault(3, m)
+            free = [tracks.start + k for k in range(4) if k not in owner]
             c = OK if len(free) > 2 else WARN if free else BAD
-            slots = " ".join("####" if i in taken else "...."
-                             for i in range(4))
-            tail = (f"[dim]free on {', '.join(str(t) for t in free)}[/]"
-                    if free else "[dim]none free[/]")
+            slots = " ".join("####" if k in owner else "...."
+                             for k in range(4))
+            said, bits = set(), []
+            for k in sorted(owner):
+                mod = owner[k]
+                if mod.key in said:
+                    continue
+                said.add(mod.key)
+                mine = ",".join(str(tracks.start + i) for i in sorted(owner)
+                                if owner[i] is mod)
+                bits.append(f"{disp(mod)} has {mine}")
+            if free:
+                bits.append(f"[{OK}]free {','.join(str(t) for t in free)}[/]")
             out.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{slots}[/]  "
-                       f"{len(taken)} of 4  {tail}")
+                       + " · ".join(bits or ["[dim]all four free[/]"]))
 
         # Rows are countable without a build; the cave is not.
         # Same rule: 31 exist, this selection loaded N.
@@ -868,8 +873,8 @@ class BenchScreen(Screen):
         # remix actually decides.
         out.append("[dim] # loaded by a module · - held by a listed reverb "
                    "· . free[/]")
-        out.append("[dim] one FX2 buffer per track; a free one can host a "
-                   "stock effect[/]")
+        out.append("[dim] one FX2 buffer per track — a free track can still "
+                   "host a stock effect that needs one[/]")
         self._paint("#pane_budget", out)
 
     def _pane_unit(self, st, probs):

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -1113,12 +1113,35 @@ class RemixerScreen(Screen):
                     out += (f"[{OK}]{'#' * fill}[/][dim]{'.' * (c - fill)}[/]")
             return out
 
-        # The footer brackets the harvested run under the bar it belongs to.
+        # ⚠️ THE FOOTER SAYS WHAT HAS ACTUALLY HAPPENED, not what could.
+        # `.` means "offered to the placer", and on a stock chooser with
+        # nothing of ours in it that is the whole run and NOTHING has been
+        # overwritten -- every one of those effects still works. Reading the
+        # dots as loss is the obvious mistake and the footer used to invite
+        # it by saying "harvested" whether or not a word had been placed.
         lo = sum(c for k, _a, _n, c in seg
                  if sp[k][0] < min((sp[h][0] for h in hv), default=0))
         span = sum(c for k, _a, _n, c in seg if k in hv)
-        foot = (" " * lo + "└" + f" harvested, {stock.region_words(tuple(hv)):,} "
-                f"words ".center(max(0, span - 2), "─") + "┘")[:w]
+        n_w = stock.region_words(tuple(hv))
+        if not any(placed.values()):
+            tries = [f" {n_w:,} words yours to place into — none taken yet ",
+                     f" {n_w:,} words, none taken ", f" {n_w:,} words "]
+        else:
+            lost = [k for k in stock.harvest_order(tuple(hv))
+                    if k.split()[0] not in st.donors_kept]
+            gone = ", ".join(titlecase(k) for k in lost)
+            tries = [f" harvested, {n_w:,} words — {gone} overwritten "
+                     if lost else f" harvested, {n_w:,} words — none "
+                                  f"overwritten ",
+                     f" harvested, {n_w:,} words — {len(lost)} overwritten ",
+                     f" harvested, {n_w:,} words "]
+        # ⚠️ THE BRACKET MUST MATCH THE RUN IT BRACKETS. A sentence longer
+        # than the span pushes `┘` past the last harvested segment and the
+        # footer then claims ground it does not mean, so it steps down to a
+        # shorter form rather than overflowing.
+        what = next((t for t in tries if len(t) <= max(0, span - 2)),
+                    tries[-1][:max(0, span - 2)])
+        foot = (" " * lo + "└" + what.center(max(0, span - 2), "─") + "┘")[:w]
         rows = (["  " + label] if label else []) + [f"[dim]A[/] " + bar("A")]
         if len(placed) > 1 or not placed:
             rows.append(f"[dim]B[/] " + bar("B"))

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -336,27 +336,38 @@ The loop is one move long: highlight one of yours in AVAILABLE and press `enter`
 
 [bold]keys[/]
   tab  next pane           up/down  move the cursor
-  enter   AVAILABLE: add it to the image (it displaces nothing).
-          LOADED: remove the row you are on.
+  enter   AVAILABLE: add it to the FX2 chooser (it displaces nothing).
+          LOADED: remove the row you are on, from ITS list.
   left/right   UNIT: the knob value, hold to run, SHIFT for ×10
-               LOADED: move the row — this is the unit's own row order
+               LOADED: move the row within its own chooser
   r  render + hear     space  replay        p  which page is previewed
   a / b  park what you just heard as A / B      , / .  play A / B
-  1  give the highlighted effect a row on FX1 too (or take it away)
+  1  put the highlighted effect on the FX1 chooser (or take it off)
   x  apply the fix the ⚠ is offering (only shown when there is one)
   d  sample folder     l  load a remix      s  save this one as a remix
   c  full check        f  choose the fallback        k  back to stock
   ?  this              esc  stop audio      q  quit
 
-[bold]the two menus are not the same shape[/]
-Every track has TWO effect slots, FX1 then FX2, and each has its own chooser list. They are not symmetric and that is the thing to hold on to:
+[bold]two slots, two chooser lists[/]
+Every track has TWO effect slots — FX1 then FX2, in that order through the audio — and each has its own chooser list. The middle pane holds BOTH, stacked, and every gesture applies to the list you are standing in: `enter` removes from it, `←→` reorders within it (a row cannot cross from one list to the other by being nudged off the end), and `1` puts the highlighted effect on FX1 or takes it off.
 
-  [bold]FX2[/] is yours to compose. LOADED is that list — the rows, their order, what is on it at all. Leaving a stock effect out takes its FX2 row and NOTHING else: its code and dispatch stay stock, so an old project that selects it still runs it.
-  [bold]FX1[/] is stock's own ten, and no image shortens it. A remix can only APPEND: `1` puts the highlighted effect of yours on the end of it. You cannot remove or reorder FX1's rows, because they are not ours to move.
+They start from opposite places, and that is the only asymmetry left:
 
-So the line under LOADED reads `FX1 chooser  stock's 10 + WarpFold`, and `p` → FX1 draws that chooser as the firmware would — with your effect on it if it is there, and stock's own if it is not.
+  [bold]FX2[/] is built from nothing. Every row on it is one this remix listed.
+  [bold]FX1[/] starts as the ten stock ships, because that is what the box does. Drop them, reorder them, add yours.
 
-The `FX1+FX2` column says which menus an effect CAN appear on, not where its rows are today; the ✓ beside it is what says whether it is in the image.
+Both are then equally yours. Leaving an effect off a chooser takes that ROW and nothing else — its code, descriptor and dispatch stay stock, so an old project that selects it still runs it, and dropping FLANGER from FX1 does not touch its FX2 row.
+
+`p` → FX1 draws the chooser you composed, as the firmware draws it.
+
+[bold]what an FX1 row costs[/]
+No words: the DSP dispatch table is indexed by the raw id and shared by both menus, so an effect's code already ran from FX1 the moment FX1 selected its id. It costs CYCLES — FX1 is four more slots on the same four tracks, so an effect on both menus can double the worst per-core load; watch the Budget's `cycles` row.
+
+Only a buffer-free INSERT of ours can take one, and the UNIT pane says which cannot and why: an FX1 buffer slot is 3,072 words against FX2's 16,384, a module with fixed FX2 buffers would write into another track's, and a bus server is one per core. The same three reasons are why stock keeps DELAY and the three reverbs off FX1 — they do not fit either.
+
+⚠️ The firmware's own NONE is always FX1 row 0 and is not shown here: it is how the slot is turned off, and no remix can lose it.
+
+The `FX1+FX2` column in the library says which menus an effect CAN appear on, not where its rows are today; the ✓ beside it is what says whether it is in the image.
 
 It costs no words. The DSP dispatch table is indexed by the raw id and shared by both menus, so the code already ran from FX1 the moment FX1 selected the id; what `1` adds is the panel side. What it DOES cost is cycles: FX1 is four more slots on the same four tracks, so an effect on both menus can double the worst per-core load — watch the Budget's `cycles` row.
 
@@ -637,8 +648,18 @@ class RemixerScreen(Screen):
         return mods + list(stock.MODULES)
 
     def loaded_rows(self):
+        """BOTH choosers, in one cursor path: FX1's rows then FX2's.
+
+        The unit has two effect slots and each has its own list; showing one
+        and tagging the other in a column was the confusion Sam named. They
+        stack, and the cursor walks through both -- so `enter` removes from
+        whichever list you are standing in and `←→` reorders that one.
+
+        -> [(menu, module)], menu being rig.FX1 or rig.FX2.
+        """
         st = self.app.state
-        return [st.mods[k] for k in st.order]
+        return ([(rig.FX1, st.mods[k]) for k in st.fx1 if k in st.mods]
+                + [(rig.FX2, st.mods[k]) for k in st.order])
 
     def unit_rows(self, mod):
         """What the UNIT cursor walks: the sample to audition, then the
@@ -676,9 +697,10 @@ class RemixerScreen(Screen):
     def selected_module(self):
         """The unit pane follows whichever pane the cursor is in -- point at
         something in the library and pane 3 previews it before you add it."""
-        rows = self.avail_rows() if self.pane == AVAILABLE else self.loaded_rows()
-        if self.pane == UNIT:
-            rows = self.loaded_rows()
+        if self.pane == AVAILABLE:
+            rows = self.avail_rows()
+        else:
+            rows = [m for _menu, m in self.loaded_rows()]
         if not rows:
             return None
         i = min(self.cur[min(self.pane, LOADED)], len(rows) - 1)
@@ -726,7 +748,7 @@ class RemixerScreen(Screen):
         # pane paints at all, so they cannot be collected on the way past.
         mod = self.selected_module()
         self._tnames = ["Available",
-                        f"FX2 chooser · {st.loaded_name or 'unsaved'}",
+                        f"Choosers · {st.loaded_name or 'unsaved'}",
                         disp(mod) if mod is not None else "Unit"]
         can_fix = bool(self.blockers(probs))
         if can_fix != getattr(self, "_can_fix", None):
@@ -823,33 +845,48 @@ class RemixerScreen(Screen):
                                              head=head, tail=2))
 
     def _pane_loaded(self, st, probs):
+        """BOTH chooser lists, stacked, both editable.
+
+        The unit has two effect slots per track and each has its own list.
+        Composing one of them while the other sat in a column as an
+        `FX1+FX2` tag is what made the relationship unreadable -- so they are
+        two headed sections here, one cursor path, and every gesture applies
+        to the list you are standing in.
+
+        ⚠️ THEY ARE NOT SYMMETRIC and the headers say how. FX2's list is
+        built from nothing: its rows, their order and its membership are all
+        the remix's. FX1's starts as stock's ten and the firmware's own NONE
+        is always its row 0, which is why no row here is numbered 0.
+        """
         rows = self.loaded_rows()
         name = st.loaded_name or "unsaved"
-        # IT IS THE FX2 CHOOSER. The rows are FX2 rows, the numbers are FX2
-        # row numbers, and `←→` reorders FX2 -- while an `FX1+FX2` in the
-        # column beside them invited "row 1 of both", which is not what any
-        # of it means. FX1's list is stock's own and is only ever appended
-        # to; the line under the rows says so.
-        out = self._head(f"FX2 chooser · {name}", LOADED)
+        out = self._head(f"Choosers · {name}", LOADED)
         head = len(out)
-        cur_line, pos = head, 0
-        for i, m in enumerate(rows):
+        cur_line = head
+        menu = None
+        pos = 0
+        for i, (mn, m) in enumerate(rows):
+            if mn != menu:
+                menu, pos = mn, 0
+                n = sum(1 for x, _ in rows if x == mn)
+                # ⚠️ JUST THE NAME AND THE COUNT. The header carried why
+                # the two lists differ ("stock's ten to start" / "yours to
+                # compose") and wrapped at 40 columns, which turns a header
+                # into two mystery rows. `?` says it in full.
+                out.append(f"[bold] {mn}[/][dim]  {n} row"
+                           f"{'' if n == 1 else 's'}[/]")
             here = self.pane == LOADED and i == self.cur[LOADED]
             if m.menu is not None:
                 pos += 1
                 row = f"{pos:>2}"
             else:
                 row = " ·"                      # no chooser row (a CF patch)
-            menus = "+".join(rig.menus(m, st.fx1)) or "—"
             words = st.words.get(m.key)
             cost = f"{words:>5}w" if words else "      "
             fb = f"[{MARK}]◀fb[/]" if st.eff_fallback == m.key else ""
-            # No insertion caret any more: `enter` appends, so there is no
-            # second cursor in another pane to keep track of.
             nm = disp(m) if m.is_stock else f"[{OURS}]{disp(m)}[/]"
-            pad = " " * max(0, 13 - len(disp(m)))
-            line = (f" [dim]{row}[/] {nm}{pad}"
-                    f"[dim]{menus:<7}{cost}[/]{fb}")
+            pad = " " * max(0, 14 - len(disp(m)))
+            line = f" [dim]{row}[/] {nm}{pad}[dim]{cost}[/]{fb}"
             if here:
                 cur_line = len(out)
             out.append(f"[reverse]{line}[/]" if here else line)
@@ -861,18 +898,8 @@ class RemixerScreen(Screen):
         # effects, and these are three of them. They leave when something
         # takes their space -- their code IS the donor region our modules are
         # written over -- so showing the trade where it happens is the point.
-        # ONE dim line, not three: the old form repeated "taken by <module>"
-        # per reverb, which said one thing three times, named an arbitrary
-        # module as the taker (eats[0] is just the first selection with DSP
-        # code -- nothing here computes a per-reverb attribution), and
-        # overran the 38-column pane so its " +1" wrapped onto its own line
-        # and read as a fourth mystery row.
         # WHICH REVERBS ARE ACTUALLY GONE, from the build's own report --
-        # not "all three, always", which is what this said before 2 Sep 2026
-        # and which was the reason the honest answer to "why can I never get
-        # the stock verbs back?" was "you cannot". A light selection keeps
-        # the ones the placement never reached; they are ordinary stock rows
-        # you can add from the library like any other.
+        # not "all three, always", which is what this said before 2 Sep 2026.
         gone = [c for c in stock.CONSUMED
                 if c.split()[0] not in st.donors_kept]
         if st.donors_kept or not gone:
@@ -885,56 +912,19 @@ class RemixerScreen(Screen):
             out.append(f"[dim {WARN}] —  Plate, Spring, Dark Rev (donors)[/]")
         # THE SHARED COST, ONCE. Every module that pins FX2 buffers costs
         # the same seven stock effects, so saying it on each of them read as
-        # two bills for one debt -- ChonVerb and BongDelay showed identical
-        # lists. It belongs to the image, so the image says it.
+        # two bills for one debt.
         pin = [m for m in st.selected if rig.pins_fx2(m)]
-        # ⚠️ NOT WHILE THE ⚠ IS UP. The ⚠ below names the same seven effects
-        # AND the key that removes them, so both lines together spent seven
-        # of a forty-column pane's rows saying one thing twice -- and this
-        # one, phrased as "no room for", read as a second unresolved error.
-        # Once the fix has been applied it is no longer a problem, it is the
-        # shape of the image you chose, so it says that instead.
         if pin and not probs:
             who = " and ".join(disp(m) for m in pin)
             out.append(f"[dim {WARN}]{escape(rig.allocating_names())} "
                        f"cannot be listed — {escape(who)} "
                        f"{'holds' if len(pin) == 1 else 'hold'} "
                        f"the buffers they need[/]")
-        # THE OTHER CHOOSER, in one line, under the one being composed.
-        # Composing FX2 while FX1 sat in a column beside it as a tag was the
-        # whole confusion: they are two lists, they are NOT symmetric, and
-        # only one of them is being composed here. FX1's is stock's own ten;
-        # a remix can append to it and can do nothing else to it -- no
-        # removing, no reordering, because those rows are not ours.
-        mine = [m for m in rows if m.key in st.fx1]
-        # TEN, not eleven: FX1's list carries the firmware's own NONE at row
-        # 0, which is not an effect. Counted off the stock rows rather than
-        # written down.
-        n_stock = sum(1 for m in stock.MODULES
-                      if m.menu.fx2_id in stock.fx1_ids())
-        lead = f" FX1 chooser  stock's {n_stock}"
-        if not mine:
-            # "(1 appends)" wrapped at 40 columns, and the hint line two
-            # rows down already says `1 FX1 row`.
-            tell = ", unchanged"
-        else:
-            # Names while they fit -- which one usually does -- and a count
-            # when they do not. A wrapped line here reads as an extra
-            # mystery row, the way the three-reverb `held by` line did.
-            names = ", ".join(disp(m) for m in mine)
-            room = self.query_one("#pane_load", Static).content_size.width
-            tell = (f" + {names}" if room <= 0 or len(lead) + 3 + len(names)
-                    <= room else f" + {len(mine)} of yours")
-        out.append(f"[dim {WARN}]{lead}{escape(tell)}[/]")
         # Everything from the notes down is the IMAGE speaking, not a row,
-        # so it stays on screen however long the list gets.
+        # so it stays on screen however long the lists get.
         tail = len(out) - rows_end
         out.append("")
-        # THE PANE SAYS WHAT ITS KEYS DO, exactly as the library pane does.
-        # `left`/`right` here is a real edit -- the order of these rows IS
-        # the order of rows on the unit's chooser -- and it was documented
-        # only in `?`, which is the one place a newcomer looks last.
-        out.append("[dim]enter removes · ←→ order · 1 FX1 row[/]")
+        out.append("[dim]enter removes · ←→ order · 1 → FX1[/]")
         out.append(self._ledger_line(st, probs))
         self._paint("#pane_load", self._fit("#pane_load", out, cur_line,
                                             head=head, tail=tail + 3))
@@ -1703,11 +1693,26 @@ class RemixerScreen(Screen):
         if not rows or self.cur[LOADED] >= len(rows):
             return
         i = self.cur[LOADED]
-        row = st.move(rows[i].key, step)
-        if row is not None:
-            st.msg = f"{disp(rows[i])} → chooser row {row}"
-        elif rows[i].key in st.sel:
-            st.msg = f"{disp(rows[i])} has no chooser row: order is moot"
+        menu, mod = rows[i]
+        # WITHIN ITS OWN LIST. The two choosers share a cursor path but not
+        # an order -- a row cannot move from FX1's list to FX2's by being
+        # nudged off the end of it, and stopping at the boundary is what
+        # says so.
+        span = [j for j, (mn, _m) in enumerate(rows) if mn == menu]
+        if i + step < span[0] or i + step > span[-1]:
+            st.msg = f"{disp(mod)} is already {'first' if step < 0 else 'last'} on {menu}"
+            return
+        if menu == rig.FX1:
+            j = st.fx1.index(mod.key)
+            st.fx1.insert(j + step, st.fx1.pop(j))
+            st.msg = f"{disp(mod)} → FX1 row {j + step + 1}"
+        else:
+            row = st.move(mod.key, step)
+            if row is not None:
+                st.msg = f"{disp(mod)} → FX2 row {row}"
+            elif mod.key in st.sel:
+                st.msg = f"{disp(mod)} has no chooser row: order is moot"
+        st.loaded_name = ""
         self.cur[LOADED] = max(0, min(len(rows) - 1, i + step))
         self.schedule_sync()      # placement order changes the image
 
@@ -1751,10 +1756,17 @@ class RemixerScreen(Screen):
             rows = self.loaded_rows()
             if not rows or self.cur[LOADED] >= len(rows):
                 return
-            mod = rows[self.cur[LOADED]]
-            st.toggle(mod.key)
+            menu, mod = rows[self.cur[LOADED]]
+            if menu == rig.FX1:
+                # OFF THE FX1 CHOOSER, not out of the image: for a stock
+                # effect the two lists are independent, and for one of ours
+                # the FX2 row is what carries the code.
+                st.fx1.remove(mod.key)
+                st.msg = f"{disp(mod)} is off the FX1 chooser"
+            else:
+                st.toggle(mod.key)
+                st.msg = f"removed {disp(mod)} from the FX2 chooser"
             st.loaded_name = ""
-            st.msg = f"removed {disp(mod)}"
             self.cur[LOADED] = max(0, self.cur[LOADED] - 1)
             self.schedule_sync()
         self.rerender()

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -1387,7 +1387,12 @@ class RemixerScreen(Screen):
                    if self.pane == UNIT else
                    "[dim]tab here to change values and audition[/]")
         out.append("")
-        out += self._preview(mod, probs)
+        # HOW MUCH ROOM IS LEFT FOR IT. The preview is the tallest thing in
+        # the remixer and it is last, so a short pane cut it mid-frame: the
+        # box lost its bottom border and its last rows with no sign that
+        # anything was missing.
+        room = self.query_one("#pane_unit", Static).content_size.height
+        out += self._preview(mod, probs, max(0, room - len(out)))
         # No pinned tail: the knobs are what the cursor is in and the preview
         # is what follows them, so a short pane shows as much of the page as
         # is left over rather than reserving room for it.
@@ -1425,7 +1430,7 @@ class RemixerScreen(Screen):
         self._panel_cache = (key, grid)
         return grid
 
-    def _preview(self, mod, probs):
+    def _preview(self, mod, probs, room=0):
         st = self.app.state
         modes = " ".join(f"[reverse]{m}[/]" if m == self.preview else
                          f"[dim]{m}[/]" for m in PREVIEWS)
@@ -1445,8 +1450,8 @@ class RemixerScreen(Screen):
         # belong to whichever effect the TRACK has selected.
         slot = self.preview
         what = ("the main menu, as the unit draws it" if slot == "MENU"
-                else f"the {slot} menu's own rows, and {escape(disp(mod))}'s "
-                     f"knob names — both as the unit draws them")
+                else f"the {slot} menu's rows, and {escape(disp(mod))}'s "
+                     f"knob names")
         head = [f"preview {modes}  [dim](p)[/]", f"[dim]{what}[/]"]
         # DO NOT DRAW SOMETHING THAT IS NOT THE SELECTION. The FX2 page
         # includes the firmware's own chooser list, so an image that is not
@@ -1516,6 +1521,28 @@ class RemixerScreen(Screen):
         # allowed to break the frame open.
         import emu_bringup
         w = emu_bringup.COLS
+        # Trailing blank rows are the page having fewer parameters than the
+        # screen has lines, not content -- and they are the first thing to
+        # give up when the pane is short.
+        while grid and not grid[-1].strip():
+            grid.pop()
+        cut = len(head) + len(grid) + 2 - room
+        if room and len(grid) - cut < 4:
+            # Below a few rows the box says nothing and costs the lines it
+            # would have said it in.
+            return head[:1] + [f"[dim]the pane is {cut} row"
+                               f"{'' if cut == 1 else 's'} short of the "
+                               f"page — make the window taller[/]"]
+        if room and cut > 0:
+            # CLIP DELIBERATELY, and say so where the bottom border would
+            # have been. A frame with no bottom edge reads as a rendering
+            # fault rather than as a short window.
+            grid = grid[:max(0, len(grid) - cut - 1)]
+            return head + [f"{edge}." + "-" * w + ".[/]"] + \
+                [f"{edge}|[/]" + escape(ln[:w].ljust(w)) + f"{edge}|[/]"
+                 for ln in grid] + \
+                [f"{edge}'[/][dim]" + f" {cut + 1} more rows — the pane is "
+                 f"short ".ljust(w, "-")[:w] + f"[/]{edge}'[/]"]
         return head + [f"{edge}." + "-" * w + ".[/]"] + \
             [f"{edge}|[/]" + escape(ln[:w].ljust(w)) + f"{edge}|[/]"
              for ln in grid] + \

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -48,7 +48,8 @@ except ImportError:
 from rich.markup import escape  # noqa: E402  (rich ships with textual)
 
 from remix import audition, registry, rig, stock  # noqa: E402
-from remix.state import BUILT_IMAGE, DONOR_WORDS, ROOT, State  # noqa: E402
+from remix.state import (BUILT_IMAGE, CAVE_BYTES, DONOR_WORDS, ROOT,  # noqa: E402
+                         State)
 
 
 def step_label(mod, name, v):
@@ -138,6 +139,33 @@ def disp(mod) -> str:
     if mod.menu is not None:
         return titlecase(mod.menu.fullname.decode("latin1") or mod.name)
     return titlecase(mod.name)
+
+
+def placeable(sel, total, used):
+    """Words this selection can still PLACE in one payload's donor region.
+
+    Not the build's own FREE figure, which reports the whole region as free
+    because nothing of OURS is in it yet: PLATE, SPRING and DARK REV's code
+    IS that region, so a reverb kept in the chooser is spending its own
+    words and has to be subtracted like anything else.
+
+    And the subtraction is not the reverbs' sizes. The region packs from
+    PLATE upward, so holding a LOW reverb makes the space above it
+    unreachable even though nothing occupies it -- keeping PLATE alone
+    leaves 2,130 words by size and 0 you can actually place. The ceiling is
+    the offset of the lowest reverb kept, which equals the plain subtraction
+    for every other combination (verified for all four).
+
+    Returns (free, cap): `total - cap` is what the listed reverbs hold, so
+    used + held + free is exactly total.
+
+    ONE definition of "free", used by both the line under LOADED and the
+    budget pane. They used to disagree on the same screen -- 2,509 there
+    against 379 here -- which is a good way to make a budget unreadable.
+    """
+    cap = min((stock.consumed_at(c) for c in stock.CONSUMED if c in sel),
+              default=total)
+    return max(0, cap - used), cap
 
 
 # Where the SOURCE row browses. out/dry/ is the curated dry set and stays the
@@ -313,6 +341,17 @@ The UNIT pane says `⚠ MIX is 0 — this renders DRY` when it applies.
 What is LEFT of the image, under the effect you are looking at. Four
 scarce things and only four: the two donor regions (one per payload),
 the FX2 buffer slots per core, the chooser rows, and the ColdFire cave.
+
+Every row is the same sentence — [bold]N free of TOTAL, and what took the
+rest[/] — so the default selection reads as what an unmodified core
+already spends rather than as a bare zero.
+
+⚠️ A REVERB YOU KEEP IN THE CHOOSER IS SPENDING WORDS. PLATE, SPRING and
+DARK REV's code IS the donor region, so the `held by` line is the trade:
+how much they are holding, and what dropping the next one buys. The
+region packs from PLATE upward, so holding a LOW reverb also makes the
+space above it unreachable — which is why keeping PLATE alone leaves
+2,130 words by size and 0 you can actually place.
 
 ⚠️ The buffer slots count what a MODULE pins — ChonVerb holds all four
 of its core's, BongDelay two of its core's, Nimbus two of whichever
@@ -718,14 +757,17 @@ class BenchScreen(Screen):
         if st.regions:
             # The free-word count is the one number worth a glance, so let
             # its COLOUR carry the answer: comfortable, tight, or spent.
+            # placeable() rather than the build's FREE, so this agrees with
+            # the budget pane two panes over -- see its docstring.
             def one(n, f):
                 # Thresholds from what this project actually lives with:
                 # payload A has shipped at FREE 4 and B at FREE 5, so double
                 # digits is already "spent" and deserves the alarm colour.
                 c = OK if f > 400 else WARN if f > 32 else BAD
-                return f"{n} [{c}]{f}[/] free"
+                return f"{n} [{c}]{f:,}[/] free"
             return "[dim]" + " · ".join(
-                one(n, f) for n, _u, f in st.regions) + "[/]"
+                one(n, placeable(st.sel, t, u)[0])
+                for n, t, u, _f in st.regions) + "[/]"
         # No build has reported yet. Say which of the two reasons it is --
         # this line used to claim "a stock chooser: 14 effects, no modules"
         # for ANY unmeasured selection, including chongbong, which has three.
@@ -743,6 +785,17 @@ class BenchScreen(Screen):
         chooser rows, and the ColdFire cave. Everything else is unbounded in
         practice.
 
+        EVERY ROW IS THE SAME SENTENCE: `N free of TOTAL · what took the
+        rest`. That uniformity is the whole point and it is what this pane
+        kept losing -- the rows line said "17 free of 31 (14 loaded)" while
+        the words line said a bare "0 free" with no total at all, and the
+        buffer line said "5,6,7,8 keep theirs" with neither. Three different
+        answers to one question is what made it unreadable.
+
+        And the TOTAL is stated even when nothing of ours is loaded, so the
+        default selection -- an unmodified unit -- says what a stock core
+        actually spends rather than reporting an alarming bare zero.
+
         Read from the BUILD's own report wherever possible (state.measure),
         because the build is the only thing that knows where the cursor
         actually stopped.
@@ -750,9 +803,10 @@ class BenchScreen(Screen):
         out = ["[bold]Budget[/]"]
         W = 10                                  # one label column throughout
 
-        def row(label, bar_full, bar_len, colour, tail):
-            return (f" {label:<{W}}[{colour}]" + "#" * bar_full + "[/][dim]"
-                    + "." * (bar_len - bar_full) + f"[/]  {tail}")
+        def left(n, total, extra=""):
+            """The one sentence every row here answers."""
+            return (f"{n:,} free of {total:,}"
+                    + (f" [dim]· {extra}[/]" if extra else ""))
 
         # EVERY ROW HERE IS: what exists, minus what this selection loaded.
         # Nothing is a constant and nothing is a build's leftover.
@@ -771,47 +825,71 @@ class BenchScreen(Screen):
         # alone leaves 2,130 words by size and 0 you can actually place. The
         # placeable figure is the offset of the lowest reverb kept, which
         # equals the subtraction for every other combination (verified for
-        # all four).
+        # all four). So `held` below is the whole tail from that reverb up,
+        # not the sum of the reverbs' own sizes -- and the three numbers on
+        # the row then add up exactly: loaded + held + free = total.
         held = [c for c in stock.CONSUMED if c in st.sel]
-        cap = min((stock.consumed_at(c) for c in held), default=DONOR_WORDS)
         nxt = min(held, key=stock.consumed_at) if held else None
 
-        def words_row(n, used):
-            free = max(0, cap - used)
-            fill = min(20, round(20 * used / DONOR_WORDS))
-            edge = min(20, round(20 * cap / DONOR_WORDS))
+        def words_row(n, total, used):
+            free, cap = placeable(st.sel, total, used)
+            fill = min(20, round(20 * used / total))
+            edge = max(fill, min(20, round(20 * cap / total)))
             c = OK if free > 400 else WARN if free > 32 else BAD
             bar = (f"[{c}]" + "#" * fill + "[/][dim]" + "." * (edge - fill)
                    + "[/][dim red]" + "-" * (20 - edge) + "[/]")
-            # NAME THE NEXT TRADE, not the state. "Plate Rev holds the
-            # rest" was true and useless -- it says which reverb is in the
-            # way without saying what dropping it buys, and at 0 free that
-            # is the only question. Both forms now answer it: how far you
-            # can go before the next one dies, or what the next one is worth.
-            gain = stock.WORDS[nxt] if nxt else 0
-            why = (f"  [dim]then {titlecase(nxt)} goes[/]" if nxt and free
-                   else f"  [dim]drop {titlecase(nxt)} for {gain:,} more[/]"
-                   if nxt else "")
-            return f" {'words ' + n:<{W}}{bar}  {free:>4} free{why}"
+            return (f" {'words ' + n:<{W}}{bar}  [{c}]{free:>5,}[/] free of "
+                    f"{total:,} [dim]· {used:,} loaded[/]")
 
         if st.regions:
-            for n, used, _f in st.regions:
-                out.append(words_row(n, used))
+            for n, total, used, _f in st.regions:
+                out.append(words_row(n, total, used))
         elif not [m for m in st.selected if m.dsp is not None]:
+            # No build to read -- and none is possible, because a selection
+            # with no module of ours has no fallback to name. The region is
+            # still fully accounted for: the three reverbs are in it.
             for n in ("A", "B"):
-                out.append(words_row(n, 0))
+                out.append(words_row(n, DONOR_WORDS, 0))
         else:
-            out.append(f" {'words':<{W}}[dim]"
-                       + "?" * 20 + "[/]  [dim]not built[/]")
+            out.append(f" {'words':<{W}}[dim]" + "?" * 20
+                       + "[/]  [dim]not built[/]")
+        # THE TRADE, ONCE. It is identical for both payloads -- the same
+        # three reverbs occupy both regions -- so printing it on each read as
+        # two facts. NAME THE NEXT TRADE, not the state: "Plate Rev holds the
+        # rest" was true and useless, because it says which reverb is in the
+        # way without saying what dropping it buys, and at 0 free that is the
+        # only live question.
+        if nxt:
+            # What dropping it actually BUYS is the gap up to the next reverb
+            # still listed, which is NOT the reverb's own size when the one
+            # above it has already gone: holding PLATE and DARK, dropping
+            # PLATE opens SPRING's words too (1,657, not 594).
+            cap = stock.consumed_at(nxt)
+            rest = min((stock.consumed_at(c) for c in held if c != nxt),
+                       default=DONOR_WORDS)
+            # "drop Dark Rev" beside "held by Dark Rev" says the name twice
+            # in eleven words; with one reverb held there is nothing to
+            # disambiguate, so it is "it".
+            which = titlecase(nxt) if len(held) > 1 else "it"
+            # The reverbs are named WITHOUT their " Rev" suffix here (the
+            # label already says these are the held reverbs) because the
+            # three-reverb form is the widest line in the pane and this pane
+            # is the narrowest column: at 77 columns it wrapped, and a
+            # wrapped budget row reads as an extra mystery row.
+            names = ", ".join(titlecase(c).replace(" Rev", "") for c in held)
+            out.append(f" {'held by':<{W}}[dim]{names} — "
+                       f"{DONOR_WORDS - cap:,} words; "
+                       f"drop {which} for {rest - cap:,} more[/]")
 
         # FX2 buffer slots. ONE PER TRACK, not a pool: each track allocates
         # FX1 then FX2, so track k's FX2 effect always gets table entry 1+2k
         # -- 0x4000, 0x8000, then the shared-window pair (docs/DSP.md, "the
         # allocator's instance model").
         #
-        # So the four boxes are FOUR TRACKS, and the useful sentence is WHO
-        # has taken which and what is left. "4 of 4, none free" was accurate
-        # and told you neither.
+        # So there are FOUR, they are FOUR TRACKS, and the useful sentence is
+        # how many are left and who took the others. The old row drew them as
+        # four groups of four glyphs, which read as SIXTEEN slots; a count
+        # against a total cannot be misread that way.
         for tag in ("A", "B"):
             tracks = rig.PAYLOAD_TRACKS[tag]
             owner = {}
@@ -829,8 +907,6 @@ class BenchScreen(Screen):
                     owner.setdefault(2, m); owner.setdefault(3, m)
             free = [tracks.start + k for k in range(4) if k not in owner]
             c = OK if len(free) > 2 else WARN if free else BAD
-            slots = " ".join("####" if k in owner else "...."
-                             for k in range(4))
             said, bits = set(), []
             for k in sorted(owner):
                 mod = owner[k]
@@ -846,43 +922,45 @@ class BenchScreen(Screen):
             # the stock reverbs not use it?" -- they use their own track's,
             # when you select them on it, and listing one in the chooser
             # claims nothing. Only a MODULE claims a buffer for the life of
-            # the image, which is why only modules appear here.
-            if free:
-                bits.append(f"[{OK}]{','.join(str(t) for t in free)} "
-                            f"keep theirs[/]")
-            out.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{slots}[/]  "
-                       + " · ".join(bits or
-                                    ["[dim]unclaimed — every track keeps its "
-                                     "own[/]"]))
+            # the image, which is why only modules appear here. The footnote
+            # below says so, once, rather than the row fighting the word.
+            out.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{len(free):>5}[/] free "
+                       f"of 4 [dim]· "
+                       + (" · ".join(bits) if bits
+                          else f"tracks {tracks.start}-{tracks.stop - 1} "
+                               f"all keep their own") + "[/]")
 
         # Rows are countable without a build; the cave is not.
-        # Same rule: 31 exist, this selection loaded N.
+        # Same sentence again: 31 exist, this selection loaded N.
         used_rows = (st.chooser_rows if st.chooser_rows is not None
                      else len(st.menu_modules))
-        free_rows = 31 - used_rows
-        c = OK if free_rows > 7 else WARN if free_rows else BAD
-        out.append(f" {'rows':<{W}}[{c}]{free_rows}[/][dim] free of 31 "
-                   f"({used_rows} loaded)[/]")
-        # Same again for the cave: a stock row clones no descriptor, plants
-        # no formatter and cuts no patch, so with no modules of ours the
-        # region is untouched. Said in words rather than a number, because
-        # the exact figure depends on where the chooser list landed and that
-        # is the build's arithmetic, not a fact to re-derive here.
+        c = OK if 31 - used_rows > 7 else WARN if used_rows < 31 else BAD
+        out.append(f" {'rows':<{W}}[{c}]{31 - used_rows:>5}[/] free of 31 "
+                   f"[dim]· {used_rows} loaded[/]")
+        # And the cave. The build reports only what is LEFT, so the total
+        # comes from state.CAVE_BYTES (pinned to build_bus's own bounds by
+        # the selftest) and the used figure is the subtraction -- which is
+        # the point: a stock chooser plants nothing on the ColdFire, so the
+        # honest reading of the default selection is the whole region free,
+        # not the wordless "untouched" this used to print.
         if st.cave_free is not None:
             c = OK if st.cave_free > 512 else WARN if st.cave_free else BAD
-            cave = f"[{c}]{st.cave_free:,}[/][dim] B free[/]"
+            out.append(f" {'cave':<{W}}[{c}]{st.cave_free:>5,}[/] free of "
+                       f"{CAVE_BYTES:,} B [dim]· "
+                       f"{CAVE_BYTES - st.cave_free:,} loaded[/]")
         elif not [m for m in st.selected if m.dsp is not None or m.cf_patches]:
-            cave = f"[{OK}]untouched[/][dim] — nothing of ours is placed[/]"
+            out.append(f" {'cave':<{W}}[{OK}]{CAVE_BYTES:>5,}[/] free of "
+                       f"{CAVE_BYTES:,} B [dim]· nothing of ours is placed[/]")
         else:
-            cave = "[dim]not built[/]"
-        out.append(f" {'cave':<{W}}{cave}")
-        # What the buffer rows COUNT, because it is not "slots in use": a
-        # stock effect takes one from the allocator at runtime, per
-        # instantiated effect per block, which no image can reserve. These
-        # are the ones a MODULE holds fixed, which is the part composing a
-        # remix actually decides.
-        out.append("[dim] # loaded by a module · - held by a listed reverb "
-                   "· . free[/]")
+            out.append(f" {'cave':<{W}}[dim]    ? free of {CAVE_BYTES:,} B "
+                       f"· not built[/]")
+        # What the words bar's three glyphs mean, and what a buffer count
+        # counts -- because it is not "slots in use": a stock effect takes
+        # one from the allocator at runtime, per instantiated effect per
+        # block, which no image can reserve. These are the ones a MODULE
+        # holds fixed, which is the part composing a remix actually decides.
+        out.append("[dim] words: # loaded by a module · - held by a listed "
+                   "reverb · . free[/]")
         out.append("[dim] one FX2 buffer per track. A module claims one for "
                    "the whole image;[/]")
         out.append("[dim] a stock effect uses its track's only while it is "

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""The remix workbench: swap effects, hear them, see the panel draw them.
+"""The remixer: swap effects, hear them, see the panel draw them.
 
     make remix          (or: .venv/bin/python3 tools/remix/app.py)
 
@@ -16,7 +16,7 @@ spare the operator a quarter-second and cost more than it saved.
 
 The model layers are headless and live next door: state.py (the composer),
 rig.py (categories, knobs), audition.py (rendering). This file is only the
-shell. Textual rather than curses: the workbench is already venv-hosted for
+shell. Textual rather than curses: the remixer is already venv-hosted for
 the emulator, and the frontend rewrite is where hand-rolled layout stopped
 paying its way.
 """
@@ -43,7 +43,7 @@ try:
     from textual.widgets import Footer, Input, OptionList, RichLog, Static
     from textual.widgets.option_list import Option
 except ImportError:
-    sys.exit("the workbench frontend needs textual -- run: make emu-setup")
+    sys.exit("the remixer frontend needs textual -- run: make emu-setup")
 
 from rich.markup import escape  # noqa: E402  (rich ships with textual)
 
@@ -103,7 +103,7 @@ _ACRONYMS = {"DJ", "EQ", "FX", "HP", "LP", "MS", "AB"}
 
 
 def titlecase(s: str) -> str:
-    """One naming rule for every name the workbench prints.
+    """One naming rule for every name the remixer prints.
 
     The lists mixed three conventions and it showed: OUR modules carry a
     panel name in camel case (`BongDelay`), the STOCK effects carry the
@@ -116,7 +116,7 @@ def titlecase(s: str) -> str:
     only re-cased when it is entirely upper (or entirely lower), and known
     acronyms keep their case.
 
-    ⚠️ This is the WORKBENCH's own text only. The emulated panel draws
+    ⚠️ This is the REMIXER's own text only. The emulated panel draws
     strings captured from the firmware and is never re-cased -- it has to
     show what the unit shows.
     """
@@ -195,20 +195,26 @@ def chooser_slot(order, key):
 
 # Where the SOURCE row browses. out/dry/ is the curated dry set and stays the
 # default (31 Aug 2026: test_audio + demo_sources are full of processed
-# renders and made the browser unusable), but a bench is used on whatever
+# renders and made the browser unusable), but a remixer gets used on whatever
 # material is to hand, so `d` points it somewhere else and CONFIG remembers.
-CONFIG = ROOT / "out" / "_audition" / "workbench.json"
+CONFIG = ROOT / "out" / "_audition" / "remixer.json"
+# Its name until 3 Sep 2026. Read as a fallback so the sample folder somebody
+# chose does not silently revert to out/dry/ because the tool was renamed;
+# the next save writes the new name and this stops mattering.
+OLD_CONFIG = ROOT / "out" / "_audition" / "workbench.json"
 DEFAULT_SOURCE_DIR = ROOT / "out" / "dry"
 
 
 def load_config():
     """{} on anything unreadable -- a corrupt settings file must not stop the
-    workbench opening, it is a convenience, not state anyone can lose work
+    remixer opening, it is a convenience, not state anyone can lose work
     from."""
-    try:
-        return json.loads(CONFIG.read_text())
-    except Exception:                                # noqa: BLE001
-        return {}
+    for path in (CONFIG, OLD_CONFIG):
+        try:
+            return json.loads(path.read_text())
+        except Exception:                            # noqa: BLE001
+            continue
+    return {}
 
 
 def save_config(cfg):
@@ -222,7 +228,11 @@ def save_config(cfg):
 def source_dir():
     """The directory the SOURCE row browses, in precedence order: the env
     override, what `d` last chose, then out/dry/."""
-    env = os.environ.get("WORKBENCH_SOURCES")
+    # WORKBENCH_SOURCES was its name until 3 Sep 2026 and is still honoured:
+    # an env var lives in somebody's shell profile, where a rename is not a
+    # rename but a silent stop working.
+    env = (os.environ.get("REMIXER_SOURCES")
+           or os.environ.get("WORKBENCH_SOURCES"))
     if env:
         return pathlib.Path(env).expanduser()
     saved = load_config().get("source_dir")
@@ -318,7 +328,7 @@ HELP = {
     # every paragraph ended in an orphan ("order", "draw", "your", "a") and
     # the page read as broken. Only the key table is hard-wrapped, and it is
     # short enough never to be re-flowed.
-    "bench": """[bold]THE BENCH[/] — compose the effects list your unit shows, and hear each one before you commit to it.
+    "remixer": """[bold]THE REMIXER[/] — compose the effects list your unit shows, and hear each one before you commit to it.
 
 [bold]AVAILABLE[/] is everything that COULD be in an image: your modules, then the stock effects the box already ships. [bold]LOADED[/] is the image you are composing, in the order the unit's chooser will show it. [bold]UNIT[/] follows the cursor — the selected effect's knobs, the firmware's own draw of its page, and `r` to hear it on the SOURCE wav.
 
@@ -414,14 +424,14 @@ class HelpScreen(ModalScreen[None]):
         self.dismiss(None)
 
 
-# ---- THE BENCH: one page, three panes ---------------------------------------
+# ---- THE REMIXER: one page, three panes ---------------------------------------
 AVAILABLE, LOADED, UNIT = 0, 1, 2
 # The unit's own order: FX1 then FX2 are the two slots on a
 # track; MAIN MENU is the odd one out and goes last.
 PREVIEWS = ("FX1", "FX2", "MENU")
 
 
-class BenchScreen(Screen):
+class RemixerScreen(Screen):
     """One page: the library, the image being composed, and the selected unit.
 
     Three panes, left to right, matching how the work actually goes: what
@@ -452,7 +462,7 @@ class BenchScreen(Screen):
         Binding("full_stop", "play_mark('B')", "play B", show=False),
         # SHOWN ONLY WHEN IT APPLIES (check_action). It is the key that
         # gets a broken selection building again -- the one gesture the
-        # workbench is built around leaves one -- and it was the only
+        # remixer is built around leaves one -- and it was the only
         # important key hidden from the footer.
         Binding("x", "fix", "fix it"),
         Binding("c", "build('check')", "full check", show=False),
@@ -472,7 +482,7 @@ class BenchScreen(Screen):
     def compose(self) -> ComposeResult:
         # A TAB BAR, but only when the panes are not all on screen. It names
         # all three and marks the one you are in, so a narrow terminal reads
-        # as a workbench showing you a third at a time rather than one with
+        # as a remixer showing you a third at a time rather than one with
         # two thirds missing. Full width, because the titles carry context
         # ("Loaded · chongbong") that will not fit in a 32-column pane head.
         yield Static(id="tabbar")
@@ -486,7 +496,7 @@ class BenchScreen(Screen):
         # against -- true, but it is context for the IMAGE, not for the one
         # effect the cursor is on, and it was charging the unit column ten
         # lines for the privilege. The preview lives in that column and is
-        # the tallest thing in the workbench (the firmware's own draw of a
+        # the tallest thing in the remixer (the firmware's own draw of a
         # page), so it was the one being truncated. Down here it costs the
         # panes nothing, and the extra width lets it read in two columns
         # instead of one long list.
@@ -519,7 +529,7 @@ class BenchScreen(Screen):
         self._dirty = False
         self.set_interval(1 / 60, self._flush)
         self._run = (None, True, 0.0, 0)   # see _accel()
-        # EDIT THE SOURCE IN ANOTHER WINDOW AND THE BENCH FOLLOWS. The image
+        # EDIT THE SOURCE IN ANOTHER WINDOW AND THE REMIXER FOLLOWS. The image
         # already tracks the SELECTION; it has to track the CODE too, or the
         # panel and every render silently describe the .asm you had a minute
         # ago. Polled rather than watched: one stat sweep of modules/ is
@@ -543,7 +553,7 @@ class BenchScreen(Screen):
     # `Stock` / `· id` / `0x04` one word per line down the screen, both list
     # panes were cut off mid-list, and the Budget strip took nine of the
     # twenty-four rows. An 80x24 terminal is what a new pair of hands opens,
-    # so that was the first impression the workbench made.
+    # so that was the first impression the remixer made.
     #
     # Below the threshold it shows ONE pane at full width and `tab` moves
     # between them, with the titles becoming a strip naming all three so the
@@ -643,7 +653,7 @@ class BenchScreen(Screen):
         -- so pressing `r` on them plays the source back unchanged. That is
         FAITHFUL: the defaults are read from the firmware's own descriptor
         (tools/remix/stock.py), an unmodified unit really does start them
-        fully dry, and seeding a different value here would make the bench
+        fully dry, and seeding a different value here would make the remixer
         lie about the page it is drawing beside. But it reads as "this effect
         does nothing", which is what it cost on 2 Sep 2026. So say it.
         """
@@ -940,7 +950,7 @@ class BenchScreen(Screen):
     def _pane_budget(self, st, probs):
         """WHAT IS LEFT, standing under the effect you are looking at.
 
-        Every other number in this workbench is read against this one -- "500
+        Every other number in this remixer is read against this one -- "500
         words" means nothing without "and 313 are free" -- and it used to be
         something you inferred from a refusal. Four scarce things, and only
         four: the two donor regions, the FX2 buffer slots per core, the
@@ -1574,7 +1584,7 @@ class BenchScreen(Screen):
         # once a frame. Every other path still renders immediately.
         self.rerender_soon()
 
-    # A HELD KEY ACCELERATES. The workbench stopped being the limit once the
+    # A HELD KEY ACCELERATES. The remixer stopped being the limit once the
     # panel render was cached (0.012 ms per key event, 86k/s) -- but macOS
     # repeats a held key at its default ~15/s after a 375 ms delay, so a
     # 0..127 knob still took ~8.5 s to sweep and there is nothing an app can
@@ -1729,7 +1739,7 @@ class BenchScreen(Screen):
     # falls back to the firmware's own NONE (schema.NO_FALLBACK), places no
     # code and assembles to A 0/2724 · B 0/2724 -- the chooser an unmodified
     # unit shows, rebuilt from our own tables. It used to be unbuildable for
-    # one reason only: the fallback had to be a module of ours, so the bench
+    # one reason only: the fallback had to be a module of ours, so the remixer
     # opened on a selection it had to apologise for ("stock -- swap a module
     # in to build it") and the panel drew nothing until you did.
 
@@ -1889,9 +1899,9 @@ class BenchScreen(Screen):
     def action_source_dir(self):
         """Point the SOURCE row at another folder, and remember it.
 
-        A bench is used on whatever material is to hand; out/dry/ is a good
+        A remixer gets used on whatever material is to hand; out/dry/ is a good
         default, not a permanent one. Remembered in out/_audition/
-        workbench.json, and WORKBENCH_SOURCES overrides both.
+        remixer.json, and REMIXER_SOURCES overrides both.
         """
         st = self.app.state
         cur = source_dir()
@@ -1900,7 +1910,7 @@ class BenchScreen(Screen):
             if not text:
                 return
             # RESOLVED before it is stored: a relative path would be read
-            # back against whatever directory the workbench is next started
+            # back against whatever directory the remixer is next started
             # from, and `make remix` being run from the repo root is a
             # convention, not a guarantee.
             d = pathlib.Path(text.strip()).expanduser()
@@ -1921,7 +1931,7 @@ class BenchScreen(Screen):
             TextPrompt("source folder for the SOURCE row:", str(cur)), chosen)
 
     def action_help(self):
-        self.app.push_screen(HelpScreen("bench"))
+        self.app.push_screen(HelpScreen("remixer"))
 
     # ---- audio -----------------------------------------------------------
     def action_render(self, mark=None):
@@ -2099,7 +2109,7 @@ class BenchScreen(Screen):
             def documented(doc):
                 pth = ROOT / f"remixes/{name}.py"
                 pth.write_text(st.as_remix(
-                    name, doc or "a selection composed in the workbench"))
+                    name, doc or "a selection composed in the remixer"))
                 st.loaded_name = name
                 st.msg = f"wrote remixes/{name}.py"
                 self.rerender()
@@ -2109,8 +2119,8 @@ class BenchScreen(Screen):
 
 
 # ---- the app ---------------------------------------------------------------
-class Workbench(App):
-    TITLE = "remix workbench"
+class Remixer(App):
+    TITLE = "remixer"
     CSS = """
     /* The panes must FILL the row for their left borders to run the whole
        way down -- a Static is only as tall as its text, so the dividers
@@ -2131,7 +2141,7 @@ class Workbench(App):
     #status { height: 1; padding: 0 1; }
     #log { height: 12; border-top: dashed $surface; }
     """
-    MODES = {"bench": BenchScreen}
+    MODES = {"remixer": RemixerScreen}
     # App-level so it works from every view; modals handle their own escape
     # first, and no screen binds it, so escape is unambiguous.
     BINDINGS = [Binding("escape", "stop_play", "stop audio")]
@@ -2150,14 +2160,15 @@ class Workbench(App):
 
     def on_mount(self):
         # ansi-dark renders in the TERMINAL's own 16-color palette, so the
-        # workbench wears whatever theme Alacritty wears instead of Textual's
-        # truecolor default. WORKBENCH_THEME picks any built-in Textual theme
+        # remixer wears whatever theme Alacritty wears instead of Textual's
+        # truecolor default. REMIXER_THEME picks any built-in Textual theme
         # (e.g. gruvbox, nord, textual-dark) for anyone who wants otherwise.
         import os
         from textual.theme import BUILTIN_THEMES
-        want = os.environ.get("WORKBENCH_THEME", "ansi-dark")
+        want = (os.environ.get("REMIXER_THEME")
+                or os.environ.get("WORKBENCH_THEME") or "ansi-dark")
         self.theme = want if want in BUILTIN_THEMES else "ansi-dark"
-        self.switch_mode("bench")
+        self.switch_mode("remixer")
 
     def play(self, path):
         """afplay, one at a time -- a new play stops the old."""
@@ -2190,5 +2201,5 @@ class Workbench(App):
 
 if __name__ == "__main__":
     if not sys.stdout.isatty():
-        sys.exit("the remix workbench needs a terminal (try: make remix)")
-    Workbench().run()
+        sys.exit("the remixer needs a terminal (try: make remix)")
+    Remixer().run()

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -578,13 +578,22 @@ class BenchScreen(Screen):
         # code -- nothing here computes a per-reverb attribution), and
         # overran the 38-column pane so its " +1" wrapped onto its own line
         # and read as a fourth mystery row.
-        eats = [m for m in st.selected if m.dsp is not None]
-        if eats:
-            out.append("[dim] —  Plate, Spring, Dark Rev (donors)[/]")
-        else:
+        # WHICH REVERBS ARE ACTUALLY GONE, from the build's own report --
+        # not "all three, always", which is what this said before 2 Sep 2026
+        # and which was the reason the honest answer to "why can I never get
+        # the stock verbs back?" was "you cannot". A light selection keeps
+        # the ones the placement never reached; they are ordinary stock rows
+        # you can add from the library like any other.
+        gone = [c for c in stock.CONSUMED
+                if c.split()[0] not in st.donors_kept]
+        if st.donors_kept or not gone:
             for cname in stock.CONSUMED:
-                pos += 1
-                out.append(f"[dim] {pos:>2} {titlecase(cname):<13}FX2[/]")
+                if cname in st.sel or cname not in gone:
+                    continue
+                out.append(f"[dim] —  {titlecase(cname):<13}"
+                           f"donor, taken[/]")
+        elif [m for m in st.selected if m.dsp is not None]:
+            out.append("[dim] —  Plate, Spring, Dark Rev (donors)[/]")
         out.append("")
         out.append(self._ledger_line(st, probs))
         self._paint("#pane_load", out)
@@ -607,6 +616,11 @@ class BenchScreen(Screen):
         if self.sync_error:
             # The build names the payload and the overrun; that IS the
             # actionable sentence, so print it rather than a pointer to it.
+            gone = self.blockers([])
+            if gone:
+                return ("[bold]⚠ x removes "
+                        + ", ".join(disp(m) for m in gone)
+                        + " — this selection needs its words[/]")
             return f"[bold]⚠ {escape(self.sync_error)}[/]"
         # THE BUILD'S OWN NUMBERS, one per payload. Not a sum of st.words
         # against DONOR_WORDS: there are TWO regions of that size and
@@ -1023,13 +1037,25 @@ class BenchScreen(Screen):
                 continue
             # "stock instance buffer: flanger and chonverb both claim ..."
             names.add(p_.split(":", 1)[1].split(" and ")[0].strip())
-        return [m for m in st.selected
-                if m.is_stock and m.name.lower() in names]
+        out = [m for m in st.selected
+               if m.is_stock and m.name.lower() in names]
+        # A DONOR ROW WHOSE WORDS THIS SELECTION TOOK. The build refuses it
+        # by name ("PLATE REV is listed in the chooser but this selection
+        # places code over it"), and that verdict is exact -- only the
+        # placement knows where the cursor stopped -- so read it rather than
+        # predicting it here.
+        if self.sync_error:
+            out += [m for m in st.selected
+                    if m.is_stock and m.key in stock.CONSUMED
+                    and f"{m.key} is listed" in self.sync_error]
+        return out
 
     def action_fix(self):
         """Apply the ⚠'s own advice."""
         st = self.app.state
         gone = self.blockers(st.problems())
+        if not gone:
+            gone = self.blockers([])
         if not gone:
             st.msg = "nothing here that removing a row would fix"
             self.rerender()

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -344,7 +344,6 @@ The loop is one move long: highlight one of yours in AVAILABLE and press `enter`
   r  render + hear     space  replay
   a / b  park what you just heard as A / B      , / .  play A / B
   1  put the highlighted effect on the FX1 chooser (or take it off)
-  h  harvest a stock effect's WORDS for your modules (or give them back)
   x  apply the fix the ⚠ is offering (only shown when there is one)
   d  sample folder     l  load a remix      s  save this one as a remix
   c  full check        f  choose the fallback        k  back to stock
@@ -399,13 +398,16 @@ Rows are NOT the scarce thing, which is why `enter` adds rather than swaps: 31 r
 Measured 3 Sep 2026 and it says the limit is ours to lift: the thirteen DSP effects are laid out CONTIGUOUSLY in 6,158 words (`P:0x007d1..0x01fdf`, no other module between them), and every one of them is SELF-CONTAINED — no control flow leaves its own span and nothing enters it but its own dispatch entry. So any effect's words could be freed by dropping it, and a run of dropped neighbours would be one bigger region. What that costs is the effect itself: today an unlisted stock effect keeps working and only loses its row, and one harvested for its words would not.
 
 [bold]on an unmodified unit every word is allocated[/]
-All 6,158 words of the payload's effect code belong to a stock effect that is using them, and the remixer opens saying exactly that: `no region — every word is a stock effect's`, the map all `─`, `all 6,158 words allocated`. NOTHING is set aside for you until you decide what to give up.
+All 6,158 words of the payload's effect code belong to a stock effect that is using them, and the remixer opens saying exactly that: `no region — every word is a stock effect's`, the map all `─`. NOTHING is set aside for you until you decide what to give up.
 
-`h` harvests the highlighted stock effect's words and `⌁` marks it in the library. The thirteen effects are laid out contiguously and every one is self-contained, so any unbroken run of them is ground your modules can be placed into. Add a module before harvesting anything and the ⚠ says so, with `x` taking the three reverbs — the biggest, and FX2-only, so they cost FX1 nothing — which is the conventional choice and not one the image imposes.
+[bold]taking an effect off BOTH menus is that decision[/]
+There is no separate harvest gesture, because there was never a separate choice: an effect on neither chooser is one you do not want, so its words are where your modules go. `⌁` marks it in the library. That is derived from the two lists, not a third thing to manage — and it reproduces what the build has always done, because FX1 lists ten of the thirteen and the reverbs are FX2-only, so a remix listing none of them on FX2 gives up exactly those three.
 
-⚠️ The run has to stay CONTIGUOUS — a module of ours is one code stream, so a gap is not a smaller region, it is two — and only the effect just below the bottom of the run or just above its top can join it. `h` says what is in the way rather than letting the build refuse later.
+Add a module before giving anything up and the ⚠ says so, with `x` dropping the three reverbs — the biggest, and FX2-only, so they cost FX1 nothing.
 
-⚠️ HARVESTED IS NOT THE SAME AS UNLISTED, and this is the one thing here that takes something away. Leaving a stock effect off a chooser costs it that row and nothing else — its code, descriptor and dispatch stay stock, so an old project that selects it still runs it. Harvesting OFFERS its words to the placer, and it loses its algorithm only where your code actually reached: the region is packed from the lowest address upward and the build reports which survived. So an effect can be `✓⌁` — listed and harvested — right up until something is placed over it.
+⚠️ BOTH menus. An effect off FX2 but still on FX1 is still wanted, and the DSP dispatch is one table shared by them, so overwriting its code would take it off FX1 too.
+
+⚠️ AND IT ONLY COSTS WHERE YOUR CODE REACHES. Your modules go in the largest unbroken run of what you gave up, packed from its lowest address; anything the placer never gets to keeps its algorithm and its dispatch and simply has no chooser row — which is exactly what unlisting a stock effect has always done.
 
 [bold]a reverb you keep listed is spending words[/]
 PLATE, SPRING and DARK REV's code IS the donor region, so the `held by` line is the live trade: what they are holding, and what dropping the next one buys. The region packs from PLATE upward, so holding a LOW reverb also makes the space above it unreachable — keeping PLATE alone leaves 2,130 words by size and 0 you can actually place.
@@ -519,10 +521,6 @@ class RemixerScreen(Screen):
         # be reached from the FX2 slot, and only because FX1's chooser list
         # could not grow where it sits.
         Binding("1", "fx1", "FX1 row", show=False),
-        # "h" for harvest: offer a stock effect's WORDS to the placer. The
-        # third state a stock effect has -- listed, unlisted, harvested --
-        # and the only one that takes something away.
-        Binding("h", "harvest", "harvest", show=False),
         Binding("l", "load", "load"),
         Binding("s", "save", "save"),
         Binding("k", "stock", "reset to stock", show=False),
@@ -888,10 +886,10 @@ class RemixerScreen(Screen):
                 group = g
                 out.append(f"[dim {WARN}]── {g} ──[/]")
             here = self.pane == AVAILABLE and i == self.cur[AVAILABLE]
-            # TWO MARKS, because a stock effect has three states and they are
-            # independent: `✓` is on a chooser, `⌁` is HARVESTED -- its words
-            # offered to the placer, which is the one thing here that takes
-            # something away. An effect can be both until our code reaches it.
+            # TWO MARKS: `✓` is on a chooser, `⌁` is in the region -- off
+            # BOTH choosers, so its words are where your modules go. The
+            # second is DERIVED from the first, which is the point: taking an
+            # effect off both menus is the decision to give up its words.
             mark = ((f"[{OK}]✓[/]" if m.key in st.sel else " ")
                     + (f"[{WARN}]⌁[/]" if m.key in st.harvest else " "))
             menus = "+".join(rig.menus(m, st.fx1)) or "—"
@@ -902,7 +900,7 @@ class RemixerScreen(Screen):
                 cur_line = len(out)
             out.append(f"[reverse]{line}[/]" if here else line)
         out.append("")
-        out.append(f"[dim]enter adds · h harvests its words (⌁)[/]")
+        out.append(f"[dim]enter adds · ⌁ = off both menus, words yours[/]")
         self._paint("#pane_avail", self._fit("#pane_avail", out, cur_line,
                                              head=head, tail=2))
 
@@ -1013,9 +1011,8 @@ class RemixerScreen(Screen):
             # whose fix ADDS rather than removes, `x` applies it first, and a
             # ⚠ saying "x removes Flanger…" while x actually harvested the
             # reverbs is the worst kind of wrong.
-            first = next((p_ for p_ in probs if p_.startswith("nothing is "
-                                                              "harvested")),
-                         None)
+            first = next((p_ for p_ in probs
+                          if p_.startswith("every stock effect")), None)
             return (f"[bold {BAD}]⚠ "
                     f"{escape(first or self._clash(probs) or probs[0])}[/]")
         if self.syncing is not None or self.synced != self.gen:
@@ -1143,7 +1140,7 @@ class RemixerScreen(Screen):
             # EVERY WORD IS A STOCK EFFECT'S. That is what an unmodified unit
             # looks like and the map has to say so, not imply a region is
             # waiting.
-            tries = [f" all {total:,} words allocated — h harvests one ",
+            tries = [f" all {total:,} words allocated to stock effects ",
                      f" all {total:,} words allocated ", f" {total:,} words "]
         elif not any(placed.values()):
             tries = [f" {n_w:,} words yours to place into — none taken yet ",
@@ -2106,17 +2103,6 @@ class RemixerScreen(Screen):
             return bool(getattr(self, "_can_fix", False))
         return True
 
-    def action_harvest(self):
-        """Offer the highlighted stock effect's words to the placer."""
-        st = self.app.state
-        mod = self.selected_module()
-        if mod is None:
-            return
-        st.msg = st.toggle_harvest(mod.key, disp(mod))
-        st.loaded_name = ""
-        self.schedule_sync()
-        self.rerender()
-
     def action_fx1(self):
         """Give the highlighted effect a row on FX1 too, or take it away."""
         st = self.app.state
@@ -2139,11 +2125,17 @@ class RemixerScreen(Screen):
         # image imposes.
         if not st.harvest and [m for m in st.selected if m.dsp is not None]:
             from remix.schema import DEFAULT_HARVEST
-            st.harvest = list(DEFAULT_HARVEST)
+            for k in DEFAULT_HARVEST:
+                if k in st.sel:
+                    st.toggle(k)
+                if k in st.fx1:
+                    st.fx1.remove(k)
             st.loaded_name = ""
-            st.msg = (f"harvested {', '.join(titlecase(k) for k in st.harvest)}"
-                      f" — {stock.region_words(DEFAULT_HARVEST):,} words to "
-                      f"place into. h picks different ones.")
+            st.msg = (f"dropped {', '.join(titlecase(k) for k in DEFAULT_HARVEST)}"
+                      f" from the choosers — "
+                      f"{stock.region_words(DEFAULT_HARVEST):,} words to place "
+                      f"into. Take off different ones for a different region.")
+            self.cur[LOADED] = min(self.cur[LOADED], max(len(st.order) - 1, 0))
             self.schedule_sync()
             self.rerender()
             return

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -1231,9 +1231,17 @@ class RemixerScreen(Screen):
             how = " + ".join(
                 f"{n}× {disp(st.mods[k]) if k in st.mods else titlecase(k)}"
                 for k, n in mix.items()) or "nothing of ours"
+            # ⚠️ STOCK ROWS ARE NOT IN THIS FIGURE, and on a card that mixes
+            # stock and ours freely that is a real hole -- a stock effect
+            # costs cycles when it is selected like any other. Only FILTER's
+            # figure has ever been measured (192/instance, docs/CHIP.md), so
+            # the row says what is missing rather than inventing the rest.
+            nstock = sum(1 for m in st.selected if m.is_stock)
+            gap = (f" · {nstock} stock rows not counted" if nstock else "")
             brief.append(("cycles", f"[{c}]{free:,}[/]"))
             side.append(f" {'cycles':<{W}}[{c}]{free:>5,}[/] free of "
-                        f"{usable:,} [dim]· worst core: {escape(how)}[/]")
+                        f"{usable:,} [dim]· worst core: {escape(how)}"
+                        f"{gap}[/]")
 
         # Rows are countable without a build; the cave is not.
         # Same sentence again: 31 exist, this selection loaded N.
@@ -2215,6 +2223,12 @@ class RemixerScreen(Screen):
 # ---- the app ---------------------------------------------------------------
 class Remixer(App):
     TITLE = "remixer"
+    # ⚠️ TEXTUAL'S COMMAND PALETTE IS OFF. It advertised itself permanently in
+    # the footer (`^p palette`) and offered five things, none of them ours:
+    # Quit and Keys duplicate `q` and `?`, Maximize does nothing useful to a
+    # pane that is not a focusable widget, and Theme and Screenshot are worth
+    # less than the footer space and the "what is that?" it cost.
+    ENABLE_COMMAND_PALETTE = False
     CSS = """
     /* The panes must FILL the row for their left borders to run the whole
        way down -- a Static is only as tall as its text, so the dividers

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -754,28 +754,46 @@ class BenchScreen(Screen):
             return (f" {label:<{W}}[{colour}]" + "#" * bar_full + "[/][dim]"
                     + "." * (bar_len - bar_full) + f"[/]  {tail}")
 
+        # EVERY ROW HERE IS: what exists, minus what this selection loaded.
+        # Nothing is a constant and nothing is a build's leftover.
+        #
+        # ⚠️ A LISTED REVERB IS LOADED. The build reports the whole 2,724 as
+        # free because nothing of OURS is placed yet -- but PLATE, SPRING and
+        # DARK REV's code is what occupies the region, so a reverb you keep
+        # in the chooser is spending its own words. Subtract them like
+        # anything else. That is the correction to "2724 free" on a stock
+        # chooser, which called the region yours while the three effects
+        # living in it were still listed.
+        #
+        # ⚠️ AND ONE PLACE THE PLAIN SUBTRACTION IS TOO GENEROUS: the region
+        # packs from PLATE upward, so holding a LOW reverb makes the space
+        # above it unreachable even though it is unoccupied. Keeping PLATE
+        # alone leaves 2,130 words by size and 0 you can actually place. The
+        # placeable figure is the offset of the lowest reverb kept, which
+        # equals the subtraction for every other combination (verified for
+        # all four).
+        held = [c for c in stock.CONSUMED if c in st.sel]
+        cap = min((stock.consumed_at(c) for c in held), default=DONOR_WORDS)
+        nxt = min(held, key=stock.consumed_at) if held else None
+
+        def words_row(n, used):
+            free = max(0, cap - used)
+            fill = min(20, round(20 * used / DONOR_WORDS))
+            edge = min(20, round(20 * cap / DONOR_WORDS))
+            c = OK if free > 400 else WARN if free > 32 else BAD
+            bar = (f"[{c}]" + "#" * fill + "[/][dim]" + "." * (edge - fill)
+                   + "[/][dim red]" + "-" * (20 - edge) + "[/]")
+            why = (f"  [dim]before {titlecase(nxt)} goes[/]" if nxt and free
+                   else f"  [dim]{titlecase(nxt)} holds the rest[/]" if nxt
+                   else "")
+            return f" {'words ' + n:<{W}}{bar}  {free:>4} free{why}"
+
         if st.regions:
-            for n, used, free in st.regions:
-                fill = min(20, round(20 * used / max(used + free, 1)))
-                c = OK if free > 400 else WARN if free > 32 else BAD
-                out.append(row(f"words {n}", fill, 20, c, f"{free:>4} free"))
+            for n, used, _f in st.regions:
+                out.append(words_row(n, used))
         elif not [m for m in st.selected if m.dsp is not None]:
-            # ⚠️ "????  not built" for a STOCK chooser was a non-answer to a
-            # question with an exact answer. A stock row places no code --
-            # no clone, no words, its dispatch is already in the image -- so
-            # a selection with no modules of ours uses ZERO of the donor
-            # region, on both payloads, and no build is needed to say so.
-            # The "????" only ever appeared here, because that is the one
-            # selection the build refuses.
-            # ⚠️ "all of it" was wrong-headed: the region is never EMPTY.
-            # It holds PLATE+SPRING+DARK's own code, which is exactly why it
-            # is the donor region. "Free" here means "yours to overwrite",
-            # not "unoccupied" -- and reading it as the latter is what
-            # prompted "so the stock doesn't use any of those resources?".
             for n in ("A", "B"):
-                out.append(row(f"words {n}", 0, 20, OK,
-                               f"{DONOR_WORDS:>4} free  "
-                               f"[dim]= the 3 reverbs' code[/]"))
+                out.append(words_row(n, 0))
         else:
             out.append(f" {'words':<{W}}[dim]"
                        + "?" * 20 + "[/]  [dim]not built[/]")
@@ -820,11 +838,13 @@ class BenchScreen(Screen):
                        f"{taken} pinned of 4  [dim]tracks {tracks}[/]{also}")
 
         # Rows are countable without a build; the cave is not.
-        rows = (st.chooser_rows if st.chooser_rows is not None
-                else len(st.menu_modules))
-        c = OK if rows < 24 else WARN if rows < 31 else BAD
-        out.append(f" {'rows':<{W}}[{c}]{rows}[/][dim] of 31 "
-                   f"(the long chooser cave)[/]")
+        # Same rule: 31 exist, this selection loaded N.
+        used_rows = (st.chooser_rows if st.chooser_rows is not None
+                     else len(st.menu_modules))
+        free_rows = 31 - used_rows
+        c = OK if free_rows > 7 else WARN if free_rows else BAD
+        out.append(f" {'rows':<{W}}[{c}]{free_rows}[/][dim] free of 31 "
+                   f"({used_rows} loaded)[/]")
         # Same again for the cave: a stock row clones no descriptor, plants
         # no formatter and cuts no patch, so with no modules of ours the
         # region is untouched. Said in words rather than a number, because
@@ -843,6 +863,8 @@ class BenchScreen(Screen):
         # instantiated effect per block, which no image can reserve. These
         # are the ones a MODULE holds fixed, which is the part composing a
         # remix actually decides.
+        out.append("[dim] # loaded by a module · - held by a listed reverb "
+                   "· . free[/]")
         out.append("[dim] pinned = held by a module; stock effects take "
                    "theirs at runtime[/]")
         self._paint("#pane_budget", out)

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -61,21 +61,39 @@ def step_label(mod, name, v):
 # COLOUR CARRIES MEANING HERE, it does not decorate. Three axes, and nothing
 # else gets colour:
 #
-#   whose is it   OURS is cyan, the box's own is plain. In a remixer that is
+#   whose is it   OURS is aqua, the box's own is plain. In a remixer that is
 #                 the distinction you scan for -- "which of these did we
 #                 write" -- and it was carried by nothing at all.
-#   what state    green fits / yellow is a trade or a caution / red blocks.
-#   what is live  magenta for the one-of-a-kind markers (the fallback).
+#   what state    green fits / ochre is a trade or a caution / red blocks.
+#   what is live  a soft purple for the one-of-a-kind markers (the fallback).
 #
-# ANSI NAMES ON PURPOSE, not hex: the workbench runs Textual's `ansi-dark`
-# so it wears the terminal's own 16 colours (WORKBENCH_THEME overrides), and
-# a hex triple would fight whatever palette Alacritty is set to.
-OURS = "cyan"          # a module from modules/
-OK = "green"           # fits, present, healthy
-WARN = "yellow"        # a trade, a caution, a knob that renders dry
-BAD = "red"            # it will not build
-MARK = "magenta"       # the fallback, and other one-of-a-kind markers
-LCD = "blue"           # the emulated panel's frame
+# ⚠️ THESE WERE ANSI NAMES AND THEY CAME OUT AS SATURATED PRIMARIES --
+# `cyan` rendered #00ffff, `yellow` #ffff00 -- because Rich resolves a name
+# to its standard value rather than delegating to the terminal, so the
+# "it wears your palette" reasoning was simply wrong. Against a warm dark
+# background that read as a wall of electric blue. These are gruvbox's own
+# tones instead: same three axes, desaturated, and chosen to sit on a dark
+# ground rather than shout off it.
+#
+# WHERE colour goes matters as much as which. The knob bars are twelve rows
+# deep, so ONE tint across them made the accent the largest thing on screen
+# and said nothing -- but neutralising them entirely went too far the other
+# way. They are graded by their OWN VALUE instead: a soft warm ramp, so the
+# variety comes from the values themselves and a row's colour means
+# something. No red in the ramp -- a full LP cutoff is not an alarm.
+OURS = "#8ec07c"       # aqua -- a module from modules/
+OK = "#b8bb26"         # green -- fits, present, healthy
+WARN = "#d79921"       # ochre -- a trade, a caution, a knob that renders dry
+BAD = "#fb4934"        # red -- it will not build
+MARK = "#d3869b"       # soft purple -- the fallback, and other lone markers
+LCD = "#665c54"        # the emulated panel's frame: chrome, so it recedes
+SRC = "#83a598"        # muted blue -- the wav you are auditioning on
+BAR = ("#b8bb26", "#d79921", "#fe8019")     # the knob ramp, low -> high
+
+
+def bar_colour(v, hi):
+    """A knob's fill colour, from where it sits in its own range."""
+    return BAR[min(int(3 * v / max(hi, 1)), 2)]
 
 
 # Words that are acronyms, not shouting, and stay upper in a title.
@@ -705,7 +723,7 @@ class BenchScreen(Screen):
             if name == "SOURCE":
                 src = (self.app.source.name if self.app.source
                        else f"(none — no wavs in {source_dir()})")
-                line = f" [dim]SOURCE[/] [{OURS}]{escape(src)}[/]"
+                line = f" [dim]SOURCE[/] [{SRC}]{escape(src)}[/]"
                 out.append(f"[reverse]{line}[/]" if here else line)
                 continue
             v = vals.get(name, 0)
@@ -715,11 +733,11 @@ class BenchScreen(Screen):
                 # accent and a flat bar -- no fill to imply a range it does
                 # not have.
                 shown = f"[{WARN}]{step_label(mod, name, v):<7}[/]"
-                bar = "[dim]" + "·" * 12 + "[/]"
+                bar = f"[{LCD}]" + "·" * 12 + "[/]"
             else:
                 shown = f"{v:>3}    "
                 fill = round(12 * v / max(hi, 1))
-                bar = (f"[{OURS}]" + "#" * fill + "[/][dim]"
+                bar = (f"[{bar_colour(v, hi)}]" + "#" * fill + "[/][dim]"
                        + "." * (12 - fill) + "[/]")
             page = "1" if slot < 6 else "2"
             line = f" {name:<6} {shown}[dim]\\[[/]{bar}[dim]] p{page}[/]"
@@ -728,7 +746,7 @@ class BenchScreen(Screen):
             out.append("[dim] (no drawn parameters)[/]")
         dry = self.dry_control(mod, vals)
         if dry:
-            out.append(f"[bold {WARN}]⚠ {dry} is 0 — this renders DRY[/]")
+            out.append(f"[{WARN}]⚠ {dry} is 0 — this renders DRY[/]")
         if self.pane == UNIT and knobs:
             name, _ = knobs[min(self.cur[UNIT], len(knobs) - 1)]
             hint = (f"the wav auditioned through this effect — left/right "

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -388,7 +388,11 @@ Five things, and the Budget strip is one row for each: the two donor regions of 
 
 CYCLES is the one that does not fail as a refusal. Over budget the DSP does not decline to build, it wedges — so the row prices the WORST core under the worst mix this selection allows, which for a card of inserts is four copies of the dearest one: nothing stops all four tracks selecting it. The budget of 3,120 is what our code may spend after stock's own share, measured 23 Aug 2026, and the count is a floor: exact for the code, optimistic about memory contention.
 
-Rows are NOT the scarce thing, which is why `enter` adds rather than swaps: 31 rows fit, and a stock effect costs zero words because its code is already in the image whether or not it has a row. Leaving a stock effect out takes its chooser row and nothing else — an old project that selects it still runs it.
+Rows are NOT the scarce thing, which is why `enter` adds rather than swaps: 31 rows fit, and leaving a stock effect out takes its chooser row and nothing else — an old project that selects it still runs it.
+
+⚠️ TODAY THE DONOR REGION IS FIXED, and that is a property of this BUILD, not of the machine. Every effect states what it occupies — `727 words, already placed` for FILTER, `2,411 of 2,724 words` for ChonVerb — but only one region is currently harvestable: the 2,724 words PLATE, SPRING and DARK REV's code occupies, which is the only space `build_bus.py` will place a module into. So dropping FILTER frees none of its 727 *yet*.
+
+Measured 3 Sep 2026 and it says the limit is ours to lift: the thirteen DSP effects are laid out CONTIGUOUSLY in 6,158 words (`P:0x007d1..0x01fdf`, no other module between them), and every one of them is SELF-CONTAINED — no control flow leaves its own span and nothing enters it but its own dispatch entry. So any effect's words could be freed by dropping it, and a run of dropped neighbours would be one bigger region. What that costs is the effect itself: today an unlisted stock effect keeps working and only loses its row, and one harvested for its words would not.
 
 [bold]a reverb you keep listed is spending words[/]
 PLATE, SPRING and DARK REV's code IS the donor region, so the `held by` line is the live trade: what they are holding, and what dropping the next one buys. The region packs from PLATE upward, so holding a LOW reverb also makes the space above it unreachable — keeping PLATE alone leaves 2,130 words by size and 0 you can actually place.

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -365,9 +365,11 @@ It is the only way to see the PANEL side of an image without flashing one. The r
 
 That is a real class of bug and it has cost real days here: a cloned descriptor inherits its donor's display formatter, so a slot can carry the right count, default and name and still draw as something else entirely — or as nothing. Three of six page-2 slots drew wrong on one flash and every check passed, because every field they checked was right.
 
-TWO INDEPENDENT THINGS SHARE THE PAGE, which is why the columns beside a row are not that row's: the chooser list scrolls down the left, and the knob names belong to whichever effect the TRACK has selected — the one named in the caption, marked `▸` when its row is on screen.
+An FX page is shown as what it IS, not as a picture of the screen: the effect's knob names in the unit's own words, in the banks the encoders are in, and the chooser rows the firmware listed (`▸` marks the one this page is for). ⚠️ A picture is not available: the chooser list and the parameter block are two overlaid WINDOWS whose coordinates are not comparable — fourteen text baselines in 64 pixels with a 7 px font — so flattening them into one grid interleaves them and reads as a mapping from each row to the labels beside it, which is not what any of it means. The strings are still the firmware's own; only their arrangement stops being a reconstruction.
 
-Honest limits: knob VALUES draw as dial graphics the string capture cannot read, so the numbers in the pane above are the truth for values and the picture is the truth for names. Nothing here touches hardware.
+MAIN MENU stays a picture, because it is one window of two plain lists and flattening it loses nothing — and seeing a patched-in top-level row drawn where it will be is the whole reason that view exists.
+
+Honest limits: knob VALUES draw as dial graphics the string capture cannot read, so only a stepped select prints one; the numbers in the pane above are the truth for values. Nothing here touches hardware.
 
 [bold]what an FX1 row costs[/]
 No words: the DSP dispatch table is indexed by the raw id and shared by both menus, so an effect's code already ran from FX1 the moment FX1 selected its id. It costs CYCLES — FX1 is four more slots on the same four tracks, so an effect on both menus can double the worst per-core load; watch the Budget's `cycles` row.
@@ -1426,9 +1428,81 @@ class RemixerScreen(Screen):
                                            effect_id=effect_id or 0x04)
         else:
             draws = emu_bringup.render_fx2(r, track=4, effect_id=effect_id)
-        grid = emu_bringup.layout_screen(draws)
-        self._panel_cache = (key, grid)
-        return grid
+        # The RAW draws, because the two readings of them -- the structured
+        # one for an FX page and the picture for the menu -- are both derived
+        # and only the capture is expensive.
+        self._panel_cache = (key, list(draws))
+        return self._panel_cache[1]
+
+    def _page(self, mod, draws):
+        """An FX page as what it IS: the effect's knob names in the unit's
+        own words, in the banks the encoders are in, and the chooser rows.
+
+        ⚠️ NOT A PICTURE OF THE SCREEN. The list and the parameter block are
+        two overlaid windows whose y origins are not comparable (fourteen
+        text baselines in 64 pixels with a 7 px font -- emu_bringup's
+        read_screen has the measurement), so flattening them into one grid
+        interleaves them and reads as a mapping from each chooser row to the
+        labels beside it. The STRINGS are still the firmware's own, which is
+        the whole point of the view; only their arrangement stops being a
+        reconstruction.
+        """
+        import emu_bringup
+        scr = emu_bringup.read_screen(draws)
+        # WHICH PAGE A ROW BELONGS TO, decided against the effect's own
+        # parameters rather than against the pixel columns -- and by MAJORITY,
+        # because a select's VALUE can coincide with a parameter's name
+        # (`BASE` is both one of FILTER's page-1 knobs and what its page-2
+        # ENV prints).
+        page = {n: ("page 1" if slot < 6 else "page 2")
+                for n, slot in self.unit_rows(mod) if n != "SOURCE"}
+        banks = {"page 1": [], "page 2": [], "": []}
+        lev = None
+        for row in scr["params"]:
+            if row and row[0] == "LEV":
+                lev, row = row[0], row[1:]
+            votes = [page.get(n, "") for n in row]
+            kind = max(set(votes), key=votes.count) if votes else ""
+            banks[kind].append(row)
+        out = []
+        w = 6
+        for kind in ("page 1", "page 2", ""):
+            if not banks[kind]:
+                continue
+            line = f" [dim]{kind:<7}[/]" if kind else " " * 8
+            # LEV IS ITS OWN COLUMN, not a fourth entry in the first bank:
+            # the unit puts it on the page-1 name row and the banks are
+            # threes, so folding it in knocked every column after it out of
+            # step with the rows below.
+            line += (lev or "").ljust(w)
+            for bank in banks[kind]:
+                line += "".join(escape(n).ljust(w) for n in bank).ljust(3 * w)
+                line += "  "
+            out.append(line.rstrip())
+            lev = None
+        if not out:
+            out = ["[dim] no parameters drawn[/]"]
+        # AND THE CHOOSER ROWS the firmware actually listed -- the visible
+        # window of them, which is what the capture holds.
+        want = disp(mod).lower()
+        names = [("[reverse]▸" + escape(n) + "[/]")
+                 if n.lower().startswith(want) else escape(n)
+                 for n in scr["list"]]
+        out.append("")
+        # PACKED, not truncated: seven chooser names on one line runs off the
+        # pane, and the one that gets cut is as likely to be the one you were
+        # looking for as any other.
+        room = self.query_one("#pane_unit", Static).content_size.width - 2
+        lead, lines, cur = f" [dim]{self.preview} rows on screen[/] ", [], ""
+        for n in names:
+            bit = (" [dim]·[/] " if cur else "") + n
+            if cur and self._vis(lead + cur + bit) > room:
+                lines.append(lead + cur)
+                lead, cur = " " * 20, n
+            else:
+                cur += bit
+        out += lines + [lead + cur]
+        return out
 
     def _preview(self, mod, probs, room=0):
         st = self.app.state
@@ -1450,8 +1524,7 @@ class RemixerScreen(Screen):
         # belong to whichever effect the TRACK has selected.
         slot = self.preview
         what = ("the main menu, as the unit draws it" if slot == "MENU"
-                else f"the {slot} menu's rows, and {escape(disp(mod))}'s "
-                     f"knob names")
+                else f"{escape(disp(mod))}'s page, in the unit's own words")
         head = [f"preview {modes}  [dim](p)[/]", f"[dim]{what}[/]"]
         # DO NOT DRAW SOMETHING THAT IS NOT THE SELECTION. The FX2 page
         # includes the firmware's own chooser list, so an image that is not
@@ -1500,20 +1573,14 @@ class RemixerScreen(Screen):
                 # of the wrong effect (CLAUDE.md, 12 Aug 2026).
                 return head[:1] + ["[dim]not in the image yet[/]"]
             effect_id = mod.menu.fx2_id
-        grid = self._panel(self.preview, effect_id)
-        # ⚠️ MARK THE SELECTED ROW. The page draws TWO independent things --
-        # the chooser list down the left, and the knob names of whichever
-        # effect the track has selected -- and our capture puts them on the
-        # same text rows, so `ChonVerb78   SHMR MODE DIFF` reads as a mapping
-        # from that row to those knobs. It is not one: the names belong to
-        # the selection, and the row beside them is just the next row of the
-        # list. The unit says which row is selected by XOR-highlighting it,
-        # which the string-capture hook cannot read (docs/EMU.md) -- but we
-        # know which effect we asked for, so say it here.
-        if effect_id is not None:
-            want = disp(mod).lower()
-            grid = [("▸" + ln[1:] if ln[1:].lower().startswith(want) else ln)
-                    for ln in grid]
+        draws = self._panel(self.preview, effect_id)
+        if self.preview != "MENU":
+            return head + self._page(mod, draws)
+        # THE MAIN MENU STAYS A PICTURE. It is one window of two plain lists,
+        # so flattening it loses nothing -- and the whole reason for the view
+        # is to see a patched-in top-level row drawn where it will be.
+        import emu_bringup
+        grid = emu_bringup.layout_screen(draws)
         # The LCD frame is chrome; the firmware's own words are the content.
         edge = f"[{LCD}]"
         # The LCD is 32 characters wide (128 px / a 4 px cell, measured), and
@@ -1526,6 +1593,8 @@ class RemixerScreen(Screen):
         # give up when the pane is short.
         while grid and not grid[-1].strip():
             grid.pop()
+        while grid and not grid[0].strip():
+            grid.pop(0)          # the menu opens with an empty line
         cut = len(head) + len(grid) + 2 - room
         if room and len(grid) - cut < 4:
             # Below a few rows the box says nothing and costs the lines it

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -26,9 +26,11 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
+import time
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
@@ -55,13 +57,48 @@ def step_label(mod, name, v):
     return lab[v] if lab and v < len(lab) else str(v)
 
 
+# Words that are acronyms, not shouting, and stay upper in a title.
+_ACRONYMS = {"DJ", "EQ", "FX", "HP", "LP", "MS", "AB"}
+
+
+def titlecase(s: str) -> str:
+    """One naming rule for every name the workbench prints.
+
+    The lists mixed three conventions and it showed: OUR modules carry a
+    panel name in camel case (`BongDelay`), the STOCK effects carry the
+    firmware's own, which is upper (`DJ EQUALIZER`, `LO-FI`), and a module
+    with no chooser row falls back to its directory slug (`tempo-sync`). So
+    one column read BongDelay / EQUALIZER / tempo-sync.
+
+    Deliberate inner capitals are LEFT ALONE -- `BongDelay` must not become
+    `Bongdelay`, which is the failure mode of a naive .title(). A word is
+    only re-cased when it is entirely upper (or entirely lower), and known
+    acronyms keep their case.
+
+    ⚠️ This is the WORKBENCH's own text only. The emulated panel draws
+    strings captured from the firmware and is never re-cased -- it has to
+    show what the unit shows.
+    """
+    def word(w):
+        if not w:
+            return w
+        if w.upper() in _ACRONYMS:
+            return w.upper()
+        if not w.isupper() and any(c.isupper() for c in w[1:]):
+            return w                      # BongDelay, ChonVerb, WarpFold
+        return w[:1].upper() + w[1:].lower()
+    parts = re.split(r"([ \-/]+)", s)
+    return "".join(word(p) if i % 2 == 0 else p
+                   for i, p in enumerate(parts))
+
+
 def disp(mod) -> str:
     """What to CALL a module on screen: the name the panel shows, not the
     directory slug. `warpfold` is a path; `WarpFold` is what the operator
     reads on the unit."""
     if mod.menu is not None:
-        return mod.menu.fullname.decode("latin1") or mod.name
-    return mod.name
+        return titlecase(mod.menu.fullname.decode("latin1") or mod.name)
+    return titlecase(mod.name)
 
 
 # Where the SOURCE row browses. out/dry/ is the curated dry set and stays the
@@ -199,8 +236,10 @@ itself, so the panel is never showing something else.
 
 [bold]keys[/]
   tab  pane            up/down  move
-  enter  SWAP the ▸ row for this one (at (end): append); on a
-         selected module, remove it
+  enter  in AVAILABLE: SWAP the ▸ row in LOADED for this one
+         (at (end): append). On one already in the image it just
+         points at its row -- THE LIBRARY ONLY ADDS.
+         in LOADED: remove the row you are on.
   left/right  knob value (UNIT) or row order (LOADED)
               hold to run; SHIFT+left/right steps by TEN
   r  render + hear     space  play last    p  preview mode
@@ -241,7 +280,15 @@ what the ⚠ is telling you to remove.
 [bold]the fallback[/]
 An id the image does not implement aliases to the FALLBACK — normally
 SEND, so an old project degrades to a send instead of noise. It is added
-for you when a selection needs one; `f` chooses another. ◀fb marks it.""",
+for you when a selection needs one; `f` chooses another. ◀fb marks it.
+
+[bold]you cannot get the three reverbs back[/]
+Not from here, and it is not the workbench refusing. Every buildable
+selection needs a fallback and SEND is the only safe one; SEND carries
+DSP code; and `build_bus.py` repoints PLATE/SPRING/DARK REV to the null
+stub UNCONDITIONALLY, whether or not code was placed over them. So every
+image loses them. PLAN.md §7 has the two build changes that would fix it
+and the argument for closing it instead.""",
 }
 
 
@@ -332,6 +379,15 @@ class BenchScreen(Screen):
         self.syncing = None
         self.sync_error = None
         self._panel_cache = (None, None)   # see _panel()
+        self._painted = {}                 # see _paint()
+        # COALESCED REPAINT. A held arrow key delivers events faster than
+        # three panes can be rebuilt, and rendering each one in turn is what
+        # makes the UI trail the key and overshoot after release. The VALUE
+        # changes on every event; the SCREEN catches up at 60 Hz, however
+        # many events arrived in between.
+        self._dirty = False
+        self.set_interval(1 / 60, self._flush)
+        self._run = (None, True, 0.0, 0)   # see _accel()
         self.query_one("#log", RichLog).display = False
         self.rerender()
 
@@ -435,7 +491,20 @@ class BenchScreen(Screen):
         self._pane_available(st)
         self._pane_loaded(st, probs)
         self._pane_unit(st, probs)
-        self.query_one("#status", Static).update(f"[dim]{escape(st.msg)}[/]")
+        self._paint("#status", f"[dim]{escape(st.msg)}[/]")
+
+    def _paint(self, wid, lines):
+        """Update a pane only when its TEXT changed.
+
+        Handing Textual an identical string still costs a Static re-render
+        and a screen diff, and a knob keystroke changes ONE pane -- the other
+        two were being rebuilt and re-diffed for nothing on every key.
+        """
+        text = "\n".join(lines) if isinstance(lines, list) else lines
+        if self._painted.get(wid) == text:
+            return
+        self._painted[wid] = text
+        self.query_one(wid, Static).update(text)
 
     def _title(self, text, pane):
         on = self.pane == pane
@@ -444,10 +513,10 @@ class BenchScreen(Screen):
 
     def _pane_available(self, st):
         rows = self.avail_rows()
-        out = [self._title("AVAILABLE", AVAILABLE), ""]
+        out = [self._title("Available", AVAILABLE), ""]
         group = None
         for i, m in enumerate(rows):
-            g = "stock effects" if m.is_stock else rig.category(m)
+            g = "Stock Effects" if m.is_stock else titlecase(rig.category(m))
             if g != group:
                 group = g
                 out.append(f"[dim]── {g} ──[/]")
@@ -458,12 +527,12 @@ class BenchScreen(Screen):
             out.append(f"[reverse]{line}[/]" if here else line)
         out.append("")
         out.append("[dim]enter SWAPS with ▸ in LOADED[/]")
-        self.query_one("#pane_avail", Static).update("\n".join(out))
+        self._paint("#pane_avail", out)
 
     def _pane_loaded(self, st, probs):
         rows = self.loaded_rows()
         name = st.loaded_name or "unsaved"
-        out = [self._title(f"LOADED · {name}", LOADED), ""]
+        out = [self._title(f"Loaded · {name}", LOADED), ""]
         pos = 0
         at = min(self.cur[LOADED], len(rows))      # the insertion point
         for i, m in enumerate(rows):
@@ -504,14 +573,14 @@ class BenchScreen(Screen):
         # and read as a fourth mystery row.
         eats = [m for m in st.selected if m.dsp is not None]
         if eats:
-            out.append("[dim] —  PLATE, SPRING, DARK REV (donors)[/]")
+            out.append("[dim] —  Plate, Spring, Dark Rev (donors)[/]")
         else:
             for cname in stock.CONSUMED:
                 pos += 1
-                out.append(f"[dim] {pos:>2} {cname:<13}FX2[/]")
+                out.append(f"[dim] {pos:>2} {titlecase(cname):<13}FX2[/]")
         out.append("")
         out.append(self._ledger_line(st, probs))
-        self.query_one("#pane_load", Static).update("\n".join(out))
+        self._paint("#pane_load", out)
 
     def _ledger_line(self, st, probs):
         """The fit, the blocker and the build state, in ONE line.
@@ -539,16 +608,21 @@ class BenchScreen(Screen):
         if st.regions:
             return "[dim]" + " · ".join(
                 f"{n} {f} free" for n, _u, f in st.regions) + "[/]"
-        return "[dim]a stock chooser: 14 effects, no modules[/]"
+        # No build has reported yet. Say which of the two reasons it is --
+        # this line used to claim "a stock chooser: 14 effects, no modules"
+        # for ANY unmeasured selection, including chongbong, which has three.
+        if not [m for m in st.selected if m.dsp is not None]:
+            return "[dim]a stock chooser: 14 effects, no modules[/]"
+        return "[dim]building…[/]"
 
     def _pane_unit(self, st, probs):
         mod = self.selected_module()
         if mod is None:
-            self.query_one("#pane_unit", Static).update(
-                self._title("UNIT", UNIT) + "\n\n[dim]nothing selected[/]")
+            self._paint("#pane_unit",
+                        self._title("Unit", UNIT) + "\n\n[dim]nothing selected[/]")
             return
         out = [self._title(disp(mod), UNIT), ""]
-        bits = [rig.category(mod)]
+        bits = [titlecase(rig.category(mod))]
         if mod.menu:
             bits.append(f"id 0x{mod.menu.fx2_id:02x}")
             bits.append("+".join(rig.menus(mod)))
@@ -599,7 +673,7 @@ class BenchScreen(Screen):
                    "[dim]tab here to change values and audition[/]")
         out.append("")
         out += self._preview(mod, probs)
-        self.query_one("#pane_unit", Static).update("\n".join(out))
+        self._paint("#pane_unit", out)
 
     # ---- the emulated panel ---------------------------------------------
     def _panel(self, mode, effect_id):
@@ -733,6 +807,15 @@ class BenchScreen(Screen):
         self.app.call_from_thread(self.rerender)
 
     # ---- input -----------------------------------------------------------
+    def rerender_soon(self):
+        """Mark the screen stale; _flush draws it on the next frame."""
+        self._dirty = True
+
+    def _flush(self):
+        if self._dirty:
+            self._dirty = False
+            self.rerender()
+
     def action_pane(self, d):
         self.pane = (self.pane + d) % 3
         self.rerender()
@@ -764,7 +847,38 @@ class BenchScreen(Screen):
                 return
         else:
             return
-        self.rerender()
+        # Coalesced: holding a key steps the value every event and repaints
+        # once a frame. Every other path still renders immediately.
+        self.rerender_soon()
+
+    # A HELD KEY ACCELERATES. The workbench stopped being the limit once the
+    # panel render was cached (0.012 ms per key event, 86k/s) -- but macOS
+    # repeats a held key at its default ~15/s after a 375 ms delay, so a
+    # 0..127 knob still took ~8.5 s to sweep and there is nothing an app can
+    # do about the RATE. So change the STEP instead: a run of events close
+    # together is a hold, and a hold means "get there", while a single tap
+    # still moves exactly one. Sweeps the full range in ~1.3 s at 15/s.
+    _RUN_GAP = 0.20              # longer than a 15/s repeat (66 ms), well
+                                 # under a deliberate double-tap
+    _RUN_STEPS = ((18, 16), (10, 8), (4, 4))   # (events held, multiplier)
+
+    def _accel(self, step, name, hi):
+        """The multiplier for this event, given how long the key has been
+        down. Only for the ±1 path -- shift is already an explicit ×10."""
+        now = time.monotonic()
+        same = (name == self._run[0]
+                and (step > 0) == self._run[1]
+                and now - self._run[2] < self._RUN_GAP)
+        run = self._run[3] + 1 if same else 0
+        self._run = (name, step > 0, now, run)
+        # A SELECT MUST NOT ACCELERATE: MODE has five positions and flying
+        # past them is not "faster", it is unusable. hi // 8 is 0 for every
+        # stepped slot and 15 for a 0..127 knob, so this gates itself.
+        ceiling = max(1, hi // 8)
+        for need, mult in self._RUN_STEPS:
+            if run >= need:
+                return step * min(mult, ceiling)
+        return step
 
     def adjust(self, step):
         """Change the selected row. Knob values live per MODULE."""
@@ -775,14 +889,19 @@ class BenchScreen(Screen):
             return
         name, _ = knobs[min(self.cur[UNIT], len(knobs) - 1)]
         if name == "SOURCE":
+            # Never accelerated: skipping files is not a faster way to pick
+            # one, and the list is short.
             files = wav_sources()
             if files:
                 i = (files.index(self.app.source)
                      if self.app.source in files else 0)
-                self.app.source = files[(i + step) % len(files)]
+                self.app.source = files[(i + (1 if step > 0 else -1))
+                                        % len(files)]
             return
         vals = st.knobs_for(mod)
         hi = rig.knob_max(mod, name)
+        if abs(step) == 1:
+            step = self._accel(step, name, hi)
         vals[name] = max(0, min(hi, vals.get(name, 0) + step))
 
     def move_row(self, step):
@@ -803,8 +922,20 @@ class BenchScreen(Screen):
             rows = self.avail_rows()
             mod = rows[min(self.cur[AVAILABLE], len(rows) - 1)]
             if mod.key in st.sel:
-                st.toggle(mod.key)
-                st.msg = f"removed {disp(mod)}"
+                # ⚠️ THIS USED TO REMOVE IT, and that cost a chongbong user
+                # both servers. A ✓ in the LIBRARY means "already in the
+                # image", so `enter` there reads as "select this", not
+                # "throw it out" -- and once the first server was gone the ▸
+                # had moved onto the OTHER one, so re-adding the first
+                # swapped the second away. One keystroke, both servers lost,
+                # and nothing on screen said that was the deal.
+                # The library ADDS. LOADED removes. Point at the row.
+                self.pane = LOADED
+                self.cur[LOADED] = st.order.index(mod.key)
+                st.msg = (f"{disp(mod)} is already in the image — "
+                          f"enter here removes it")
+                self.rerender()
+                return
             else:
                 # SWAP, not insert. An image is a fixed budget -- 2,724
                 # words and a list somebody has to scroll -- so putting
@@ -835,7 +966,7 @@ class BenchScreen(Screen):
             mod = rows[self.cur[LOADED]]
             st.toggle(mod.key)
             st.loaded_name = ""
-            st.msg = f"removed {mod.key}"
+            st.msg = f"removed {disp(mod)}"
             self.cur[LOADED] = max(0, self.cur[LOADED] - 1)
             self.schedule_sync()
         self.rerender()

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -1091,7 +1091,6 @@ class RemixerScreen(Screen):
         held = [c for c in stock.CONSUMED if c in st.sel]
         nxt = min(held, key=stock.consumed_at) if held else None
 
-        seen = set()                            # which bar glyphs are drawn
         # THE SAME FOUR ANSWERS, for a terminal with no room for the rows.
         # Collected as (label, coloured number) while the full rows are
         # built, so the short form cannot drift from the long one.
@@ -1099,8 +1098,6 @@ class RemixerScreen(Screen):
 
         def words_row(n, total, used):
             free, cap = placeable(st.sel, total, used)
-            seen.update(g for g, n in (("#", used), ("-", total - cap),
-                                       (".", free)) if n)
             fill = min(20, round(20 * used / total))
             edge = max(fill, min(20, round(20 * cap / total)))
             c = OK if free > 400 else WARN if free > 32 else BAD
@@ -1113,12 +1110,14 @@ class RemixerScreen(Screen):
         if st.regions:
             for n, total, used, _f in st.regions:
                 out.append(words_row(n, total, used))
+            out.append(None)                # the key goes here -- see below
         elif not [m for m in st.selected if m.dsp is not None]:
             # No build to read -- and none is possible, because a selection
             # with no module of ours has no fallback to name. The region is
             # still fully accounted for: the three reverbs are in it.
             for n in ("A", "B"):
                 out.append(words_row(n, DONOR_WORDS, 0))
+            out.append(None)
         else:
             # WHY it is not built, not just that it is not. This row is where
             # the eye lands after the gesture that broke the selection, and
@@ -1277,9 +1276,16 @@ class RemixerScreen(Screen):
         # -- which is fair, because it IS three unrelated definitions, and
         # the only thing on the pane a reader cannot decode from the words
         # beside it. Aligned under the label column so it reads as a key.
-        key = [(g, w) for g, w in (("#", "loaded by a module"),
-                                   ("-", "held by a reverb you kept listed"),
-                                   (".", "free")) if g in seen]
+        # ⚠️ THERE IS NO GLYPH LEGEND ANY MORE. It sat at the bottom of the
+        # strip labelled `bar`, in the same label column as `words A`,
+        # `cycles` and `cave` -- so it read as a fifth scarce thing called
+        # "bar" whose value was "held by a reverb you kept listed". Moving it
+        # under the bars it decodes fixed the mislabelling and left the
+        # better question standing: every row already says in WORDS what its
+        # bar says in glyphs (`0 free of 2,724 · 0 loaded`, `held by Plate,
+        # Spring, Dark`), so the legend was decoding a picture of a sentence
+        # printed beside it.
+        out = [ln for ln in out if ln is not None]
         # A SHORT TERMINAL GETS THE NUMBERS, NOT THE ROWS. Nine lines of
         # budget out of twenty-four is the pane crowding out the thing it is
         # supposed to be read against. One line keeps every figure and the
@@ -1303,20 +1309,7 @@ class RemixerScreen(Screen):
             self._budget_resized(len(lines) + 1)
             self._paint("#pane_budget", lines + [cur])
             return
-        rows, wide = self._two_up(out, side)
-        # THE KEY FOLLOWS THE LAYOUT. Stacked, it is one glyph per line --
-        # three definitions strung along one line read as a run-on sentence,
-        # which is what it was until 2 Sep 2026. Side by side there is room
-        # to space them out, and wide gaps make three columns of a key
-        # rather than a sentence.
-        if wide and len(key) > 1:
-            rows.append(f" {'bar':<{W}}[dim]"
-                        + "".join(f"{g}  {w}".ljust(38) for g, w in key)
-                        + "[/]")
-        else:
-            for i, (glyph, what) in enumerate(key):
-                rows.append(f" {'bar' if not i else '':<{W}}"
-                            f"[dim]{glyph}  {what}[/]")
+        rows, _wide = self._two_up(out, side)
         # Its own height is what the panes above are laid out against, so a
         # change in it invalidates them.
         self._budget_resized(len(rows))
@@ -1372,10 +1365,16 @@ class RemixerScreen(Screen):
         # WHAT IT COSTS, while you are still deciding. "Will this fit beside
         # what I already have" is what the library pane is really asked, and
         # every answer used to arrive only as a refusal after adding it.
+        # ⚠️ ONE LINE EACH, which is how resources() has always returned
+        # them and what docs/REMIXER.md's "one line per menu" describes.
+        # Joining them with ` · ` made one long sentence that Textual then
+        # flowed, so the FX1 and FX2 answers broke across lines mid-phrase
+        # and a simple fact read as a caveat -- which is the exact mistake
+        # that split them into separate strings in the first place.
         res = rig.resources(mod, st.words.get(mod.key), st.fx1,
                             mod.key in st.sel)
-        if res:
-            out.append(f"[{WARN}]{escape(' · '.join(res))}[/]")
+        for line in res:
+            out.append(f"[{WARN}]{escape(line)}[/]")
         out.append("")
 
         head = len(out)
@@ -1599,24 +1598,23 @@ class RemixerScreen(Screen):
         self.rerender_soon()
 
     def describe(self):
-        """The status line follows the CURSOR, not the last thing you did.
+        """Moving the cursor CLEARS the status line.
 
-        It was an action log -- "added Nimbus · added Send as the fallback" --
-        which is read as context for whatever is under the cursor now, so it
-        went stale the moment you scrolled and described a row you had left.
-        An action still writes it; moving replaces it.
+        ⚠️ IT USED TO REPEAT THE UNIT PANE. Every cursor move wrote the
+        effect's category, id, resource sentence and membership into the
+        status bar -- which is word for word what the UNIT pane already
+        prints under the effect's name, except that the pane WRAPS and this
+        was one row, so the copy that got truncated mid-sentence was the
+        redundant one. Deleted rather than moved: a column of the budget
+        strip is 62 columns against the 138 this already had, so "give it
+        more room" and "put it in the strip" pull opposite ways.
+
+        Clearing is what is left, and it is the right half of the old
+        behaviour: an action message ("added Nimbus · added Send as the
+        fallback") is context for the moment it happened, so it must not
+        still be sitting there describing a row you have since left.
         """
-        st = self.app.state
-        mod = self.selected_module()
-        if mod is None or self.pane == UNIT:
-            return
-        bits = [rig.category(mod)]
-        if mod.menu is not None:
-            bits.append(f"id 0x{mod.menu.fx2_id:02x}")
-        bits += rig.resources(mod, st.words.get(mod.key), st.fx1,
-                              mod.key in st.sel)
-        bits.append("in the image" if mod.key in st.sel else "not in the image")
-        st.msg = f"{disp(mod)} — {' · '.join(bits)}"
+        self.app.state.msg = ""
 
     def rerender_soon(self):
         """Mark the screen stale; _flush draws it on the next frame."""
@@ -2234,7 +2232,8 @@ class Remixer(App):
     #pane_budget { height: auto; padding: 0 1;
                    border-top: dashed $surface; }
     #tabbar { height: 1; padding: 0 1; }
-    #status { height: 1; padding: 0 1; }
+    /* auto, so an empty status line takes no row at all. */
+    #status { height: auto; padding: 0 1; }
     #log { height: 12; border-top: dashed $surface; }
     """
     MODES = {"remixer": RemixerScreen}

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -283,7 +283,7 @@ itself, so the panel is never showing something else.
   r  render + hear     space  play last    p  preview mode
   a / b  park what you hear as A / B      , / .  play A / B
   x  apply the ⚠'s own fix
-  d  source folder     l  load remix       s  save remix
+  d  sample folder     l  load remix       s  save remix
   c  full check        f  fallback         k  back to stock
   ?  this
 
@@ -391,9 +391,14 @@ class BenchScreen(Screen):
     BINDINGS = [
         Binding("tab", "pane(1)", "pane"),
         Binding("shift+tab", "pane(-1)", "prev pane", show=False),
-        Binding("enter", "add_remove", "swap / remove"),
+        # "swap / remove" was stale from the moment enter stopped swapping.
+        Binding("enter", "add_remove", "add / remove"),
         Binding("r", "render", "hear it"),
         Binding("space", "play", "play last"),
+        # The sample folder belongs on the footer: it is the one setting that
+        # is about YOUR material rather than about the image, so it is the
+        # one a new pair of hands looks for and cannot guess.
+        Binding("d", "source_dir", "sample folder"),
         Binding("p", "preview", "preview page", show=False),
         Binding("a", "mark('A')", "A = this", show=False),
         Binding("b", "mark('B')", "B = this", show=False),
@@ -402,10 +407,9 @@ class BenchScreen(Screen):
         Binding("x", "fix", "apply the fix", show=False),
         Binding("c", "build('check')", "full check", show=False),
         Binding("f", "fallback", "fallback", show=False),
-        Binding("l", "load", "load remix"),
-        Binding("s", "save", "save remix"),
+        Binding("l", "load", "load"),
+        Binding("s", "save", "save"),
         Binding("k", "stock", "reset to stock", show=False),
-        Binding("d", "source_dir", "source folder", show=False),
         Binding("question_mark", "help", "what is this?"),
         Binding("q", "app.quit", "quit"),
     ]
@@ -1167,8 +1171,19 @@ class BenchScreen(Screen):
         if buf:
             gone = self.blockers(probs)
             if gone:
-                return ("x removes " + ", ".join(disp(m) for m in gone)
-                        + " — they need the same buffer")
+                # NAME THE CULPRIT AND COUNT THEM. Listing seven effects
+                # took four lines of the pane and still did not say WHY or
+                # WHICH module was doing it -- "why did adding nimbus remove
+                # so many?" is the question it produced. The list is one
+                # keystroke away and the reason is what is actually wanted.
+                st = self.app.state
+                pin = [m for m in st.selected
+                       if getattr(m, "claims", None) is not None
+                       and m.claims.owns_fx2_buffers]
+                who = disp(pin[0]) if pin else "this module"
+                return (f"{who} pins the buffer {len(gone)} stock effect"
+                        f"{'s' if len(gone) != 1 else ''} allocate — "
+                        f"x removes them")
             names = [p.split(":", 1)[1].split(" and ")[0].strip().upper()
                      for p in buf]
             return "also remove " + ", ".join(names)

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -236,17 +236,31 @@ itself, so the panel is never showing something else.
 
 [bold]keys[/]
   tab  pane            up/down  move
-  enter  in AVAILABLE: SWAP the ▸ row in LOADED for this one
-         (at (end): append). On one already in the image it just
-         points at its row -- THE LIBRARY ONLY ADDS.
+  enter  in AVAILABLE: ADD it to the image. On one already in,
+         just point at its row -- THE LIBRARY ONLY ADDS.
          in LOADED: remove the row you are on.
   left/right  knob value (UNIT) or row order (LOADED)
               hold to run; SHIFT+left/right steps by TEN
   r  render + hear     space  play last    p  preview mode
-  a  mark it A         , / .  play A / B
+  a / b  park what you hear as A / B      , / .  play A / B
+  x  apply the ⚠'s own fix
   d  source folder     l  load remix       s  save remix
   c  full check        f  fallback         k  back to stock
   ?  this
+
+[bold]adding does not displace anything[/]
+`enter` used to SWAP -- the new effect took the highlighted row's slot
+and that row was dropped. That was the ledger's scarcity applied to your
+gesture, where it does not belong: the chooser cave holds 31 rows and a
+STOCK row costs zero words (no code placed, no descriptor cloned). Only
+WORDS are scarce, and only for modules of ours. So `enter` adds, and the
+one line under LOADED speaks up if the budget is actually breached.
+
+[bold]A / B compares two EFFECTS[/]
+Not two renders ago against now. `r` to hear one, `a` to park it, point
+at the rival, `b` -- which re-renders it on the SAME source -- then `,`
+and `.` to flip between them. That is the question a remixer exists to
+answer: is mine better than the one the box came with?
 
 [bold]why an effect can render DRY[/]
 SIX of the eleven stock effects ship with their wet control at zero —
@@ -342,9 +356,11 @@ class BenchScreen(Screen):
         Binding("r", "render", "hear it"),
         Binding("space", "play", "play last"),
         Binding("p", "preview", "preview page", show=False),
-        Binding("a", "mark('A')", "mark A", show=False),
+        Binding("a", "mark('A')", "A = this", show=False),
+        Binding("b", "mark('B')", "B = this", show=False),
         Binding("comma", "play_mark('A')", "play A", show=False),
         Binding("full_stop", "play_mark('B')", "play B", show=False),
+        Binding("x", "fix", "apply the fix", show=False),
         Binding("c", "build('check')", "full check", show=False),
         Binding("f", "fallback", "fallback", show=False),
         Binding("l", "load", "load remix"),
@@ -526,7 +542,7 @@ class BenchScreen(Screen):
             line = f" {mark} {disp(m):<13} [dim]{menus}[/]"
             out.append(f"[reverse]{line}[/]" if here else line)
         out.append("")
-        out.append("[dim]enter SWAPS with ▸ in LOADED[/]")
+        out.append("[dim]enter adds it to the image[/]")
         self._paint("#pane_avail", out)
 
     def _pane_loaded(self, st, probs):
@@ -534,7 +550,6 @@ class BenchScreen(Screen):
         name = st.loaded_name or "unsaved"
         out = [self._title(f"Loaded · {name}", LOADED), ""]
         pos = 0
-        at = min(self.cur[LOADED], len(rows))      # the insertion point
         for i, m in enumerate(rows):
             here = self.pane == LOADED and i == self.cur[LOADED]
             if m.menu is not None:
@@ -546,18 +561,10 @@ class BenchScreen(Screen):
             words = st.words.get(m.key)
             cost = f"{words:>5}w" if words else "      "
             fb = "◀fb" if st.eff_fallback == m.key else ""
-            # ▸ marks where an `enter` from the library would land. It has
-            # to be visible from the OTHER pane too -- "adds at the LOADED
-            # cursor" is useless advice when the cursor is only drawn on the
-            # pane you are standing in.
-            caret = "▸" if i == at else " "
-            line = (f"{caret}{row} {disp(m):<13}"
-                    f"[dim]{menus:<7}{cost}[/]{fb}")
+            # No insertion caret any more: `enter` appends, so there is no
+            # second cursor in another pane to keep track of.
+            line = f" {row} {disp(m):<13}[dim]{menus:<7}{cost}[/]{fb}"
             out.append(f"[reverse]{line}[/]" if here else line)
-        if at >= len(rows):
-            tail = "▸    [dim](end)[/]"
-            out.append(f"[reverse]{tail}[/]"
-                       if self.pane == LOADED else tail)
         if not rows:
             out.append("[dim] (empty — add from the left)[/]")
         # THE THREE REVERBS ARE PART OF A STOCK CHOOSER and belong in this
@@ -830,9 +837,7 @@ class BenchScreen(Screen):
         rows = (self.avail_rows() if self.pane == AVAILABLE else
                 self.loaded_rows() if self.pane == LOADED else
                 self.unit_rows(self.selected_module()))
-        # LOADED gets one extra position, past the last row: that is "append",
-        # and without it there is no way to add at the end.
-        n = max(len(rows) + (1 if self.pane == LOADED else 0), 1)
+        n = max(len(rows), 1)
         if ev.key in ("down", "j"):
             self.cur[self.pane] = min(n - 1, self.cur[self.pane] + 1)
         elif ev.key in ("up", "k"):
@@ -937,32 +942,25 @@ class BenchScreen(Screen):
                 self.rerender()
                 return
             else:
-                # SWAP, not insert. An image is a fixed budget -- 2,724
-                # words and a list somebody has to scroll -- so putting
-                # something in normally means taking something out, and the
-                # new effect takes the old one's SLOT. The ▸ at (end) is the
-                # exception: there, it appends.
-                loaded = self.loaded_rows()
-                at = self.cur[LOADED]
-                if at < len(loaded) and st.swap(loaded[at].key, mod.key):
-                    rowno = len([k for k in st.order[:at + 1]
-                                 if st.mods[k].menu is not None])
-                    st.msg = (f"swapped {disp(loaded[at])} → {disp(mod)}"
-                              f" at chooser row {rowno}")
-                else:
-                    st.insert_at(mod.key, len(st.order))
-                    st.msg = f"added {disp(mod)} at the end"
-                # The consequences go to the ⚠ line, which is beside the
-                # rows they are about. Appending them here produced a
-                # run-on that the status bar then truncated -- and the part
-                # it cut was the only actionable half of the sentence.
+                # ⚠️ THIS USED TO SWAP: the module took the ▸ row's slot and
+                # that row was dropped. The justification was "an image is a
+                # fixed budget, so putting something in means taking
+                # something out" -- which is the LEDGER's scarcity imported
+                # into the operator's gesture, where it does not apply.
+                # Rows are not the scarce thing: the long-list cave holds 31
+                # of them, and a STOCK row costs zero words (no code placed,
+                # no descriptor cloned). Only WORDS are scarce, and only for
+                # modules of ours. So add, and let the budget speak up if it
+                # is actually breached -- which is what the ⚠ line is for.
+                st.insert_at(mod.key, len(st.order))
+                st.msg = f"added {disp(mod)}"
                 st.msg += self.ensure_fallback()
             st.loaded_name = ""
             self.schedule_sync()
         elif self.pane == LOADED:
             rows = self.loaded_rows()
             if not rows or self.cur[LOADED] >= len(rows):
-                return                       # the append position: no row
+                return
             mod = rows[self.cur[LOADED]]
             st.toggle(mod.key)
             st.loaded_name = ""
@@ -1008,6 +1006,42 @@ class BenchScreen(Screen):
                 and all("no fallback" in p for p in probs)
                 and not any(not m.is_stock for m in self.app.state.selected))
 
+    def blockers(self, probs):
+        """The modules whose removal would clear the ⚠, if that is the shape
+        of the problem.
+
+        A buffer clash is the one that costs four effects at once: FLANGER,
+        CHORUS, SPATIALIZER and COMB each take a per-track instance buffer at
+        exactly the addresses ChonVerb's tank and BongDelay's line hardcode.
+        Naming them was already better than four walls of text -- but naming
+        them still hands the operator a chore. `x` does it.
+        """
+        st = self.app.state
+        names = set()
+        for p_ in probs:
+            if "stock instance buffer" not in p_:
+                continue
+            # "stock instance buffer: flanger and chonverb both claim ..."
+            names.add(p_.split(":", 1)[1].split(" and ")[0].strip())
+        return [m for m in st.selected
+                if m.is_stock and m.name.lower() in names]
+
+    def action_fix(self):
+        """Apply the ⚠'s own advice."""
+        st = self.app.state
+        gone = self.blockers(st.problems())
+        if not gone:
+            st.msg = "nothing here that removing a row would fix"
+            self.rerender()
+            return
+        for m in gone:
+            st.toggle(m.key)
+        st.loaded_name = ""
+        st.msg = "removed " + ", ".join(disp(m) for m in gone)
+        self.cur[LOADED] = min(self.cur[LOADED], max(len(st.order) - 1, 0))
+        self.schedule_sync()
+        self.rerender()
+
     def _clash(self, probs):
         """One readable, IMPERATIVE sentence for whatever stands.
 
@@ -1021,7 +1055,10 @@ class BenchScreen(Screen):
             return ""
         buf = [p for p in probs if "stock instance buffer" in p]
         if buf:
-            # "stock instance buffer: flanger and chonverb both claim ..."
+            gone = self.blockers(probs)
+            if gone:
+                return ("x removes " + ", ".join(disp(m) for m in gone)
+                        + " — they need the same buffer")
             names = [p.split(":", 1)[1].split(" and ")[0].strip().upper()
                      for p in buf]
             return "also remove " + ", ".join(names)
@@ -1093,21 +1130,28 @@ class BenchScreen(Screen):
         self.app.push_screen(HelpScreen("bench"))
 
     # ---- audio -----------------------------------------------------------
-    def action_render(self):
+    def action_render(self, mark=None):
         app, st = self.app, self.app.state
         mod = self.selected_module()
         if mod is None or rig.category(mod) == rig.SYSTEM:
             st.msg = "that module is plumbing — nothing to hear"
         elif app.source is None:
-            st.msg = "no source wav — put some in out/dry/"
+            st.msg = f"no source wav in {source_dir()} — d changes folder"
         elif app.rendering:
             st.msg = "a render is already running"
         else:
-            self.render_worker(mod, dict(st.knobs_for(mod)), app.source)
+            # An A/B must compare EFFECTS, so B is rendered on A's source
+            # rather than on whatever the SOURCE row happens to say now.
+            src = app.source
+            if mark == "B" and "A" in app.marks:
+                src = app.ab_source or src
+            elif mark is None:
+                app.ab_source = None
+            self.render_worker(mod, dict(st.knobs_for(mod)), src, mark)
         self.rerender()
 
     @work(thread=True, exclusive=True, group="render")
-    def render_worker(self, mod, values, source):
+    def render_worker(self, mod, values, source, mark=None):
         app = self.app
 
         def log(msg):
@@ -1125,8 +1169,19 @@ class BenchScreen(Screen):
         changed = {n: v for n, v in values.items()
                    if v != rig.default_knobs(mod).get(n)}
         desc = " ".join(f"{n}={v}" for n, v in changed.items()) or "defaults"
-        app.history.append((f"{mod.name} · {desc}", path))
-        app.state.msg = f"rendered → {path.name}"
+        label = f"{disp(mod)} · {desc}"
+        app.history.append((label, path))
+        app.ab_source = source
+        if mark:
+            app.marks[mark] = (label, path)
+            audition._journal({"event": "mark", "which": mark,
+                               "label": label, "out": path.name})
+            other = app.marks.get("A" if mark == "B" else "B")
+            app.state.msg = (f"{mark} = {label}"
+                             + (f"   ·   , and . to A/B against "
+                                f"{other[0]}" if other else ""))
+        else:
+            app.state.msg = f"rendered → {path.name}"
         app.call_from_thread(app.play, path)
         app.call_from_thread(self.rerender)
 
@@ -1141,23 +1196,43 @@ class BenchScreen(Screen):
         self.rerender()
 
     def action_mark(self, which):
+        """Park the last render as A or B.
+
+        The A/B that matters in a REMIXER is not "two renders ago vs now" --
+        it is "the box's effect vs mine", which is the whole question an
+        upgraded LO-FI asks. So `a` parks what you just heard and `b`
+        RE-RENDERS the effect the cursor is on now, on the same source, so
+        the pair is always two effects rather than two accidents of history.
+        """
         app = self.app
-        if app.history:
+        if which == "A":
+            if not app.history:
+                app.state.msg = "nothing rendered yet — r first"
+                self.rerender()
+                return
             label, path = app.history[-1]
-            app.marks[which] = path
-            app.state.msg = f"marked {which}: {label}"
-            audition._journal({"event": "mark", "which": which,
+            app.marks["A"] = (label, path)
+            app.state.msg = f"A = {label} · now point at another effect and b"
+            audition._journal({"event": "mark", "which": "A",
                                "label": label, "out": path.name})
-        self.rerender()
+            self.rerender()
+            return
+        # B: render whatever the cursor is on, against the same source.
+        if "A" not in app.marks:
+            app.state.msg = "mark A first (a), then point at the rival and b"
+            self.rerender()
+            return
+        self.action_render(mark="B")
 
     def action_play_mark(self, which):
         app = self.app
-        p = app.marks.get(which)
-        if p:
-            app.play(p)
-            app.state.msg = f"playing {which}: {p.name}"
+        got = app.marks.get(which)
+        if got:
+            label, path = got
+            app.play(path)
+            app.state.msg = f"{which}: {label}"
         else:
-            app.state.msg = f"no {which} mark yet"
+            app.state.msg = f"no {which} yet"
         self.rerender()
 
     # ---- build, measure, load, save --------------------------------------
@@ -1259,7 +1334,8 @@ class Workbench(App):
         self.state = State()
         self.source = (wav_sources() or [None])[0]
         self.history = []                  # [(label, path)]
-        self.marks = {}                    # "A"/"B" -> path
+        self.marks = {}                    # "A"/"B" -> (label, path)
+        self.ab_source = None              # the wav an A/B pair shares
         self.status = ""                   # state.msg is the live line now
         self.rendering = False
         self.boot = None                   # the booted image, or None

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -718,6 +718,12 @@ class BenchScreen(Screen):
             bits.append(f"tracks {tr.start}-{tr.stop - 1}")
         out.append(f"[dim]{' · '.join(bits)}[/]")
         out.append(f"[dim]{escape(mod.doc)}[/]")
+        # WHAT IT COSTS, while you are still deciding. "Will this fit beside
+        # what I already have" is what the library pane is really asked, and
+        # every answer used to arrive only as a refusal after adding it.
+        res = rig.resources(mod, st.words.get(mod.key))
+        if res:
+            out.append(f"[{WARN}]{escape(' · '.join(res))}[/]")
         out.append("")
 
         knobs = self.unit_rows(mod)
@@ -931,12 +937,7 @@ class BenchScreen(Screen):
         bits = [rig.category(mod)]
         if mod.menu is not None:
             bits.append(f"id 0x{mod.menu.fx2_id:02x}")
-        w = st.words.get(mod.key)
-        if w:
-            bits.append(f"{w} words")
-        elif mod.is_stock:
-            bits.append("no code placed" if mod.key not in stock.CONSUMED
-                        else "its code IS the donor region")
+        bits += rig.resources(mod, st.words.get(mod.key))
         bits.append("in the image" if mod.key in st.sel else "not in the image")
         st.msg = f"{disp(mod)} — {' · '.join(bits)}"
 

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -958,8 +958,10 @@ class EmuScreen(Screen):
         if ev.key in tuple("12345678"):
             app.track = int(ev.key)
             if self.view == "fx2":
+                # Follow the new track's assignment; do NOT write back.
+                # Changing track is navigation, and an empty track would
+                # otherwise silently inherit whatever row happened to show.
                 self.sync_row()
-                self.pending = self.select_row()
         elif self.view == "fx2" and ev.key in ("left", "right", "h", "l"):
             rows = self.chooser()
             if not rows:

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -652,6 +652,17 @@ class BenchScreen(Screen):
                            f"donor, taken[/]")
         elif [m for m in st.selected if m.dsp is not None]:
             out.append(f"[dim {WARN}] —  Plate, Spring, Dark Rev (donors)[/]")
+        # THE SHARED COST, ONCE. Every module that pins FX2 buffers costs
+        # the same seven stock effects, so saying it on each of them read as
+        # two bills for one debt -- ChonVerb and BongDelay showed identical
+        # lists. It belongs to the image, so the image says it.
+        pin = [m for m in st.selected if rig.pins_fx2(m)]
+        if pin:
+            out.append(f"[dim {WARN}]no room for "
+                       f"{escape(rig.allocating_names())} — "
+                       f"{escape(disp(pin[0]))}"
+                       f"{' and ' + disp(pin[1]) if len(pin) > 1 else ''} "
+                       f"pin their slots[/]")
         out.append("")
         out.append(self._ledger_line(st, probs))
         self._paint("#pane_load", out)

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -153,10 +153,13 @@ of rows on the panel, so left/right there is a real edit. [bold]UNIT[/]
 follows the cursor: the selected effect's knobs, and the firmware's own
 draw of its page.
 
-You start at [bold]stock[/] — the chooser an unmodified unit shows. Add
-to what the box already does. A remix must name a fallback for ids it
-does not implement (SEND is the safe one), so adding a module means
-adding SEND too; the LOADED pane says so when it matters.
+You start at [bold]stock[/] — the chooser an unmodified unit shows, all
+fourteen effects including the three reverbs. Composing is [bold]trading[/]:
+the donor region is 2,724 words and the chooser is a list somebody has to
+scroll, so `enter` SWAPS the ▸ row for the highlighted module rather than
+growing the list. One trade is often not enough — the first module of
+ours needs SEND in the list, and a big one can push you past the region —
+and the status line names what else has to go.
 
 ● in the LOADED pane means "in the image on disk". An effect that is
 loaded but not built is not previewed: its id is not in the image, so
@@ -164,7 +167,9 @@ the firmware would draw a convincing picture of the WRONG effect.
 
 [bold]keys[/]
   tab  pane            up/down  move
-  enter  add / remove  left/right  knob value (UNIT) or row order (LOADED)
+  enter  SWAP the ▸ row for this one (at (end): append); on a
+         selected module, remove it
+  left/right  knob value (UNIT) or row order (LOADED)
   p  preview mode      r  render + hear     space  play last
   b  build             c  check             w  word cost
   l  load remix        s  save remix        f  fallback
@@ -295,7 +300,7 @@ class BenchScreen(Screen):
     BINDINGS = [
         Binding("tab", "pane(1)", "pane"),
         Binding("shift+tab", "pane(-1)", "prev pane", show=False),
-        Binding("enter", "add_remove", "add / remove"),
+        Binding("enter", "add_remove", "swap / remove"),
         Binding("p", "preview", "preview"),
         Binding("r", "render", "render+hear"),
         Binding("space", "play", "play last"),
@@ -427,7 +432,7 @@ class BenchScreen(Screen):
             line = f" {mark} {disp(m):<13} [dim]{menus}[/]"
             out.append(f"[reverse]{line}[/]" if here else line)
         out.append("")
-        out.append("[dim]enter adds at ▸ in LOADED[/]")
+        out.append("[dim]enter SWAPS with ▸ in LOADED[/]")
         self.query_one("#pane_avail", Static).update("\n".join(out))
 
     def _pane_loaded(self, st):
@@ -702,15 +707,24 @@ class BenchScreen(Screen):
                 st.toggle(mod.key)
                 st.msg = f"removed {disp(mod)}"
             else:
-                # AT THE LOADED CURSOR, not appended. Chooser order is the
-                # panel's row order, so where it lands is the question.
-                at = min(self.cur[LOADED], len(st.order))
-                st.insert_at(mod.key, at)
-                rowno = len([k for k in st.order[:at + 1]
-                              if st.mods[k].menu is not None])
-                st.msg = (f"added {disp(mod)} at chooser row {rowno}"
-                          if mod.menu is not None
-                          else f"added {disp(mod)} (no chooser row)")
+                # SWAP, not insert. An image is a fixed budget -- 2,724
+                # words and a list somebody has to scroll -- so putting
+                # something in normally means taking something out, and the
+                # new effect takes the old one's SLOT. The ▸ at (end) is the
+                # exception: there, it appends.
+                loaded = self.loaded_rows()
+                at = self.cur[LOADED]
+                if at < len(loaded) and st.swap(loaded[at].key, mod.key):
+                    rowno = len([k for k in st.order[:at + 1]
+                                 if st.mods[k].menu is not None])
+                    st.msg = (f"swapped {disp(loaded[at])} → {disp(mod)}"
+                              f" at chooser row {rowno}")
+                else:
+                    st.insert_at(mod.key, len(st.order))
+                    st.msg = f"added {disp(mod)} at the end"
+                more = self.knock_ons()
+                if more:
+                    st.msg += " · " + more
             st.loaded_name = ""
         elif self.pane == LOADED:
             rows = self.loaded_rows()
@@ -722,6 +736,26 @@ class BenchScreen(Screen):
             st.msg = f"removed {mod.key}"
             self.cur[LOADED] = max(0, self.cur[LOADED] - 1)
         self.rerender()
+
+    def knock_ons(self):
+        """What ELSE this swap now requires -- the multi-swap case.
+
+        One trade is often not enough: the first module of ours needs SEND in
+        the list (nothing else is a safe fallback), a module can push the
+        selection past the donor region, and the ledger refuses some pairs
+        outright. All three are things the build would refuse LATER, so say
+        them at the moment the swap is made, and name the remedy rather than
+        the rule.
+        """
+        probs = self.app.state.problems()
+        if not probs:
+            return ""
+        first = probs[0]
+        if "no fallback" in first:
+            return "now needs Send — swap another row for it"
+        if "exceeds" in first:
+            return first + "; swap something else out too"
+        return first
 
     def action_stock(self):
         self.app.state.load_stock()

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -783,9 +783,15 @@ class BenchScreen(Screen):
             c = OK if free > 400 else WARN if free > 32 else BAD
             bar = (f"[{c}]" + "#" * fill + "[/][dim]" + "." * (edge - fill)
                    + "[/][dim red]" + "-" * (20 - edge) + "[/]")
-            why = (f"  [dim]before {titlecase(nxt)} goes[/]" if nxt and free
-                   else f"  [dim]{titlecase(nxt)} holds the rest[/]" if nxt
-                   else "")
+            # NAME THE NEXT TRADE, not the state. "Plate Rev holds the
+            # rest" was true and useless -- it says which reverb is in the
+            # way without saying what dropping it buys, and at 0 free that
+            # is the only question. Both forms now answer it: how far you
+            # can go before the next one dies, or what the next one is worth.
+            gain = stock.WORDS[nxt] if nxt else 0
+            why = (f"  [dim]then {titlecase(nxt)} goes[/]" if nxt and free
+                   else f"  [dim]drop {titlecase(nxt)} for {gain:,} more[/]"
+                   if nxt else "")
             return f" {'words ' + n:<{W}}{bar}  {free:>4} free{why}"
 
         if st.regions:

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -386,6 +386,8 @@ Only a buffer-free INSERT can take one, and the UNIT pane says which cannot and 
 Under 118 columns the panes come in pairs that slide with the focus; under 92, one at a time. The tab bar at the top names all three and marks where you are. Lists longer than the pane scroll with the cursor and say so (`↑ 6 more`).
 
 [bold]what is actually scarce[/]
+Every row says what it IS in a column of its own, and under them is a MAP of the payload's effect code, drawn to scale from the real spans: thirteen segments, one per stock effect, `─` for the ones this selection keeps, `.` for the harvested run and `#` for how far your code reached into it. One bar per payload, because the layout is identical in both and only the fill differs. That is the picture the twenty-glyph `words` bar could not draw — it needed a legend and still said neither WHERE in the payload the region is nor WHICH effects it costs, and once the region became a choice those were the only two questions.
+
 Five things, and the Budget strip is one row for each: the two donor regions of 2,724 words (one per payload, and only YOUR modules spend them), the FX2 buffer slots (one per track, per core), the per-core CYCLES, the 31 chooser rows, and the ColdFire cave. Every row reads the same way — [bold]N free of TOTAL, and what took the rest[/].
 
 CYCLES is the one that does not fail as a refusal. Over budget the DSP does not decline to build, it wedges — so the row prices the WORST core under the worst mix this selection allows, which for a card of inserts is four copies of the dearest one: nothing stops all four tracks selecting it. The budget of 3,120 is what our code may spend after stock's own share, measured 23 Aug 2026, and the count is a floor: exact for the code, optimistic about memory contention.
@@ -1051,6 +1053,77 @@ class RemixerScreen(Screen):
             return "[dim]a stock chooser: 14 effects, no modules[/]"
         return "[dim]building…[/]"
 
+    # Short enough to label a segment of the map. The panel names are the
+    # firmware's own and too long for a bar thirteen effects wide.
+    _MAP_ABBR = {"FILTER": "FILT", "SPATIALIZER": "SPAT", "EQUALIZER": "EQ",
+                 "PHASER": "PHSR", "FLANGER": "FLNG", "CHORUS": "CHOR",
+                 "PLATE REV": "PLATE", "SPRING REV": "SPRING",
+                 "DARK REV": "DARK", "COMPRESSOR": "COMP", "LO-FI": "LOFI",
+                 "DJ EQ": "DJEQ", "COMB FILTER": "COMB"}
+
+    def _memory_map(self, st, width):
+        """The payload's effect code, to scale, with the harvested run marked.
+
+        ⚠️ THIS IS WHAT THE `words` BARS COULD NOT SAY. Twenty glyphs of
+        `#`/`-`/`.` needed a legend to decode and still showed neither WHERE
+        in the payload the region is nor WHICH effects it costs -- and once
+        the region became a choice (Remix.harvest) those were the two
+        questions. Drawn from stock.p_spans, so it cannot drift from what the
+        build places.
+
+        One label row, one bar per payload -- the layout is identical in both
+        and only the fill differs -- and a footer naming the run.
+        """
+        try:
+            sp = stock.p_spans("A")
+        except Exception:                            # noqa: BLE001
+            return []
+        run = sorted((a, n, k) for k, (a, n) in sp.items())
+        total = sum(n for _a, n, _k in run)
+        hv = set(st.harvest)
+        w = max(40, width - 6)
+        # ⚠️ CUMULATIVE ROUNDING, so the widths sum to exactly `w` and no
+        # segment is starved by the ones before it. Rounding each one on its
+        # own and giving the remainder to the last left COMB with two columns
+        # and its label cut to `CO`.
+        seg, off, col = [], 0, 0
+        for a, n, k in run:
+            off += n
+            nxt = round(off * w / total)
+            seg.append((k, a, n, nxt - col))
+            col = nxt
+        # A label needs four columns. Below that the names are noise and the
+        # bar still says everything the footer names.
+        label = ("".join(self._MAP_ABBR[k][:c].center(c)
+                         for k, _a, _n, c in seg)
+                 if min(c for _k, _a, _n, c in seg) >= 4 else None)
+        base = min((sp[h][0] for h in hv), default=0)
+        placed = {t: u for t, _tot, u, _f in st.regions}
+
+        def bar(tag):
+            got = placed.get(tag)
+            out = ""
+            for k, a, n, c in seg:
+                if k not in hv:
+                    out += f"[dim]{'─' * c}[/]"
+                elif got is None:
+                    out += f"[dim]{'.' * c}[/]"
+                else:
+                    fill = max(0, min(c, round((got - (a - base)) * c / n)))
+                    out += (f"[{OK}]{'#' * fill}[/][dim]{'.' * (c - fill)}[/]")
+            return out
+
+        # The footer brackets the harvested run under the bar it belongs to.
+        lo = sum(c for k, _a, _n, c in seg
+                 if sp[k][0] < min((sp[h][0] for h in hv), default=0))
+        span = sum(c for k, _a, _n, c in seg if k in hv)
+        foot = (" " * lo + "└" + f" harvested, {stock.region_words(tuple(hv)):,} "
+                f"words ".center(max(0, span - 2), "─") + "┘")[:w]
+        rows = (["  " + label] if label else []) + [f"[dim]A[/] " + bar("A")]
+        if len(placed) > 1 or not placed:
+            rows.append(f"[dim]B[/] " + bar("B"))
+        return rows + ["  " + f"[dim]{foot}[/]"]
+
     def _pane_budget(self, st, probs):
         """WHAT IS LEFT, standing under the effect you are looking at.
 
@@ -1090,6 +1163,38 @@ class RemixerScreen(Screen):
             return (f"{n:,} free of {total:,}"
                     + (f" [dim]· {extra}[/]" if extra else ""))
 
+        # ⚠️ WHAT EACH ROW *IS*. The numbers were self-consistent and still
+        # left "what is a cave?" unanswered, and the strip has forty columns
+        # spare. One short phrase each, in a column of its own so they read
+        # as a key rather than as more detail on the figure.
+        WHAT = {
+            "words A": "where your modules' code goes, core 0",
+            "words B": "the same on core 1",
+            "FX2 buf A": "one 16K Y buffer per track",
+            "FX2 buf B": "one 16K Y buffer per track",
+            "cycles": "DSP time, per core per sample",
+            "rows": "entries the FX2 menu can hold",
+            "cave": "spare ColdFire bytes for patches",
+        }
+        # The descriptor column is placed at the END, once every row's real
+        # width is known -- a fixed column either collides with the longest
+        # row or leaves a canyon after the shortest, and which is longest
+        # changes with the selection.
+        def why(key, line):
+            return f"\0{key}\0{line}"
+
+        def columns(rows, width):
+            """Lay the rows out with their descriptors in one column, or
+            without them when the terminal cannot hold both."""
+            split = [r.split("\0")[1:] if r.startswith("\0") else ["", r]
+                     for r in rows]
+            widest = max((self._vis(t) for _k, t in split), default=0)
+            longest = max((len(WHAT[k]) for k, _t in split if k), default=0)
+            if widest + 2 + longest > width:
+                return [t for _k, t in split]
+            return [t + " " * (widest + 2 - self._vis(t))
+                    + f"[dim]{WHAT[k]}[/]" if k else t for k, t in split]
+
         # EVERY ROW HERE IS: what exists, minus what this selection loaded.
         # Nothing is a constant and nothing is a build's leftover.
         #
@@ -1124,15 +1229,17 @@ class RemixerScreen(Screen):
         brief = []
 
         def words_row(n, total, used):
-            free, cap = placeable(st.sel, total, used, st.harvest)
-            fill = min(20, round(20 * used / total))
-            edge = max(fill, min(20, round(20 * cap / total)))
+            # ⚠️ NO BAR HERE ANY MORE. Twenty glyphs of `#`/`-`/`.` needed a
+            # legend to decode and still could not show WHERE in the payload
+            # the region is or which effects it costs. The map below is that
+            # picture, drawn from the real spans, and it does the job for
+            # both payloads at once.
+            free, _cap = placeable(st.sel, total, used, st.harvest)
             c = OK if free > 400 else WARN if free > 32 else BAD
-            bar = (f"[{c}]" + "#" * fill + "[/][dim]" + "." * (edge - fill)
-                   + "[/][dim red]" + "-" * (20 - edge) + "[/]")
             brief.append((f"words {n}", f"[{c}]{free:,}[/]"))
-            return (f" {'words ' + n:<{W}}{bar}  [{c}]{free:>5,}[/] free of "
-                    f"{total:,} [dim]· {used:,} loaded[/]")
+            return why(f"words {n}",
+                       f" {'words ' + n:<{W}}[{c}]{free:>5,}[/] free of "
+                       f"{total:,} [dim]· {used:,} loaded[/]")
 
         if st.regions:
             for n, total, used, _f in st.regions:
@@ -1152,10 +1259,13 @@ class RemixerScreen(Screen):
             # `????  not built` sent you looking for a build key that does
             # not exist. The ⚠ in LOADED holds the sentence; say which way to
             # look and which key applies it.
-            why = ("[dim]not built — [/][bold]x[/][dim] applies the ⚠ in "
-                   "LOADED[/]" if self.blockers(probs)
-                   else "[dim]not built — see the ⚠ in LOADED[/]")
-            out.append(f" {'words':<{W}}[dim]" + "?" * 20 + f"[/]  {why}")
+            # (named `unbuilt`, not `why` -- that is the descriptor helper
+            # three rows of this function down, and shadowing it turned every
+            # later row into "'str' object is not callable")
+            unbuilt = ("[dim]not built — [/][bold]x[/][dim] applies the ⚠ in "
+                       "CHOOSERS[/]" if self.blockers(probs)
+                       else "[dim]not built — see the ⚠ in CHOOSERS[/]")
+            out.append(f" {'words':<{W}}{unbuilt}")
             brief.append(("words", "[dim]not built[/]"))
         # THE TRADE, ONCE. It is identical for both payloads -- the same
         # three reverbs occupy both regions -- so printing it on each read as
@@ -1238,11 +1348,13 @@ class RemixerScreen(Screen):
                 # "can I add another"; the list answers "where does it go".
                 bits.append(",".join(str(t) for t in free) + " free")
             brief.append((f"buf {tag}", f"[{c}]{len(free)}/4[/]"))
-            side.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{len(free):>5}[/] free "
-                       f"of 4 [dim]· "
-                       + (" · ".join(bits) if bits
-                          else f"tracks {tracks.start}-{tracks.stop - 1}, "
-                               f"no module claims one") + "[/]")
+            side.append(why("FX2 buf " + tag,
+                            f" {'FX2 buf ' + tag:<{W}}[{c}]{len(free):>5}[/] "
+                            f"free of 4 [dim]· "
+                            + (" · ".join(bits) if bits
+                               else f"tracks {tracks.start}-"
+                                    f"{tracks.stop - 1}, no module claims "
+                                    f"one") + "[/]"))
 
         # CYCLES. The fourth scarce thing was really the fifth: over the
         # per-core budget the DSP does not refuse the image, it WEDGES
@@ -1271,9 +1383,10 @@ class RemixerScreen(Screen):
                               or m.key.split()[0] in st.donors_kept))
             gap = (f" · {nstock} stock rows not counted" if nstock else "")
             brief.append(("cycles", f"[{c}]{free:,}[/]"))
-            side.append(f" {'cycles':<{W}}[{c}]{free:>5,}[/] free of "
-                        f"{usable:,} [dim]· worst core: {escape(how)}"
-                        f"{gap}[/]")
+            side.append(why("cycles",
+                            f" {'cycles':<{W}}[{c}]{free:>5,}[/] free of "
+                            f"{usable:,} [dim]· worst core: {escape(how)}"
+                            f"{gap}[/]"))
 
         # Rows are countable without a build; the cave is not.
         # Same sentence again: 31 exist, this selection loaded N.
@@ -1281,8 +1394,9 @@ class RemixerScreen(Screen):
                      else len(st.menu_modules))
         c = OK if 31 - used_rows > 7 else WARN if used_rows < 31 else BAD
         brief.append(("rows", f"[{c}]{31 - used_rows}[/]"))
-        side.append(f" {'rows':<{W}}[{c}]{31 - used_rows:>5}[/] free of 31 "
-                   f"[dim]· {used_rows} loaded[/]")
+        side.append(why("rows",
+                        f" {'rows':<{W}}[{c}]{31 - used_rows:>5}[/] free of "
+                        f"31 [dim]· {used_rows} loaded[/]"))
         # And the cave. The build reports only what is LEFT, so the total
         # comes from state.CAVE_BYTES (pinned to build_bus's own bounds by
         # the selftest) and the used figure is the subtraction -- which is
@@ -1292,17 +1406,21 @@ class RemixerScreen(Screen):
         if st.cave_free is not None:
             c = OK if st.cave_free > 512 else WARN if st.cave_free else BAD
             brief.append(("cave", f"[{c}]{st.cave_free:,} B[/]"))
-            side.append(f" {'cave':<{W}}[{c}]{st.cave_free:>5,}[/] free of "
-                       f"{CAVE_BYTES:,} B [dim]· "
-                       f"{CAVE_BYTES - st.cave_free:,} loaded[/]")
+            side.append(why("cave",
+                            f" {'cave':<{W}}[{c}]{st.cave_free:>5,}[/] free "
+                            f"of {CAVE_BYTES:,} B [dim]· "
+                            f"{CAVE_BYTES - st.cave_free:,} loaded[/]"))
         elif not [m for m in st.selected if m.dsp is not None or m.cf_patches]:
             brief.append(("cave", f"[{OK}]{CAVE_BYTES:,} B[/]"))
-            side.append(f" {'cave':<{W}}[{OK}]{CAVE_BYTES:>5,}[/] free of "
-                       f"{CAVE_BYTES:,} B [dim]· nothing of ours is placed[/]")
+            side.append(why("cave",
+                            f" {'cave':<{W}}[{OK}]{CAVE_BYTES:>5,}[/] free "
+                            f"of {CAVE_BYTES:,} B [dim]· nothing of ours is "
+                            f"placed[/]"))
         else:
             brief.append(("cave", "[dim]not built[/]"))
-            side.append(f" {'cave':<{W}}[dim]    ? free of {CAVE_BYTES:,} B "
-                       f"· not built[/]")
+            side.append(why("cave",
+                            f" {'cave':<{W}}[dim]    ? free of "
+                            f"{CAVE_BYTES:,} B · not built[/]"))
         # ONE legend line, decoding the ONE thing on this pane that is not
         # already words: the bar's three glyphs. What an FX2 buffer count
         # counts used to be spelled out here in two further lines of prose
@@ -1349,7 +1467,11 @@ class RemixerScreen(Screen):
             self._budget_resized(len(lines) + 1)
             self._paint("#pane_budget", lines + [cur])
             return
-        rows, _wide = self._two_up(out, side)
+        # ⚠️ ONE COLUMN NOW, not two. The descriptor column is what the
+        # second column's width used to be spent on, and a row that says
+        # what it is beats a row that fits beside another one.
+        rows = columns(out + side, self.app.size.width - 2)
+        rows += self._memory_map(st, self.app.size.width - 2)
         # Its own height is what the panes above are laid out against, so a
         # change in it invalidates them.
         self._budget_resized(len(rows))

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -758,21 +758,59 @@ class BenchScreen(Screen):
     def knock_ons(self):
         """What ELSE this swap now requires -- the multi-swap case.
 
-        One trade is often not enough: the first module of ours needs SEND in
-        the list (nothing else is a safe fallback), a module can push the
-        selection past the donor region, and the ledger refuses some pairs
-        outright. All three are things the build would refuse LATER, so say
-        them at the moment the swap is made, and name the remedy rather than
-        the rule.
+        One trade is frequently not enough, and the reasons are unequal:
+
+        * A BUFFER CLASH is the expensive one and the ledger states it one
+          PAIR at a time -- adding ChonVerb to a stock chooser produces four
+          near-identical sentences (FLANGER, CHORUS, SPATIALIZER and COMB all
+          take a per-track instance buffer at the addresses its tank
+          hardcodes). Reported as four walls of text it is unreadable and it
+          is not obvious that the answer is "remove those four". Aggregated
+          into one sentence that names them.
+        * THE FALLBACK is cheap and is fixed here rather than reported. A
+          chooser row costs nothing (32 fit in the long cave), so making the
+          operator sacrifice an effect for SEND was an invention of this UI,
+          not a constraint of the image. It is added, and said out loud.
+        * WORDS are the real budget and the only one where something has to
+          go.
         """
-        probs = self.app.state.problems()
+        st = self.app.state
+        probs = st.problems()
+
+        # The fallback: satisfy it rather than demand a trade for it.
+        if any("no fallback" in p for p in probs) and "SEND" in st.mods:
+            send = st.mods["SEND"]
+            room = (send.key in st.words and
+                    sum(st.words[m.key] for m in st.selected
+                        if m.dsp is not None and m.key in st.words)
+                    + st.words[send.key] <= DONOR_WORDS)
+            if send.key not in st.sel and (room or send.key not in st.words):
+                st.insert_at(send.key, len(st.order))
+                probs = st.problems()
+                extra = "added Send too (the only safe fallback)"
+                rest = self._clash(probs)
+                return extra + (" · " + rest if rest else "")
+        rest = self._clash(probs)
+        return rest
+
+    def _clash(self, probs):
+        """One readable sentence for whatever still stands."""
         if not probs:
             return ""
+        buf = [p for p in probs if "stock instance buffer" in p]
+        if buf:
+            # "stock instance buffer: flanger and chonverb both claim ..."
+            names = []
+            for p in buf:
+                a = p.split(":", 1)[1].split(" and ")[0].strip()
+                names.append(a.upper())
+            return (f"needs the FX2 buffer region — also swap out "
+                    f"{', '.join(names)}")
         first = probs[0]
-        if "no fallback" in first:
-            return "now needs Send — swap another row for it"
         if "exceeds" in first:
             return first + "; swap something else out too"
+        if "no fallback" in first:
+            return "needs a fallback — press f to choose one"
         return first
 
     def action_stock(self):

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -451,6 +451,11 @@ class BenchScreen(Screen):
         Binding("x", "fix", "fix it"),
         Binding("c", "build('check')", "full check", show=False),
         Binding("f", "fallback", "fallback", show=False),
+        # "1" for FX1, on the row the cursor is on. This is the other half
+        # of a GLOBAL remixer: until 3 Sep 2026 an effect of ours could only
+        # be reached from the FX2 slot, and only because FX1's chooser list
+        # could not grow where it sits.
+        Binding("1", "fx1", "FX1 row", show=False),
         Binding("l", "load", "load"),
         Binding("s", "save", "save"),
         Binding("k", "stock", "reset to stock", show=False),
@@ -780,7 +785,7 @@ class BenchScreen(Screen):
                 out.append(f"[dim {WARN}]── {g} ──[/]")
             here = self.pane == AVAILABLE and i == self.cur[AVAILABLE]
             mark = (f"[{OK}]✓[/]" if m.key in st.sel else " ")
-            menus = "+".join(rig.menus(m)) or "—"
+            menus = "+".join(rig.menus(m, st.fx1)) or "—"
             nm = disp(m) if m.is_stock else f"[{OURS}]{disp(m)}[/]"
             pad = " " * max(0, 13 - len(disp(m)))
             line = f" {mark} {nm}{pad} [dim]{menus}[/]"
@@ -805,7 +810,7 @@ class BenchScreen(Screen):
                 row = f"{pos:>2}"
             else:
                 row = " ·"                      # no chooser row (a CF patch)
-            menus = "+".join(rig.menus(m)) or "—"
+            menus = "+".join(rig.menus(m, st.fx1)) or "—"
             words = st.words.get(m.key)
             cost = f"{words:>5}w" if words else "      "
             fb = f"[{MARK}]◀fb[/]" if st.eff_fallback == m.key else ""
@@ -873,7 +878,7 @@ class BenchScreen(Screen):
         # `left`/`right` here is a real edit -- the order of these rows IS
         # the order of rows on the unit's chooser -- and it was documented
         # only in `?`, which is the one place a newcomer looks last.
-        out.append("[dim]enter removes · ← → moves the row[/]")
+        out.append("[dim]enter removes · ←→ order · 1 FX1 row[/]")
         out.append(self._ledger_line(st, probs))
         self._paint("#pane_load", self._fit("#pane_load", out, cur_line,
                                             head=head, tail=tail + 3))
@@ -1256,7 +1261,7 @@ class BenchScreen(Screen):
         bits = [titlecase(rig.category(mod))]
         if mod.menu:
             bits.append(f"id 0x{mod.menu.fx2_id:02x}")
-            bits.append("+".join(rig.menus(mod)))
+            bits.append("+".join(rig.menus(mod, st.fx1)))
         tr = rig.track_range(mod)
         if len(tr):
             bits.append(f"tracks {tr.start}-{tr.stop - 1}")
@@ -1265,7 +1270,7 @@ class BenchScreen(Screen):
         # WHAT IT COSTS, while you are still deciding. "Will this fit beside
         # what I already have" is what the library pane is really asked, and
         # every answer used to arrive only as a refusal after adding it.
-        res = rig.resources(mod, st.words.get(mod.key))
+        res = rig.resources(mod, st.words.get(mod.key), st.fx1)
         if res:
             out.append(f"[{WARN}]{escape(' · '.join(res))}[/]")
         out.append("")
@@ -1512,7 +1517,7 @@ class BenchScreen(Screen):
         bits = [rig.category(mod)]
         if mod.menu is not None:
             bits.append(f"id 0x{mod.menu.fx2_id:02x}")
-        bits += rig.resources(mod, st.words.get(mod.key))
+        bits += rig.resources(mod, st.words.get(mod.key), st.fx1)
         bits.append("in the image" if mod.key in st.sel else "not in the image")
         st.msg = f"{disp(mod)} — {' · '.join(bits)}"
 
@@ -1768,6 +1773,18 @@ class BenchScreen(Screen):
         if action == "fix":
             return bool(getattr(self, "_can_fix", False))
         return True
+
+    def action_fx1(self):
+        """Give the highlighted effect a row on FX1 too, or take it away."""
+        st = self.app.state
+        mod = self.selected_module()
+        if mod is None:
+            return
+        st.msg = st.toggle_fx1(mod.key)
+        if mod.key in st.sel:
+            st.loaded_name = ""
+            self.schedule_sync()         # it changes the image
+        self.rerender()
 
     def action_fix(self):
         """Apply the ⚠'s own advice."""

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -1255,9 +1255,11 @@ class BenchScreen(Screen):
         # placement knows where the cursor stopped -- so read it rather than
         # predicting it here.
         if self.sync_error:
+            # The build names EVERY donor row this selection overruns, so
+            # one press clears them all rather than one per rebuild.
             out += [m for m in st.selected
                     if m.is_stock and m.key in stock.CONSUMED
-                    and f"{m.key} is listed" in self.sync_error]
+                    and m.key in self.sync_error]
         return out
 
     def action_fix(self):

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -405,7 +405,9 @@ There is no separate harvest gesture, because there was never a separate choice:
 
 Add a module before giving anything up and the ⚠ says so, with `x` dropping the three reverbs — the biggest, and FX2-only, so they cost FX1 nothing.
 
-⚠️ BOTH menus. An effect off FX2 but still on FX1 is still wanted, and the DSP dispatch is one table shared by them, so overwriting its code would take it off FX1 too.
+⚠️ BOTH menus. An effect off FX2 but still on FX1 is still wanted, and the DSP dispatch is one table shared by them, so overwriting its code would take it off FX1 too. Removing it says which: `still on FX1, so its 329 words stay its own` or `off both menus now, so its 329 words join the region`.
+
+⚠️ THE TWO LISTS STAY INDEPENDENT, and they have to. "Off one is off both" would be simpler to operate and would make the shipping remix impossible: chongbong's FX2 chooser is ChonVerb, BongDelay and Send, so every stock effect is off FX2 — and taking them off FX1 with it would leave the unit with NO FX1 EFFECTS AT ALL and hand your modules all 6,158 words they did not ask for.
 
 ⚠️ AND IT ONLY COSTS WHERE YOUR CODE REACHES. Your modules go in the largest unbroken run of what you gave up, packed from its lowest address; anything the placer never gets to keeps its algorithm and its dispatch and simply has no chooser row — which is exactly what unlisting a stock effect has always done.
 
@@ -1995,6 +1997,7 @@ class RemixerScreen(Screen):
             if not rows or self.cur[LOADED] >= len(rows):
                 return
             menu, mod = rows[self.cur[LOADED]]
+            was = set(st.harvest)
             if menu == rig.FX1:
                 # OFF THE FX1 CHOOSER, not out of the image: for a stock
                 # effect the two lists are independent, and for one of ours
@@ -2004,10 +2007,33 @@ class RemixerScreen(Screen):
             else:
                 st.toggle(mod.key)
                 st.msg = f"removed {disp(mod)} from the FX2 chooser"
+            # ⚠️ AND WHETHER THAT FREED ANYTHING. Giving up a stock effect's
+            # words means taking it off BOTH menus -- the DSP dispatch is one
+            # table shared by them -- so a removal that leaves it on the
+            # other one frees nothing, and said nothing about why. The two
+            # lists have to stay independent: chongbong's FX2 chooser is
+            # ChonVerb/BongDelay/Send, so "off one is off both" would strip
+            # FX1 to zero rows and take every stock effect with it.
+            st.msg += self._freed(mod, was, set(st.harvest))
             st.loaded_name = ""
             self.cur[LOADED] = max(0, self.cur[LOADED] - 1)
             self.schedule_sync()
         self.rerender()
+
+    def _freed(self, mod, before, after):
+        """What a removal did to the region, in a clause."""
+        st = self.app.state
+        if not mod.is_stock or mod.key not in stock.p_spans("A"):
+            return ""
+        w = stock.WORDS.get(mod.key, 0)
+        if mod.key in after and mod.key not in before:
+            return (f" — off both menus now, so its {w:,} words join the "
+                    f"region ({stock.region_words(tuple(after)):,} total)")
+        if mod.key not in after:
+            other = "FX1" if mod.key in st.fx1 else "FX2"
+            return (f" — still on {other}, so its {w:,} words stay its own; "
+                    f"take it off there too to free them")
+        return ""
 
     def ensure_fallback(self):
         """Satisfy the fallback rule rather than demanding a trade for it.

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -332,10 +332,16 @@ The loop is one move long: highlight one of yours in AVAILABLE and press `enter`
                LOADED: move the row — this is the unit's own row order
   r  render + hear     space  replay        p  which page is previewed
   a / b  park what you just heard as A / B      , / .  play A / B
+  1  give the highlighted effect a row on FX1 too (or take it away)
   x  apply the fix the ⚠ is offering (only shown when there is one)
   d  sample folder     l  load a remix      s  save this one as a remix
   c  full check        f  choose the fallback        k  back to stock
   ?  this              esc  stop audio      q  quit
+
+[bold]FX1 as well as FX2[/]
+The unit has two effect slots per track and stock lists different sets on them: ten effects on FX1, those ten plus DELAY and the three reverbs on FX2. `1` puts the highlighted effect of yours on FX1 too — the `FX1+FX2` column follows, and `s` saves it with the remix.
+
+It costs no words. The DSP dispatch table is indexed by the raw id and shared by both menus, so the code already ran from FX1 the moment FX1 selected the id; what `1` adds is the panel side. What it DOES cost is cycles: FX1 is four more slots on the same four tracks, so an effect on both menus can double the worst per-core load — watch the Budget's `cycles` row. An effect that replaces a stock one is already on FX1 and says so instead.
 
 [bold]a narrow terminal shows fewer panes[/]
 Under 118 columns the panes come in pairs that slide with the focus; under 92, one at a time. The tab bar at the top names all three and marks where you are. Lists longer than the pane scroll with the cursor and say so (`↑ 6 more`).
@@ -1270,7 +1276,8 @@ class BenchScreen(Screen):
         # WHAT IT COSTS, while you are still deciding. "Will this fit beside
         # what I already have" is what the library pane is really asked, and
         # every answer used to arrive only as a refusal after adding it.
-        res = rig.resources(mod, st.words.get(mod.key), st.fx1)
+        res = rig.resources(mod, st.words.get(mod.key), st.fx1,
+                            mod.key in st.sel)
         if res:
             out.append(f"[{WARN}]{escape(' · '.join(res))}[/]")
         out.append("")
@@ -1517,7 +1524,8 @@ class BenchScreen(Screen):
         bits = [rig.category(mod)]
         if mod.menu is not None:
             bits.append(f"id 0x{mod.menu.fx2_id:02x}")
-        bits += rig.resources(mod, st.words.get(mod.key), st.fx1)
+        bits += rig.resources(mod, st.words.get(mod.key), st.fx1,
+                              mod.key in st.sel)
         bits.append("in the image" if mod.key in st.sel else "not in the image")
         st.msg = f"{disp(mod)} — {' · '.join(bits)}"
 

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -1264,7 +1264,11 @@ class RemixerScreen(Screen):
             # costs cycles when it is selected like any other. Only FILTER's
             # figure has ever been measured (192/instance, docs/CHIP.md), so
             # the row says what is missing rather than inventing the rest.
-            nstock = sum(1 for m in st.selected if m.is_stock)
+            # Not the ones this selection HARVESTED past: their code is
+            # gone, so nothing can select them and they cost no cycles.
+            nstock = sum(1 for m in st.selected if m.is_stock
+                         and (m.key not in st.harvest
+                              or m.key.split()[0] in st.donors_kept))
             gap = (f" · {nstock} stock rows not counted" if nstock else "")
             brief.append(("cycles", f"[{c}]{free:,}[/]"))
             side.append(f" {'cycles':<{W}}[{c}]{free:>5,}[/] free of "
@@ -1900,8 +1904,11 @@ class RemixerScreen(Screen):
         if self.sync_error:
             # The build names EVERY donor row this selection overruns, so
             # one press clears them all rather than one per rebuild.
+            # ⚠️ THIS SELECTION'S HARVEST, not the three reverbs. The build
+            # refuses a listed effect whose words it placed over, and which
+            # effects those are is now the remix's own choice.
             out += [m for m in st.selected
-                    if m.is_stock and m.key in stock.CONSUMED
+                    if m.is_stock and m.key in st.harvest
                     and m.key in self.sync_error]
         return out
 

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -427,14 +427,29 @@ class BenchScreen(Screen):
             line = f" {mark} {disp(m):<13} [dim]{menus}[/]"
             out.append(f"[reverse]{line}[/]" if here else line)
         # The three stock REVERBS are absent from every list above, and their
-        # absence is the kind that reads as a bug. Say where they went.
-        out.append("[dim]── consumed ──[/]")
+        # absence is the kind that reads as a bug. Say where they went -- and
+        # say it CONDITIONALLY, because "consumed" is a property of the
+        # SELECTION, not a law. Their code is the region our modules are
+        # written over, so a selection carrying no module of ours takes
+        # nothing from them. (Precedent: CHORUS was a donor until v98 and got
+        # its dispatch back the moment we stopped taking its code.)
+        eats = [m for m in st.selected if m.dsp is not None]
+        out.append("[dim]── the three reverbs ──[/]")
         for name in stock.CONSUMED:
             out.append(f"[dim]   {name:<13} —[/]")
-        out.append("[dim]   these ARE the donor region")
-        out.append("   every module packs into[/]")
+        if eats:
+            out.append("[dim]   their code is the region")
+            out.append(f"   {escape(disp(eats[0]))} and "
+                       f"{len(eats) - 1} other" +
+                       ("s" if len(eats) != 2 else "") + " sit in[/]"
+                       if len(eats) > 1 else
+                       f"   {escape(disp(eats[0]))} sits in[/]")
+        else:
+            out.append("[dim]   nothing here takes their code —")
+            out.append("   a stock-only image would keep")
+            out.append("   them, but cannot be built yet[/]")
         out.append("")
-        out.append("[dim]enter adds at LOADED cursor[/]")
+        out.append("[dim]enter adds at ▸ in LOADED[/]")
         self.query_one("#pane_avail", Static).update("\n".join(out))
 
     def _pane_loaded(self, st):
@@ -442,6 +457,7 @@ class BenchScreen(Screen):
         name = st.loaded_name or "unsaved"
         out = [self._title(f"LOADED · {name}", LOADED), ""]
         pos = 0
+        at = min(self.cur[LOADED], len(rows))      # the insertion point
         for i, m in enumerate(rows):
             here = self.pane == LOADED and i == self.cur[LOADED]
             if m.menu is not None:
@@ -454,8 +470,17 @@ class BenchScreen(Screen):
             cost = f"[dim]{words:>5}w[/]" if words else "      "
             built = "●" if self.in_image(m) else " "
             fb = "◀fb" if st.eff_fallback == m.key else "   "
-            line = f" {row} {built} {disp(m):<13}[dim]{menus:<7}[/]{cost}{fb}"
+            # ▸ marks where an `enter` from the library would land. It has
+            # to be visible from the OTHER pane too -- "adds at the LOADED
+            # cursor" is useless advice when the cursor is only drawn on the
+            # pane you are standing in.
+            caret = "▸" if i == at else " "
+            line = f"{caret}{row} {built} {disp(m):<13}[dim]{menus:<7}[/]{cost}{fb}"
             out.append(f"[reverse]{line}[/]" if here else line)
+        if at >= len(rows):
+            tail = "▸    [dim](end)[/]"
+            out.append(f"[reverse]{tail}[/]"
+                       if self.pane == LOADED else tail)
         if not rows:
             out.append("[dim] (empty — add from the left)[/]")
         probs = st.problems()
@@ -622,7 +647,9 @@ class BenchScreen(Screen):
         rows = (self.avail_rows() if self.pane == AVAILABLE else
                 self.loaded_rows() if self.pane == LOADED else
                 self.unit_rows(self.selected_module()))
-        n = max(len(rows), 1)
+        # LOADED gets one extra position, past the last row: that is "append",
+        # and without it there is no way to add at the end.
+        n = max(len(rows) + (1 if self.pane == LOADED else 0), 1)
         if ev.key in ("down", "j"):
             self.cur[self.pane] = min(n - 1, self.cur[self.pane] + 1)
         elif ev.key in ("up", "k"):
@@ -663,9 +690,9 @@ class BenchScreen(Screen):
         so this is a real edit, not a view preference."""
         st = self.app.state
         rows = self.loaded_rows()
-        if not rows:
+        if not rows or self.cur[LOADED] >= len(rows):
             return
-        i = min(self.cur[LOADED], len(rows) - 1)
+        i = self.cur[LOADED]
         st.move(rows[i].key, step)
         self.cur[LOADED] = max(0, min(len(rows) - 1, i + step))
 
@@ -690,9 +717,9 @@ class BenchScreen(Screen):
             st.loaded_name = ""
         elif self.pane == LOADED:
             rows = self.loaded_rows()
-            if not rows:
-                return
-            mod = rows[min(self.cur[LOADED], len(rows) - 1)]
+            if not rows or self.cur[LOADED] >= len(rows):
+                return                       # the append position: no row
+            mod = rows[self.cur[LOADED]]
             st.toggle(mod.key)
             st.loaded_name = ""
             st.msg = f"removed {mod.key}"

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -1128,9 +1128,14 @@ class RemixerScreen(Screen):
             prev = (k, a + n)
         # Per-run usage when the build reported it; otherwise the whole
         # region is one run and the single figure IS that run's.
+        # ⚠️ BY RUN INDEX, NOT BY ADDRESS. The bar is drawn once from payload
+        # A's spans because the LAYOUT is identical in both, but the two
+        # payloads put those effects at different addresses (docs/DSP.md
+        # s11) -- so keying B's usage on A's bases found nothing and drew
+        # payload B as untouched however much had been placed in it.
         by_run = {}
-        for tag, b, _n, u in st.runs:
-            by_run.setdefault(tag, {})[b] = u
+        for tag, _b, _n, u in st.runs:
+            by_run.setdefault(tag, []).append(u)
 
         def bar(tag):
             got = placed.get(tag)
@@ -1140,10 +1145,11 @@ class RemixerScreen(Screen):
                 if k not in hv:
                     out += f"[dim]{'─' * c}[/]"
                     continue
-                grp = next(g for g in runs_cols if any(x[0] == k for x in g))
-                rbase = grp[0][1]
-                u = (used.get(rbase) if used is not None
-                     else (got if rbase == runs_cols[0][0][1] else 0))
+                ri = next(i for i, g in enumerate(runs_cols)
+                          if any(x[0] == k for x in g))
+                rbase = runs_cols[ri][0][1]
+                u = (used[ri] if used is not None and ri < len(used)
+                     else (got if ri == 0 else 0))
                 if u is None or got is None:
                     out += f"[dim]{'.' * c}[/]"
                 else:

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -418,7 +418,13 @@ class BenchScreen(Screen):
         with Horizontal():
             yield Static(id="pane_avail")
             yield Static(id="pane_load")
-            yield Static(id="pane_unit")
+            # The third column is TWO stacked panes: the selected effect, and
+            # a standing budget under it. What is left of the image is the
+            # context you read every other number against, so it should not
+            # be something you have to go and ask for.
+            with Vertical(id="col_unit"):
+                yield Static(id="pane_unit")
+                yield Static(id="pane_budget")
         yield Static(id="status")
         yield RichLog(id="log", highlight=False, markup=False)
         yield Footer()
@@ -560,6 +566,7 @@ class BenchScreen(Screen):
         self._pane_available(st)
         self._pane_loaded(st, probs)
         self._pane_unit(st, probs)
+        self._pane_budget(st)
         self._paint("#status", f"[dim]{escape(st.msg)}[/]")
 
     def _paint(self, wid, lines):
@@ -713,6 +720,66 @@ class BenchScreen(Screen):
         if not [m for m in st.selected if m.dsp is not None]:
             return "[dim]a stock chooser: 14 effects, no modules[/]"
         return "[dim]building…[/]"
+
+    def _pane_budget(self, st):
+        """WHAT IS LEFT, standing under the effect you are looking at.
+
+        Every other number in this workbench is read against this one -- "500
+        words" means nothing without "and 313 are free" -- and it used to be
+        something you inferred from a refusal. Four scarce things, and only
+        four: the two donor regions, the FX2 buffer slots per core, the
+        chooser rows, and the ColdFire cave. Everything else is unbounded in
+        practice.
+
+        Read from the BUILD's own report wherever possible (state.measure),
+        because the build is the only thing that knows where the cursor
+        actually stopped.
+        """
+        out = ["[bold]Budget[/]"]
+        W = 10                                  # one label column throughout
+
+        def row(label, bar_full, bar_len, colour, tail):
+            return (f" {label:<{W}}[{colour}]" + "#" * bar_full + "[/][dim]"
+                    + "." * (bar_len - bar_full) + f"[/]  {tail}")
+
+        if st.regions:
+            for n, used, free in st.regions:
+                fill = min(20, round(20 * used / max(used + free, 1)))
+                c = OK if free > 400 else WARN if free > 32 else BAD
+                out.append(row(f"words {n}", fill, 20, c, f"{free:>4} free"))
+        else:
+            out.append(f" {'words':<{W}}[dim]"
+                       + "?" * 20 + "[/]  [dim]not built[/]")
+
+        # FX2 buffer slots, per core. Four each, and a pinner takes two or
+        # all four of ONE core's -- which is why the two servers coexist.
+        for tag, tracks in (("A", "5-8"), ("B", "1-4")):
+            taken = 0
+            for m in st.selected:
+                if not rig.pins_fx2(m):
+                    continue
+                tr = rig.track_range(m)
+                here = (not len(tr) or len(tr) == 8
+                        or (tag == "A" and tr.start == 5)
+                        or (tag == "B" and tr.start == 1))
+                if here:
+                    taken = max(taken, rig.pinned_slots(m))
+            free = 4 - taken
+            c = OK if free > 2 else WARN if free else BAD
+            out.append(row(f"FX2 buf {tag}", 5 * taken, 20, c,
+                           f"{free} of 4  [dim]tracks {tracks}[/]"))
+
+        # Rows are countable without a build; the cave is not.
+        rows = (st.chooser_rows if st.chooser_rows is not None
+                else len(st.menu_modules))
+        c = OK if rows < 24 else WARN if rows < 31 else BAD
+        out.append(f" {'rows':<{W}}[{c}]{rows}[/][dim] of 31 "
+                   f"(the long chooser cave)[/]")
+        cave = (f"[{OK if st.cave_free > 512 else WARN if st.cave_free else BAD}]"
+                f"{st.cave_free:,}[/][dim] B free[/]"
+                if st.cave_free is not None else "[dim]not built[/]")
+        out.append(f" {'cave':<{W}}{cave}")
+        self._paint("#pane_budget", out)
 
     def _pane_unit(self, st, probs):
         mod = self.selected_module()
@@ -885,6 +952,10 @@ class BenchScreen(Screen):
             return          # both write out/mainos_bus.bin; the render's
                             # closing rerender() will kick this again
         if self.app.state.problems() if probs is None else probs:
+            # AND FORGET THE LAST BUILD'S NUMBERS. They describe a different
+            # selection, and a budget that silently belongs to the image you
+            # had two edits ago is worse than no budget at all.
+            self.app.state.forget_build()
             self.synced, self.app.boot = self.gen, None
             return          # it would not build; the ⚠ line says why
         self.syncing = self.gen
@@ -1499,9 +1570,18 @@ class BenchScreen(Screen):
 class Workbench(App):
     TITLE = "remix workbench"
     CSS = """
-    #pane_avail { width: 32; padding: 0 1; }
-    #pane_load  { width: 40; padding: 0 1; border-left: dashed $surface; }
-    #pane_unit  { width: 1fr; padding: 0 1; border-left: dashed $surface; }
+    /* The panes must FILL the row for their left borders to run the whole
+       way down -- a Static is only as tall as its text, so the dividers
+       stopped wherever the shortest column ran out. */
+    Horizontal { height: 1fr; }
+    #pane_avail { width: 32; padding: 0 1; height: 100%; }
+    #pane_load  { width: 40; padding: 0 1; height: 100%;
+                  border-left: dashed $surface; }
+    #col_unit   { width: 1fr; height: 100%;
+                  border-left: dashed $surface; }
+    #pane_unit  { height: 1fr; padding: 0 1; }
+    #pane_budget { height: auto; padding: 0 1;
+                   border-top: dashed $surface; }
     #status { height: 1; padding: 0 1; }
     #log { height: 12; border-top: dashed $surface; }
     """

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -348,8 +348,15 @@ The loop is one move long: highlight one of yours in AVAILABLE and press `enter`
   c  full check        f  choose the fallback        k  back to stock
   ?  this              esc  stop audio      q  quit
 
-[bold]FX1 as well as FX2[/]
-The unit has two effect slots per track and stock lists different sets on them: ten effects on FX1, those ten plus DELAY and the three reverbs on FX2. `1` puts the highlighted effect of yours on FX1 too — the `FX1+FX2` column follows, and `s` saves it with the remix.
+[bold]the two menus are not the same shape[/]
+Every track has TWO effect slots, FX1 then FX2, and each has its own chooser list. They are not symmetric and that is the thing to hold on to:
+
+  [bold]FX2[/] is yours to compose. LOADED is that list — the rows, their order, what is on it at all. Leaving a stock effect out takes its FX2 row and NOTHING else: its code and dispatch stay stock, so an old project that selects it still runs it.
+  [bold]FX1[/] is stock's own ten, and no image shortens it. A remix can only APPEND: `1` puts the highlighted effect of yours on the end of it. You cannot remove or reorder FX1's rows, because they are not ours to move.
+
+So the line under LOADED reads `FX1 chooser  stock's 10 + WarpFold`, and `p` → FX1 draws that chooser as the firmware would — with your effect on it if it is there, and stock's own if it is not.
+
+The `FX1+FX2` column says which menus an effect CAN appear on, not where its rows are today; the ✓ beside it is what says whether it is in the image.
 
 It costs no words. The DSP dispatch table is indexed by the raw id and shared by both menus, so the code already ran from FX1 the moment FX1 selected the id; what `1` adds is the panel side. What it DOES cost is cycles: FX1 is four more slots on the same four tracks, so an effect on both menus can double the worst per-core load — watch the Budget's `cycles` row.
 
@@ -719,7 +726,7 @@ class RemixerScreen(Screen):
         # pane paints at all, so they cannot be collected on the way past.
         mod = self.selected_module()
         self._tnames = ["Available",
-                        f"Loaded · {st.loaded_name or 'unsaved'}",
+                        f"FX2 chooser · {st.loaded_name or 'unsaved'}",
                         disp(mod) if mod is not None else "Unit"]
         can_fix = bool(self.blockers(probs))
         if can_fix != getattr(self, "_can_fix", None):
@@ -818,7 +825,12 @@ class RemixerScreen(Screen):
     def _pane_loaded(self, st, probs):
         rows = self.loaded_rows()
         name = st.loaded_name or "unsaved"
-        out = self._head(f"Loaded · {name}", LOADED)
+        # IT IS THE FX2 CHOOSER. The rows are FX2 rows, the numbers are FX2
+        # row numbers, and `←→` reorders FX2 -- while an `FX1+FX2` in the
+        # column beside them invited "row 1 of both", which is not what any
+        # of it means. FX1's list is stock's own and is only ever appended
+        # to; the line under the rows says so.
+        out = self._head(f"FX2 chooser · {name}", LOADED)
         head = len(out)
         cur_line, pos = head, 0
         for i, m in enumerate(rows):
@@ -888,6 +900,32 @@ class RemixerScreen(Screen):
                        f"cannot be listed — {escape(who)} "
                        f"{'holds' if len(pin) == 1 else 'hold'} "
                        f"the buffers they need[/]")
+        # THE OTHER CHOOSER, in one line, under the one being composed.
+        # Composing FX2 while FX1 sat in a column beside it as a tag was the
+        # whole confusion: they are two lists, they are NOT symmetric, and
+        # only one of them is being composed here. FX1's is stock's own ten;
+        # a remix can append to it and can do nothing else to it -- no
+        # removing, no reordering, because those rows are not ours.
+        mine = [m for m in rows if m.key in st.fx1]
+        # TEN, not eleven: FX1's list carries the firmware's own NONE at row
+        # 0, which is not an effect. Counted off the stock rows rather than
+        # written down.
+        n_stock = sum(1 for m in stock.MODULES
+                      if m.menu.fx2_id in stock.fx1_ids())
+        lead = f" FX1 chooser  stock's {n_stock}"
+        if not mine:
+            # "(1 appends)" wrapped at 40 columns, and the hint line two
+            # rows down already says `1 FX1 row`.
+            tell = ", unchanged"
+        else:
+            # Names while they fit -- which one usually does -- and a count
+            # when they do not. A wrapped line here reads as an extra
+            # mystery row, the way the three-reverb `held by` line did.
+            names = ", ".join(disp(m) for m in mine)
+            room = self.query_one("#pane_load", Static).content_size.width
+            tell = (f" + {names}" if room <= 0 or len(lead) + 3 + len(names)
+                    <= room else f" + {len(mine)} of yours")
+        out.append(f"[dim {WARN}]{lead}{escape(tell)}[/]")
         # Everything from the notes down is the IMAGE speaking, not a row,
         # so it stays on screen however long the list gets.
         tail = len(out) - rows_end
@@ -1380,7 +1418,8 @@ class RemixerScreen(Screen):
         if mode == "MENU":
             draws = emu_bringup.render_menu(r, emu_bringup.MENU_ROOT_DESC, 0)
         elif mode == "FX1":
-            draws = emu_bringup.render_fx1(r, track=4, effect_id=0x04)
+            draws = emu_bringup.render_fx1(r, track=4,
+                                           effect_id=effect_id or 0x04)
         else:
             draws = emu_bringup.render_fx2(r, track=4, effect_id=effect_id)
         grid = emu_bringup.layout_screen(draws)
@@ -1388,6 +1427,7 @@ class RemixerScreen(Screen):
         return grid
 
     def _preview(self, mod, probs):
+        st = self.app.state
         modes = " ".join(f"[reverse]{m}[/]" if m == self.preview else
                          f"[dim]{m}[/]" for m in PREVIEWS)
         head = [f"preview {modes}  [dim](p)[/]",
@@ -1411,7 +1451,23 @@ class RemixerScreen(Screen):
             return head + ["[bold]did not reach the RTOS handoff[/] — a "
                            "patch may have broken early init"]
         effect_id = None
-        if self.preview == "FX2":
+        if self.preview == "FX1":
+            # ⚠️ IT ALWAYS DREW FILTER. The one view that could show what an
+            # effect looks like on FX1 was pinned to effect_id 0x04, so
+            # putting one of yours on FX1 and pressing `p` showed the stock
+            # filter's page -- harmless while nothing of ours could be on
+            # FX1, and actively misleading the moment one could.
+            on = rig.menus(mod, st.fx1)
+            if rig.FX1 in on and mod.menu is not None:
+                effect_id = mod.menu.fx2_id
+            else:
+                # Stock's own chooser as it ships, which is what an FX1 row
+                # would be added to -- said, rather than left to look like
+                # this effect's page.
+                effect_id = 0x04
+                head = head[:1] + [f"[dim]— {escape(disp(mod))} has no FX1 "
+                                   f"row; this is stock's chooser —[/]"]
+        elif self.preview == "FX2":
             if mod.menu is None:
                 return head + ["[dim]no chooser row: this module patches the "
                                "firmware rather than adding an effect[/]"]

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -1,28 +1,23 @@
 #!/usr/bin/env python3
-"""The remix workbench, organized the way an Octatrack user thinks: TRACKS.
+"""The remix workbench: swap effects, hear them, see the panel draw them.
 
     make remix          (or: .venv/bin/python3 tools/remix/app.py)
 
-Three views, one rig:
+ONE page, three panes -- AVAILABLE (what could be in the image), LOADED
+(what is), UNIT (the selected effect's knobs and the firmware's own draw of
+its page). The loop it exists for is one move long: point at a stock effect,
+`enter` to swap one of ours in, `r` to hear it.
 
-  RIG (home)   eight tracks, an effect on each. Pick a track, see the
-               effect's real param pages (manifest names, page 1 = knobs
-               A-F), dial values, render through the DSP emulator, hear it,
-               A/B renders. This is the trial-a-sound loop and the reason
-               the workbench exists.
-  REMIX        the composer: which modules the IMAGE contains, grouped as an
-               operator meets them -- bus servers (with their track range),
-               inserts (any track), system plumbing. Collisions, fit, save/
-               load, build and check -- on the LIVE selection, no save needed.
-  EMU          the built image booted in the Tier-0 ColdFire emulator
-               (docs/EMU.md), showing the firmware's own menu and param page
-               renders for the rig's selected track. Booting IS the no-flash
-               gate; the boot is cached until the image changes.
+THE IMAGE FOLLOWS THE SELECTION. Every selection change rebuilds and
+re-boots in the background -- a build is ~0.3 s and a ColdFire boot ~5 s --
+so the panel on the right always draws what the middle pane says. There is
+no build key and no stale state to reason about; that apparatus existed to
+spare the operator a quarter-second and cost more than it saved.
 
 The model layers are headless and live next door: state.py (the composer),
-rig.py (tracks), audition.py (rendering). This file is only the shell.
-Textual rather than curses: the workbench is already venv-hosted for the
-emulator, and the frontend rewrite is where hand-rolled layout stopped
+rig.py (categories, knobs), audition.py (rendering). This file is only the
+shell. Textual rather than curses: the workbench is already venv-hosted for
+the emulator, and the frontend rewrite is where hand-rolled layout stopped
 paying its way.
 """
 
@@ -49,8 +44,8 @@ except ImportError:
 from rich.markup import escape  # noqa: E402  (rich ships with textual)
 
 from remix import audition, registry, rig, stock  # noqa: E402
-from remix.state import (BUILT_IMAGE, DONOR_WORDS, ROOT,  # noqa: E402
-                         STOCK_ROOTS, State)
+from remix.state import BUILT_IMAGE, ROOT, State  # noqa: E402
+
 
 def step_label(mod, name, v):
     """A select's value as the manifest labels it, else the raw number."""
@@ -150,107 +145,43 @@ HELP = {
 then the stock effects the unit already ships. [bold]LOADED[/] is the
 image you are composing, in CHOOSER ORDER — the order here is the order
 of rows on the panel, so left/right there is a real edit. [bold]UNIT[/]
-follows the cursor: the selected effect's knobs, and the firmware's own
-draw of its page.
+follows the cursor: the selected effect's knobs, the firmware's own draw
+of its page, and `r` to hear it on the SOURCE wav.
 
-You start at [bold]stock[/] — the chooser an unmodified unit shows, all
-fourteen effects including the three reverbs. Composing is [bold]trading[/]:
-the donor region is 2,724 words and the chooser is a list somebody has to
-scroll, so `enter` SWAPS the ▸ row for the highlighted module rather than
-growing the list. One trade is often not enough — the first module of
-ours needs SEND in the list, and a big one can push you past the region —
-and the status line names what else has to go.
-
-● in the LOADED pane means "in the image on disk". An effect that is
-loaded but not built is not previewed: its id is not in the image, so
-the firmware would draw a convincing picture of the WRONG effect.
+The loop is one move long: point at a stock effect in LOADED, highlight
+one of yours in AVAILABLE, `enter`. The image rebuilds and re-boots by
+itself, so the panel is never showing something else.
 
 [bold]keys[/]
   tab  pane            up/down  move
   enter  SWAP the ▸ row for this one (at (end): append); on a
          selected module, remove it
   left/right  knob value (UNIT) or row order (LOADED)
-  p  preview mode      r  render + hear     space  play last
-  b  build             c  check             w  word cost
-  l  load remix        s  save remix        f  fallback
-  k  back to stock     ?  this""",
-    "rig": """[bold]THE RIG — your bench, not the unit[/]
+  r  render + hear     space  play last    p  preview mode
+  a  mark it A         , / .  play A / B
+  l  load remix        s  save remix       f  fallback
+  c  full check        k  back to stock    ?  this
 
-Assign an effect to a track, dial its knobs, render a source wav through
-the effect's real DSP code and hear it. Audio comes from the local DSP
-emulator (~6x real time); nothing here touches hardware.
+[bold]the one line under LOADED[/]
+It says the only two things that can stop you: whether the selection
+fits the 2,724-word donor region, and — with a ⚠ — the effects you have
+to remove before it will build. Everything else the pane used to explain
+is here instead.
 
-[bold]keys[/]
-  1-8       select track             enter      pick the track's effect
-  up/down   move between rows        left/right adjust (shift = coarse)
-  r         render + play            space      replay the last render
-  a / b     mark the last render     , / .      replay mark A / B
-  esc       stop audio               backspace  clear the effect
-  x         the remix composer       e          the emulated unit
+[bold]why some stock effects go dim[/]
+Every image replaces the whole FX2 chooser, but only THREE stock effects
+are CONSUMED: PLATE, SPRING and DARK REV, whose code is the donor region
+your modules are written over. The other eleven keep their code and knobs
+in every image and only lose their chooser row — an old project that
+selects one still runs it. Four of them (SPATIALIZER, FLANGER, CHORUS,
+COMB FILTER) take a per-track instance buffer at the addresses the servers
+hardcode, so they cannot sit beside ChonVerb, Nimbus or BongDelay; that is
+what the ⚠ is telling you to remove.
 
-[bold]why some effects are missing on a track[/]
-The two BUS EFFECTS each live on one of the unit's two DSP cores:
-ChonVerb serves tracks 5-8 and BongDelay tracks 1-4 (measured, and
-inverted from what you'd guess). INSERTS run on any track. The knob
-rows mirror the unit's two FX2 SETUP pages: page 1 = encoders A-F,
-page 2 alternates knob/select. The dim ? line explains whichever
-knob the cursor is on.""",
-    "remix": """[bold]THE COMPOSER — what the firmware image contains[/]
-
-A remix is a named selection of modules built into one firmware image.
-Toggle modules here; the right panel answers, continuously: what the
-FX2 chooser will show on the unit, whether anything collides (the same
-ledger the build runs), and whether the DSP fits the 2724-word donor
-region (w assembles for real numbers).
-
-Effects the image leaves out don't vanish on the unit: an old project
-selecting an absent id is aliased to the FALLBACK (normally SEND), so
-it degrades to a send instead of noise. * marks an explicit fallback,
-~ an automatic one.
-
-[bold]what happens to the stock effects[/]
-Every image replaces the whole FX2 chooser, but only THREE stock
-effects are consumed -- PLATE, SPRING and DARK REV, whose code is the
-donor region the modules pack into. The other eleven keep their code
-and knobs in every image and only lose their row. Toggle one under
-STOCK FX2 to keep its row: it costs nothing. Four of them (SPAT, FLNG,
-CHOR, COMB) take a per-track buffer where the servers keep theirs, so
-they are refused beside ChonVerb, Nimbus or BongDelay. Row order is
-selection order; [ and ] move the cursored module. More than seven
-rows and the chooser scrolls, as stock's does.
-
-[bold]keys[/]
-  space  toggle module        f  make it the fallback
-  [ / ]  move earlier/later   w  assemble + measure
-  b      build the selection  c  build + full check
-  l      load a saved remix   s  save this selection
-  v      rig                  e  emulated unit""",
-    "emu": """[bold]THE EMULATED UNIT — the real firmware, screen only[/]
-
-Your built image, booted in a local ColdFire emulator, drawing its own
-screens: the MAIN MENU (patched-in entries render exactly as the unit
-would), the FX2/FX1 SETUP pages and the PLAYBACK page. There is no
-audio and no key matrix — this view is the no-flash confidence check:
-does the image boot cleanly, does the panel draw what the manifests
-promised.
-
-Knob VALUES draw as dial graphics the text capture cannot read, so the
-rig's numbers are always the truth for values. The boot is cached and
-repeats only when the image changes.
-
-[bold]The FX2 view is the whole loop.[/] left/right cycles every effect
-the image offers AND every module that could be added; picking one the
-image HAS assigns it to the track (the rig follows). Picking one it does
-NOT have is not drawn — an id the image lacks resolves to the fallback,
-so the firmware would draw a convincing picture of the wrong effect —
-so [bold]a[/] stages it in the composer and [bold]b[/] builds and re-boots.
-Cycling past several unbuilt effects costs nothing; only b builds.
-
-[bold]keys[/]
-  m  main menu      f  FX2 (cycles effects; the rig follows)
-  o  FX1 (stock)    p  playback page
-  a  stage an unbuilt effect     b  build the selection + re-boot
-  1-8  track        up/down  menu cursor   left/right  cycle""",
+[bold]the fallback[/]
+An id the image does not implement aliases to the FALLBACK — normally
+SEND, so an old project degrades to a send instead of noise. It is added
+for you when a selection needs one; `f` chooses another. ◀fb marks it.""",
 }
 
 
@@ -301,15 +232,13 @@ class BenchScreen(Screen):
         Binding("tab", "pane(1)", "pane"),
         Binding("shift+tab", "pane(-1)", "prev pane", show=False),
         Binding("enter", "add_remove", "swap / remove"),
-        Binding("p", "preview", "preview"),
-        Binding("r", "render", "render+hear"),
+        Binding("r", "render", "hear it"),
         Binding("space", "play", "play last"),
+        Binding("p", "preview", "preview page", show=False),
         Binding("a", "mark('A')", "mark A", show=False),
         Binding("comma", "play_mark('A')", "play A", show=False),
         Binding("full_stop", "play_mark('B')", "play B", show=False),
-        Binding("b", "build('bus')", "build"),
-        Binding("c", "build('check')", "check", show=False),
-        Binding("w", "measure", "word cost", show=False),
+        Binding("c", "build('check')", "full check", show=False),
         Binding("f", "fallback", "fallback", show=False),
         Binding("l", "load", "load remix"),
         Binding("s", "save", "save remix"),
@@ -331,9 +260,16 @@ class BenchScreen(Screen):
         self.pane = LOADED
         self.cur = [0, 0, 0]
         self.preview = "FX2"
-        self.booting = False
         self.rows_mtime = None
         self.built = []                  # (fx2_id, module) from the image
+        # The image tracks the selection: `gen` counts selection changes,
+        # `synced` is the one the booted image reflects, `syncing` is the one
+        # a worker is currently building. A rebuild is kicked whenever they
+        # disagree -- see schedule_sync().
+        self.gen = 0
+        self.synced = None
+        self.syncing = None
+        self.sync_error = None
         self.query_one("#log", RichLog).display = False
         self.rerender()
 
@@ -450,15 +386,15 @@ class BenchScreen(Screen):
                 row = " ·"                      # no chooser row (a CF patch)
             menus = "+".join(rig.menus(m)) or "—"
             words = st.words.get(m.key)
-            cost = f"[dim]{words:>5}w[/]" if words else "      "
-            built = "●" if self.in_image(m) else " "
-            fb = "◀fb" if st.eff_fallback == m.key else "   "
+            cost = f"{words:>5}w" if words else "      "
+            fb = "◀fb" if st.eff_fallback == m.key else ""
             # ▸ marks where an `enter` from the library would land. It has
             # to be visible from the OTHER pane too -- "adds at the LOADED
             # cursor" is useless advice when the cursor is only drawn on the
             # pane you are standing in.
             caret = "▸" if i == at else " "
-            line = f"{caret}{row} {built} {disp(m):<13}[dim]{menus:<7}[/]{cost}{fb}"
+            line = (f"{caret}{row} {disp(m):<13}"
+                    f"[dim]{menus:<7}{cost}[/]{fb}")
             out.append(f"[reverse]{line}[/]" if here else line)
         if at >= len(rows):
             tail = "▸    [dim](end)[/]"
@@ -471,47 +407,51 @@ class BenchScreen(Screen):
         # effects, and these are three of them. They leave when something
         # takes their space -- their code IS the donor region our modules are
         # written over -- so showing the trade where it happens is the point.
-        # (Precedent: CHORUS was a donor until v98 and got its stock dispatch
-        # back the moment the build stopped taking its code.)
+        # ONE dim line, not three: the old form repeated "taken by <module>"
+        # per reverb, which said one thing three times, named an arbitrary
+        # module as the taker (eats[0] is just the first selection with DSP
+        # code -- nothing here computes a per-reverb attribution), and
+        # overran the 38-column pane so its " +1" wrapped onto its own line
+        # and read as a fourth mystery row.
         eats = [m for m in st.selected if m.dsp is not None]
-        for name in stock.CONSUMED:
-            if eats:
-                out.append(f"[dim]  –  {name:<13} taken by "
-                           f"{escape(disp(eats[0]))}"
-                           f"{f' +{len(eats) - 1}' if len(eats) > 1 else ''}[/]")
-            else:
+        if eats:
+            out.append("[dim] —  PLATE, SPRING, DARK REV (donors)[/]")
+        else:
+            for cname in stock.CONSUMED:
                 pos += 1
-                out.append(f"[dim] {pos:>2}   {name:<13}FX2[/]")
-        probs = st.problems()
+                out.append(f"[dim] {pos:>2} {cname:<13}FX2[/]")
         out.append("")
-        # THE BUDGET, because it is the actual constraint and it was
-        # invisible. Rows are nearly free -- seven in place, up to 32 in the
-        # long cave -- and STOCK rows cost NOTHING AT ALL, since their code
-        # is already in the image whether or not they have a row. The 2,724
-        # words are spent only by modules of ours, so "will this fit" is a
-        # question about them alone, and a swap of a stock row for a module
-        # frees nothing.
-        code = [m for m in st.selected if m.dsp is not None]
-        known = [m for m in code if m.key in st.words]
-        if code and len(known) == len(code):
-            used = sum(st.words[m.key] for m in code)
-            free = DONOR_WORDS - used
-            out.append(f"[dim]donor region {used}/{DONOR_WORDS} · "
-                       f"{'[/][bold]' if free < 0 else ''}{free} free[/]")
-        elif code:
-            out.append(f"[dim]{len(code)} module"
-                       f"{'s' if len(code) != 1 else ''} spending the "
-                       f"{DONOR_WORDS}-word region — w measures[/]")
-        out.append("[dim]● = in the built image · ◀fb = fallback[/]")
-        out.append("[dim]dim = stock, lost to the donor region[/]"
-                   if eats else
-                   "[dim]a stock chooser: 14 effects, no modules[/]")
-        out.append("[dim]← → moves this row (= its panel slot)[/]"
-                   if self.pane == LOADED else
-                   "[dim]tab here to reorder or remove[/]")
-        if probs:
-            out.append(f"[bold]⚠ {escape(probs[0])}[/]")
+        out.append(self._ledger_line(st))
         self.query_one("#pane_load", Static).update("\n".join(out))
+
+    def _ledger_line(self, st):
+        """The fit, the blocker and the build state, in ONE line.
+
+        This pane used to close with five: a donor-region budget, a ● legend,
+        a "dim = stock" legend, a keys hint and a ⚠ -- roughly half its
+        height spent explaining constraints rather than showing the image.
+        Only two questions are actually live while swapping: does this fit,
+        and is the panel on the right showing it yet. The rest moved to `?`.
+        """
+        probs = st.problems()
+        if self.untouched_stock(probs):
+            return "[dim]stock — swap a module in to build it[/]"
+        if probs:
+            return f"[bold]⚠ {escape(self._clash(probs) or probs[0])}[/]"
+        if self.syncing is not None or self.synced != self.gen:
+            return "[dim]building…[/]"
+        if self.sync_error:
+            # The build names the payload and the overrun; that IS the
+            # actionable sentence, so print it rather than a pointer to it.
+            return f"[bold]⚠ {escape(self.sync_error)}[/]"
+        # THE BUILD'S OWN NUMBERS, one per payload. Not a sum of st.words
+        # against DONOR_WORDS: there are TWO regions of that size and
+        # SPEC=1 puts a server on each, so the sum is not a quantity
+        # anything has to fit (see state.problems).
+        if st.regions:
+            return "[dim]" + " · ".join(
+                f"{n} {f} free" for n, _u, f in st.regions) + "[/]"
+        return "[dim]a stock chooser: 14 effects, no modules[/]"
 
     def _pane_unit(self, st):
         mod = self.selected_module()
@@ -571,38 +511,29 @@ class BenchScreen(Screen):
         self.query_one("#pane_unit", Static).update("\n".join(out))
 
     # ---- the emulated panel ---------------------------------------------
-    def stale(self):
-        """Does the image on disk still match the selection? The preview
-        draws the IMAGE, and when the two disagree it shows one set of
-        effects while the LOADED pane shows another -- which reads as a bug
-        rather than as staleness unless it is said out loud."""
-        want = [m.key for m in self.app.state.menu_modules if not m.is_stock]
-        got = [m.key for _, m in self.image_rows() if m is not None
-               and not m.is_stock]
-        return want != got
-
     def _preview(self, mod):
         modes = " ".join(f"[reverse]{m}[/]" if m == self.preview else
                          f"[dim]{m}[/]" for m in PREVIEWS)
         head = [f"preview {modes}  [dim](p)[/]",
-                "[dim]— drawn by the firmware, from the image on disk —[/]"]
-        # STALE MEANS DO NOT DRAW. Labelling it was not enough: the FX2 page
-        # includes the firmware's own chooser list, so a stale image puts a
-        # different set of effects on screen beside the LOADED pane and reads
-        # as "why are those loaded?". Same principle the unbuilt-module case
-        # already used -- do not draw a convincing picture of the wrong thing.
-        # ⚠️ Boot FIRST, then decide what to show. Returning early on stale
-        # skipped ensure_boot() entirely, so a workbench that opened stale --
-        # which is every fresh launch -- never started the emulator at all,
-        # and the preview stayed dead for the whole session.
+                "[dim]— drawn by the firmware, from your selection —[/]"]
+        # DO NOT DRAW SOMETHING THAT IS NOT THE SELECTION. The FX2 page
+        # includes the firmware's own chooser list, so an image that is not
+        # this selection puts a different set of effects on screen beside the
+        # LOADED pane and reads as "why are those loaded?". The answer is no
+        # longer to explain it -- ensure_sync() rebuilds -- but while that is
+        # in flight there is still nothing honest to show.
+        self.ensure_sync()
         r = self.app.boot
-        if r is None:
-            self.ensure_boot()
-            return head + ["[dim]booting the emulator...[/]"]
-        if self.stale():
-            return head[:1] + [
-                "[bold]the image on disk is not this selection[/]",
-                "[dim]b builds it, then this shows YOUR image[/]"]
+        probs = self.app.state.problems()
+        if self.untouched_stock(probs):
+            return head[:1] + ["[dim]swap a module in and this draws it[/]"]
+        if probs:
+            return head[:1] + ["[dim]not built — see the ⚠ in LOADED[/]"]
+        if self.sync_error:
+            return head[:1] + [f"[bold]build failed[/] [dim]— "
+                               f"{escape(self.sync_error)}[/]"]
+        if self.syncing is not None or r is None:
+            return head[:1] + ["[dim]building and booting…[/]"]
         if not r.reached_handoff:
             return head + ["[bold]did not reach the RTOS handoff[/] — a "
                            "patch may have broken early init"]
@@ -616,12 +547,11 @@ class BenchScreen(Screen):
                 return head + ["[dim]no chooser row: this module patches the "
                                "firmware rather than adding an effect[/]"]
             if not self.in_image(mod):
-                return head + [
-                    f"[bold]not in the built image[/] — b builds the "
-                    f"selection",
-                    "[dim]the page is not drawn: an id the image does not",
-                    "implement resolves to the fallback, so the firmware",
-                    "would draw the WRONG effect (CLAUDE.md, 12 Aug).[/]"]
+                # Rare now that the image follows the selection, but kept:
+                # an id the image does not implement resolves to the
+                # FALLBACK, so the firmware would draw a convincing picture
+                # of the wrong effect (CLAUDE.md, 12 Aug 2026).
+                return head[:1] + ["[dim]not in the image yet[/]"]
             draws = emu_bringup.render_fx2(r, track=4,
                                            effect_id=mod.menu.fx2_id)
         grid = emu_bringup.layout_screen(draws)
@@ -629,28 +559,63 @@ class BenchScreen(Screen):
             ["|" + escape(ln.ljust(44)) + "|" for ln in grid] + \
             ["'" + "-" * 44 + "'"]
 
-    def ensure_boot(self):
-        if not BUILT_IMAGE.exists() or self.booting:
-            return
-        mtime = BUILT_IMAGE.stat().st_mtime
-        if self.app.boot is not None and self.app.boot_mtime == mtime:
-            return
-        self.booting = True
-        self.boot_worker(mtime)
+    # ---- keeping the image equal to the selection ------------------------
+    # There used to be a stale() gate here: the preview refused to draw when
+    # the image on disk was not the selection, and printed a bold two-line
+    # disclaimer telling the operator to press b. Every fresh launch is
+    # stale, so the headline feature opened showing a disclaimer -- and what
+    # it was guarding is a 0.26 s build (`make bus` from a touched manifest,
+    # measured 2 Sep 2026) plus a 4.6 s ColdFire boot, both already on a
+    # worker thread. So the image just follows the selection instead.
+    def schedule_sync(self):
+        """The selection changed. Rebuild and re-boot, after a short pause so
+        a run of swaps costs one build rather than one per keystroke."""
+        self.gen += 1
+        self.set_timer(0.35, self.ensure_sync)
 
-    @work(thread=True, exclusive=True, group="boot")
-    def boot_worker(self, mtime):
-        app = self.app
-        try:
-            import emu_bringup
-            r = emu_bringup.boot(str(BUILT_IMAGE))
-        except Exception as e:                       # noqa: BLE001
-            r = None
-            app.state.msg = f"emulator unavailable — {e} (make emu-setup)"
-        self.booting = False
-        if r is not None:
-            app.boot, app.boot_mtime = r, mtime
-        app.call_from_thread(self.rerender)
+    def ensure_sync(self):
+        """Start the rebuild if the image is behind and nothing is in the
+        way. Idempotent and cheap -- rerender() calls it, so a kick that
+        arrives during a render or a build is simply picked up by the next
+        one rather than queued."""
+        if self.syncing is not None or self.synced == self.gen:
+            return
+        if self.app.rendering:
+            return          # both write out/mainos_bus.bin; the render's
+                            # closing rerender() will kick this again
+        if self.app.state.problems():
+            self.synced, self.app.boot = self.gen, None
+            return          # it would not build; the ⚠ line says why
+        self.syncing = self.gen
+        self.sync_worker(self.gen)
+
+    @work(thread=True, group="sync")
+    def sync_worker(self, gen):
+        """Build the live selection, then boot it.
+
+        state.measure() IS the build -- the same `REMIX=x XBUS=1 SPEC=1
+        build_bus.py` that `make bus` runs -- and it parses the per-module
+        word counts out of the build report on the way past. So one call
+        does what the old b (build) and w (word cost) keys did separately.
+        """
+        st = self.app.state
+        ok, note = st.measure(None)
+        r = None
+        if ok:
+            try:
+                import emu_bringup
+                r = emu_bringup.boot(str(BUILT_IMAGE))
+            except Exception as e:                   # noqa: BLE001
+                note = f"emulator unavailable — {e} (make emu-setup)"
+        if gen == self.gen:                          # not superseded
+            self.app.boot = r
+            self.sync_error = None if ok else note
+            self.synced = gen
+            self.rows_mtime = None                   # chooser rows re-read
+            if not ok:
+                st.msg = f"build failed: {note}"
+        self.syncing = None
+        self.app.call_from_thread(self.rerender)
 
     # ---- input -----------------------------------------------------------
     def action_pane(self, d):
@@ -715,6 +680,7 @@ class BenchScreen(Screen):
         i = self.cur[LOADED]
         st.move(rows[i].key, step)
         self.cur[LOADED] = max(0, min(len(rows) - 1, i + step))
+        self.schedule_sync()      # placement order changes the image
 
     def action_add_remove(self):
         st = self.app.state
@@ -740,10 +706,13 @@ class BenchScreen(Screen):
                 else:
                     st.insert_at(mod.key, len(st.order))
                     st.msg = f"added {disp(mod)} at the end"
-                more = self.knock_ons()
-                if more:
-                    st.msg += " · " + more
+                # The consequences go to the ⚠ line, which is beside the
+                # rows they are about. Appending them here produced a
+                # run-on that the status bar then truncated -- and the part
+                # it cut was the only actionable half of the sentence.
+                st.msg += self.ensure_fallback()
             st.loaded_name = ""
+            self.schedule_sync()
         elif self.pane == LOADED:
             rows = self.loaded_rows()
             if not rows or self.cur[LOADED] >= len(rows):
@@ -753,62 +722,66 @@ class BenchScreen(Screen):
             st.loaded_name = ""
             st.msg = f"removed {mod.key}"
             self.cur[LOADED] = max(0, self.cur[LOADED] - 1)
+            self.schedule_sync()
         self.rerender()
 
-    def knock_ons(self):
-        """What ELSE this swap now requires -- the multi-swap case.
+    def ensure_fallback(self):
+        """Satisfy the fallback rule rather than demanding a trade for it.
 
-        One trade is frequently not enough, and the reasons are unequal:
+        A chooser row costs nothing (32 fit in the long cave), so making the
+        operator sacrifice an effect for SEND was an invention of this UI,
+        not a constraint of the image. Add it and say so in four words.
 
-        * A BUFFER CLASH is the expensive one and the ledger states it one
-          PAIR at a time -- adding ChonVerb to a stock chooser produces four
-          near-identical sentences (FLANGER, CHORUS, SPATIALIZER and COMB all
-          take a per-track instance buffer at the addresses its tank
-          hardcodes). Reported as four walls of text it is unreadable and it
-          is not obvious that the answer is "remove those four". Aggregated
-          into one sentence that names them.
-        * THE FALLBACK is cheap and is fixed here rather than reported. A
-          chooser row costs nothing (32 fit in the long cave), so making the
-          operator sacrifice an effect for SEND was an invention of this UI,
-          not a constraint of the image. It is added, and said out loud.
-        * WORDS are the real budget and the only one where something has to
-          go.
+        This is all that survives of knock_ons(), which also REPORTED the
+        buffer clashes and the word budget into the status line. Those two
+        belong on the ⚠ line beside the rows they are about, where they are
+        re-derived every render instead of being a snapshot of the moment
+        one swap happened.
         """
         st = self.app.state
-        probs = st.problems()
+        if not any("no fallback" in p for p in st.problems()):
+            return ""
+        send = st.mods.get("SEND")
+        if send is None or send.key in st.sel:
+            return ""
+        st.insert_at(send.key, len(st.order))
+        return " · added Send as the fallback"
 
-        # The fallback: satisfy it rather than demand a trade for it.
-        if any("no fallback" in p for p in probs) and "SEND" in st.mods:
-            send = st.mods["SEND"]
-            room = (send.key in st.words and
-                    sum(st.words[m.key] for m in st.selected
-                        if m.dsp is not None and m.key in st.words)
-                    + st.words[send.key] <= DONOR_WORDS)
-            if send.key not in st.sel and (room or send.key not in st.words):
-                st.insert_at(send.key, len(st.order))
-                probs = st.problems()
-                extra = "added Send too (the only safe fallback)"
-                rest = self._clash(probs)
-                return extra + (" · " + rest if rest else "")
-        rest = self._clash(probs)
-        return rest
+    def untouched_stock(self, probs):
+        """Is this the LAUNCH state rather than a mistake?
+
+        An untouched stock chooser cannot build and is documented not to
+        pretend it can (state.load_stock): a remix must name a fallback for
+        the ids it does not implement, and no stock effect is a safe one --
+        it would PROCESS the unknown id rather than pass it. But that is the
+        state the bench OPENS in, so reporting it as ⚠ makes a fresh launch
+        look broken. Say what the next move is instead. The moment a module
+        of ours goes in, SEND comes with it and this stops applying.
+        """
+        return (bool(probs)
+                and all("no fallback" in p for p in probs)
+                and not any(not m.is_stock for m in self.app.state.selected))
 
     def _clash(self, probs):
-        """One readable sentence for whatever still stands."""
+        """One readable, IMPERATIVE sentence for whatever stands.
+
+        A buffer clash is the expensive one and the ledger states it a PAIR
+        at a time -- adding ChonVerb to a stock chooser yields four
+        near-identical sentences (FLANGER, CHORUS, SPATIALIZER and COMB all
+        take a per-track instance buffer at the addresses its tank
+        hardcodes). Four walls of text do not read as "remove those four".
+        """
         if not probs:
             return ""
         buf = [p for p in probs if "stock instance buffer" in p]
         if buf:
             # "stock instance buffer: flanger and chonverb both claim ..."
-            names = []
-            for p in buf:
-                a = p.split(":", 1)[1].split(" and ")[0].strip()
-                names.append(a.upper())
-            return (f"needs the FX2 buffer region — also swap out "
-                    f"{', '.join(names)}")
+            names = [p.split(":", 1)[1].split(" and ")[0].strip().upper()
+                     for p in buf]
+            return "also remove " + ", ".join(names)
         first = probs[0]
         if "exceeds" in first:
-            return first + "; swap something else out too"
+            return first + " — remove something else"
         if "no fallback" in first:
             return "needs a fallback — press f to choose one"
         return first
@@ -816,6 +789,7 @@ class BenchScreen(Screen):
     def action_stock(self):
         self.app.state.load_stock()
         self.cur = [0, 0, 0]
+        self.schedule_sync()
         self.rerender()
 
     def action_fallback(self):
@@ -831,6 +805,7 @@ class BenchScreen(Screen):
             if key:
                 st.fallback = key
                 st.msg = f"unimplemented ids alias to {key}"
+                self.schedule_sync()
             self.rerender()
         self.app.push_screen(Chooser("unimplemented ids alias to:", opts), done)
 
@@ -906,18 +881,6 @@ class BenchScreen(Screen):
         self.rerender()
 
     # ---- build, measure, load, save --------------------------------------
-    def action_measure(self):
-        st = self.app.state
-        st.msg = "assembling for word counts..."
-        self.rerender()
-        self.measure_worker()
-
-    @work(thread=True, exclusive=True, group="measure")
-    def measure_worker(self):
-        st = self.app.state
-        st.measure(None)
-        self.app.call_from_thread(self.rerender)
-
     def action_build(self, target):
         st = self.app.state
         probs = st.problems()
@@ -944,11 +907,12 @@ class BenchScreen(Screen):
             rc = p.wait()
         finally:
             st.scratch_cleanup()
-        st.msg = (f"make {target}: {'OK' if rc == 0 else f'FAILED (rc {rc})'}"
-                  f" — the built image is this selection")
-        if rc == 0:
-            self.app.boot = None          # the preview must re-boot
-            self.rows_mtime = None        # and the ● markers re-read
+        st.msg = f"make {target}: {'OK' if rc == 0 else f'FAILED (rc {rc})'}"
+        # `make check` shells out to build_bus.py several times WITHOUT
+        # XBUS/SPEC (verify_burn does), so whatever it leaves at the
+        # artifact's path is not this selection. Re-sync rather than trust
+        # it -- the same reason the Makefile's own check target rebuilds.
+        self.synced = None
         self.app.call_from_thread(self.rerender)
 
     def action_load(self):
@@ -960,6 +924,7 @@ class BenchScreen(Screen):
             elif name:
                 self.app.state.load(name)
             self.cur = [0, 0, 0]
+            self.schedule_sync()
             self.rerender()
         self.app.push_screen(
             Chooser("load:", [("stock", "stock (an unmodified unit)")]
@@ -1017,8 +982,7 @@ class Workbench(App):
         self.marks = {}                    # "A"/"B" -> path
         self.status = ""                   # state.msg is the live line now
         self.rendering = False
-        self.boot = None                   # cached emulator BootResult
-        self.boot_mtime = None
+        self.boot = None                   # the booted image, or None
         self.player = None                 # the running afplay
 
     def on_mount(self):

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -398,8 +398,10 @@ Rows are NOT the scarce thing, which is why `enter` adds rather than swaps: 31 r
 
 Measured 3 Sep 2026 and it says the limit is ours to lift: the thirteen DSP effects are laid out CONTIGUOUSLY in 6,158 words (`P:0x007d1..0x01fdf`, no other module between them), and every one of them is SELF-CONTAINED — no control flow leaves its own span and nothing enters it but its own dispatch entry. So any effect's words could be freed by dropping it, and a run of dropped neighbours would be one bigger region. What that costs is the effect itself: today an unlisted stock effect keeps working and only loses its row, and one harvested for its words would not.
 
-[bold]the donor region is a CHOICE, not a place[/]
-The thirteen DSP effects are laid out contiguously — 6,158 words in each payload — and every one is self-contained, so ANY unbroken run of them is ground your modules can be placed into. `h` harvests the highlighted stock effect's words and `⌁` marks it in the library. The three reverbs are only the default: they are the biggest and FX2-only, so taking them costs FX1 nothing.
+[bold]on an unmodified unit every word is allocated[/]
+All 6,158 words of the payload's effect code belong to a stock effect that is using them, and the remixer opens saying exactly that: `no region — every word is a stock effect's`, the map all `─`, `all 6,158 words allocated`. NOTHING is set aside for you until you decide what to give up.
+
+`h` harvests the highlighted stock effect's words and `⌁` marks it in the library. The thirteen effects are laid out contiguously and every one is self-contained, so any unbroken run of them is ground your modules can be placed into. Add a module before harvesting anything and the ⚠ says so, with `x` taking the three reverbs — the biggest, and FX2-only, so they cost FX1 nothing — which is the conventional choice and not one the image imposes.
 
 ⚠️ The run has to stay CONTIGUOUS — a module of ours is one code stream, so a gap is not a smaller region, it is two — and only the effect just below the bottom of the run or just above its top can join it. `h` says what is in the way rather than letting the build refuse later.
 
@@ -778,7 +780,8 @@ class RemixerScreen(Screen):
         self._tnames = ["Available",
                         f"Choosers · {st.loaded_name or 'unsaved'}",
                         disp(mod) if mod is not None else "Unit"]
-        can_fix = bool(self.blockers(probs))
+        can_fix = bool(self.blockers(probs)) or (
+            not st.harvest and [m for m in st.selected if m.dsp is not None])
         if can_fix != getattr(self, "_can_fix", None):
             self._can_fix = can_fix
             self.refresh_bindings()          # the footer follows it
@@ -1006,8 +1009,15 @@ class RemixerScreen(Screen):
         and is the panel on the right showing it yet. The rest moved to `?`.
         """
         if probs:
+            # ⚠️ NOTHING TO PLACE INTO OUTRANKS THE REST. It is the only one
+            # whose fix ADDS rather than removes, `x` applies it first, and a
+            # ⚠ saying "x removes Flanger…" while x actually harvested the
+            # reverbs is the worst kind of wrong.
+            first = next((p_ for p_ in probs if p_.startswith("nothing is "
+                                                              "harvested")),
+                         None)
             return (f"[bold {BAD}]⚠ "
-                    f"{escape(self._clash(probs) or probs[0])}[/]")
+                    f"{escape(first or self._clash(probs) or probs[0])}[/]")
         if self.syncing is not None or self.synced != self.gen:
             return f"[dim {WARN}]building…[/]"
         if self.sync_error:
@@ -1043,6 +1053,11 @@ class RemixerScreen(Screen):
             boot = ("" if r is None else
                     " [dim]· boots[/]" if r.reached_handoff else
                     f" [{BAD}]· DID NOT REACH THE RTOS HANDOFF[/]")
+            # "0 free" against a region that does not exist reads as "no
+            # space"; the truth is that nothing has been given up yet.
+            if not st.harvest:
+                return ("[dim]no region — every word is a stock effect's[/]"
+                        + boot)
             return "[dim]" + " · ".join(
                 one(n, placeable(st.sel, t, u, st.harvest)[0])
                 for n, t, u, _f in st.regions) + "[/]" + boot
@@ -1119,11 +1134,18 @@ class RemixerScreen(Screen):
         # overwritten -- every one of those effects still works. Reading the
         # dots as loss is the obvious mistake and the footer used to invite
         # it by saying "harvested" whether or not a word had been placed.
-        lo = sum(c for k, _a, _n, c in seg
-                 if sp[k][0] < min((sp[h][0] for h in hv), default=0))
-        span = sum(c for k, _a, _n, c in seg if k in hv)
+        lo = (0 if not hv else
+              sum(c for k, _a, _n, c in seg
+                  if sp[k][0] < min(sp[h][0] for h in hv)))
+        span = sum(c for k, _a, _n, c in seg if k in hv) if hv else w
         n_w = stock.region_words(tuple(hv))
-        if not any(placed.values()):
+        if not hv:
+            # EVERY WORD IS A STOCK EFFECT'S. That is what an unmodified unit
+            # looks like and the map has to say so, not imply a region is
+            # waiting.
+            tries = [f" all {total:,} words allocated — h harvests one ",
+                     f" all {total:,} words allocated ", f" {total:,} words "]
+        elif not any(placed.values()):
             tries = [f" {n_w:,} words yours to place into — none taken yet ",
                      f" {n_w:,} words, none taken ", f" {n_w:,} words "]
         else:
@@ -1264,7 +1286,17 @@ class RemixerScreen(Screen):
                        f" {'words ' + n:<{W}}[{c}]{free:>5,}[/] free of "
                        f"{total:,} [dim]· {used:,} loaded[/]")
 
-        if st.regions:
+        if not st.harvest:
+            # ⚠️ NOT "0 free of 0". A build with nothing harvested reports a
+            # zero-word region, which is true and reads as "you have no
+            # space" -- the truth is that nothing has been given up yet and
+            # every word belongs to a stock effect that is using it.
+            for n in ("A", "B"):
+                brief.append((f"words {n}", "[dim]none[/]"))
+                out.append(why(f"words {n}",
+                               f" {'words ' + n:<{W}}[dim]no region — every "
+                               f"word is a stock effect's[/]"))
+        elif st.regions:
             for n, total, used, _f in st.regions:
                 out.append(words_row(n, total, used))
             out.append(None)                # the key goes here -- see below
@@ -1272,9 +1304,9 @@ class RemixerScreen(Screen):
             # No build to read -- and none is possible, because a selection
             # with no module of ours has no fallback to name. The region is
             # still fully accounted for: the three reverbs are in it.
+            reg = stock.region_words(tuple(st.harvest))
             for n in ("A", "B"):
-                out.append(words_row(n, stock.region_words(tuple(st.harvest)),
-                                     0))
+                out.append(words_row(n, reg, 0))
             out.append(None)
         else:
             # WHY it is not built, not just that it is not. This row is where
@@ -2100,6 +2132,21 @@ class RemixerScreen(Screen):
     def action_fix(self):
         """Apply the ⚠'s own advice."""
         st = self.app.state
+        # NOTHING TO PLACE INTO comes first: it is the only ⚠ whose fix ADDS
+        # rather than removes, and on a stock chooser it is the first one you
+        # meet. The three reverbs are the conventional choice -- the biggest,
+        # and FX2-only, so taking them costs FX1 nothing -- not a default the
+        # image imposes.
+        if not st.harvest and [m for m in st.selected if m.dsp is not None]:
+            from remix.schema import DEFAULT_HARVEST
+            st.harvest = list(DEFAULT_HARVEST)
+            st.loaded_name = ""
+            st.msg = (f"harvested {', '.join(titlecase(k) for k in st.harvest)}"
+                      f" — {stock.region_words(DEFAULT_HARVEST):,} words to "
+                      f"place into. h picks different ones.")
+            self.schedule_sync()
+            self.rerender()
+            return
         gone = self.blockers(st.problems())
         if not gone:
             gone = self.blockers([])

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -456,6 +456,7 @@ class BenchScreen(Screen):
         # the time it takes to switch windows.
         self._src = audition._newest_input_mtime()
         self.set_interval(1.5, self._poll_source)
+        self.measure_all()
         self.query_one("#log", RichLog).display = False
         self.rerender()
 
@@ -907,6 +908,17 @@ class BenchScreen(Screen):
         self.app.call_from_thread(self.rerender)
 
     # ---- input -----------------------------------------------------------
+    @work(thread=True, group="words")
+    def measure_all(self):
+        """Word counts for every module, so the library can say what a thing
+        costs BEFORE you add it. ~2 s once, then cached (state.measure_every).
+        """
+        try:
+            self.app.state.measure_every()
+        except Exception:                            # noqa: BLE001
+            return                     # a cost readout is never worth a crash
+        self.app.call_from_thread(self.rerender)
+
     def _poll_source(self):
         """Rebuild when a module's source changed under us."""
         try:
@@ -917,6 +929,7 @@ class BenchScreen(Screen):
             return
         self._src = now
         self.app.state.msg = "module source changed — rebuilding"
+        self.measure_all()             # its word count may have moved too
         # The AUDIO is not re-rendered: it plays out loud and would fire on
         # every save. The image and the panel refresh; `r` is one key.
         self.schedule_sync()

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -503,13 +503,18 @@ class BenchScreen(Screen):
         with Horizontal():
             yield Static(id="pane_avail")
             yield Static(id="pane_load")
-            # The third column is TWO stacked panes: the selected effect, and
-            # a standing budget under it. What is left of the image is the
-            # context you read every other number against, so it should not
-            # be something you have to go and ask for.
-            with Vertical(id="col_unit"):
-                yield Static(id="pane_unit")
-                yield Static(id="pane_budget")
+            yield Static(id="pane_unit")
+        # THE BUDGET IS A FULL-WIDTH STRIP, not the bottom half of the third
+        # column. It sat under the UNIT pane, on the argument that what is
+        # left of the image is the context you read every other number
+        # against -- true, but it is context for the IMAGE, not for the one
+        # effect the cursor is on, and it was charging the unit column ten
+        # lines for the privilege. The preview lives in that column and is
+        # the tallest thing in the workbench (the firmware's own draw of a
+        # page), so it was the one being truncated. Down here it costs the
+        # panes nothing, and the extra width lets it read in two columns
+        # instead of one long list.
+        yield Static(id="pane_budget")
         yield Static(id="status")
         yield RichLog(id="log", highlight=False, markup=False)
         yield Footer()
@@ -833,6 +838,12 @@ class BenchScreen(Screen):
         actually stopped.
         """
         out = ["[bold]Budget[/]"]
+        # TWO GROUPS, because the pane is now a full-width strip: what the
+        # WORDS cost (per payload, plus the reverbs holding the rest) and
+        # what the COUNTABLE things cost (buffers, rows, cave). They read
+        # side by side when the terminal is wide enough and stack when it is
+        # not -- one list either way, so nothing is hidden on a narrow one.
+        out, side = [], []
         W = 10                                  # one label column throughout
 
         def left(n, total, extra=""):
@@ -969,7 +980,7 @@ class BenchScreen(Screen):
                 # WHICH ones are left, beside how many. The count answers
                 # "can I add another"; the list answers "where does it go".
                 bits.append(",".join(str(t) for t in free) + " free")
-            out.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{len(free):>5}[/] free "
+            side.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{len(free):>5}[/] free "
                        f"of 4 [dim]· "
                        + (" · ".join(bits) if bits
                           else f"tracks {tracks.start}-{tracks.stop - 1}, "
@@ -980,7 +991,7 @@ class BenchScreen(Screen):
         used_rows = (st.chooser_rows if st.chooser_rows is not None
                      else len(st.menu_modules))
         c = OK if 31 - used_rows > 7 else WARN if used_rows < 31 else BAD
-        out.append(f" {'rows':<{W}}[{c}]{31 - used_rows:>5}[/] free of 31 "
+        side.append(f" {'rows':<{W}}[{c}]{31 - used_rows:>5}[/] free of 31 "
                    f"[dim]· {used_rows} loaded[/]")
         # And the cave. The build reports only what is LEFT, so the total
         # comes from state.CAVE_BYTES (pinned to build_bus's own bounds by
@@ -990,14 +1001,14 @@ class BenchScreen(Screen):
         # not the wordless "untouched" this used to print.
         if st.cave_free is not None:
             c = OK if st.cave_free > 512 else WARN if st.cave_free else BAD
-            out.append(f" {'cave':<{W}}[{c}]{st.cave_free:>5,}[/] free of "
+            side.append(f" {'cave':<{W}}[{c}]{st.cave_free:>5,}[/] free of "
                        f"{CAVE_BYTES:,} B [dim]· "
                        f"{CAVE_BYTES - st.cave_free:,} loaded[/]")
         elif not [m for m in st.selected if m.dsp is not None or m.cf_patches]:
-            out.append(f" {'cave':<{W}}[{OK}]{CAVE_BYTES:>5,}[/] free of "
+            side.append(f" {'cave':<{W}}[{OK}]{CAVE_BYTES:>5,}[/] free of "
                        f"{CAVE_BYTES:,} B [dim]· nothing of ours is placed[/]")
         else:
-            out.append(f" {'cave':<{W}}[dim]    ? free of {CAVE_BYTES:,} B "
+            side.append(f" {'cave':<{W}}[dim]    ? free of {CAVE_BYTES:,} B "
                        f"· not built[/]")
         # ONE legend line, decoding the ONE thing on this pane that is not
         # already words: the bar's three glyphs. What an FX2 buffer count
@@ -1015,10 +1026,52 @@ class BenchScreen(Screen):
         key = [(g, w) for g, w in (("#", "loaded by a module"),
                                    ("-", "held by a reverb you kept listed"),
                                    (".", "free")) if g in seen]
-        for i, (glyph, what) in enumerate(key):
-            out.append(f" {'bar' if not i else '':<{W}}"
-                       f"[dim]{glyph}  {what}[/]")
-        self._paint("#pane_budget", out)
+        rows, wide = self._two_up(out, side)
+        # THE KEY FOLLOWS THE LAYOUT. Stacked, it is one glyph per line --
+        # three definitions strung along one line read as a run-on sentence,
+        # which is what it was until 2 Sep 2026. Side by side there is room
+        # to space them out, and wide gaps make three columns of a key
+        # rather than a sentence.
+        if wide and len(key) > 1:
+            rows.append(f" {'bar':<{W}}[dim]"
+                        + "".join(f"{g}  {w}".ljust(38) for g, w in key)
+                        + "[/]")
+        else:
+            for i, (glyph, what) in enumerate(key):
+                rows.append(f" {'bar' if not i else '':<{W}}"
+                            f"[dim]{glyph}  {what}[/]")
+        self._paint("#pane_budget", ["[bold]Budget[/]"] + rows)
+
+    # Rich markup is not width: padding by len() on a marked-up string puts
+    # the second column somewhere different on every row.
+    _MARKUP = re.compile(r"\[/?[^\]]*\]")
+
+    @classmethod
+    def _vis(cls, line):
+        return len(cls._MARKUP.sub("", line))
+
+    def _two_up(self, left, right):
+        """Side by side if the terminal is wide enough, stacked if not.
+
+        The threshold is measured off the CONTENT, not guessed: the widest
+        line each column actually produced this render, plus a gutter. So a
+        selection whose held-by line is short gets two columns on a terminal
+        where a longer one would not, which is the right way round -- the
+        test is whether it fits, not whether the window is big.
+        """
+        lw = max((self._vis(x) for x in left), default=0)
+        rw = max((self._vis(x) for x in right), default=0)
+        gutter = 3
+        if not right or lw + gutter + rw + 2 > self.app.size.width:
+            return left + right, False
+        pad = lw + gutter
+        rows = max(len(left), len(right))
+        out = []
+        for i in range(rows):
+            a = left[i] if i < len(left) else ""
+            b = right[i] if i < len(right) else ""
+            out.append(a + " " * (pad - self._vis(a)) + b if b else a)
+        return out, True
 
     def _pane_unit(self, st, probs):
         mod = self.selected_module()
@@ -1829,9 +1882,8 @@ class Workbench(App):
     #pane_avail { width: 32; padding: 0 1; height: 100%; }
     #pane_load  { width: 40; padding: 0 1; height: 100%;
                   border-left: dashed $surface; }
-    #col_unit   { width: 1fr; height: 100%;
+    #pane_unit  { width: 1fr; height: 100%; padding: 0 1;
                   border-left: dashed $surface; }
-    #pane_unit  { height: 1fr; padding: 0 1; }
     #pane_budget { height: auto; padding: 0 1;
                    border-top: dashed $surface; }
     #status { height: 1; padding: 0 1; }

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -426,28 +426,6 @@ class BenchScreen(Screen):
             menus = "+".join(rig.menus(m)) or "—"
             line = f" {mark} {disp(m):<13} [dim]{menus}[/]"
             out.append(f"[reverse]{line}[/]" if here else line)
-        # The three stock REVERBS are absent from every list above, and their
-        # absence is the kind that reads as a bug. Say where they went -- and
-        # say it CONDITIONALLY, because "consumed" is a property of the
-        # SELECTION, not a law. Their code is the region our modules are
-        # written over, so a selection carrying no module of ours takes
-        # nothing from them. (Precedent: CHORUS was a donor until v98 and got
-        # its dispatch back the moment we stopped taking its code.)
-        eats = [m for m in st.selected if m.dsp is not None]
-        out.append("[dim]── the three reverbs ──[/]")
-        for name in stock.CONSUMED:
-            out.append(f"[dim]   {name:<13} —[/]")
-        if eats:
-            out.append("[dim]   their code is the region")
-            out.append(f"   {escape(disp(eats[0]))} and "
-                       f"{len(eats) - 1} other" +
-                       ("s" if len(eats) != 2 else "") + " sit in[/]"
-                       if len(eats) > 1 else
-                       f"   {escape(disp(eats[0]))} sits in[/]")
-        else:
-            out.append("[dim]   nothing here takes their code —")
-            out.append("   a stock-only image would keep")
-            out.append("   them, but cannot be built yet[/]")
         out.append("")
         out.append("[dim]enter adds at ▸ in LOADED[/]")
         self.query_one("#pane_avail", Static).update("\n".join(out))
@@ -483,9 +461,28 @@ class BenchScreen(Screen):
                        if self.pane == LOADED else tail)
         if not rows:
             out.append("[dim] (empty — add from the left)[/]")
+        # THE THREE REVERBS ARE PART OF A STOCK CHOOSER and belong in this
+        # list, not off in the library: an unmodified unit shows fourteen FX2
+        # effects, and these are three of them. They leave when something
+        # takes their space -- their code IS the donor region our modules are
+        # written over -- so showing the trade where it happens is the point.
+        # (Precedent: CHORUS was a donor until v98 and got its stock dispatch
+        # back the moment the build stopped taking its code.)
+        eats = [m for m in st.selected if m.dsp is not None]
+        for name in stock.CONSUMED:
+            if eats:
+                out.append(f"[dim]  –  {name:<13} taken by "
+                           f"{escape(disp(eats[0]))}"
+                           f"{f' +{len(eats) - 1}' if len(eats) > 1 else ''}[/]")
+            else:
+                pos += 1
+                out.append(f"[dim] {pos:>2}   {name:<13}FX2[/]")
         probs = st.problems()
         out.append("")
         out.append("[dim]● = in the built image · ◀fb = fallback[/]")
+        out.append("[dim]dim = stock, lost to the donor region[/]"
+                   if eats else
+                   "[dim]a stock chooser: 14 effects, no modules[/]")
         out.append("[dim]← → moves this row (= its panel slot)[/]"
                    if self.pane == LOADED else
                    "[dim]tab here to reorder or remove[/]")

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -1798,7 +1798,7 @@ class RemixerScreen(Screen):
         mod = self.selected_module()
         if mod is None:
             return
-        st.msg = st.toggle_fx1(mod.key)
+        st.msg = st.toggle_fx1(mod.key, disp(mod))
         if mod.key in st.sel:
             st.loaded_name = ""
             self.schedule_sync()         # it changes the image

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -916,6 +916,30 @@ class BenchScreen(Screen):
         self.schedule_sync()
         self.rerender_soon()
 
+    def describe(self):
+        """The status line follows the CURSOR, not the last thing you did.
+
+        It was an action log -- "added Nimbus · added Send as the fallback" --
+        which is read as context for whatever is under the cursor now, so it
+        went stale the moment you scrolled and described a row you had left.
+        An action still writes it; moving replaces it.
+        """
+        st = self.app.state
+        mod = self.selected_module()
+        if mod is None or self.pane == UNIT:
+            return
+        bits = [rig.category(mod)]
+        if mod.menu is not None:
+            bits.append(f"id 0x{mod.menu.fx2_id:02x}")
+        w = st.words.get(mod.key)
+        if w:
+            bits.append(f"{w} words")
+        elif mod.is_stock:
+            bits.append("no code placed" if mod.key not in stock.CONSUMED
+                        else "its code IS the donor region")
+        bits.append("in the image" if mod.key in st.sel else "not in the image")
+        st.msg = f"{disp(mod)} — {' · '.join(bits)}"
+
     def rerender_soon(self):
         """Mark the screen stale; _flush draws it on the next frame."""
         self._dirty = True
@@ -942,8 +966,10 @@ class BenchScreen(Screen):
         n = max(len(rows), 1)
         if ev.key in ("down", "j"):
             self.cur[self.pane] = min(n - 1, self.cur[self.pane] + 1)
+            self.describe()
         elif ev.key in ("up", "k"):
             self.cur[self.pane] = max(0, self.cur[self.pane] - 1)
+            self.describe()
         elif ev.key in ("left", "right", "h", "shift+left", "shift+right"):
             step = 1 if ev.key in ("right", "shift+right") else -1
             if self.pane == UNIT:
@@ -1176,14 +1202,19 @@ class BenchScreen(Screen):
                 # WHICH module was doing it -- "why did adding nimbus remove
                 # so many?" is the question it produced. The list is one
                 # keystroke away and the reason is what is actually wanted.
+                # BOTH: the cause AND the names. Listing seven names alone
+                # produced "why did adding nimbus remove so many?"; replacing
+                # them with a count alone produced "it's worse now that it
+                # doesn't show which ones". The reason belongs first because
+                # it is the question, and the list belongs after it because
+                # it is the answer's evidence.
                 st = self.app.state
                 pin = [m for m in st.selected
                        if getattr(m, "claims", None) is not None
                        and m.claims.owns_fx2_buffers]
                 who = disp(pin[0]) if pin else "this module"
-                return (f"{who} pins the buffer {len(gone)} stock effect"
-                        f"{'s' if len(gone) != 1 else ''} allocate — "
-                        f"x removes them")
+                return (f"{who} pins the buffer these {len(gone)} allocate — "
+                        f"x removes " + ", ".join(disp(m) for m in gone))
             names = [p.split(":", 1)[1].split(" and ")[0].strip().upper()
                      for p in buf]
             return "also remove " + ", ".join(names)

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -804,44 +804,41 @@ class BenchScreen(Screen):
             out.append(f" {'words':<{W}}[dim]"
                        + "?" * 20 + "[/]  [dim]not built[/]")
 
-        # FX2 buffer slots, per core. Four each, and a pinner takes two or
-        # all four of ONE core's -- which is why the two servers coexist.
-        for tag, tracks in (("A", "5-8"), ("B", "1-4")):
-            taken = 0
+        # FX2 buffer slots. ONE PER TRACK, not a pool: each track allocates
+        # FX1 then FX2, so track k's FX2 effect always gets table entry 1+2k
+        # -- 0x4000, 0x8000, then the shared-window pair (docs/DSP.md, "the
+        # allocator's instance model"). So a slot is not "a buffer somebody
+        # might take", it is one particular track's buffer, and naming the
+        # tracks that are still free is the useful form: those are the ones
+        # that can still host an allocating stock effect.
+        for tag, tracks in (("A", rig.PAYLOAD_TRACKS["A"]),
+                            ("B", rig.PAYLOAD_TRACKS["B"])):
+            taken = set()
             for m in st.selected:
                 if not rig.pins_fx2(m):
                     continue
                 tr = rig.track_range(m)
                 here = (not len(tr) or len(tr) == 8
-                        or (tag == "A" and tr.start == 5)
-                        or (tag == "B" and tr.start == 1))
-                if here:
-                    taken = max(taken, rig.pinned_slots(m))
-            free = 4 - taken
-            c = OK if free > 2 else WARN if free else BAD
-            # "4 of 4" was ambiguous and read as the opposite of what it
-            # meant: the bar shows what is PINNED and the number what is
-            # FREE, so an empty bar beside "4 of 4" looked like "all four
-            # used". Say "free", as the word rows do, and draw the four
-            # slots as four groups so the picture and the number agree.
-            slots = " ".join("####" if i < taken else "...."
+                        or tr.start == tracks.start)
+                if not here:
+                    continue
+                # The core-private pair is tracks 1-2 of the core, the
+                # shared-window pair tracks 3-4 (rig.pinned_slots counts
+                # them; this needs to know WHICH).
+                cl = getattr(m, "claims", None)
+                if cl is not None and cl.owns_fx2_buffers:
+                    taken |= {0, 1}
+                from remix.schema import YBase
+                if m.dsp is not None and m.dsp.ybase is not YBase.NEVER:
+                    taken |= {2, 3}
+            free = [tracks.start + i for i in range(4) if i not in taken]
+            c = OK if len(free) > 2 else WARN if free else BAD
+            slots = " ".join("####" if i in taken else "...."
                              for i in range(4))
-            # SAY WHAT IS COUNTED IN THE NUMBER ITSELF. "N of 4 free" still
-            # invited "free for what?", and the honest answer -- slots a
-            # MODULE holds fixed -- is not what a reader assumes a budget row
-            # means. A stock effect is not in this count at all: it takes one
-            # from the allocator at runtime, which no image can reserve.
-            # AND WHO ELSE WANTS THEM. "0 pinned of 4" is true and reads as
-            # "nothing is using these", which is false: every allocating
-            # stock effect in the chooser takes one at runtime. The image
-            # cannot reserve those, so they are not part of the count -- but
-            # leaving them unmentioned made the row lie by omission.
-            share = sum(1 for m in st.selected if m.is_stock
-                        and m.claims is not None
-                        and m.claims.stock_instance_buffer)
-            also = f"  [dim]+{share} stock share[/]" if share else ""
+            tail = (f"[dim]free on {', '.join(str(t) for t in free)}[/]"
+                    if free else "[dim]none free[/]")
             out.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{slots}[/]  "
-                       f"{taken} pinned of 4  [dim]tracks {tracks}[/]{also}")
+                       f"{len(taken)} of 4  {tail}")
 
         # Rows are countable without a build; the cave is not.
         # Same rule: 31 exist, this selection loaded N.
@@ -871,8 +868,8 @@ class BenchScreen(Screen):
         # remix actually decides.
         out.append("[dim] # loaded by a module · - held by a listed reverb "
                    "· . free[/]")
-        out.append("[dim] pinned = held by a module; stock effects take "
-                   "theirs at runtime[/]")
+        out.append("[dim] one FX2 buffer per track; a free one can host a "
+                   "stock effect[/]")
         self._paint("#pane_budget", out)
 
     def _pane_unit(self, st, probs):

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -199,9 +199,18 @@ Knob VALUES draw as dial graphics the text capture cannot read, so the
 rig's numbers are always the truth for values. The boot is cached and
 repeats only when the image changes.
 
+[bold]The FX2 view is the whole loop.[/] left/right cycles every effect
+the image offers AND every module that could be added; picking one the
+image HAS assigns it to the track (the rig follows). Picking one it does
+NOT have is not drawn — an id the image lacks resolves to the fallback,
+so the firmware would draw a convincing picture of the wrong effect —
+so [bold]a[/] stages it in the composer and [bold]b[/] builds and re-boots.
+Cycling past several unbuilt effects costs nothing; only b builds.
+
 [bold]keys[/]
-  m  main menu      f  FX2 (follows the rig's track + effect)
+  m  main menu      f  FX2 (cycles effects; the rig follows)
   o  FX1 (stock)    p  playback page
+  a  stage an unbuilt effect     b  build the selection + re-boot
   1-8  track        up/down  menu cursor   left/right  cycle""",
 }
 
@@ -767,6 +776,8 @@ class EmuScreen(Screen):
         Binding("m", "view('menu')", "menu"),
         Binding("f", "view('fx2')", "FX2"),
         Binding("left,right", "noop", "cycle effect"),
+        Binding("a", "stage", "stage effect"),
+        Binding("b", "build", "build + re-boot"),
         Binding("o", "view('fx1')", "FX1"),
         Binding("p", "view('play')", "playback"),
         Binding("v", "app.switch_mode('rig')", "rig"),
@@ -799,13 +810,53 @@ class EmuScreen(Screen):
         self.ensure_boot()
 
     def chooser(self):
-        """The built image's FX2 rows, re-read whenever the image changes."""
+        """Everything this view can cycle: the rows the BUILT IMAGE offers,
+        then every other module that COULD have a row, marked as not built.
+
+        The second group is the point of the view -- "the effect I want is
+        not in this image" is the normal case, and the answer has to be
+        reachable from here rather than a trip to the composer. A pending row
+        is never RENDERED: its id is not in the image, so it would resolve to
+        the fallback and draw a convincing picture of the wrong effect. That
+        is the 12 Aug trap in panel form, so the view refuses instead.
+        """
+        # ONLY the image can change these rows. Staging changes the
+        # composer's selection, not the image, and the "STAGED" wording is
+        # read live at render time -- rebuilding here on a selection change
+        # also reset the cursor to row 0, so pressing `a` walked away from
+        # the effect you had just staged.
         mt = BUILT_IMAGE.stat().st_mtime if BUILT_IMAGE.exists() else None
         if mt != self.rows_mtime:
-            self.rows, self.rows_mtime = rig.built_chooser(), mt
+            was = self.current_key()
+            built = [(eid, m, True) for eid, m in rig.built_chooser()]
+            have = {m.key for _, m, _ in built if m is not None}
+            pending = [(m.menu.fx2_id, m, False)
+                       for m in registry.modules().values()
+                       if m.menu is not None and m.key not in have
+                       and rig.category(m) != rig.SYSTEM]
+            pending.sort(key=lambda r: r[1].name)
+            self.rows = built + pending
+            self.rows_mtime = mt
             self.rowi = 0
-            self.sync_row()
+            # Stay on the same EFFECT across a rebuild -- you stage one, press
+            # b, and want to be looking at it now that it is built, not sent
+            # back to row 0.
+            if not (was and self.goto_key(was)):
+                self.sync_row()
         return self.rows
+
+    def current_key(self):
+        if self.rows and 0 <= self.rowi < len(self.rows):
+            _, m, _ = self.rows[self.rowi]
+            return m.key if m is not None else None
+        return None
+
+    def goto_key(self, key) -> bool:
+        for i, (_, m, _) in enumerate(self.rows):
+            if m is not None and m.key == key:
+                self.rowi = i
+                return True
+        return False
 
     def sync_row(self):
         """Point the cursor at whatever the rig has on this track, if the
@@ -814,8 +865,8 @@ class EmuScreen(Screen):
         mod = self.app.rig.effect(self.app.track)
         if mod is None:
             return
-        for i, (_, m) in enumerate(self.rows):
-            if m is not None and m.key == mod.key:
+        for i, (_, m, built) in enumerate(self.rows):
+            if built and m is not None and m.key == mod.key:
                 self.rowi = i
                 return
 
@@ -829,7 +880,9 @@ class EmuScreen(Screen):
         app = self.app
         if not self.rows:
             return ""
-        eid, mod = self.rows[self.rowi]
+        eid, mod, built = self.rows[self.rowi]
+        if not built:
+            return ""                    # nothing to assign until it is built
         if mod is None:
             return f"id 0x{eid:02x} is in the list but no manifest claims it"
         if rig.category(mod) == rig.SYSTEM:
@@ -910,16 +963,33 @@ class EmuScreen(Screen):
                 self.query_one("#emunote", Static).update("")
                 return
             self.rowi %= len(rows)
-            eid, mod = rows[self.rowi]
-            draws = emu_bringup.render_fx2(r, track=track0, effect_id=eid)
+            eid, mod, built = rows[self.rowi]
             name = (mod.menu.fullname.decode("latin1") if mod
                     else f"unclaimed 0x{eid:02x}")
+            if not built:
+                staged = mod.key in app.state.sel
+                self.query_one("#lcd", Static).update(
+                    f"[bold]{escape(name)}[/] (0x{eid:02x}) is "
+                    f"{'STAGED' if staged else 'NOT'} in this image.\n\n"
+                    + ("  staged in the composer — press [bold]b[/] to build "
+                       "it and re-boot\n" if staged else
+                       "  press [bold]a[/] to stage it, then [bold]b[/] to "
+                       "build and re-boot\n")
+                    + "\n  [dim]the page is not drawn: an id this image does "
+                      "not implement resolves to\n  the fallback, so the "
+                      "firmware would draw a convincing picture of the\n"
+                      "  WRONG effect (CLAUDE.md, 12 Aug 2026).[/]")
+                self.query_one("#emunote", Static).update(
+                    f"[dim]{escape(self.pending)}[/]" if self.pending else
+                    "[dim]left/right cycles · a stages · b builds[/]")
+                return
+            draws = emu_bringup.render_fx2(r, track=track0, effect_id=eid)
             title = (f"FX2 SETUP — T{app.track}, row {self.rowi + 1}/"
                      f"{len(rows)}: {name} (0x{eid:02x})")
             note = (self.pending or
-                    "left/right cycles the image's chooser · 1-8 changes "
-                    "track · values draw as dials the string hook cannot "
-                    "read, so the rig's numbers are the truth")
+                    "left/right cycles · a stages an unbuilt effect · b "
+                    "builds · 1-8 changes track · values draw as dials the "
+                    "string hook cannot read, so the rig's numbers are true")
             if mod and mod.name == "bongdelay":
                 note = ("a SPEC image aliases the delay's DSP to SEND on "
                         "payload A — the page may draw empty; " + note)
@@ -940,6 +1010,43 @@ class EmuScreen(Screen):
                         + ["'" + "-" * 46 + "'"])
         self.query_one("#lcd", Static).update(lcd)
         self.query_one("#emunote", Static).update(f"[dim]{note}[/]")
+
+    def action_stage(self):
+        """Add the cycled-to module to the COMPOSER's live selection. Staging
+        only -- the image is not rebuilt until `b`, so cycling past several
+        unbuilt effects costs nothing."""
+        rows = self.chooser()
+        if self.view != "fx2" or not rows:
+            return
+        _, mod, built = rows[self.rowi]
+        if built or mod is None:
+            self.pending = "already in this image — nothing to stage"
+        elif mod.key in self.app.state.sel:
+            self.pending = f"{mod.key} is already staged — b builds it"
+        else:
+            self.app.state.toggle(mod.key)
+            probs = self.app.state.problems()
+            self.pending = (f"staged {mod.key} — b builds and re-boots"
+                            if not probs else
+                            f"staged {mod.key}, but the build would refuse: "
+                            f"{probs[0]}")
+        self.rerender()
+
+    async def action_build(self):
+        """Build the composer's live selection. The build lives on the REMIX
+        screen because that is where its log pane is, and switching there IS
+        the useful behaviour: you watch it build.
+
+        ⚠️ `await` the mode switch. Firing the build straight after
+        `switch_mode` reaches the screen before its `on_mount` has run and
+        dies on a half-built widget -- the screen exists, its state does not.
+        """
+        if self.app.state.problems():
+            self.pending = f"refusing: {self.app.state.problems()[0]}"
+            self.rerender()
+            return
+        await self.app.switch_mode("remix")
+        self.app.screen.action_build("bus")
 
     def action_help(self, view):
         self.app.push_screen(HelpScreen(view))

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -23,6 +23,8 @@ paying its way.
 
 from __future__ import annotations
 
+import json
+import os
 import pathlib
 import shutil
 import subprocess
@@ -62,21 +64,58 @@ def disp(mod) -> str:
     return mod.name
 
 
-def wav_sources():
-    """Source WAVs to audition: out/dry/ -- the curated DRY set (31 Aug 2026;
-    test_audio + demo_sources are full of processed renders and made the
-    browser unusable). Falls back to the old dirs only when out/dry is
-    missing or empty (a fresh tree before anyone copies sources in)."""
-    d = ROOT / "out" / "dry"
+# Where the SOURCE row browses. out/dry/ is the curated dry set and stays the
+# default (31 Aug 2026: test_audio + demo_sources are full of processed
+# renders and made the browser unusable), but a bench is used on whatever
+# material is to hand, so `d` points it somewhere else and CONFIG remembers.
+CONFIG = ROOT / "out" / "_audition" / "workbench.json"
+DEFAULT_SOURCE_DIR = ROOT / "out" / "dry"
+
+
+def load_config():
+    """{} on anything unreadable -- a corrupt settings file must not stop the
+    workbench opening, it is a convenience, not state anyone can lose work
+    from."""
+    try:
+        return json.loads(CONFIG.read_text())
+    except Exception:                                # noqa: BLE001
+        return {}
+
+
+def save_config(cfg):
+    try:
+        CONFIG.parent.mkdir(parents=True, exist_ok=True)
+        CONFIG.write_text(json.dumps(cfg, indent=2) + "\n")
+    except OSError:
+        pass                                    # not worth an error dialog
+
+
+def source_dir():
+    """The directory the SOURCE row browses, in precedence order: the env
+    override, what `d` last chose, then out/dry/."""
+    env = os.environ.get("WORKBENCH_SOURCES")
+    if env:
+        return pathlib.Path(env).expanduser()
+    saved = load_config().get("source_dir")
+    if saved:
+        return pathlib.Path(saved).expanduser()
+    return DEFAULT_SOURCE_DIR
+
+
+def wav_sources(d=None):
+    """The wavs in the source directory. Falls back to the old scattered dirs
+    only when the chosen one is missing or empty -- a fresh tree, before
+    anyone has copied sources in."""
+    d = d or source_dir()
     if d.is_dir():
         out = sorted(d.glob("*.wav"))
         if out:
             return out
     out = []
-    for sub in ("test_audio", "demo_sources"):
-        d = ROOT / "out" / sub
-        if d.is_dir():
-            out += sorted(d.glob("*.wav"))
+    for name in ("dry", "test_audio", "demo_sources"):
+        alt = ROOT / "out" / name
+        if alt.is_dir() and alt != d:
+            out += sorted(alt.glob("*.wav"))
     return out
 
 
@@ -89,14 +128,20 @@ class TextPrompt(ModalScreen[str]):
     #box { width: 60; height: auto; border: round $primary; padding: 1; }
     """
 
-    def __init__(self, question):
+    def __init__(self, question, value=""):
         super().__init__()
         self.question = question
+        self.value = value
 
     def compose(self) -> ComposeResult:
         with Vertical(id="box"):
-            yield Static(self.question)
-            yield Input()
+            # ESCAPED, because a question is data. A path in the prompt --
+            # "source folder [/Users/.../out/dry]:" -- parsed as Rich markup
+            # and raised MarkupError: closing tag does not match any open
+            # tag. Same family as the 31 Aug pass that escaped every
+            # data-driven string in the panes; a prompt is one too.
+            yield Static(escape(self.question))
+            yield Input(value=self.value)
 
     def on_input_submitted(self, ev):
         self.dismiss(ev.value.strip())
@@ -157,10 +202,25 @@ itself, so the panel is never showing something else.
   enter  SWAP the ▸ row for this one (at (end): append); on a
          selected module, remove it
   left/right  knob value (UNIT) or row order (LOADED)
+              hold to run; SHIFT+left/right steps by TEN
   r  render + hear     space  play last    p  preview mode
   a  mark it A         , / .  play A / B
-  l  load remix        s  save remix       f  fallback
-  c  full check        k  back to stock    ?  this
+  d  source folder     l  load remix       s  save remix
+  c  full check        f  fallback         k  back to stock
+  ?  this
+
+[bold]why an effect can render DRY[/]
+SIX of the eleven stock effects ship with their wet control at zero —
+PHASER, FLANGER, CHORUS and COMB (MIX), SPATIALIZER and DELAY (SEND) —
+so `r` on one of them at its defaults plays the source back unchanged.
+That is faithful: the defaults are read from the firmware's own
+descriptor, and an unmodified unit really does start them fully dry.
+The UNIT pane says `⚠ MIX is 0 — this renders DRY` when it applies.
+
+[bold]the SOURCE row[/]
+`left`/`right` cycles the wavs in the source folder; `d` points it at
+another one and remembers the choice (out/_audition/workbench.json).
+`WORKBENCH_SOURCES` overrides both.
 
 [bold]the one line under LOADED[/]
 It says the only two things that can stop you: whether the selection
@@ -243,6 +303,7 @@ class BenchScreen(Screen):
         Binding("l", "load", "load remix"),
         Binding("s", "save", "save remix"),
         Binding("k", "stock", "reset to stock", show=False),
+        Binding("d", "source_dir", "source folder", show=False),
         Binding("question_mark", "help", "what is this?"),
         Binding("q", "app.quit", "quit"),
     ]
@@ -270,6 +331,7 @@ class BenchScreen(Screen):
         self.synced = None
         self.syncing = None
         self.sync_error = None
+        self._panel_cache = (None, None)   # see _panel()
         self.query_one("#log", RichLog).display = False
         self.rerender()
 
@@ -301,6 +363,26 @@ class BenchScreen(Screen):
         return rows + [(n, sl) for n, sl in sorted(mod.knob_map().items(),
                                                    key=lambda kv: kv[1])
                        if mod.params[sl].active]
+
+    @staticmethod
+    def dry_control(mod, vals):
+        """The wet/dry control that is sitting at zero, if one is.
+
+        SIX of the eleven stock effects ship with their wet control at 0 --
+        PHASER, FLANGER, CHORUS and COMB (MIX), SPATIALIZER and DELAY (SEND)
+        -- so pressing `r` on them plays the source back unchanged. That is
+        FAITHFUL: the defaults are read from the firmware's own descriptor
+        (tools/remix/stock.py), an unmodified unit really does start them
+        fully dry, and seeding a different value here would make the bench
+        lie about the page it is drawing beside. But it reads as "this effect
+        does nothing", which is what it cost on 2 Sep 2026. So say it.
+        """
+        if mod is None:
+            return None
+        for name in ("MIX", "SEND"):
+            if name in vals and vals[name] == 0:
+                return name
+        return None
 
     def selected_module(self):
         """The unit pane follows whichever pane the cursor is in -- point at
@@ -342,10 +424,17 @@ class BenchScreen(Screen):
 
     # ---- render ----------------------------------------------------------
     def rerender(self):
+        """One pass over the three panes.
+
+        problems() runs the ledger and costs ~2.4 ms (measured 2 Sep 2026);
+        three panes asking it independently made every keystroke pay ~7 ms
+        for one answer. Compute it here and hand it down.
+        """
         st = self.app.state
+        probs = st.problems()
         self._pane_available(st)
-        self._pane_loaded(st)
-        self._pane_unit(st)
+        self._pane_loaded(st, probs)
+        self._pane_unit(st, probs)
         self.query_one("#status", Static).update(f"[dim]{escape(st.msg)}[/]")
 
     def _title(self, text, pane):
@@ -371,7 +460,7 @@ class BenchScreen(Screen):
         out.append("[dim]enter SWAPS with ▸ in LOADED[/]")
         self.query_one("#pane_avail", Static).update("\n".join(out))
 
-    def _pane_loaded(self, st):
+    def _pane_loaded(self, st, probs):
         rows = self.loaded_rows()
         name = st.loaded_name or "unsaved"
         out = [self._title(f"LOADED · {name}", LOADED), ""]
@@ -421,10 +510,10 @@ class BenchScreen(Screen):
                 pos += 1
                 out.append(f"[dim] {pos:>2} {cname:<13}FX2[/]")
         out.append("")
-        out.append(self._ledger_line(st))
+        out.append(self._ledger_line(st, probs))
         self.query_one("#pane_load", Static).update("\n".join(out))
 
-    def _ledger_line(self, st):
+    def _ledger_line(self, st, probs):
         """The fit, the blocker and the build state, in ONE line.
 
         This pane used to close with five: a donor-region budget, a ● legend,
@@ -433,7 +522,6 @@ class BenchScreen(Screen):
         Only two questions are actually live while swapping: does this fit,
         and is the panel on the right showing it yet. The rest moved to `?`.
         """
-        probs = st.problems()
         if self.untouched_stock(probs):
             return "[dim]stock — swap a module in to build it[/]"
         if probs:
@@ -453,7 +541,7 @@ class BenchScreen(Screen):
                 f"{n} {f} free" for n, _u, f in st.regions) + "[/]"
         return "[dim]a stock chooser: 14 effects, no modules[/]"
 
-    def _pane_unit(self, st):
+    def _pane_unit(self, st, probs):
         mod = self.selected_module()
         if mod is None:
             self.query_one("#pane_unit", Static).update(
@@ -477,7 +565,7 @@ class BenchScreen(Screen):
             here = self.pane == UNIT and i == self.cur[UNIT]
             if name == "SOURCE":
                 src = (self.app.source.name if self.app.source
-                       else "(none — put wavs in out/dry/)")
+                       else f"(none — no wavs in {source_dir()})")
                 line = f" SOURCE {escape(src)}"
                 out.append(f"[reverse]{line}[/]" if here else line)
                 continue
@@ -495,11 +583,14 @@ class BenchScreen(Screen):
             out.append(f"[reverse]{line}[/]" if here else line)
         if not knobs:
             out.append("[dim] (no drawn parameters)[/]")
+        dry = self.dry_control(mod, vals)
+        if dry:
+            out.append(f"[bold]⚠ {dry} is 0 — this renders DRY[/]")
         if self.pane == UNIT and knobs:
             name, _ = knobs[min(self.cur[UNIT], len(knobs) - 1)]
-            hint = ("the wav auditioned through this effect — left/right "
-                    "cycles what is in out/dry/" if name == "SOURCE"
-                    else rig.knob_doc(mod, name) or "")
+            hint = (f"the wav auditioned through this effect — left/right "
+                    f"cycles {source_dir()}, d changes it"
+                    if name == "SOURCE" else rig.knob_doc(mod, name) or "")
             out.append("")
             out.append(f"[dim]? {escape(hint)}[/]")
         out.append("")
@@ -507,11 +598,40 @@ class BenchScreen(Screen):
                    if self.pane == UNIT else
                    "[dim]tab here to change values and audition[/]")
         out.append("")
-        out += self._preview(mod)
+        out += self._preview(mod, probs)
         self.query_one("#pane_unit", Static).update("\n".join(out))
 
     # ---- the emulated panel ---------------------------------------------
-    def _preview(self, mod):
+    def _panel(self, mode, effect_id):
+        """The firmware's own draw of one page, CACHED.
+
+        ⚠️ This is what made a HELD arrow key lag. render_fx2 costs 15-96 ms
+        (mean 32; render_fx1 16, render_menu 8 -- measured 2 Sep 2026), and
+        rerender() ran it on every keystroke, so under key repeat the work
+        per key exceeded the repeat interval and the UI fell behind the key,
+        then kept stepping after release. Single presses always felt fine,
+        which is why it read as "slow when holding" rather than as latency.
+
+        Nothing a keystroke does can change this picture: knob VALUES draw as
+        dial graphics the string-capture hook cannot read (docs/EMU.md), so
+        the page depends only on WHICH page, WHICH effect, and which boot.
+        """
+        key = (mode, effect_id, self.synced)
+        if self._panel_cache[0] == key:
+            return self._panel_cache[1]
+        import emu_bringup
+        r = self.app.boot
+        if mode == "MENU":
+            draws = emu_bringup.render_menu(r, emu_bringup.MENU_ROOT_DESC, 0)
+        elif mode == "FX1":
+            draws = emu_bringup.render_fx1(r, track=4, effect_id=0x04)
+        else:
+            draws = emu_bringup.render_fx2(r, track=4, effect_id=effect_id)
+        grid = emu_bringup.layout_screen(draws)
+        self._panel_cache = (key, grid)
+        return grid
+
+    def _preview(self, mod, probs):
         modes = " ".join(f"[reverse]{m}[/]" if m == self.preview else
                          f"[dim]{m}[/]" for m in PREVIEWS)
         head = [f"preview {modes}  [dim](p)[/]",
@@ -522,9 +642,8 @@ class BenchScreen(Screen):
         # LOADED pane and reads as "why are those loaded?". The answer is no
         # longer to explain it -- ensure_sync() rebuilds -- but while that is
         # in flight there is still nothing honest to show.
-        self.ensure_sync()
+        self.ensure_sync(probs)
         r = self.app.boot
-        probs = self.app.state.problems()
         if self.untouched_stock(probs):
             return head[:1] + ["[dim]swap a module in and this draws it[/]"]
         if probs:
@@ -537,12 +656,8 @@ class BenchScreen(Screen):
         if not r.reached_handoff:
             return head + ["[bold]did not reach the RTOS handoff[/] — a "
                            "patch may have broken early init"]
-        import emu_bringup
-        if self.preview == "MENU":
-            draws = emu_bringup.render_menu(r, emu_bringup.MENU_ROOT_DESC, 0)
-        elif self.preview == "FX1":
-            draws = emu_bringup.render_fx1(r, track=4, effect_id=0x04)
-        else:
+        effect_id = None
+        if self.preview == "FX2":
             if mod.menu is None:
                 return head + ["[dim]no chooser row: this module patches the "
                                "firmware rather than adding an effect[/]"]
@@ -552,9 +667,8 @@ class BenchScreen(Screen):
                 # FALLBACK, so the firmware would draw a convincing picture
                 # of the wrong effect (CLAUDE.md, 12 Aug 2026).
                 return head[:1] + ["[dim]not in the image yet[/]"]
-            draws = emu_bringup.render_fx2(r, track=4,
-                                           effect_id=mod.menu.fx2_id)
-        grid = emu_bringup.layout_screen(draws)
+            effect_id = mod.menu.fx2_id
+        grid = self._panel(self.preview, effect_id)
         return head + ["." + "-" * 44 + "."] + \
             ["|" + escape(ln.ljust(44)) + "|" for ln in grid] + \
             ["'" + "-" * 44 + "'"]
@@ -573,17 +687,18 @@ class BenchScreen(Screen):
         self.gen += 1
         self.set_timer(0.35, self.ensure_sync)
 
-    def ensure_sync(self):
+    def ensure_sync(self, probs=None):
         """Start the rebuild if the image is behind and nothing is in the
         way. Idempotent and cheap -- rerender() calls it, so a kick that
         arrives during a render or a build is simply picked up by the next
-        one rather than queued."""
+        one rather than queued. `probs` is rerender's already-computed
+        answer; the timer path has none and pays for its own."""
         if self.syncing is not None or self.synced == self.gen:
             return
         if self.app.rendering:
             return          # both write out/mainos_bus.bin; the render's
                             # closing rerender() will kick this again
-        if self.app.state.problems():
+        if self.app.state.problems() if probs is None else probs:
             self.synced, self.app.boot = self.gen, None
             return          # it would not build; the ⚠ line says why
         self.syncing = self.gen
@@ -808,6 +923,40 @@ class BenchScreen(Screen):
                 self.schedule_sync()
             self.rerender()
         self.app.push_screen(Chooser("unimplemented ids alias to:", opts), done)
+
+    def action_source_dir(self):
+        """Point the SOURCE row at another folder, and remember it.
+
+        A bench is used on whatever material is to hand; out/dry/ is a good
+        default, not a permanent one. Remembered in out/_audition/
+        workbench.json, and WORKBENCH_SOURCES overrides both.
+        """
+        st = self.app.state
+        cur = source_dir()
+
+        def chosen(text):
+            if not text:
+                return
+            # RESOLVED before it is stored: a relative path would be read
+            # back against whatever directory the workbench is next started
+            # from, and `make remix` being run from the repo root is a
+            # convention, not a guarantee.
+            d = pathlib.Path(text.strip()).expanduser()
+            d = d.resolve() if d.exists() else d
+            if not d.is_dir():
+                st.msg = f"not a directory: {d}"
+            elif not sorted(d.glob("*.wav")):
+                st.msg = f"no .wav files in {d}"
+            else:
+                cfg = load_config()
+                cfg["source_dir"] = str(d)
+                save_config(cfg)
+                files = wav_sources(d)
+                self.app.source = files[0] if files else None
+                st.msg = f"{len(files)} wavs from {d}"
+            self.rerender()
+        self.app.push_screen(
+            TextPrompt("source folder for the SOURCE row:", str(cur)), chosen)
 
     def action_help(self):
         self.app.push_screen(HelpScreen("bench"))

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -840,10 +840,20 @@ class BenchScreen(Screen):
                 mine = ",".join(str(tracks.start + i) for i in sorted(owner)
                                 if owner[i] is mod)
                 bits.append(f"{disp(mod)} has {mine}")
+            # ⚠️ "free" KEEPS BEING READ AS "unused", and it is not: a track
+            # whose buffer no module has claimed still HAS that buffer, ready
+            # for whatever is selected there. That is the whole answer to "do
+            # the stock reverbs not use it?" -- they use their own track's,
+            # when you select them on it, and listing one in the chooser
+            # claims nothing. Only a MODULE claims a buffer for the life of
+            # the image, which is why only modules appear here.
             if free:
-                bits.append(f"[{OK}]free {','.join(str(t) for t in free)}[/]")
+                bits.append(f"[{OK}]{','.join(str(t) for t in free)} "
+                            f"keep theirs[/]")
             out.append(f" {'FX2 buf ' + tag:<{W}}[{c}]{slots}[/]  "
-                       + " · ".join(bits or ["[dim]all four free[/]"]))
+                       + " · ".join(bits or
+                                    ["[dim]unclaimed — every track keeps its "
+                                     "own[/]"]))
 
         # Rows are countable without a build; the cave is not.
         # Same rule: 31 exist, this selection loaded N.
@@ -873,8 +883,10 @@ class BenchScreen(Screen):
         # remix actually decides.
         out.append("[dim] # loaded by a module · - held by a listed reverb "
                    "· . free[/]")
-        out.append("[dim] one FX2 buffer per track — a free track can still "
-                   "host a stock effect that needs one[/]")
+        out.append("[dim] one FX2 buffer per track. A module claims one for "
+                   "the whole image;[/]")
+        out.append("[dim] a stock effect uses its track's only while it is "
+                   "selected there.[/]")
         self._paint("#pane_budget", out)
 
     def _pane_unit(self, st, probs):

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -1420,8 +1420,17 @@ class RemixerScreen(Screen):
         st = self.app.state
         modes = " ".join(f"[reverse]{m}[/]" if m == self.preview else
                          f"[dim]{m}[/]" for m in PREVIEWS)
+        # WHAT IT IS SHOWING, not that it is showing something. "drawn by
+        # the firmware, from your selection" said where the picture came
+        # from, which is the one thing you can see; what was missing is
+        # WHICH page and for WHICH effect -- and the FX pages all open with
+        # the same title and the same chooser column, so they look alike.
+        # NOT the page title -- the LCD draws that itself two lines down,
+        # and saying it twice is how the caption came to say nothing.
+        what = ("the main menu" if self.preview == "MENU"
+                else f"{escape(disp(mod))} on track 5")
         head = [f"preview {modes}  [dim](p)[/]",
-                "[dim]— drawn by the firmware, from your selection —[/]"]
+                f"[dim]{what}, as the unit draws it[/]"]
         # DO NOT DRAW SOMETHING THAT IS NOT THE SELECTION. The FX2 page
         # includes the firmware's own chooser list, so an image that is not
         # this selection puts a different set of effects on screen beside the
@@ -1455,8 +1464,9 @@ class RemixerScreen(Screen):
                 # would be added to -- said, rather than left to look like
                 # this effect's page.
                 effect_id = 0x04
-                head = head[:1] + [f"[dim]— {escape(disp(mod))} has no FX1 "
-                                   f"row; this is stock's chooser —[/]"]
+                head = head[:1] + [
+                    f"[dim]{escape(disp(mod))} has no FX1 row — this is the "
+                    f"chooser without it[/]"]
         elif self.preview == "FX2":
             if mod.menu is None:
                 return head + ["[dim]no chooser row: this module patches the "
@@ -1471,10 +1481,13 @@ class RemixerScreen(Screen):
         grid = self._panel(self.preview, effect_id)
         # The LCD frame is chrome; the firmware's own words are the content.
         edge = f"[{LCD}]"
-        return head + [f"{edge}." + "-" * 44 + ".[/]"] + \
-            [f"{edge}|[/]" + escape(ln.ljust(44)) + f"{edge}|[/]"
+        # The no-fuse rule can push a fragment past the nominal 42 columns,
+        # and a row longer than the frame breaks it open.
+        w = 44
+        return head + [f"{edge}." + "-" * w + ".[/]"] + \
+            [f"{edge}|[/]" + escape(ln[:w].ljust(w)) + f"{edge}|[/]"
              for ln in grid] + \
-            [f"{edge}'" + "-" * 44 + "'[/]"]
+            [f"{edge}'" + "-" * w + "'[/]"]
 
     # ---- keeping the image equal to the selection ------------------------
     # There used to be a stale() gate here: the preview refused to draw when

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -484,6 +484,24 @@ class BenchScreen(Screen):
                 out.append(f"[dim] {pos:>2}   {name:<13}FX2[/]")
         probs = st.problems()
         out.append("")
+        # THE BUDGET, because it is the actual constraint and it was
+        # invisible. Rows are nearly free -- seven in place, up to 32 in the
+        # long cave -- and STOCK rows cost NOTHING AT ALL, since their code
+        # is already in the image whether or not they have a row. The 2,724
+        # words are spent only by modules of ours, so "will this fit" is a
+        # question about them alone, and a swap of a stock row for a module
+        # frees nothing.
+        code = [m for m in st.selected if m.dsp is not None]
+        known = [m for m in code if m.key in st.words]
+        if code and len(known) == len(code):
+            used = sum(st.words[m.key] for m in code)
+            free = DONOR_WORDS - used
+            out.append(f"[dim]donor region {used}/{DONOR_WORDS} · "
+                       f"{'[/][bold]' if free < 0 else ''}{free} free[/]")
+        elif code:
+            out.append(f"[dim]{len(code)} module"
+                       f"{'s' if len(code) != 1 else ''} spending the "
+                       f"{DONOR_WORDS}-word region — w measures[/]")
         out.append("[dim]● = in the built image · ◀fb = fallback[/]")
         out.append("[dim]dim = stock, lost to the donor region[/]"
                    if eats else

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -351,7 +351,9 @@ The loop is one move long: highlight one of yours in AVAILABLE and press `enter`
 [bold]FX1 as well as FX2[/]
 The unit has two effect slots per track and stock lists different sets on them: ten effects on FX1, those ten plus DELAY and the three reverbs on FX2. `1` puts the highlighted effect of yours on FX1 too — the `FX1+FX2` column follows, and `s` saves it with the remix.
 
-It costs no words. The DSP dispatch table is indexed by the raw id and shared by both menus, so the code already ran from FX1 the moment FX1 selected the id; what `1` adds is the panel side. What it DOES cost is cycles: FX1 is four more slots on the same four tracks, so an effect on both menus can double the worst per-core load — watch the Budget's `cycles` row. An effect that replaces a stock one is already on FX1 and says so instead.
+It costs no words. The DSP dispatch table is indexed by the raw id and shared by both menus, so the code already ran from FX1 the moment FX1 selected the id; what `1` adds is the panel side. What it DOES cost is cycles: FX1 is four more slots on the same four tracks, so an effect on both menus can double the worst per-core load — watch the Budget's `cycles` row.
+
+Only a buffer-free INSERT can take one, and the UNIT pane says which cannot and why: an FX1 buffer slot is 3,072 words against FX2's 16,384, a module with fixed FX2 buffers would write into another track's, and a bus server is one per core. An effect that replaces a stock one is already on FX1 and says that instead.
 
 [bold]a narrow terminal shows fewer panes[/]
 Under 118 columns the panes come in pairs that slide with the focus; under 92, one at a time. The tab bar at the top names all three and marks where you are. Lists longer than the pane scroll with the cursor and say so (`↑ 6 more`).

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -360,6 +360,15 @@ Both are then equally yours. Leaving an effect off a chooser takes that ROW and 
 
 `p` → FX1 draws the chooser you composed, as the firmware draws it.
 
+[bold]what the preview is for[/]
+It is the only way to see the PANEL side of an image without flashing one. The remixer's own panes say what you asked for; this says what the firmware will actually draw from the tables the build wrote — the effect names on the chooser rows, in the order they will scroll, and the knob labels the page will put under each encoder.
+
+That is a real class of bug and it has cost real days here: a cloned descriptor inherits its donor's display formatter, so a slot can carry the right count, default and name and still draw as something else entirely — or as nothing. Three of six page-2 slots drew wrong on one flash and every check passed, because every field they checked was right.
+
+TWO INDEPENDENT THINGS SHARE THE PAGE, which is why the columns beside a row are not that row's: the chooser list scrolls down the left, and the knob names belong to whichever effect the TRACK has selected — the one named in the caption, marked `▸` when its row is on screen.
+
+Honest limits: knob VALUES draw as dial graphics the string capture cannot read, so the numbers in the pane above are the truth for values and the picture is the truth for names. Nothing here touches hardware.
+
 [bold]what an FX1 row costs[/]
 No words: the DSP dispatch table is indexed by the raw id and shared by both menus, so an effect's code already ran from FX1 the moment FX1 selected its id. It costs CYCLES — FX1 is four more slots on the same four tracks, so an effect on both menus can double the worst per-core load; watch the Budget's `cycles` row.
 
@@ -1427,10 +1436,18 @@ class RemixerScreen(Screen):
         # the same title and the same chooser column, so they look alike.
         # NOT the page title -- the LCD draws that itself two lines down,
         # and saying it twice is how the caption came to say nothing.
-        what = ("the main menu" if self.preview == "MENU"
-                else f"{escape(disp(mod))} on track 5")
-        head = [f"preview {modes}  [dim](p)[/]",
-                f"[dim]{what}, as the unit draws it[/]"]
+        # WHAT THE PAGE IS, in the terms of the two things on it. "as the
+        # unit draws it" said where the picture came from, which is the one
+        # thing you can already see.
+        # TWO THINGS ARE ON THIS PAGE and the caption has to name both, or
+        # the rows and the labels beside them read as a mapping. They are
+        # not: the chooser list scrolls down the left, and the knob names
+        # belong to whichever effect the TRACK has selected.
+        slot = self.preview
+        what = ("the main menu, as the unit draws it" if slot == "MENU"
+                else f"the {slot} menu's own rows, and {escape(disp(mod))}'s "
+                     f"knob names — both as the unit draws them")
+        head = [f"preview {modes}  [dim](p)[/]", f"[dim]{what}[/]"]
         # DO NOT DRAW SOMETHING THAT IS NOT THE SELECTION. The FX2 page
         # includes the firmware's own chooser list, so an image that is not
         # this selection puts a different set of effects on screen beside the
@@ -1479,11 +1496,26 @@ class RemixerScreen(Screen):
                 return head[:1] + ["[dim]not in the image yet[/]"]
             effect_id = mod.menu.fx2_id
         grid = self._panel(self.preview, effect_id)
+        # ⚠️ MARK THE SELECTED ROW. The page draws TWO independent things --
+        # the chooser list down the left, and the knob names of whichever
+        # effect the track has selected -- and our capture puts them on the
+        # same text rows, so `ChonVerb78   SHMR MODE DIFF` reads as a mapping
+        # from that row to those knobs. It is not one: the names belong to
+        # the selection, and the row beside them is just the next row of the
+        # list. The unit says which row is selected by XOR-highlighting it,
+        # which the string-capture hook cannot read (docs/EMU.md) -- but we
+        # know which effect we asked for, so say it here.
+        if effect_id is not None:
+            want = disp(mod).lower()
+            grid = [("▸" + ln[1:] if ln[1:].lower().startswith(want) else ln)
+                    for ln in grid]
         # The LCD frame is chrome; the firmware's own words are the content.
         edge = f"[{LCD}]"
-        # The no-fuse rule can push a fragment past the nominal 42 columns,
-        # and a row longer than the frame breaks it open.
-        w = 44
+        # The LCD is 32 characters wide (128 px / a 4 px cell, measured), and
+        # a row the no-fuse rule pushed past that is clipped rather than
+        # allowed to break the frame open.
+        import emu_bringup
+        w = emu_bringup.COLS
         return head + [f"{edge}." + "-" * w + ".[/]"] + \
             [f"{edge}|[/]" + escape(ln[:w].ljust(w)) + f"{edge}|[/]"
              for ln in grid] + \

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -340,7 +340,7 @@ The loop is one move long: highlight one of yours in AVAILABLE and press `enter`
           LOADED: remove the row you are on, from ITS list.
   left/right   UNIT: the knob value, hold to run, SHIFT for ×10
                LOADED: move the row within its own chooser
-  r  render + hear     space  replay        p  which page is previewed
+  r  render + hear     space  replay
   a / b  park what you just heard as A / B      , / .  play A / B
   1  put the highlighted effect on the FX1 chooser (or take it off)
   x  apply the fix the ⚠ is offering (only shown when there is one)
@@ -365,9 +365,11 @@ It is the only way to see the PANEL side of an image without flashing one. The r
 
 That is a real class of bug and it has cost real days here: a cloned descriptor inherits its donor's display formatter, so a slot can carry the right count, default and name and still draw as something else entirely — or as nothing. Three of six page-2 slots drew wrong on one flash and every check passed, because every field they checked was right.
 
-An FX page is shown as what it IS, not as a picture of the screen: the effect's knob names in the unit's own words, in the banks the encoders are in, and the chooser rows the firmware listed (`▸` marks the one this page is for). ⚠️ A picture is not available: the chooser list and the parameter block are two overlaid WINDOWS whose coordinates are not comparable — fourteen text baselines in 64 pixels with a 7 px font — so flattening them into one grid interleaves them and reads as a mapping from each row to the labels beside it, which is not what any of it means. The strings are still the firmware's own; only their arrangement stops being a reconstruction.
+BOTH MENUS AT ONCE, no switcher, docked to the bottom of the pane so it does not move as you scroll between effects with different numbers of knobs. It shows the effect's knob names in the unit's own words, in the banks the encoders are in, and each chooser's rows as the firmware lists them (`▸` marks the row this effect is on).
 
-MAIN MENU stays a picture, because it is one window of two plain lists and flattening it loses nothing — and seeing a patched-in top-level row drawn where it will be is the whole reason that view exists.
+⚠️ There WAS a `p` key cycling FX1 / FX2 / MENU, and all three of its problems were the switcher. FX1 and FX2 resolve the SAME descriptor for anything listed on both — the build points both id tables at one clone — so switching showed the same knob names twice and only the chooser rows differed, which is the one thing worth seeing side by side. And the MAIN MENU is the same picture in every remix that exists: a selection changes it only by writing the tables at 0x400cbc00, and every remix so far changes ZERO bytes of them. So it is a line — `menu unchanged by this selection` — and it becomes a picture on the day something patches it, which is the day that view was built for.
+
+⚠️ A picture of an FX page is not available: the chooser list and the parameter block are two overlaid WINDOWS whose coordinates are not comparable — fourteen text baselines in 64 pixels with a 7 px font — so flattening them into one grid interleaves them and reads as a mapping from each row to the labels beside it, which is not what any of it means. The strings are still the firmware's own; only their arrangement stops being a reconstruction.
 
 Honest limits: knob VALUES draw as dial graphics the string capture cannot read, so only a stepped select prints one; the numbers in the pane above are the truth for values. Nothing here touches hardware.
 
@@ -459,7 +461,10 @@ class HelpScreen(ModalScreen[None]):
 AVAILABLE, LOADED, UNIT = 0, 1, 2
 # The unit's own order: FX1 then FX2 are the two slots on a
 # track; MAIN MENU is the odd one out and goes last.
-PREVIEWS = ("FX1", "FX2", "MENU")
+# ⚠️ THERE WAS A `p` KEY cycling FX1 / FX2 / MENU here. Both FX pages are the
+# same descriptor for anything listed on both, so it showed the same knob
+# names twice; the MAIN MENU is the same picture in every remix that exists.
+# Both are on screen at once now -- see _panel_block.
 
 
 class RemixerScreen(Screen):
@@ -486,7 +491,6 @@ class RemixerScreen(Screen):
         # is about YOUR material rather than about the image, so it is the
         # one a new pair of hands looks for and cannot guess.
         Binding("d", "source_dir", "sample folder"),
-        Binding("p", "preview", "preview page", show=False),
         Binding("a", "mark('A')", "A = this", show=False),
         Binding("b", "mark('B')", "B = this", show=False),
         Binding("comma", "play_mark('A')", "play A", show=False),
@@ -539,7 +543,6 @@ class RemixerScreen(Screen):
     def on_mount(self):
         self.pane = LOADED
         self.cur = [0, 0, 0]
-        self.preview = "FX2"
         self.rows_mtime = None
         self.built = []                  # (fx2_id, module) from the image
         # The image tracks the selection: `gen` counts selection changes,
@@ -550,7 +553,7 @@ class RemixerScreen(Screen):
         self.synced = None
         self.syncing = None
         self.sync_error = None
-        self._panel_cache = (None, None)   # see _panel()
+        self._panel_cache = {}              # see _panel()
         self._painted = {}                 # see _paint()
         # COALESCED REPAINT. A held arrow key delivers events faster than
         # three panes can be rebuilt, and rendering each one in turn is what
@@ -765,10 +768,17 @@ class RemixerScreen(Screen):
         if can_fix != getattr(self, "_can_fix", None):
             self._can_fix = can_fix
             self.refresh_bindings()          # the footer follows it
+        # ⚠️ THE BUDGET IS PAINTED FIRST, and it changes the panes' HEIGHT.
+        # It is `height: auto`, so a row appearing there -- the cycles row
+        # arriving when a build lands, the legend gaining a glyph -- steals a
+        # row from the three panes above. Nothing resized, so on_resize does
+        # not fire and _paint sees unchanged text, and the panes went on
+        # laying out against a height they no longer had: the bottom line of
+        # the unit pane was clipped away with nothing saying so.
+        self._pane_budget(st, probs)
         self._pane_available(st)
         self._pane_loaded(st, probs)
         self._pane_unit(st, probs)
-        self._pane_budget(st, probs)
         if not self.wide_screen:
             self._paint("#tabbar", "  ".join(
                 (f"[reverse bold] {escape(t)} [/]" if i == self.pane
@@ -776,7 +786,25 @@ class RemixerScreen(Screen):
                 for i, t in enumerate(self._tnames)) + "  [dim]· tab[/]")
         self._paint("#status", f"[dim]{escape(st.msg)}[/]")
 
-    def _fit(self, wid, out, cur_line, head, tail=0):
+    def _budget_resized(self, n):
+        """The budget's own height changed, so the panes above it are laid
+        out against a stale one.
+
+        ⚠️ READING content_size DURING A RENDER GIVES THE PREVIOUS LAYOUT --
+        Textual has not re-laid-out yet -- so invalidating the panes is not
+        enough on its own: the pass that follows must be a SEPARATE one. The
+        symptom was the unit pane's last line clipped away with nothing
+        saying so, on the render where the cycles row arrived and took a row
+        off every pane.
+        """
+        if n == getattr(self, "_budget_h", None):
+            return
+        self._budget_h = n
+        for wid in ("#pane_avail", "#pane_load", "#pane_unit"):
+            self._painted.pop(wid, None)
+        self.rerender_soon()
+
+    def _fit(self, wid, out, cur_line, head, tail=0, height=None):
         """A LIST TALLER THAN THE PANE HAS TO SCROLL, or the rows past the
         fold are unreachable -- at 80x24 the library ran out nine modules
         short and the cursor simply walked off the bottom of the screen with
@@ -788,7 +816,8 @@ class RemixerScreen(Screen):
         The first and last row of a clipped window say so, because a list
         that silently starts at item nine is worse than one that scrolls.
         """
-        h = self.query_one(wid, Static).content_size.height
+        h = (self.query_one(wid, Static).content_size.height
+             if height is None else height)
         if h <= 0 or len(out) <= h:          # h is 0 before the first layout
             return out
         body = out[head:len(out) - tail] if tail else out[head:]
@@ -1259,6 +1288,7 @@ class RemixerScreen(Screen):
                     cur = " " * 8 + it
                 else:
                     cur += sep + it
+            self._budget_resized(len(lines) + 1)
             self._paint("#pane_budget", lines + [cur])
             return
         rows, wide = self._two_up(out, side)
@@ -1275,6 +1305,9 @@ class RemixerScreen(Screen):
             for i, (glyph, what) in enumerate(key):
                 rows.append(f" {'bar' if not i else '':<{W}}"
                             f"[dim]{glyph}  {what}[/]")
+        # Its own height is what the panes above are laid out against, so a
+        # change in it invalidates them.
+        self._budget_resized(len(rows))
         self._paint("#pane_budget", ["[bold]Budget[/]"] + rows)
 
     # Rich markup is not width: padding by len() on a marked-up string puts
@@ -1389,17 +1422,32 @@ class RemixerScreen(Screen):
                    if self.pane == UNIT else
                    "[dim]tab here to change values and audition[/]")
         out.append("")
-        # HOW MUCH ROOM IS LEFT FOR IT. The preview is the tallest thing in
-        # the remixer and it is last, so a short pane cut it mid-frame: the
-        # box lost its bottom border and its last rows with no sign that
-        # anything was missing.
-        room = self.query_one("#pane_unit", Static).content_size.height
-        out += self._preview(mod, probs, max(0, room - len(out)))
-        # No pinned tail: the knobs are what the cursor is in and the preview
-        # is what follows them, so a short pane shows as much of the page as
-        # is left over rather than reserving room for it.
+        # ⚠️ DOCKED TO THE BOTTOM. The block sat straight after the knob
+        # rows, so it moved up and down the pane with the number of knobs --
+        # five for WarpFold, thirteen for Filter -- and the thing you were
+        # reading was never in the same place twice.
+        block = self._panel_block(mod, probs)
+        # ⚠️ THE ARITHMETIC IS DONE HERE, not in _fit. This pane has three
+        # parts with three different claims on the space -- a fixed head, a
+        # scrollable middle the cursor lives in, and a block that must stay
+        # docked at the bottom -- and threading that through the generic
+        # windower produced a pane whose block was sometimes simply absent.
+        # One row of slack, deliberately: content_size read DURING a render
+        # is the previous layout's and came back a row optimistic often
+        # enough to clip the block's last line away silently. Being wrong by
+        # one costs a blank row; being right to the row costs a line.
+        room = self.query_one("#pane_unit", Static).content_size.height - 1
+        # ⚠️ WHEN BOTH CANNOT FIT, THE BLOCK GOES AND SAYS SO. Windowing the
+        # knobs down to nothing to keep it would take away the thing the
+        # cursor is standing in; silently dropping it is what a docked block
+        # must never do.
+        if room > 0 and room - len(out) - len(block) < -6:
+            block = [f"[dim]what the unit will draw — the pane is "
+                     f"{len(block) + len(out) - room} rows short[/]"]
+        out += [""] * max(0, room - len(out) - len(block)) + block
         self._paint("#pane_unit", self._fit("#pane_unit", out, cur_line,
-                                            head=head))
+                                            head=head, tail=len(block),
+                                            height=room))
 
     # ---- the emulated panel ---------------------------------------------
     def _panel(self, mode, effect_id):
@@ -1417,8 +1465,8 @@ class RemixerScreen(Screen):
         the page depends only on WHICH page, WHICH effect, and which boot.
         """
         key = (mode, effect_id, self.synced)
-        if self._panel_cache[0] == key:
-            return self._panel_cache[1]
+        if key in self._panel_cache:
+            return self._panel_cache[key]
         import emu_bringup
         r = self.app.boot
         if mode == "MENU":
@@ -1430,30 +1478,33 @@ class RemixerScreen(Screen):
             draws = emu_bringup.render_fx2(r, track=4, effect_id=effect_id)
         # The RAW draws, because the two readings of them -- the structured
         # one for an FX page and the picture for the menu -- are both derived
-        # and only the capture is expensive.
-        self._panel_cache = (key, list(draws))
-        return self._panel_cache[1]
+        # and only the capture is expensive. Several are held at once: BOTH
+        # menus are on screen at all times now, so a keystroke that changes
+        # neither must not re-capture either.
+        if len(self._panel_cache) > 8:
+            self._panel_cache.clear()
+        self._panel_cache[key] = list(draws)
+        return self._panel_cache[key]
 
-    def _page(self, mod, draws):
-        """An FX page as what it IS: the effect's knob names in the unit's
-        own words, in the banks the encoders are in, and the chooser rows.
+    def _page_rows(self, mod, draws):
+        """An FX page's knob names, in the banks the encoders are in.
 
-        ⚠️ NOT A PICTURE OF THE SCREEN. The list and the parameter block are
-        two overlaid windows whose y origins are not comparable (fourteen
-        text baselines in 64 pixels with a 7 px font -- emu_bringup's
-        read_screen has the measurement), so flattening them into one grid
-        interleaves them and reads as a mapping from each chooser row to the
-        labels beside it. The STRINGS are still the firmware's own, which is
-        the whole point of the view; only their arrangement stops being a
-        reconstruction.
+        ⚠️ NOT A PICTURE OF THE SCREEN. The chooser list and the parameter
+        block are two overlaid windows whose y origins are not comparable
+        (fourteen text baselines in 64 pixels with a 7 px font --
+        emu_bringup.read_screen has the measurement), so flattening them into
+        one grid interleaves them and reads as a mapping from each chooser
+        row to the labels beside it. The STRINGS are still the firmware's
+        own, which is the whole point of the view; only their arrangement
+        stops being a reconstruction.
         """
         import emu_bringup
         scr = emu_bringup.read_screen(draws)
         # WHICH PAGE A ROW BELONGS TO, decided against the effect's own
-        # parameters rather than against the pixel columns -- and by MAJORITY,
-        # because a select's VALUE can coincide with a parameter's name
-        # (`BASE` is both one of FILTER's page-1 knobs and what its page-2
-        # ENV prints).
+        # parameters rather than against the pixel columns -- and by
+        # MAJORITY, because a select's VALUE can coincide with a parameter's
+        # name (`BASE` is both one of FILTER's page-1 knobs and what its
+        # page-2 ENV prints).
         page = {n: ("page 1" if slot < 6 else "page 2")
                 for n, slot in self.unit_rows(mod) if n != "SOURCE"}
         banks = {"page 1": [], "page 2": [], "": []}
@@ -1464,8 +1515,7 @@ class RemixerScreen(Screen):
             votes = [page.get(n, "") for n in row]
             kind = max(set(votes), key=votes.count) if votes else ""
             banks[kind].append(row)
-        out = []
-        w = 6
+        out, w = [], 6
         for kind in ("page 1", "page 2", ""):
             if not banks[kind]:
                 continue
@@ -1480,142 +1530,111 @@ class RemixerScreen(Screen):
                 line += "  "
             out.append(line.rstrip())
             lev = None
-        if not out:
-            out = ["[dim] no parameters drawn[/]"]
-        # AND THE CHOOSER ROWS the firmware actually listed -- the visible
-        # window of them, which is what the capture holds.
+        return out or ["[dim] no parameters drawn[/]"]
+
+    def _rows_line(self, label, draws, mod):
+        """One chooser's rows as the FIRMWARE lists them, packed to the pane.
+
+        Not the same statement as the CHOOSERS pane, which shows what you
+        asked for: this is what the build actually wrote into the image, in
+        the window the screen shows. `▸` is the row this effect sits on --
+        the unit says so by XOR-highlighting it, which the string capture
+        cannot read (docs/EMU.md).
+        """
+        import emu_bringup
         want = disp(mod).lower()
-        names = [("[reverse]▸" + escape(n) + "[/]")
-                 if n.lower().startswith(want) else escape(n)
-                 for n in scr["list"]]
-        out.append("")
-        # PACKED, not truncated: seven chooser names on one line runs off the
-        # pane, and the one that gets cut is as likely to be the one you were
-        # looking for as any other.
-        room = self.query_one("#pane_unit", Static).content_size.width - 2
-        lead, lines, cur = f" [dim]{self.preview} rows on screen[/] ", [], ""
+        names = [(f"[reverse]▸{escape(n)}[/]"
+                  if n.lower().startswith(want) else escape(n))
+                 for n in emu_bringup.read_screen(draws)["list"]]
+        if not names:
+            return [f" [dim]{label:<5}no rows drawn[/]"]
+        # PACKED, not truncated: the name that gets cut is as likely to be
+        # the one you were looking for as any other.
+        # ⚠️ FLOORED AT 30. content_size read during a render is the previous
+        # layout's, and a stale narrow one packed the names ONE PER LINE --
+        # fourteen lines of chooser on a pane that had two to spare.
+        room = max(30, self.query_one("#pane_unit", Static).content_size.width
+                   - 2)
+        lead, out, cur = f" [dim]{label:<5}[/]", [], ""
         for n in names:
             bit = (" [dim]·[/] " if cur else "") + n
             if cur and self._vis(lead + cur + bit) > room:
-                lines.append(lead + cur)
-                lead, cur = " " * 20, n
+                if len(out) == 1:               # two lines is the whole budget
+                    cur += " [dim]…[/]"
+                    break
+                out.append(lead + cur)
+                lead, cur = " " * 6, n
             else:
                 cur += bit
-        out += lines + [lead + cur]
-        return out
+        return out + [lead + cur]
 
-    def _preview(self, mod, probs, room=0):
+    def _panel_block(self, mod, probs):
+        """WHAT THE UNIT WILL DRAW, both menus at once, no switcher.
+
+        ⚠️ THERE WAS A `p` KEY cycling FX1 / FX2 / MENU, and all three of its
+        problems were the switcher. The FX1 and FX2 pages are the SAME
+        descriptor for anything listed on both -- the build points both id
+        tables at one clone and verify_menu asserts it -- so switching
+        between them showed the same knob names twice and only the chooser
+        rows differed, which is the one thing worth seeing side by side. And
+        the MAIN MENU is the same picture in every remix that exists: a
+        selection changes it only by writing the tables at 0x400cbc00, and
+        every remix so far changes ZERO bytes of them (rig.menu_patched).
+        So it is a line, and it becomes a picture on the day something
+        patches it -- which is the day that view was built for.
+        """
         st = self.app.state
-        modes = " ".join(f"[reverse]{m}[/]" if m == self.preview else
-                         f"[dim]{m}[/]" for m in PREVIEWS)
-        # WHAT IT IS SHOWING, not that it is showing something. "drawn by
-        # the firmware, from your selection" said where the picture came
-        # from, which is the one thing you can see; what was missing is
-        # WHICH page and for WHICH effect -- and the FX pages all open with
-        # the same title and the same chooser column, so they look alike.
-        # NOT the page title -- the LCD draws that itself two lines down,
-        # and saying it twice is how the caption came to say nothing.
-        # WHAT THE PAGE IS, in the terms of the two things on it. "as the
-        # unit draws it" said where the picture came from, which is the one
-        # thing you can already see.
-        # TWO THINGS ARE ON THIS PAGE and the caption has to name both, or
-        # the rows and the labels beside them read as a mapping. They are
-        # not: the chooser list scrolls down the left, and the knob names
-        # belong to whichever effect the TRACK has selected.
-        slot = self.preview
-        what = ("the main menu, as the unit draws it" if slot == "MENU"
-                else f"{escape(disp(mod))}'s page, in the unit's own words")
-        head = [f"preview {modes}  [dim](p)[/]", f"[dim]{what}[/]"]
-        # DO NOT DRAW SOMETHING THAT IS NOT THE SELECTION. The FX2 page
-        # includes the firmware's own chooser list, so an image that is not
-        # this selection puts a different set of effects on screen beside the
-        # LOADED pane and reads as "why are those loaded?". The answer is no
-        # longer to explain it -- ensure_sync() rebuilds -- but while that is
-        # in flight there is still nothing honest to show.
+        head = ["[bold]what the unit will draw[/]"]
         self.ensure_sync(probs)
         r = self.app.boot
         if probs:
-            return head[:1] + ["[dim]not built — see the ⚠ in LOADED[/]"]
+            return head + ["[dim]not built — see the ⚠ in CHOOSERS[/]"]
         if self.sync_error:
-            return head[:1] + [f"[bold]build failed[/] [dim]— "
-                               f"{escape(self.sync_error)}[/]"]
+            return head + [f"[dim]build failed — {escape(self.sync_error)}[/]"]
         if self.syncing is not None or r is None:
-            return head[:1] + ["[dim]building and booting…[/]"]
+            return head + ["[dim]building and booting…[/]"]
         if not r.reached_handoff:
             return head + ["[bold]did not reach the RTOS handoff[/] — a "
                            "patch may have broken early init"]
-        effect_id = None
-        if self.preview == "FX1":
-            # ⚠️ IT ALWAYS DREW FILTER. The one view that could show what an
-            # effect looks like on FX1 was pinned to effect_id 0x04, so
-            # putting one of yours on FX1 and pressing `p` showed the stock
-            # filter's page -- harmless while nothing of ours could be on
-            # FX1, and actively misleading the moment one could.
-            on = rig.menus(mod, st.fx1)
-            if rig.FX1 in on and mod.menu is not None:
-                effect_id = mod.menu.fx2_id
-            else:
-                # Stock's own chooser as it ships, which is what an FX1 row
-                # would be added to -- said, rather than left to look like
-                # this effect's page.
-                effect_id = 0x04
-                head = head[:1] + [
-                    f"[dim]{escape(disp(mod))} has no FX1 row — this is the "
-                    f"chooser without it[/]"]
-        elif self.preview == "FX2":
-            if mod.menu is None:
-                return head + ["[dim]no chooser row: this module patches the "
-                               "firmware rather than adding an effect[/]"]
-            if not self.in_image(mod):
-                # Rare now that the image follows the selection, but kept:
-                # an id the image does not implement resolves to the
-                # FALLBACK, so the firmware would draw a convincing picture
-                # of the wrong effect (CLAUDE.md, 12 Aug 2026).
-                return head[:1] + ["[dim]not in the image yet[/]"]
-            effect_id = mod.menu.fx2_id
-        draws = self._panel(self.preview, effect_id)
-        if self.preview != "MENU":
-            return head + self._page(mod, draws)
-        # THE MAIN MENU STAYS A PICTURE. It is one window of two plain lists,
-        # so flattening it loses nothing -- and the whole reason for the view
-        # is to see a patched-in top-level row drawn where it will be.
+        if mod.menu is None:
+            return head + ["[dim]no chooser row: this module patches the "
+                           "firmware rather than adding an effect[/]"]
+        if not self.in_image(mod):
+            # An id the image does not implement resolves to the FALLBACK,
+            # so the firmware would draw a convincing picture of the wrong
+            # effect (CLAUDE.md, 12 Aug 2026).
+            return head + ["[dim]not in the image yet[/]"]
+        eid = mod.menu.fx2_id
+        on_fx1 = rig.FX1 in rig.menus(mod, st.fx1)
+        d2 = self._panel("FX2", eid)
+        out = head + self._page_rows(mod, d2)
+        # FX1's chooser is stock's own when this effect has no row on it, and
+        # saying so is the point: it is where an FX1 row WOULD be added.
+        out += self._rows_line("FX1", self._panel("FX1", eid if on_fx1
+                                                  else 0x04), mod)
+        out += self._rows_line("FX2", d2, mod)
+        n = rig.menu_patched()
+        out.append(f" [dim]menu [/]" + ("[dim]unchanged by this selection[/]"
+                                        if not n else
+                                        f"[{WARN}]{n} bytes patched[/]"))
+        if n:
+            out += self._menu_picture()
+        return out
+
+    def _menu_picture(self):
+        """The MAIN MENU as the firmware draws it -- shown only when the
+        selection actually changes it, which is the case that view exists
+        for (a patched-in top-level row, PLAN.md section 5)."""
         import emu_bringup
-        grid = emu_bringup.layout_screen(draws)
-        # The LCD frame is chrome; the firmware's own words are the content.
-        edge = f"[{LCD}]"
-        # The LCD is 32 characters wide (128 px / a 4 px cell, measured), and
-        # a row the no-fuse rule pushed past that is clipped rather than
-        # allowed to break the frame open.
-        import emu_bringup
-        w = emu_bringup.COLS
-        # Trailing blank rows are the page having fewer parameters than the
-        # screen has lines, not content -- and they are the first thing to
-        # give up when the pane is short.
+        grid = emu_bringup.layout_screen(self._panel("MENU", None))
         while grid and not grid[-1].strip():
             grid.pop()
         while grid and not grid[0].strip():
-            grid.pop(0)          # the menu opens with an empty line
-        cut = len(head) + len(grid) + 2 - room
-        if room and len(grid) - cut < 4:
-            # Below a few rows the box says nothing and costs the lines it
-            # would have said it in.
-            return head[:1] + [f"[dim]the pane is {cut} row"
-                               f"{'' if cut == 1 else 's'} short of the "
-                               f"page — make the window taller[/]"]
-        if room and cut > 0:
-            # CLIP DELIBERATELY, and say so where the bottom border would
-            # have been. A frame with no bottom edge reads as a rendering
-            # fault rather than as a short window.
-            grid = grid[:max(0, len(grid) - cut - 1)]
-            return head + [f"{edge}." + "-" * w + ".[/]"] + \
-                [f"{edge}|[/]" + escape(ln[:w].ljust(w)) + f"{edge}|[/]"
-                 for ln in grid] + \
-                [f"{edge}'[/][dim]" + f" {cut + 1} more rows — the pane is "
-                 f"short ".ljust(w, "-")[:w] + f"[/]{edge}'[/]"]
-        return head + [f"{edge}." + "-" * w + ".[/]"] + \
+            grid.pop(0)
+        edge, w = f"[{LCD}]", emu_bringup.COLS
+        return [f"{edge}." + "-" * w + ".[/]"] + \
             [f"{edge}|[/]" + escape(ln[:w].ljust(w)) + f"{edge}|[/]"
-             for ln in grid] + \
-            [f"{edge}'" + "-" * w + "'[/]"]
+             for ln in grid] + [f"{edge}'" + "-" * w + "'[/]"]
 
     # ---- keeping the image equal to the selection ------------------------
     # There used to be a stale() gate here: the preview refused to draw when
@@ -1740,11 +1759,6 @@ class RemixerScreen(Screen):
     def action_pane(self, d):
         self.pane = (self.pane + d) % 3
         self._relayout()          # on a narrow screen `tab` IS the layout
-        self.rerender()
-
-    def action_preview(self):
-        self.preview = PREVIEWS[(PREVIEWS.index(self.preview) + 1)
-                                % len(PREVIEWS)]
         self.rerender()
 
     def on_key(self, ev):

--- a/tools/remix/audition.py
+++ b/tools/remix/audition.py
@@ -1,6 +1,6 @@
 """Render ANY effect on a source wav, knobs addressed by their MANIFEST names.
 
-The one audition entry point for the workbench: chonverb goes through
+The one audition entry point for the remixer: chonverb goes through
 tools/render_reverb.py (wet extraction, per-mode image cache, ring-out tail),
 everything else through tools/send_probe.py --wav. The caller never learns
 which -- it says "render warpfold with MIX=127 on this wav" and gets a path.
@@ -96,7 +96,7 @@ def _ensure_insert_mem(mod, log=print):
     send = registry.by_name("send")
     scratch = ROOT / "remixes/_audition.py"
     scratch.write_text(
-        f'"""_audition -- scratch: {mod.name} + SEND, for the workbench.\n\n'
+        f'"""_audition -- scratch: {mod.name} + SEND, for the remixer.\n\n'
         f'Written and removed by tools/remix/audition.py.\n"""\n\n'
         f'from remix.schema import Remix\n\n'
         f'REMIX = Remix(\n'

--- a/tools/remix/index.py
+++ b/tools/remix/index.py
@@ -61,6 +61,8 @@ def main():
         default = "  <- default" if name == registry.DEFAULT_REMIX else ""
         print(f"  {r.name:<12} {r.doc}{default}")
         print(f"      modules: {', '.join(r.modules)}")
+        if r.fx1:
+            print(f"      also on the FX1 chooser: {', '.join(r.fx1)}")
         print(f"      unimplemented ids fall back to: {r.fallback}")
         print()
     print("Build one with:  make bus REMIX=<name>")

--- a/tools/remix/index.py
+++ b/tools/remix/index.py
@@ -52,7 +52,9 @@ def main():
             knobs = ", ".join(f"{n}@{i}" for n, i in sorted(
                 m.knob_map().items(), key=lambda kv: kv[1]))
             print(f"      knobs: {knobs}")
-    print(f"\n  consumed by every remix (their code is the donor region): "
+    # ⚠️ NOT "every remix" any more: the donor region is a CHOICE
+    # (schema.Remix.harvest), and each remix's is printed with it below.
+    print(f"\n  harvested by default (their code is the donor region): "
           f"{', '.join(stock.CONSUMED)}\n")
 
     print("REMIXES  (remixes/<name>.py)\n")
@@ -63,6 +65,8 @@ def main():
         print(f"      modules: {', '.join(r.modules)}")
         if r.fx1:
             print(f"      also on the FX1 chooser: {', '.join(r.fx1)}")
+        if tuple(r.harvest) != stock.CONSUMED:
+            print(f"      harvests: {', '.join(r.harvest)}")
         print(f"      unimplemented ids fall back to: {r.fallback}")
         print()
     print("Build one with:  make bus REMIX=<name>")

--- a/tools/remix/index.py
+++ b/tools/remix/index.py
@@ -52,9 +52,10 @@ def main():
             knobs = ", ".join(f"{n}@{i}" for n, i in sorted(
                 m.knob_map().items(), key=lambda kv: kv[1]))
             print(f"      knobs: {knobs}")
-    # ⚠️ NOT "every remix" any more: the donor region is a CHOICE
-    # (schema.Remix.harvest), and each remix's is printed with it below.
-    print(f"\n  harvested by default (their code is the donor region): "
+    # ⚠️ NOT "every remix" any more: what a remix gives up is DERIVED from
+    # its two choosers -- an effect on neither is one it does not want -- and
+    # each remix's is printed with it below when it differs from these.
+    print(f"\n  given up by most remixes (on neither chooser): "
           f"{', '.join(stock.CONSUMED)}\n")
 
     print("REMIXES  (remixes/<name>.py)\n")
@@ -65,8 +66,13 @@ def main():
         print(f"      modules: {', '.join(r.modules)}")
         if r.fx1:
             print(f"      also on the FX1 chooser: {', '.join(r.fx1)}")
-        if tuple(r.harvest) != stock.CONSUMED:
-            print(f"      harvests: {', '.join(r.harvest)}")
+        _hv = stock.region_of(stock.harvested(
+            set(r.modules) | set(r.fx1 or [
+                k for k in stock.p_spans("A")
+                if registry.modules()[k].menu.fx2_id in stock.fx1_ids()])))
+        if tuple(_hv) != stock.CONSUMED:
+            print(f"      gives up (on neither chooser): "
+                  f"{', '.join(_hv) or 'nothing'}")
         print(f"      unimplemented ids fall back to: {r.fallback}")
         print()
     print("Build one with:  make bus REMIX=<name>")

--- a/tools/remix/ledger.py
+++ b/tools/remix/ledger.py
@@ -150,13 +150,20 @@ def check(selected) -> list[str]:
     stocked = [m for m in selected
                if getattr(m, "claims", None) is not None
                and m.claims.stock_instance_buffer]
+    # ⚠️ THIS REFUSES AN FX2 CHOOSER ROW, NOT THE EFFECT. A stock effect left
+    # out of a remix keeps its code, descriptor and dispatch, so the four
+    # dual-menu ones are still on FX1 and still work -- and the collision
+    # cannot follow them there, because the allocator keeps SEPARATE tables
+    # and an FX1 slot tops out at 0x3fff while every FX2 buffer a module of
+    # ours pins starts at 0x4000 or in the shared window.
     for a in stocked:
         for b in fixed:
             clash("stock instance buffer", a.name, b.name,
-                  "the allocator's per-track buffer slots -- the stock "
+                  "the allocator's per-track FX2 buffer slots -- the stock "
                   "effect's buffer lands on whichever track hosts it and "
                   "that is where the module's fixed buffers are; the chooser "
-                  "cannot keep them on different cores")
+                  "cannot keep them on different cores. Its FX2 ROW is what "
+                  "is refused: on FX1 it keeps working, out of reach")
 
     # ---- core-private Y ---------------------------------------------------
     # Low Y is per CORE. Two effects that can share a core share these words,

--- a/tools/remix/ledger.py
+++ b/tools/remix/ledger.py
@@ -132,17 +132,21 @@ def check(selected) -> list[str]:
     #   core 0 FX2:  0x4000  0x8000  0x30000  0x34000
     #   core 1 FX2:  0x4000  0x8000  0x38000  0x3c000
     #
-    # ChonVerb is ALL FOUR of core 0's -- tank in the first two, relocated
-    # buffers in the other two -- so any allocating stock effect sharing that
-    # core certainly collides. Nimbus is the first two. BongDelay is core 1's
-    # LAST TWO (its lines are based at 0x38000), so a stock effect there
-    # collides only if the allocator hands it slot 3 or 4.
+    # ⚠️ AND THE SLOTS ARE ONE PER TRACK, not a pool: each track allocates
+    # FX1 then FX2, so track k's FX2 effect always gets entry 1+2k
+    # (docs/DSP.md, "the allocator's instance model"). Nothing is first-come.
     #
-    # THAT IS STILL A REFUSAL, and the reason is the difference between
-    # "certain" and "unpredictable": which slot an effect gets depends on how
-    # many FX2 effects the dispatcher has already walked this block, and
-    # which track the operator picks is not something an image can constrain.
-    # Each works perfectly alone, which is the worst shape a defect can have.
+    #   ChonVerb   all four of its core's -- tank in tracks 1-2's slots,
+    #              relocated buffers in tracks 3-4's. No track on that core
+    #              can host an allocating stock effect.
+    #   Nimbus     tracks 1-2's slots of whichever core hosts it.
+    #   BongDelay  tracks 3-4's (its lines are based at 0x38000/0x3c000), so
+    #              on ITS core an allocating stock effect is safe on tracks
+    #              1-2 and collides on 3-4.
+    #
+    # THAT IS STILL A REFUSAL, because the chooser is ONE LIST for all eight
+    # tracks: the image cannot say "FLANGER, but only on tracks 1-2". Each
+    # works perfectly alone, which is the worst shape a defect can have.
     fixed = [m for m in selected
              if (getattr(m, "claims", None) is not None
                  and m.claims.owns_fx2_buffers)

--- a/tools/remix/ledger.py
+++ b/tools/remix/ledger.py
@@ -124,13 +124,25 @@ def check(selected) -> list[str]:
                   "of them can be hosted on a given core; each works alone")
 
     # ---- stock effects that allocate an instance buffer -------------------
-    # The allocator's bases are per TRACK SLOT (docs/DSP.md section 10):
-    # core 0 hands out Y:0x4000 / 0x8000 / 0x30000 / 0x34000, core 1
-    # Y:0x4000 / 0x8000 / 0x38000 / 0x3c000. ChonVerb's tank is all four of
-    # core 0's, Nimbus's line the first two, BongDelay's line core 1's last
-    # two -- so CHORUS on track 6 beside ChonVerb on track 5 writes into the
-    # tank. Each works perfectly alone, and which track the operator picks
-    # is not something an image can constrain, so the PAIR is refused.
+    # The allocator's bases are per TRACK SLOT, and this is MEASURED -- read
+    # from X:0x255 in BOTH payloads of the pristine image, 2 Sep 2026 (the
+    # words are little-endian, which only shows above 0x10000, and reading
+    # them big-endian gives a plausible 0x00003 instead of 0x30000):
+    #
+    #   core 0 FX2:  0x4000  0x8000  0x30000  0x34000
+    #   core 1 FX2:  0x4000  0x8000  0x38000  0x3c000
+    #
+    # ChonVerb is ALL FOUR of core 0's -- tank in the first two, relocated
+    # buffers in the other two -- so any allocating stock effect sharing that
+    # core certainly collides. Nimbus is the first two. BongDelay is core 1's
+    # LAST TWO (its lines are based at 0x38000), so a stock effect there
+    # collides only if the allocator hands it slot 3 or 4.
+    #
+    # THAT IS STILL A REFUSAL, and the reason is the difference between
+    # "certain" and "unpredictable": which slot an effect gets depends on how
+    # many FX2 effects the dispatcher has already walked this block, and
+    # which track the operator picks is not something an image can constrain.
+    # Each works perfectly alone, which is the worst shape a defect can have.
     fixed = [m for m in selected
              if (getattr(m, "claims", None) is not None
                  and m.claims.owns_fx2_buffers)

--- a/tools/remix/registry.py
+++ b/tools/remix/registry.py
@@ -22,6 +22,9 @@ import sys
 import types
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from remix.schema import NO_FALLBACK, on_the_bus  # noqa: E402
 MODULES_DIR = ROOT / "modules"
 
 _cache: dict[str, object] | None = None
@@ -184,6 +187,22 @@ def remix(name: str = DEFAULT_REMIX):
         if k not in known:
             raise SystemExit(f"remix {name!r} selects unknown module {k!r} -- "
                              f"have {sorted(known)}")
+    # ⚠️ THE FIRMWARE'S OWN NONE IS ONLY SAFE WHEN THERE IS NO BUS. An
+    # unassigned track then runs nothing at all -- including the housekeeping
+    # block -- and a remix with a server on one core and no participant on
+    # core 0 would leave the rotation frozen and the accumulators uncleared.
+    # With neither a server nor a client in the image there is no bus to
+    # keep, so the question does not arise. See schema.NO_FALLBACK for the
+    # whole argument and for why it cannot be settled by a local test.
+    if r.fallback == NO_FALLBACK:
+        on_bus = [k for k in r.modules if on_the_bus(known[k])]
+        if on_bus:
+            raise SystemExit(
+                f"remix {name!r}: fallback {NO_FALLBACK!r} is only for a remix "
+                f"with no bus participant, and this one has "
+                f"{', '.join(sorted(on_bus))} -- an unassigned track would run "
+                f"nothing, so nobody would flip the rotation or clear the "
+                f"accumulators. Use fallback=\"SEND\".")
     return r
 
 

--- a/tools/remix/registry.py
+++ b/tools/remix/registry.py
@@ -94,11 +94,26 @@ def modules() -> dict[str, object]:
             raise SystemExit(f"module {seen_dirs[m.key]} claims the key "
                              f"{m.key!r}, which is a stock effect's")
         if m.menu.fx2_id in seen_ids:
-            raise SystemExit(
-                f"module {seen_ids[m.menu.fx2_id]} claims FX2 id "
-                f"0x{m.menu.fx2_id:02x}, which is stock {m.key}'s -- the "
-                f"dispatch tables are shared with FX1, so it would hijack "
-                f"that effect on both menus")
+            # A DECLARED replacement is allowed to share the id -- that is
+            # what it declared. It must name THIS effect, though: replacing
+            # LO-FI while sitting on PHASER's id is a typo that would
+            # otherwise ship.
+            other = found.get(seen_ids[m.menu.fx2_id]) or \
+                next((x for x in found.values()
+                      if x.menu is not None
+                      and x.menu.fx2_id == m.menu.fx2_id), None)
+            rep = other.menu.replaces if (other is not None
+                                          and other.menu is not None) else None
+            if rep != m.key:
+                raise SystemExit(
+                    f"module {seen_ids[m.menu.fx2_id]} claims FX2 id "
+                    f"0x{m.menu.fx2_id:02x}, which is stock {m.key}'s -- the "
+                    f"dispatch tables are shared with FX1, so it would hijack "
+                    f"that effect on both menus"
+                    + (f" (it declares replaces={rep!r}, not {m.key!r})"
+                       if rep else ""))
+            found[m.key] = m
+            continue
         seen_ids[m.menu.fx2_id] = m.key
         found[m.key] = m
     _cache = found

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -16,7 +16,7 @@ Categories and track ranges are DERIVED from the manifests, never declared
 here -- the manifest is the single place a module states what it is
 (schema.py's whole reason to exist):
 
-  SERVER  harness.is_server -- pays the bus costs, lives in ONE payload, and
+  BUS     harness.is_server -- pays the bus costs, lives in ONE payload, and
           the payload decides its tracks: A serves TRACKS 5-8, B serves
           TRACKS 1-4 (measured 10 Aug 2026 via the MrkVerb32 marker flash,
           INVERTED from every earlier assumption -- test the reverb on
@@ -48,7 +48,14 @@ TRACKS = range(1, 9)
 # one place the workbench states it.
 PAYLOAD_TRACKS = {"A": range(5, 9), "B": range(1, 5)}
 
-SERVER, INSERT, STOCK, SYSTEM = "server", "insert", "stock", "system"
+# BUS, not "server". It is the natural opposite of INSERT and the word this
+# project already uses for the thing itself (docs/XBUS.md, `make bus`, the
+# bus accumulators): an effect either sits IN a track or is fed BY tracks
+# over the bus. The module KEYS stay "REVERB SERVER"/"DELAY SERVER" -- they
+# are written into saved remixes and the build report -- and `is_server` is
+# still what the manifest declares. This is the word the operator reads.
+BUS, INSERT, STOCK, SYSTEM = "bus", "insert", "stock", "system"
+SERVER = BUS                    # the old name, for anything still saying it
 
 
 def category(mod) -> str:
@@ -102,20 +109,30 @@ def menus(mod) -> tuple[str, ...]:
     them different lists: ten effects on FX1, those ten plus DELAY and the
     three reverbs on FX2.
 
-    Our own modules are FX2-only, and that is a BUILD limit rather than a
-    hardware one. The DSP dispatch tables are indexed by the raw id and
+    Our own modules are FX2-only UNLESS THEY REPLACE A STOCK EFFECT, in
+    which case they take that effect's FX1 row as well -- the build repoints
+    both FX1 tables (build_bus.py, docs/MODULES.md), confirmed by asking the
+    emulated firmware to draw the page. Everything below is about a module
+    wanting a NEW row rather than an existing one.
+
+    Otherwise our modules are FX2-only, and that is a BUILD limit rather than
+    a hardware one. The DSP dispatch tables are indexed by the raw id and
     SHARED between the two menus, so a module's code already runs from FX1
     the moment FX1 selects its id (that is exactly how Rungs ran wherever
     FX1 chose EQUALIZER). What is missing is the panel side: FX1's 15-entry
     chooser cannot grow in place and has to be relocated to a cave
     (`tools/build_fx1.py` proved it can be), and no manifest field asks for
     a row. `verify_menu` asserts FX1's list and id lookup are byte-identical
-    to stock, deliberately, until that lands.
+    to stock APART FROM the entries a declared replacement owns.
     """
     from remix import stock as _stock
     if mod.menu is None:
         return ()
     if mod.is_stock:
+        return (FX1, FX2) if mod.menu.fx2_id in _stock.fx1_ids() else (FX2,)
+    # A replacement inherits its target's menus, because it inherits its id
+    # and the build repoints both of FX1's tables to it.
+    if mod.menu.replaces:
         return (FX1, FX2) if mod.menu.fx2_id in _stock.fx1_ids() else (FX2,)
     return (FX2,)
 
@@ -215,21 +232,30 @@ def resources(mod, words=None) -> list[str]:
         # region, so listing one costs whatever a module of ours would have
         # written over it.
         from remix import stock
-        out.append("its code IS the donor region"
-                   if mod.key in stock.CONSUMED else "0 words (already in the image)")
+        # A DONOR REVERB IS FREE UNTIL YOUR CODE REACHES IT. The region is
+        # packed from PLATE upward, so each one survives exactly as long as
+        # the modules of ours stay under its offset -- which is the number
+        # worth knowing, and it is arithmetic rather than a rule.
+        if mod.key in stock.CONSUMED:
+            at = stock.consumed_at(mod.key)
+            out.append("yours overwrite it first" if at == 0 else
+                       f"free while your modules stay under {at:,} words")
+        else:
+            out.append("free — already in the image")
     elif words:
-        out.append(f"{words} words")
+        out.append(f"{words} of 2,724 words")
     elif mod.dsp is not None:
-        out.append("words: build to measure")
-    if mod.dsp is not None and not mod.is_stock:
-        pay = getattr(mod.dsp, "payloads", None)
-        if pay:
-            out.append("payload " + "+".join(sorted(pay)))
+        out.append("measuring…")
     claims = getattr(mod, "claims", None)
+    # THE CONSEQUENCE, not the address. "pins Y:0x4000-0xBFFF" is where the
+    # buffer is; what the operator is deciding is what it will cost them,
+    # which is the seven stock effects it cannot sit beside. The address is
+    # in docs/DSP.md section 10 and belongs there.
     if claims is not None and getattr(claims, "owns_fx2_buffers", False):
-        out.append("pins Y:0x4000-0xBFFF (the FX2 buffer region)")
+        out.append(f"needs the whole FX2 buffer region "
+                   f"(blocks {_n_allocating()} stock effects)")
     if claims is not None and getattr(claims, "stock_instance_buffer", False):
-        out.append("takes an allocator buffer")
+        out.append("takes 1 of the 4 FX2 buffer slots")
     py = ledger.private_y(mod)
     if py:
         out.append(f"{len(py)} core-private Y word"
@@ -240,3 +266,12 @@ def resources(mod, words=None) -> list[str]:
         out.append(f"{len(caves)} ColdFire cave{'s' if len(caves) != 1 else ''}"
                    + (f", {hooks} hooked" if hooks else ""))
     return out
+
+
+def _n_allocating() -> int:
+    """How many stock effects take a buffer from the host's allocator, and so
+    cannot sit beside a module that pins the region. Counted, not written
+    down: it went from four to seven the day the reverbs became listable."""
+    from remix import stock
+    return sum(1 for m in stock.MODULES
+               if m.claims is not None and m.claims.stock_instance_buffer)

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -91,6 +91,56 @@ def available(track: int) -> list:
     return [m for m in effects() if track in track_range(m)]
 
 
+# ---- what the BUILT IMAGE offers -------------------------------------------
+# The rig says what the operator is auditioning; this says what the image on
+# disk would actually put in the FX2 chooser, which is not the same thing --
+# the composer's live selection can be ahead of the last build, and the emu
+# view boots the FILE. Read from the image so the answer is the image's, not
+# a re-derivation of what we think we built.
+#
+# ⚠️ The two constants are copies. `tools/build_bus.py` writes the list and
+# `tools/verify_menu.py` checks it, and both spell them out with the same
+# provenance note; a third copy is the price of not importing a verify script
+# for its globals (verify_menu binds REMIX from the environment at import,
+# which is exactly the wrong source of truth here). If the caves ever move,
+# they move in three places -- `verify_menu` fails loudly if they disagree.
+BUILT_IMAGE = ROOT / "out/mainos_bus.bin"
+_LIST_REF = 0x400375f4                  # the operand naming the live list
+_LIST_CAVES = (0x400d6b00, 0x400d7bbc)  # short list, or the long one
+
+
+def built_chooser(image=None) -> list[tuple[int, object]]:
+    """The FX2 chooser rows the built image offers, in the panel's own order.
+
+    -> [(fx2_id, module_or_None)], empty if there is no image or its list
+    does not land in a known cave. `module_or_None` is None for an id no
+    manifest claims, which should not happen in an image we built and is
+    surfaced rather than hidden if it does.
+    """
+    from dsp_modmap import BASE
+    img_path = pathlib.Path(image) if image else BUILT_IMAGE
+    if not img_path.exists():
+        return []
+    img = img_path.read_bytes()
+
+    def rd32(a):
+        i = a - BASE
+        return int.from_bytes(img[i:i + 4], "big") if 0 <= i <= len(img) - 4 else 0
+
+    live = rd32(_LIST_REF)
+    if live not in _LIST_CAVES:
+        return []
+    rows, a = [], live
+    while len(rows) < 32:                    # the long cave's capacity
+        ptr = rd32(a)
+        if not ptr:                          # the list's own terminator
+            break
+        fx_id = rd32(ptr) & 0xff             # descriptor's own id word, P+0
+        rows.append((fx_id, registry.by_id(fx_id)))
+        a += 4
+    return rows
+
+
 def default_knobs(mod) -> dict[str, int]:
     """Manifest defaults for every named, drawn slot -- the values a fresh
     part boots with, which is also the honest render baseline (the SHMR=64

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -337,13 +337,32 @@ def resources(mod, words=None, fx1_rows=(), selected=True) -> list[str]:
     out = []
 
     # ---- the donor region: words ----------------------------------------
+    #
+    # ⚠️ A STOCK EFFECT SAYS WHAT IT USES, like everything else here. It used
+    # to say "free", which is a MARGINAL cost worn as an absolute: listing it
+    # costs no donor words because its code is already placed, and that is
+    # true -- but in a remixer whose whole point is mixing stock and ours
+    # freely, one kind of effect answering "how much does this use?" with
+    # "free" and the other with "2,411 of 2,724 words" makes them look like
+    # different KINDS of thing. They are not. They are effects, and every one
+    # of them occupies words, a buffer slot and cycles.
     if mod.is_stock:
+        w = stock.WORDS.get(mod.key, 0)
         if mod.key in stock.CONSUMED:
+            # These three are the exception that proves it: their words ARE
+            # the donor region, so they are the only stock effects whose
+            # words are yours to take.
             at = stock.consumed_at(mod.key)
+            out.append(f"{w:,} words — and they are the donor region")
             out.append("yours overwrite it first" if at == 0 else
-                       f"free while your modules stay under {at:,} words")
+                       f"survives while your modules stay under {at:,} words")
+        elif w:
+            # The consequence, not the mechanism: they are not in the donor
+            # region, so they are not yours to trade either way.
+            out.append(f"{w:,} words, already placed — listing it costs none "
+                       f"and dropping it frees none")
         else:
-            out.append("free — already in the image")
+            out.append("no DSP words — it runs on the ColdFire side")
         # WHAT LEAVING IT OUT ACTUALLY COSTS, in words rather than by a dash
         # in a column. The two menus are not symmetric: FX1's chooser is
         # stock's own and no image shortens it, so an unlisted effect that

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -214,28 +214,30 @@ def knob_max(mod, name: str) -> int:
 
 
 def resources(mod, words=None) -> list[str]:
-    """What this effect COSTS, in the terms the ledger refuses things over.
+    """What this effect COSTS, ONE LINE PER MENU.
 
-    Shown while scrolling, because "will this fit beside what I have" is the
-    question the library pane is really being asked, and every answer was
-    previously only available after a refusal.
+    Shown while scrolling, because "will this fit beside what I have" is what
+    the library pane is really being asked, and every answer used to arrive
+    only as a refusal after adding it.
 
-    Derived wherever it can be (private Y is scanned, caves and hooks are
-    counted from the manifest, words come from the build) so nothing here can
-    go stale against the module it describes.
+    ⚠️ THE MENUS ARE SEPARATE and running them together was unreadable. FX1
+    and FX2 have their OWN allocator tables (measured, X:0x255 in both
+    payloads): FX1 hands out 0x1000/0x1c00/0x2800/0x3400 at 3,072 words
+    each, FX2 hands out 0x4000/0x8000 plus a shared-window pair at 16,384.
+    They do not overlap, so a cost on one is not a cost on the other -- and
+    saying so in a subordinate clause ("FX2 rows only, FX1 keeps its 4") made
+    a simple fact sound like a caveat. A line each states it instead.
+
+    Derived wherever it can be: private Y is scanned from the module's own
+    source, caves counted from the manifest, words taken from a real build,
+    the affected stock effects read off their claims.
     """
-    from remix import ledger
+    from remix import ledger, stock
+    from remix.schema import YBase
     out = []
+
+    # ---- the donor region: words ----------------------------------------
     if mod.is_stock:
-        # A stock row places no code and clones no descriptor. The three
-        # reverbs are the exception that proves it: their code IS the donor
-        # region, so listing one costs whatever a module of ours would have
-        # written over it.
-        from remix import stock
-        # A DONOR REVERB IS FREE UNTIL YOUR CODE REACHES IT. The region is
-        # packed from PLATE upward, so each one survives exactly as long as
-        # the modules of ours stay under its offset -- which is the number
-        # worth knowing, and it is arithmetic rather than a rule.
         if mod.key in stock.CONSUMED:
             at = stock.consumed_at(mod.key)
             out.append("yours overwrite it first" if at == 0 else
@@ -246,37 +248,39 @@ def resources(mod, words=None) -> list[str]:
         out.append(f"{words} of 2,724 words")
     elif mod.dsp is not None:
         out.append("measuring…")
-    claims = getattr(mod, "claims", None)
-    # THE CONSEQUENCE, not the address. "pins Y:0x4000-0xBFFF" is where the
-    # buffer is; what the operator is deciding is what it will cost them,
-    # which is the seven stock effects it cannot sit beside. The address is
-    # in docs/DSP.md section 10 and belongs there.
-    # ⚠️ MIRROR THE LEDGER'S OWN TEST, or a module's cost goes unreported.
-    # BongDelay declares owns_fx2_buffers=False -- its lines are in the
-    # shared window, not the 0x4000 region -- so this line said nothing about
-    # buffers for it, while the ledger refused it beside all seven anyway.
-    # The ledger's `fixed` set is owns_fx2_buffers OR ybase is not NEVER, and
-    # the second half is why: core 1's allocator hands out 0x38000/0x3c000,
-    # which is exactly where a substituted ybase puts its buffers.
-    from remix.schema import YBase
-    pins = claims is not None and getattr(claims, "owns_fx2_buffers", False)
+
+    # ---- one line per menu ----------------------------------------------
+    allocates = (getattr(mod, "claims", None) is not None
+                 and mod.claims.stock_instance_buffer)
+    on = menus(mod)
+    pins = (getattr(mod, "claims", None) is not None
+            and mod.claims.owns_fx2_buffers)
     window = mod.dsp is not None and mod.dsp.ybase is not YBase.NEVER
-    # HOW MANY, exactly: owns_fx2_buffers is the two CORE-PRIVATE slots
-    # (0x4000/0x8000) and a substituted ybase is the two SHARED-WINDOW ones
-    # (0x30000/0x34000 on core 0, 0x38000/0x3c000 on core 1 -- measured from
-    # X:0x255 in both payloads). ChonVerb has both and so takes all four;
-    # Nimbus only the first pair; BongDelay only the second.
-    if pins or window:
+
+    if mod.menu is None:
+        pass                    # no chooser row at all: neither menu applies
+    elif FX1 in on:
+        out.append("FX1  " + ("takes 1 of the 4 slots (3,072 words each)"
+                              if allocates else "no buffer"))
+    else:
+        # Not on FX1 at all, so the FX1 allocator never hands it anything.
+        out.append("FX1  no row — takes nothing")
+
+    if mod.menu is None:
+        pass
+    elif pins or window:
         n = 2 * pins + 2 * window
-        where = ("all 4 FX2 buffer slots" if n == 4 else
-                 "2 core-private FX2 slots" if pins else
-                 "2 shared-window FX2 slots")
-        out.append(f"pins {where} — costs {_allocating_names()}")
-        # Precisely how many, because FX1 never listed the three reverbs:
-        # it keeps the four dual-menu ones, not all seven.
-        out.append(f"FX2 rows only — FX1 keeps its {_allocating_on_fx1()}")
-    if claims is not None and getattr(claims, "stock_instance_buffer", False):
-        out.append("takes 1 of the 4 FX2 buffer slots")
+        which = ("all 4 slots" if n == 4 else
+                 "2 core-private slots" if pins else
+                 "2 shared-window slots")
+        out.append(f"FX2  pins {which} — costs the rows of "
+                   f"{_allocating_names()}")
+    elif allocates:
+        out.append("FX2  takes 1 of the 4 slots (16,384 words each)")
+    else:
+        out.append("FX2  no buffer")
+
+    # ---- everything else -------------------------------------------------
     py = ledger.private_y(mod)
     if py:
         out.append(f"{len(py)} core-private Y word"

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -163,6 +163,65 @@ def menus(mod, fx1_rows=()) -> tuple[str, ...]:
 # without booting anything.
 MENU_TABLES = (0x400cbc00, 0x400cc700)
 
+# The id-indexed tables each menu resolves, and the two name fields inside a
+# page descriptor (docs/PARAM_PAGES.md section 2). Read from the BUILT image
+# rather than from the manifest: the manifest is what was ASKED for, and the
+# whole point of looking is that a cloned descriptor can carry something else.
+_FX1_IDS, _FX2_IDS = 0x400d5f58, 0x400d5fdc
+_FX1_ID2POS, _FX2_ID2POS = 0x400d60d0, 0x400d6150
+_NONE_DESC = 0x400d4618
+_P_ABBR, _P_FULLNAME = 0x04, 0x09
+_P_NAMES, _P_PENABLE_LO, _P_PENABLE_HI = 0x16, 0x18e, 0x18a
+
+
+def drawn_as(fx2_id: int, img: bytes | None = None):
+    """What the built image will make the unit PRINT for this id, and the
+    chooser row each menu opens on.
+
+    -> {"name", "abbr", "slots", "fx1", "fx2"} -- fx1/fx2 being the cursor
+    row or None when that menu does not list the id at all -- or None if
+    there is no image. `img` defaults to the built one; verify_menu passes
+    the bytes it already has.
+    """
+    if img is None:
+        from remix.state import BUILT_IMAGE
+        if not BUILT_IMAGE.exists():
+            return None
+        img = BUILT_IMAGE.read_bytes()
+    base = 0x40000400
+
+    def rd32(a):
+        i = a - base
+        return int.from_bytes(img[i:i + 4], "big") if 0 <= i < len(img) - 3 else 0
+
+    def field(p, off, n):
+        i = p - base + off
+        return img[i:i + n].split(b"\0")[0].decode("latin1", "replace")
+
+    p2 = rd32(_FX2_IDS + fx2_id * 4)
+    p1 = rd32(_FX1_IDS + fx2_id * 4)
+    desc = p2 if p2 and p2 != _NONE_DESC else p1
+    if not desc or desc == _NONE_DESC:
+        return None
+    # THE TWELVE SLOT NAMES the panel will print, and which are enabled --
+    # the same two words stock.py reads, from the same descriptor. This is
+    # the field a CLONE inherits from its donor, so reading it back out of
+    # the built image is the check that the build wrote what was asked for.
+    lo = rd32(desc + _P_PENABLE_LO)
+    hi = rd32(desc + _P_PENABLE_HI)
+    slots = []
+    for i in range(12):
+        on = bool(((lo if i < 8 else hi) >> (4 * (i if i < 8 else i - 8))) & 1)
+        nm = field(desc, _P_NAMES + i * 6, 6)
+        slots.append(nm if on and nm else None)
+    return {"name": field(desc, _P_FULLNAME, 13),
+            "abbr": field(desc, _P_ABBR, 5),
+            "slots": tuple(slots),
+            "fx1": (rd32(_FX1_ID2POS + fx2_id * 4)
+                    if p1 and p1 != _NONE_DESC else None),
+            "fx2": (rd32(_FX2_ID2POS + fx2_id * 4)
+                    if p2 and p2 != _NONE_DESC else None)}
+
 
 def menu_patched() -> int:
     """Bytes of the MAIN MENU tables this build changed. 0 = the unit's own

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -271,7 +271,7 @@ def resources(mod, words=None) -> list[str]:
         where = ("all 4 FX2 buffer slots" if n == 4 else
                  "2 core-private FX2 slots" if pins else
                  "2 shared-window FX2 slots")
-        out.append(f"pins {where} (blocks {_n_allocating()} stock effects)")
+        out.append(f"pins {where} — costs {_allocating_names()}")
     if claims is not None and getattr(claims, "stock_instance_buffer", False):
         out.append("takes 1 of the 4 FX2 buffer slots")
     py = ledger.private_y(mod)
@@ -286,10 +286,27 @@ def resources(mod, words=None) -> list[str]:
     return out
 
 
-def _n_allocating() -> int:
-    """How many stock effects take a buffer from the host's allocator, and so
-    cannot sit beside a module that pins the region. Counted, not written
-    down: it went from four to seven the day the reverbs became listable."""
+def _allocating_names() -> str:
+    """WHICH stock effects a buffer-pinning module costs you, by name.
+
+    It is a fixed set, so naming it beats counting it -- "blocks 7 stock
+    effects" makes you go and find out which seven, and the answer never
+    changes. The three reverbs collapse to a phrase because they always go
+    together (their code IS the donor region) and spelling all three out
+    doubles the line for nothing.
+
+    Derived from the manifests, not written down: it went from four to seven
+    the day the reverbs became listable.
+    """
     from remix import stock
-    return sum(1 for m in stock.MODULES
-               if m.claims is not None and m.claims.stock_instance_buffer)
+    names = [m for m in stock.MODULES
+             if m.claims is not None and m.claims.stock_instance_buffer]
+    revs = [m for m in names if m.key in stock.CONSUMED]
+    rest = [m.menu.fullname.decode("latin1").title()
+            for m in names if m.key not in stock.CONSUMED]
+    if len(revs) == len(stock.CONSUMED) and revs:
+        rest.append(f"the {len(revs)} reverbs")
+    elif revs:
+        rest += [m.menu.fullname.decode("latin1").title() for m in revs]
+    return ", ".join(rest[:-1]) + " and " + rest[-1] if len(rest) > 1 else \
+        (rest[0] if rest else "nothing")

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -276,12 +276,19 @@ def resources(mod, words=None, fx1_rows=(), selected=True) -> list[str]:
                       if mod.key in fx1_rows else ""))
     else:
         # Not on FX1 at all, so the FX1 allocator never hands it anything.
-        # The `1` hint only where `1` would work: on an effect that is in
-        # the image. Offering it beside one you are merely previewing sends
-        # you to a refusal.
-        out.append("FX1  no row — 1 adds one: no words, 4 slots of cycles"
-                   if selected and not mod.is_stock and mod.menu is not None
-                   else "FX1  no row — takes nothing")
+        # The `1` hint only where `1` would work. Offering it beside an
+        # effect you are merely previewing, or one the build would refuse,
+        # sends you to a refusal you could have been told about here --
+        # which is what this line exists for.
+        from remix.state import fx1_hazard
+        why = fx1_hazard(mod) if not mod.is_stock else None
+        if why:
+            out.append(f"FX1  no row — and cannot take one: {why}")
+        elif selected and not mod.is_stock and mod.menu is not None:
+            out.append("FX1  no row — 1 adds one: no words, 4 slots of "
+                       "cycles")
+        else:
+            out.append("FX1  no row — takes nothing")
 
     if mod.menu is None:
         pass

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -1,4 +1,4 @@
-"""What a module IS, in the terms the workbench and the harness need.
+"""What a module IS, in the terms the remixer and the harness need.
 
 Everything below this speaks modules and payloads. This layer answers the
 questions a person asks instead: what kind of thing is this, which tracks can
@@ -8,7 +8,7 @@ actually offer.
 ⚠️ The per-TRACK rig this file was named for is GONE (2 Sep 2026). Eight
 tracks with an effect on each was a second place to say what a remix already
 says, and knob values belong to the EFFECT rather than to a track -- so the
-workbench is one page about an image, and `State.knobs_for(mod)` holds the
+remixer is one page about an image, and `State.knobs_for(mod)` holds the
 values. The helpers below survived because they were never about tracks:
 they are about modules.
 
@@ -25,7 +25,7 @@ here -- the manifest is the single place a module states what it is
           payloads, runs on any track.
   STOCK   a stock FX2 effect the remix keeps in the chooser (Kind.STOCK,
           tools/remix/stock.py) -- code already in both payloads, any
-          track. No knobs here: the workbench has no manifest for stock
+          track. No knobs here: the remixer has no manifest for stock
           params, and no local render yet either.
   SYSTEM  everything else: the SEND client, ColdFire patches. Plumbing the
           image needs, never something you put on a track.
@@ -45,7 +45,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 TRACKS = range(1, 9)
 # Which tracks each payload's core serves. Measured 10 Aug 2026 (MrkVerb32
 # marker flash); the inversion from old docs cost two flashes, so this is the
-# one place the workbench states it.
+# one place the remixer states it.
 PAYLOAD_TRACKS = {"A": range(5, 9), "B": range(1, 5)}
 
 # BUS, not "server". It is the natural opposite of INSERT and the word this
@@ -373,7 +373,7 @@ def allocating_names() -> str:
 
 def pins_fx2(mod) -> bool:
     """Does this module hold FX2 instance buffers at fixed addresses? The
-    ledger's own `fixed` test, in one place so the workbench cannot drift
+    ledger's own `fixed` test, in one place so the remixer cannot drift
     from it (it did: BongDelay declares owns_fx2_buffers=False because its
     lines are in the shared window, and the pane said nothing about buffers
     for it while the ledger refused it beside all seven)."""

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -251,9 +251,27 @@ def resources(mod, words=None) -> list[str]:
     # buffer is; what the operator is deciding is what it will cost them,
     # which is the seven stock effects it cannot sit beside. The address is
     # in docs/DSP.md section 10 and belongs there.
-    if claims is not None and getattr(claims, "owns_fx2_buffers", False):
-        out.append(f"needs the whole FX2 buffer region "
-                   f"(blocks {_n_allocating()} stock effects)")
+    # ⚠️ MIRROR THE LEDGER'S OWN TEST, or a module's cost goes unreported.
+    # BongDelay declares owns_fx2_buffers=False -- its lines are in the
+    # shared window, not the 0x4000 region -- so this line said nothing about
+    # buffers for it, while the ledger refused it beside all seven anyway.
+    # The ledger's `fixed` set is owns_fx2_buffers OR ybase is not NEVER, and
+    # the second half is why: core 1's allocator hands out 0x38000/0x3c000,
+    # which is exactly where a substituted ybase puts its buffers.
+    from remix.schema import YBase
+    pins = claims is not None and getattr(claims, "owns_fx2_buffers", False)
+    window = mod.dsp is not None and mod.dsp.ybase is not YBase.NEVER
+    # HOW MANY, exactly: owns_fx2_buffers is the two CORE-PRIVATE slots
+    # (0x4000/0x8000) and a substituted ybase is the two SHARED-WINDOW ones
+    # (0x30000/0x34000 on core 0, 0x38000/0x3c000 on core 1 -- measured from
+    # X:0x255 in both payloads). ChonVerb has both and so takes all four;
+    # Nimbus only the first pair; BongDelay only the second.
+    if pins or window:
+        n = 2 * pins + 2 * window
+        where = ("all 4 FX2 buffer slots" if n == 4 else
+                 "2 core-private FX2 slots" if pins else
+                 "2 shared-window FX2 slots")
+        out.append(f"pins {where} (blocks {_n_allocating()} stock effects)")
     if claims is not None and getattr(claims, "stock_instance_buffer", False):
         out.append("takes 1 of the 4 FX2 buffer slots")
     py = ledger.private_y(mod)

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -156,6 +156,28 @@ def menus(mod, fx1_rows=()) -> tuple[str, ...]:
     return tuple(on)
 
 
+# The MAIN MENU's tables: the five list descriptors and the row arrays they
+# point at (docs/MAINMENU.md section 2). A remix changes the top-level menu
+# only by writing here, so comparing this span against the pristine image
+# answers "does this selection change the main menu" exactly, instantly, and
+# without booting anything.
+MENU_TABLES = (0x400cbc00, 0x400cc700)
+
+
+def menu_patched() -> int:
+    """Bytes of the MAIN MENU tables this build changed. 0 = the unit's own
+    menu, unchanged -- which is every remix so far."""
+    from remix.state import BUILT_IMAGE
+    from remix import stock as _stock
+    img = BUILT_IMAGE.read_bytes() if BUILT_IMAGE.exists() else None
+    raw = _stock._image()
+    if img is None or raw is None:
+        return 0
+    lo, hi = (a - 0x40000400 for a in MENU_TABLES)
+    return sum(1 for i in range(lo, min(hi, len(img), len(raw)))
+               if img[i] != raw[i])
+
+
 # ---- what the BUILT IMAGE offers -------------------------------------------
 # The rig says what the operator is auditioning; this says what the image on
 # disk would actually put in the FX2 chooser, which is not the same thing --

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -133,13 +133,27 @@ def menus(mod, fx1_rows=()) -> tuple[str, ...]:
     from remix import stock as _stock
     if mod.menu is None:
         return ()
-    if mod.is_stock:
-        return (FX1, FX2) if mod.menu.fx2_id in _stock.fx1_ids() else (FX2,)
-    # A replacement inherits its target's menus, because it inherits its id
-    # and the build repoints both of FX1's tables to it.
-    if mod.menu.replaces:
-        return (FX1, FX2) if mod.menu.fx2_id in _stock.fx1_ids() else (FX2,)
-    return (FX1, FX2) if mod.key in fx1_rows else (FX2,)
+    # ⚠️ CAPABILITY, NOT CURRENT ROWS -- deliberately, after trying the other
+    # way on 3 Sep 2026. Gating the FX2 half on "is it in the image" is more
+    # literally true (an unlisted FLANGER really has no FX2 row) and it made
+    # the LIBRARY worse: every module you had not added yet read `—`, which
+    # the missing ✓ beside it already said, in place of the one thing the
+    # library is for -- what this effect COULD be. The consequence of leaving
+    # a stock effect out belongs on its resource line, where there is room to
+    # say it in words; see resources().
+    on = []
+    if mod.is_stock or mod.menu.replaces:
+        # A replacement inherits its target's menus, because it inherits its
+        # id and the build repoints both of FX1's tables to it.
+        # A replacement CARRIES the stock effect's id, so its own fx2_id is
+        # already the one to test.
+        fx2_id = mod.menu.fx2_id
+        if fx2_id in _stock.fx1_ids():
+            on.append(FX1)
+    elif mod.key in fx1_rows:
+        on.append(FX1)
+    on.append(FX2)
+    return tuple(on)
 
 
 # ---- what the BUILT IMAGE offers -------------------------------------------
@@ -249,6 +263,16 @@ def resources(mod, words=None, fx1_rows=(), selected=True) -> list[str]:
                        f"free while your modules stay under {at:,} words")
         else:
             out.append("free — already in the image")
+        # WHAT LEAVING IT OUT ACTUALLY COSTS, in words rather than by a dash
+        # in a column. The two menus are not symmetric: FX1's chooser is
+        # stock's own and no image shortens it, so an unlisted effect that
+        # FX1 lists is still there on FX1 -- and one FX2 only ever listed
+        # (DELAY, the three reverbs) is gone from the panel entirely.
+        if not selected:
+            out.append("not listed — it keeps its FX1 row; only the FX2 one "
+                       "is lost" if mod.menu.fx2_id in stock.fx1_ids()
+                       else "not listed — and it was FX2-only, so it has no "
+                            "row at all in this image")
     elif words:
         out.append(f"{words} of 2,724 words")
     elif mod.dsp is not None:

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -101,7 +101,7 @@ def available(track: int) -> list:
 FX1, FX2 = "FX1", "FX2"
 
 
-def menus(mod) -> tuple[str, ...]:
+def menus(mod, fx1_rows=()) -> tuple[str, ...]:
     """The chooser(s) this module has a row on.
 
     FX1 and FX2 are two slots on the SAME track -- the payload split decides
@@ -115,15 +115,20 @@ def menus(mod) -> tuple[str, ...]:
     emulated firmware to draw the page. Everything below is about a module
     wanting a NEW row rather than an existing one.
 
-    Otherwise our modules are FX2-only, and that is a BUILD limit rather than
-    a hardware one. The DSP dispatch tables are indexed by the raw id and
-    SHARED between the two menus, so a module's code already runs from FX1
-    the moment FX1 selects its id (that is exactly how Rungs ran wherever
-    FX1 chose EQUALIZER). What is missing is the panel side: FX1's 15-entry
-    chooser cannot grow in place and has to be relocated to a cave
-    (`tools/build_fx1.py` proved it can be), and no manifest field asks for
-    a row. `verify_menu` asserts FX1's list and id lookup are byte-identical
-    to stock APART FROM the entries a declared replacement owns.
+    And since 3 Sep 2026 a REMIX can ask for the row outright: `Remix.fx1`
+    lists the modules that also get one, `fx1_rows` here is that set, and the
+    build relocates FX1's chooser into the cave and writes FX1's own id and
+    cursor tables. It costs no words -- the DSP dispatch is one table indexed
+    by the raw id and shared by both menus, so the code already ran from FX1
+    the moment FX1 selected its id (that is exactly how Rungs ran wherever
+    FX1 chose EQUALIZER); what was missing was only the panel side, and only
+    because FX1's list ends at 0x400d608c with FX2's beginning four bytes
+    later. What it does cost is cycles: an FX1 effect runs on a track that is
+    already running an FX2 one.
+
+    `verify_menu` asserts FX1's list and id lookup are byte-identical to
+    stock APART FROM the entries a declared replacement or a declared
+    `Remix.fx1` row owns.
     """
     from remix import stock as _stock
     if mod.menu is None:
@@ -134,7 +139,7 @@ def menus(mod) -> tuple[str, ...]:
     # and the build repoints both of FX1's tables to it.
     if mod.menu.replaces:
         return (FX1, FX2) if mod.menu.fx2_id in _stock.fx1_ids() else (FX2,)
-    return (FX2,)
+    return (FX1, FX2) if mod.key in fx1_rows else (FX2,)
 
 
 # ---- what the BUILT IMAGE offers -------------------------------------------
@@ -213,7 +218,7 @@ def knob_max(mod, name: str) -> int:
     return (count - 1) if count is not None else 127
 
 
-def resources(mod, words=None) -> list[str]:
+def resources(mod, words=None, fx1_rows=()) -> list[str]:
     """What this effect COSTS, ONE LINE PER MENU.
 
     Shown while scrolling, because "will this fit beside what I have" is what
@@ -252,7 +257,7 @@ def resources(mod, words=None) -> list[str]:
     # ---- one line per menu ----------------------------------------------
     allocates = (getattr(mod, "claims", None) is not None
                  and mod.claims.stock_instance_buffer)
-    on = menus(mod)
+    on = menus(mod, fx1_rows)
     pins = (getattr(mod, "claims", None) is not None
             and mod.claims.owns_fx2_buffers)
     window = mod.dsp is not None and mod.dsp.ybase is not YBase.NEVER
@@ -260,11 +265,20 @@ def resources(mod, words=None) -> list[str]:
     if mod.menu is None:
         pass                    # no chooser row at all: neither menu applies
     elif FX1 in on:
+        # ⚠️ AN FX1 ROW IS FREE IN WORDS AND NOT FREE. The code is already
+        # placed either way -- the dispatch table is shared -- so the only
+        # bill is CYCLES, and it is a big one: FX1 is four more slots on the
+        # same four tracks, so listing an effect on both menus can double the
+        # worst per-core load. The Budget's cycles row carries the number.
         out.append("FX1  " + ("takes 1 of the 4 slots (3,072 words each)"
-                              if allocates else "no buffer"))
+                              if allocates else "no buffer")
+                   + (" · a row costs no words, 4 slots of cycles"
+                      if mod.key in fx1_rows else ""))
     else:
         # Not on FX1 at all, so the FX1 allocator never hands it anything.
-        out.append("FX1  no row — takes nothing")
+        out.append("FX1  no row — 1 adds one: no words, 4 slots of cycles"
+                   if not mod.is_stock and mod.menu is not None
+                   else "FX1  no row — takes nothing")
 
     if mod.menu is None:
         pass

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -1,15 +1,16 @@
-"""The bench rig: eight tracks, an effect on each, knobs where the unit has them.
+"""What a module IS, in the terms the workbench and the harness need.
 
-This is the layer the workbench was missing. Everything below it speaks
-modules and payloads; an Octatrack user thinks in TRACKS -- which effect is
-on track 5, what its page-1 knobs read, what the chooser offers on track 2.
-The rig states that mapping once so the audition view, the emulator preview
-and the composer all mean the same thing by "T5".
+Everything below this speaks modules and payloads. This layer answers the
+questions a person asks instead: what kind of thing is this, which tracks can
+host it, which chooser does it appear on, what does the image on disk
+actually offer.
 
-A rig is a BENCH FIXTURE, not a firmware statement: it is deliberately not
-part of a remix file (a remix says what the image contains; the rig says what
-the operator is currently listening to) and it persists to out/_rig.json so a
-restarted workbench picks up where it left off.
+⚠️ The per-TRACK rig this file was named for is GONE (2 Sep 2026). Eight
+tracks with an effect on each was a second place to say what a remix already
+says, and knob values belong to the EFFECT rather than to a track -- so the
+workbench is one page about an image, and `State.knobs_for(mod)` holds the
+values. The helpers below survived because they were never about tracks:
+they are about modules.
 
 Categories and track ranges are DERIVED from the manifests, never declared
 here -- the manifest is the single place a module states what it is
@@ -32,7 +33,6 @@ here -- the manifest is the single place a module states what it is
 
 from __future__ import annotations
 
-import json
 import pathlib
 import sys
 
@@ -41,7 +41,6 @@ from remix import registry  # noqa: E402
 from remix.schema import Kind  # noqa: E402
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
-RIG_FILE = ROOT / "out/_rig.json"
 
 TRACKS = range(1, 9)
 # Which tracks each payload's core serves. Measured 10 Aug 2026 (MrkVerb32
@@ -89,6 +88,36 @@ def effects() -> list:
 
 def available(track: int) -> list:
     return [m for m in effects() if track in track_range(m)]
+
+
+# ---- which MENU a module appears on ----------------------------------------
+FX1, FX2 = "FX1", "FX2"
+
+
+def menus(mod) -> tuple[str, ...]:
+    """The chooser(s) this module has a row on.
+
+    FX1 and FX2 are two slots on the SAME track -- the payload split decides
+    which TRACKS a module can appear on, never which slot -- and stock gives
+    them different lists: ten effects on FX1, those ten plus DELAY and the
+    three reverbs on FX2.
+
+    Our own modules are FX2-only, and that is a BUILD limit rather than a
+    hardware one. The DSP dispatch tables are indexed by the raw id and
+    SHARED between the two menus, so a module's code already runs from FX1
+    the moment FX1 selects its id (that is exactly how Rungs ran wherever
+    FX1 chose EQUALIZER). What is missing is the panel side: FX1's 15-entry
+    chooser cannot grow in place and has to be relocated to a cave
+    (`tools/build_fx1.py` proved it can be), and no manifest field asks for
+    a row. `verify_menu` asserts FX1's list and id lookup are byte-identical
+    to stock, deliberately, until that lands.
+    """
+    from remix import stock as _stock
+    if mod.menu is None:
+        return ()
+    if mod.is_stock:
+        return (FX1, FX2) if mod.menu.fx2_id in _stock.fx1_ids() else (FX2,)
+    return (FX2,)
 
 
 # ---- what the BUILT IMAGE offers -------------------------------------------
@@ -165,57 +194,3 @@ def knob_max(mod, name: str) -> int:
     slot = mod.knob_map()[name]
     count = mod.params[slot].count
     return (count - 1) if count is not None else 127
-
-
-class Rig:
-    """Per-track effect assignment + per-track knob values."""
-
-    def __init__(self):
-        self.assign: dict[int, str | None] = {t: None for t in TRACKS}
-        self.knobs: dict[int, dict[str, int]] = {t: {} for t in TRACKS}
-        self.load()
-
-    def set_effect(self, track: int, key: str | None):
-        if key is not None:
-            mod = registry.by_key(key)
-            if track not in track_range(mod):
-                raise ValueError(
-                    f"{mod.name} cannot run on T{track} (tracks "
-                    f"{track_range(mod).start}-{track_range(mod).stop - 1})")
-            self.knobs[track] = default_knobs(mod)
-        else:
-            self.knobs[track] = {}
-        self.assign[track] = key
-
-    def effect(self, track: int):
-        k = self.assign.get(track)
-        return registry.by_key(k) if k else None
-
-    # ---- persistence ----------------------------------------------------
-    def save(self):
-        RIG_FILE.parent.mkdir(parents=True, exist_ok=True)
-        RIG_FILE.write_text(json.dumps(
-            {"assign": {str(t): k for t, k in self.assign.items()},
-             "knobs": {str(t): v for t, v in self.knobs.items()}}, indent=1))
-
-    def load(self):
-        try:
-            d = json.loads(RIG_FILE.read_text())
-        except (OSError, ValueError):
-            return
-        keys = set(registry.modules())
-        for t in TRACKS:
-            k = d.get("assign", {}).get(str(t))
-            if k in keys and t in track_range(registry.by_key(k)):
-                self.assign[t] = k
-                # Keep only knobs the manifest still names, seed the rest
-                # from defaults -- a renamed knob must not resurrect a stale
-                # value under its old meaning.
-                mod = registry.by_key(k)
-                fresh = default_knobs(mod)
-                stored = d.get("knobs", {}).get(str(t), {})
-                for n in fresh:
-                    if n in stored and \
-                            0 <= int(stored[n]) <= knob_max(mod, n):
-                        fresh[n] = int(stored[n])
-                self.knobs[t] = fresh

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -313,7 +313,8 @@ def knob_max(mod, name: str) -> int:
     return (count - 1) if count is not None else 127
 
 
-def resources(mod, words=None, fx1_rows=(), selected=True) -> list[str]:
+def resources(mod, words=None, fx1_rows=(), selected=True,
+              harvest=()) -> list[str]:
     """What this effect COSTS, ONE LINE PER MENU.
 
     Shown while scrolling, because "will this fit beside what I have" is what
@@ -334,6 +335,7 @@ def resources(mod, words=None, fx1_rows=(), selected=True) -> list[str]:
     """
     from remix import ledger, stock
     from remix.schema import YBase
+    harvest = tuple(harvest) or stock.CONSUMED
     out = []
 
     # ---- the donor region: words ----------------------------------------
@@ -348,12 +350,13 @@ def resources(mod, words=None, fx1_rows=(), selected=True) -> list[str]:
     # of them occupies words, a buffer slot and cycles.
     if mod.is_stock:
         w = stock.WORDS.get(mod.key, 0)
-        if mod.key in stock.CONSUMED:
+        if mod.key in harvest:
             # These three are the exception that proves it: their words ARE
             # the donor region, so they are the only stock effects whose
             # words are yours to take.
-            at = stock.consumed_at(mod.key)
-            out.append(f"{w:,} words — and they are the donor region")
+            at = stock.consumed_at(mod.key, tuple(harvest))
+            out.append(f"{w:,} words — harvested, so they are yours to "
+                       f"place into")
             out.append("yours overwrite it first" if at == 0 else
                        f"survives while your modules stay under {at:,} words")
         elif w:
@@ -364,7 +367,12 @@ def resources(mod, words=None, fx1_rows=(), selected=True) -> list[str]:
             # rows. Same shape as the `bar` legend and as the buffer-clash
             # lists before it: an image-level fact charged to every row. The
             # Budget's `held by` line says it once, where it belongs.
-            out.append(f"{w:,} words, already placed")
+            # ⚠️ ONLY WHERE `h` WOULD WORK. The run has to stay contiguous,
+            # so offering it beside an effect in the middle of the survivors
+            # sends you to a refusal this line could have spared you.
+            out.append(f"{w:,} words, already placed — h harvests them"
+                       if mod.key in stock.harvest_neighbours(harvest) else
+                       f"{w:,} words, already placed")
         else:
             out.append("no DSP words — it runs on the ColdFire side")
         # WHAT LEAVING IT OUT ACTUALLY COSTS, in words rather than by a dash

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -218,7 +218,7 @@ def knob_max(mod, name: str) -> int:
     return (count - 1) if count is not None else 127
 
 
-def resources(mod, words=None, fx1_rows=()) -> list[str]:
+def resources(mod, words=None, fx1_rows=(), selected=True) -> list[str]:
     """What this effect COSTS, ONE LINE PER MENU.
 
     Shown while scrolling, because "will this fit beside what I have" is what
@@ -276,8 +276,11 @@ def resources(mod, words=None, fx1_rows=()) -> list[str]:
                       if mod.key in fx1_rows else ""))
     else:
         # Not on FX1 at all, so the FX1 allocator never hands it anything.
+        # The `1` hint only where `1` would work: on an effect that is in
+        # the image. Offering it beside one you are merely previewing sends
+        # you to a refusal.
         out.append("FX1  no row — 1 adds one: no words, 4 slots of cycles"
-                   if not mod.is_stock and mod.menu is not None
+                   if selected and not mod.is_stock and mod.menu is not None
                    else "FX1  no row — takes nothing")
 
     if mod.menu is None:

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -272,6 +272,9 @@ def resources(mod, words=None) -> list[str]:
                  "2 core-private FX2 slots" if pins else
                  "2 shared-window FX2 slots")
         out.append(f"pins {where} — costs {_allocating_names()}")
+        # Precisely how many, because FX1 never listed the three reverbs:
+        # it keeps the four dual-menu ones, not all seven.
+        out.append(f"FX2 rows only — FX1 keeps its {_allocating_on_fx1()}")
     if claims is not None and getattr(claims, "stock_instance_buffer", False):
         out.append("takes 1 of the 4 FX2 buffer slots")
     py = ledger.private_y(mod)
@@ -286,6 +289,16 @@ def resources(mod, words=None) -> list[str]:
     return out
 
 
+def _allocating_on_fx1() -> int:
+    """How many of the allocating stock effects FX1 also lists -- the ones a
+    remix does NOT take away from you. The reverbs are not among them, which
+    is why this is counted rather than assumed to be all of them."""
+    from remix import stock
+    return sum(1 for m in stock.MODULES
+               if m.claims is not None and m.claims.stock_instance_buffer
+               and FX1 in menus(m))
+
+
 def _allocating_names() -> str:
     """WHICH stock effects a buffer-pinning module costs you, by name.
 
@@ -294,6 +307,18 @@ def _allocating_names() -> str:
     changes. The three reverbs collapse to a phrase because they always go
     together (their code IS the donor region) and spelling all three out
     doubles the line for nothing.
+
+    ⚠️ WHAT IS LOST IS THE FX2 ROW, NOT THE EFFECT. Leaving a stock effect
+    out of a remix takes its chooser row and nothing else -- its code,
+    descriptor and dispatch stay stock on both cores -- so FLANGER, CHORUS,
+    SPATIALIZER and COMB are still there on FX1, and still work.
+
+    And the collision cannot follow them there. The allocator keeps SEPARATE
+    tables: FX1 hands out 0x1000/0x1c00/0x2800/0x3400 at 3,072 words each,
+    topping out at 0x3fff, while every FX2 buffer a module of ours pins
+    starts at 0x4000 or in the shared window (measured, X:0x255 in both
+    payloads). An FX1 allocation physically cannot reach them. The three
+    reverbs are the exception only because FX1 never listed them.
 
     Derived from the manifests, not written down: it went from four to seven
     the day the reverbs became listable.

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -355,8 +355,8 @@ def resources(mod, words=None, fx1_rows=(), selected=True,
             # the donor region, so they are the only stock effects whose
             # words are yours to take.
             at = stock.consumed_at(mod.key, tuple(harvest))
-            out.append(f"{w:,} words — harvested, so they are yours to "
-                       f"place into")
+            out.append(f"{w:,} words — off both menus, so they are yours "
+                       f"to place into")
             out.append("yours overwrite it first" if at == 0 else
                        f"survives while your modules stay under {at:,} words")
         elif w:
@@ -367,12 +367,7 @@ def resources(mod, words=None, fx1_rows=(), selected=True,
             # rows. Same shape as the `bar` legend and as the buffer-clash
             # lists before it: an image-level fact charged to every row. The
             # Budget's `held by` line says it once, where it belongs.
-            # ⚠️ ONLY WHERE `h` WOULD WORK. The run has to stay contiguous,
-            # so offering it beside an effect in the middle of the survivors
-            # sends you to a refusal this line could have spared you.
-            out.append(f"{w:,} words, already placed — h harvests them"
-                       if mod.key in stock.harvest_neighbours(harvest) else
-                       f"{w:,} words, already placed")
+            out.append(f"{w:,} words, already placed")
         else:
             out.append("no DSP words — it runs on the ColdFire side")
         # WHAT LEAVING IT OUT ACTUALLY COSTS, in words rather than by a dash

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -269,12 +269,25 @@ def resources(mod, words=None) -> list[str]:
     if mod.menu is None:
         pass
     elif pins or window:
+        # WHAT THIS MODULE PINS, AND WHERE. The list of stock effects it
+        # costs you does NOT belong here: it is the same seven for every
+        # pinner, so printing it per module made ChonVerb and BongDelay look
+        # like two separate bills for one debt. It is a property of the
+        # SELECTION -- the ledger refuses an allocating stock effect beside
+        # ANY pinner -- so the LOADED pane states it once.
+        #
+        # What genuinely differs is which slots, on which core, for which
+        # tracks, and that is worth saying: ChonVerb is all four of core 0's
+        # and BongDelay two of core 1's, and they serve different tracks.
         n = 2 * pins + 2 * window
-        which = ("all 4 slots" if n == 4 else
-                 "2 core-private slots" if pins else
-                 "2 shared-window slots")
-        out.append(f"FX2  pins {which} — costs the rows of "
-                   f"{_allocating_names()}")
+        which = ("all 4 buffer slots" if n == 4 else
+                 "2 core-private buffer slots" if pins else
+                 "2 shared-window buffer slots")
+        tr = track_range(mod)
+        where = (f"on the core serving tracks {tr.start}-{tr.stop - 1}"
+                 if len(tr) and len(tr) != len(TRACKS)
+                 else "on whichever core hosts it")
+        out.append(f"FX2  pins {which} {where}")
     elif allocates:
         out.append("FX2  takes 1 of the 4 slots (16,384 words each)")
     else:
@@ -303,7 +316,7 @@ def _allocating_on_fx1() -> int:
                and FX1 in menus(m))
 
 
-def _allocating_names() -> str:
+def allocating_names() -> str:
     """WHICH stock effects a buffer-pinning module costs you, by name.
 
     It is a fixed set, so naming it beats counting it -- "blocks 7 stock
@@ -339,3 +352,15 @@ def _allocating_names() -> str:
         rest += [m.menu.fullname.decode("latin1").title() for m in revs]
     return ", ".join(rest[:-1]) + " and " + rest[-1] if len(rest) > 1 else \
         (rest[0] if rest else "nothing")
+
+
+def pins_fx2(mod) -> bool:
+    """Does this module hold FX2 instance buffers at fixed addresses? The
+    ledger's own `fixed` test, in one place so the workbench cannot drift
+    from it (it did: BongDelay declares owns_fx2_buffers=False because its
+    lines are in the shared window, and the pane said nothing about buffers
+    for it while the ledger refused it beside all seven)."""
+    from remix.schema import YBase
+    c = getattr(mod, "claims", None)
+    return bool((c is not None and c.owns_fx2_buffers)
+                or (mod.dsp is not None and mod.dsp.ybase is not YBase.NEVER))

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -364,3 +364,18 @@ def pins_fx2(mod) -> bool:
     c = getattr(mod, "claims", None)
     return bool((c is not None and c.owns_fx2_buffers)
                 or (mod.dsp is not None and mod.dsp.ybase is not YBase.NEVER))
+
+
+def pinned_slots(mod) -> int:
+    """How many of a core's FOUR FX2 buffer slots this module holds fixed.
+
+    owns_fx2_buffers is the two CORE-PRIVATE slots (0x4000/0x8000); a
+    substituted ybase is the two SHARED-WINDOW ones (0x30000/0x34000 on core
+    0, 0x38000/0x3c000 on core 1 -- measured, X:0x255 in both payloads).
+    ChonVerb has both and so holds all four; Nimbus the first pair;
+    BongDelay the second.
+    """
+    from remix.schema import YBase
+    c = getattr(mod, "claims", None)
+    return (2 * bool(c is not None and c.owns_fx2_buffers)
+            + 2 * bool(mod.dsp is not None and mod.dsp.ybase is not YBase.NEVER))

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -194,3 +194,49 @@ def knob_max(mod, name: str) -> int:
     slot = mod.knob_map()[name]
     count = mod.params[slot].count
     return (count - 1) if count is not None else 127
+
+
+def resources(mod, words=None) -> list[str]:
+    """What this effect COSTS, in the terms the ledger refuses things over.
+
+    Shown while scrolling, because "will this fit beside what I have" is the
+    question the library pane is really being asked, and every answer was
+    previously only available after a refusal.
+
+    Derived wherever it can be (private Y is scanned, caves and hooks are
+    counted from the manifest, words come from the build) so nothing here can
+    go stale against the module it describes.
+    """
+    from remix import ledger
+    out = []
+    if mod.is_stock:
+        # A stock row places no code and clones no descriptor. The three
+        # reverbs are the exception that proves it: their code IS the donor
+        # region, so listing one costs whatever a module of ours would have
+        # written over it.
+        from remix import stock
+        out.append("its code IS the donor region"
+                   if mod.key in stock.CONSUMED else "0 words (already in the image)")
+    elif words:
+        out.append(f"{words} words")
+    elif mod.dsp is not None:
+        out.append("words: build to measure")
+    if mod.dsp is not None and not mod.is_stock:
+        pay = getattr(mod.dsp, "payloads", None)
+        if pay:
+            out.append("payload " + "+".join(sorted(pay)))
+    claims = getattr(mod, "claims", None)
+    if claims is not None and getattr(claims, "owns_fx2_buffers", False):
+        out.append("pins Y:0x4000-0xBFFF (the FX2 buffer region)")
+    if claims is not None and getattr(claims, "stock_instance_buffer", False):
+        out.append("takes an allocator buffer")
+    py = ledger.private_y(mod)
+    if py:
+        out.append(f"{len(py)} core-private Y word"
+                   f"{'s' if len(py) != 1 else ''}")
+    caves = list(mod.cf_patches)
+    if caves:
+        hooks = sum(1 for c in caves if c.hook_addr is not None)
+        out.append(f"{len(caves)} ColdFire cave{'s' if len(caves) != 1 else ''}"
+                   + (f", {hooks} hooked" if hooks else ""))
+    return out

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -357,10 +357,14 @@ def resources(mod, words=None, fx1_rows=(), selected=True) -> list[str]:
             out.append("yours overwrite it first" if at == 0 else
                        f"survives while your modules stay under {at:,} words")
         elif w:
-            # The consequence, not the mechanism: they are not in the donor
-            # region, so they are not yours to trade either way.
-            out.append(f"{w:,} words, already placed — listing it costs none "
-                       f"and dropping it frees none")
+            # ⚠️ THE NUMBER, AND NOTHING ELSE. This said "— listing it costs
+            # none and dropping it frees none" for one day, which is true and
+            # is a property of the DONOR REGION rather than of this effect,
+            # so it printed the same sentence on ten of the fourteen stock
+            # rows. Same shape as the `bar` legend and as the buffer-clash
+            # lists before it: an image-level fact charged to every row. The
+            # Budget's `held by` line says it once, where it belongs.
+            out.append(f"{w:,} words, already placed")
         else:
             out.append("no DSP words — it runs on the ColdFire side")
         # WHAT LEAVING IT OUT ACTUALLY COSTS, in words rather than by a dash

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -523,6 +523,12 @@ def on_the_bus(mod) -> bool:
     return h is not None and (h.is_server or h.bus_client)
 
 
+# The three the project has always harvested: the biggest stock effects, and
+# FX2-only, so taking them costs FX1 nothing. They are the DEFAULT rather
+# than the rule -- see Remix.harvest.
+DEFAULT_HARVEST = ("PLATE REV", "SPRING REV", "DARK REV")
+
+
 @dataclass(frozen=True)
 class Remix:
     """A named selection of modules, composed into one firmware image.
@@ -603,6 +609,28 @@ class Remix:
     # Streamz, BodeShift, Hello World -- and SEND, which is buffer-free
     # (untested there, but nothing measured argues against it).
     fx1: tuple[str, ...] = ()
+    # ---- which stock effects this remix HARVESTS for their words ----------
+    # The donor region is not a place, it is a CHOICE. The thirteen DSP
+    # effects are laid out contiguously -- 6,158 words in both payloads --
+    # and every one is self-contained, so any of them can be overwritten with
+    # a module of ours (measured 3 Sep 2026; stock.p_spans has the layout and
+    # the containment sweep is in tools/dsp_reach.py). What has always been
+    # "the 2,724-word donor region" is the middle third of that run, chosen
+    # because the three reverbs are the biggest and the least missed.
+    #
+    # ⚠️ THEY MUST BE CONTIGUOUS. A module of ours is one code stream, so the
+    # harvested set has to be an unbroken run; the build refuses a gap rather
+    # than silently placing across a survivor.
+    #
+    # ⚠️ HARVESTED IS NOT THE SAME AS UNLISTED. Leaving a stock effect out of
+    # `modules` takes its chooser row and nothing else -- its code, descriptor
+    # and dispatch stay stock, so an old project that selects it still runs
+    # it. Naming it here offers its words to the placer, and it loses its
+    # algorithm only where our code actually REACHED it: the region is packed
+    # from the lowest harvested address upward and the build reports which
+    # survived. That is exactly how the three reverbs have always behaved
+    # (remixes/restock.py keeps two of them), generalised to any effect.
+    harvest: tuple[str, ...] = DEFAULT_HARVEST
 
     def __post_init__(self):
         if self.fallback != NO_FALLBACK and self.fallback not in self.modules:
@@ -617,3 +645,9 @@ class Remix:
         # registry is in scope: build_bus.py refuses, selftest pins it.
         if len(set(self.fx1)) != len(self.fx1):
             raise ValueError(f"remix {self.name!r}: duplicate fx1 keys")
+        if len(set(self.harvest)) != len(self.harvest):
+            raise ValueError(f"remix {self.name!r}: duplicate harvest keys")
+        if not self.harvest:
+            raise ValueError(
+                f"remix {self.name!r}: harvest=() leaves nowhere to place a "
+                f"module. Name the stock effects whose words it may take.")

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -378,6 +378,17 @@ class Harness:
 
     layout_char: str | None = None    # its letter in send_probe layout strings
     is_server: bool = False
+    # Does this module take part in the cross-core bus as a CLIENT -- write
+    # the shared accumulators and carry the housekeeping block? Declared, not
+    # inferred: `is_server` is the other half and neither is derivable from
+    # the kind (SEND is a DSP_CLIENT, but so would a non-bus utility be).
+    #
+    # It exists for ONE decision, and it is a safety one: an image with no
+    # bus participant at all has no rotation to flip and no accumulator to
+    # clear, which is the only condition under which unimplemented ids may
+    # fall back to the firmware's own NONE rather than to SEND. See
+    # NO_FALLBACK below.
+    bus_client: bool = False
 
 
 @dataclass(frozen=True)
@@ -467,6 +478,44 @@ class Module:
                 if p.name}
 
 
+# ---- the fallback that is not a module -------------------------------------
+# An unimplemented id has to dispatch SOMEWHERE, and the answer has always
+# been a module of ours -- SEND, which passes the audio through and only taps
+# it. That costs 215-250 words, and an INSERT-ONLY remix was paying them for
+# a client nothing reads: with no server in the image, nothing ever consumes
+# the bus accumulators SEND writes. restock.py says so in its own docstring
+# -- PLATE REV is missing from it ONLY because SEND's words land on PLATE's.
+#
+# So a remix may name this sentinel instead, and unimplemented ids resolve to
+# the FIRMWARE's own NONE: its descriptor (the one at list position 0 of a
+# stock FX2 chooser, which our rebuilt list otherwise drops) and, on the DSP
+# side, the per-payload null stub the build already points silenced donor ids
+# at. It costs one list row -- four bytes of cave -- and no words at all.
+#
+# ⚠️ IT IS REFUSED BESIDE ANY BUS PARTICIPANT, and that is the whole safety
+# argument. Housekeeping -- flipping the rotation word and clearing the
+# accumulators, once per block -- is gated to payload A and done by the FIRST
+# CORE-0 PARTICIPANT DISPATCHED that block (send_client.asm's `bus_seen`
+# election). Today every unassigned track runs SEND, so core 0 always has
+# one. Under this fallback an unassigned track runs nothing, so a project
+# with tracks 5-8 all unassigned has no housekeeper -- and a server on the
+# OTHER core then reads an accumulator that is never rotated and never
+# cleared. With no server and no client in the image there is no bus, no
+# rotation and nothing to clear, so the question does not arise. That is the
+# only case this is allowed in; registry.remix() enforces it.
+#
+# ⚠️ AND IT CANNOT BE SETTLED LOCALLY EITHER WAY: dsp_host is single-core, so
+# no local test can reproduce a bus timing defect (CLAUDE.md). The refusal is
+# what keeps the question off the table rather than answered by inference.
+NO_FALLBACK = "NONE"
+
+
+def on_the_bus(mod) -> bool:
+    """Does this module take part in the cross-core bus, either end?"""
+    h = getattr(mod, "harness", None)
+    return h is not None and (h.is_server or h.bus_client)
+
+
 @dataclass(frozen=True)
 class Remix:
     """A named selection of modules, composed into one firmware image.
@@ -498,10 +547,11 @@ class Remix:
     name: str
     doc: str
     modules: tuple[str, ...]
-    fallback: str                # module KEY that unimplemented ids alias to
+    fallback: str                # module KEY that unimplemented ids alias to,
+                                 # or NO_FALLBACK for the firmware's own NONE
 
     def __post_init__(self):
-        if self.fallback not in self.modules:
+        if self.fallback != NO_FALLBACK and self.fallback not in self.modules:
             raise ValueError(
                 f"remix {self.name!r}: fallback {self.fallback!r} is not in "
                 f"the remix, so ids aliased to it would dispatch nowhere")

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -523,9 +523,15 @@ def on_the_bus(mod) -> bool:
     return h is not None and (h.is_server or h.bus_client)
 
 
-# The three the project has always harvested: the biggest stock effects, and
-# FX2-only, so taking them costs FX1 nothing. They are the DEFAULT rather
-# than the rule -- see Remix.harvest.
+# The three the project has always harvested, and what `x` offers when a
+# selection has nowhere to place: the biggest stock effects, and FX2-only, so
+# taking them costs FX1 nothing.
+#
+# ⚠️ THIS IS NOT A FIELD ANY MORE. Which effects a remix gives up is DERIVED
+# from its two choosers -- an effect on neither is one it does not want, and
+# "remove from the chooser" and "harvest" were the same act described twice
+# (stock.harvested). It reproduces every shipped remix exactly, because FX1
+# lists ten of the thirteen and the reverbs are FX2-only.
 DEFAULT_HARVEST = ("PLATE REV", "SPRING REV", "DARK REV")
 
 
@@ -609,28 +615,6 @@ class Remix:
     # Streamz, BodeShift, Hello World -- and SEND, which is buffer-free
     # (untested there, but nothing measured argues against it).
     fx1: tuple[str, ...] = ()
-    # ---- which stock effects this remix HARVESTS for their words ----------
-    # The donor region is not a place, it is a CHOICE. The thirteen DSP
-    # effects are laid out contiguously -- 6,158 words in both payloads --
-    # and every one is self-contained, so any of them can be overwritten with
-    # a module of ours (measured 3 Sep 2026; stock.p_spans has the layout and
-    # the containment sweep is in tools/dsp_reach.py). What has always been
-    # "the 2,724-word donor region" is the middle third of that run, chosen
-    # because the three reverbs are the biggest and the least missed.
-    #
-    # ⚠️ THEY MUST BE CONTIGUOUS. A module of ours is one code stream, so the
-    # harvested set has to be an unbroken run; the build refuses a gap rather
-    # than silently placing across a survivor.
-    #
-    # ⚠️ HARVESTED IS NOT THE SAME AS UNLISTED. Leaving a stock effect out of
-    # `modules` takes its chooser row and nothing else -- its code, descriptor
-    # and dispatch stay stock, so an old project that selects it still runs
-    # it. Naming it here offers its words to the placer, and it loses its
-    # algorithm only where our code actually REACHED it: the region is packed
-    # from the lowest harvested address upward and the build reports which
-    # survived. That is exactly how the three reverbs have always behaved
-    # (remixes/restock.py keeps two of them), generalised to any effect.
-    harvest: tuple[str, ...] = DEFAULT_HARVEST
 
     def __post_init__(self):
         if self.fallback != NO_FALLBACK and self.fallback not in self.modules:
@@ -645,10 +629,4 @@ class Remix:
         # registry is in scope: build_bus.py refuses, selftest pins it.
         if len(set(self.fx1)) != len(self.fx1):
             raise ValueError(f"remix {self.name!r}: duplicate fx1 keys")
-        if len(set(self.harvest)) != len(self.harvest):
-            raise ValueError(f"remix {self.name!r}: duplicate harvest keys")
-        # ⚠️ `harvest=()` IS LEGAL. On an unmodified unit every one of the
-        # 6,158 words is allocated -- each stock effect is using its own --
-        # so "nothing harvested" is the honest starting point, and a remix of
-        # nothing but stock rows needs no region at all. build_bus.py refuses
-        # it only when there is code to place.
+

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -167,6 +167,31 @@ class MenuEntry:
     abbr: bytes                        # <=4 chars, in a 5-byte field
     fullname: bytes                    # <=12 chars, in a 13-byte field
     build_tag: bool = False            # append the image's build tag
+    # ---- taking a STOCK effect's id, on purpose -------------------------
+    # The key of the stock effect this module REPLACES, e.g. "LO-FI". Set it
+    # and the module may carry that effect's fx2 id; leave it None and a
+    # stock id is refused, which is the default and the safe one.
+    #
+    # WHAT YOU ARE ASKING FOR. The DSP dispatch tables are indexed by the raw
+    # id and shared by both menus, so your code runs wherever that id is
+    # selected -- FX2 and FX1 alike, and in every saved project that already
+    # chose it. That is the POINT of an upgraded stock effect and it is also
+    # the whole hazard: Rungs sat on EQUALIZER's 0x0c and Nimbus on DJ EQ's
+    # 0x0d from 29 Aug to 2 Sep 2026, in every local image, and the remixes
+    # WITHOUT them aliased those ids to SEND, taking FX1's EQUALIZER away
+    # too. The difference now is that it is declared and checked rather than
+    # accidental: a remix that omits a replacement leaves the stock effect
+    # exactly as it found it (build_bus.py), and verify_replaces.py proves
+    # both halves.
+    #
+    # ⚠️ FX1's DESCRIPTOR IS NOT REPOINTED. FX1_IDS (0x400d5f58) and FX2_IDS
+    # (0x400d5fdc) are separate tables: your code runs from FX1, but FX1's
+    # page still draws the STOCK effect's knob names. Same family as "a slot
+    # can draw a knob and publish nothing" -- the panel and the DSP are
+    # separate mechanisms and neither validates the other. Match the stock
+    # layout, or accept that FX1 mislabels it. (tools/build_fx1.py knows how
+    # to write that table if this is ever wanted.)
+    replaces: str | None = None
 
     def __post_init__(self):
         # 0x00-0x03 are the ids stock treats as bare synonyms for "no effect";
@@ -367,13 +392,25 @@ class Module:
             raise ValueError(f"{self.name}: expected 12 param slots, "
                              f"got {len(self.params)}")
         if (self.menu is not None and self.kind is not Kind.STOCK
-                and self.menu.fx2_id in STOCK_FX2_IDS):
+                and self.menu.fx2_id in STOCK_FX2_IDS
+                and not self.menu.replaces):
             raise ValueError(
                 f"{self.name}: fx2 id 0x{self.menu.fx2_id:02x} belongs to a "
                 f"STOCK effect -- the dispatch tables are shared with FX1, so "
                 f"this id would hijack that effect on both menus (see "
-                f"STOCK_FX2_IDS). Free ids: "
+                f"STOCK_FX2_IDS). Declare MenuEntry(replaces=\"<KEY>\") if "
+                f"that is what you mean. Free ids: "
                 f"{', '.join(f'0x{i:02x}' for i in range(0x04, 0x20) if i not in STOCK_FX2_IDS)}")
+        if self.menu is not None and self.menu.replaces:
+            if self.kind is Kind.STOCK:
+                raise ValueError(f"{self.name}: a STOCK entry cannot replace "
+                                 f"anything -- it IS the stock effect")
+            if self.menu.fx2_id not in STOCK_FX2_IDS:
+                raise ValueError(
+                    f"{self.name}: replaces={self.menu.replaces!r} but fx2 id "
+                    f"0x{self.menu.fx2_id:02x} is not a stock effect's -- a "
+                    f"replacement must carry the id it replaces, or the stock "
+                    f"effect stays and yours is a separate row")
         if self.kind is Kind.STOCK and (self.dsp is not None or self.cf_patches):
             raise ValueError(f"{self.name}: a STOCK entry carries no code or "
                              f"caves -- they are already in the image (its "

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -611,10 +611,9 @@ class Remix:
                 f"the remix, so ids aliased to it would dispatch nowhere")
         if len(set(self.modules)) != len(self.modules):
             raise ValueError(f"remix {self.name!r}: duplicate module keys")
-        for k in self.fx1:
-            if k not in self.modules:
-                raise ValueError(
-                    f"remix {self.name!r}: fx1={k!r} is not in the remix, so "
-                    f"there is no descriptor for FX1's row to point at")
+        # ⚠️ NO PER-KEY CHECK HERE. An fx1 key may be a STOCK effect,
+        # which need not be in `modules` at all -- FX1's list and FX2's
+        # are independent. What each key may be is decided where the
+        # registry is in scope: build_bus.py refuses, selftest pins it.
         if len(set(self.fx1)) != len(self.fx1):
             raise ValueError(f"remix {self.name!r}: duplicate fx1 keys")

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -647,7 +647,8 @@ class Remix:
             raise ValueError(f"remix {self.name!r}: duplicate fx1 keys")
         if len(set(self.harvest)) != len(self.harvest):
             raise ValueError(f"remix {self.name!r}: duplicate harvest keys")
-        if not self.harvest:
-            raise ValueError(
-                f"remix {self.name!r}: harvest=() leaves nowhere to place a "
-                f"module. Name the stock effects whose words it may take.")
+        # ⚠️ `harvest=()` IS LEGAL. On an unmodified unit every one of the
+        # 6,158 words is allocated -- each stock effect is using its own --
+        # so "nothing harvested" is the honest starting point, and a remix of
+        # nothing but stock rows needs no region at all. build_bus.py refuses
+        # it only when there is code to place.

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -184,13 +184,24 @@ class MenuEntry:
     # exactly as it found it (build_bus.py), and verify_replaces.py proves
     # both halves.
     #
-    # ⚠️ FX1's DESCRIPTOR IS NOT REPOINTED. FX1_IDS (0x400d5f58) and FX2_IDS
-    # (0x400d5fdc) are separate tables: your code runs from FX1, but FX1's
-    # page still draws the STOCK effect's knob names. Same family as "a slot
-    # can draw a knob and publish nothing" -- the panel and the DSP are
-    # separate mechanisms and neither validates the other. Match the stock
-    # layout, or accept that FX1 mislabels it. (tools/build_fx1.py knows how
-    # to write that table if this is ever wanted.)
+    # ⚠️ IF YOUR REPLACEMENT ALLOCATES A BUFFER, SIZE IT FOR FX1. The host's
+    # allocator keeps SEPARATE tables and they are not the same size
+    # (measured, X:0x255 in both payloads): an FX2 slot is 16,384 words,
+    # an FX1 slot is 3,072. Your code runs from BOTH menus the moment it
+    # takes a stock id, so an effect that asks for a buffer and assumes the
+    # FX2 size will overrun its allocation by 13,312 words the first time
+    # somebody selects it on FX1. That is the same class as the stock
+    # reverbs being FX2-only: they do not fit an FX1 allocation either.
+    # Nothing checks this -- a buffer size is not visible to the schema --
+    # so it is written here, where the id is taken.
+    #
+    # FX1's DESCRIPTOR IS REPOINTED TOO. FX1_IDS (0x400d5f58) and FX2_IDS
+    # (0x400d5fdc) are separate tables -- the DSP dispatch is shared, the
+    # descriptors are not -- so a replacement that only took FX2 would RUN
+    # from FX1 under the stock effect's knob names, which is "a slot can draw
+    # a knob and publish nothing" in reverse. The build repoints both of
+    # FX1's tables (its id lookup and the row the encoder scrolls), in place,
+    # and verify_replaces.py checks both menus in both directions.
     replaces: str | None = None
 
     def __post_init__(self):

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -192,8 +192,15 @@ class MenuEntry:
     # FX2 size will overrun its allocation by 13,312 words the first time
     # somebody selects it on FX1. That is the same class as the stock
     # reverbs being FX2-only: they do not fit an FX1 allocation either.
-    # Nothing checks this -- a buffer size is not visible to the schema --
-    # so it is written here, where the id is taken.
+    #
+    # ✅ CHECKED SINCE 3 SEP 2026, where it can be. "Nothing checks this"
+    # stood while a buffer size was invisible to the schema -- but the three
+    # ways a module cannot survive on FX1 are declarable, and `Claims` and
+    # `DspSection` already declare them, so `state.fx1_hazard()` decides and
+    # build_bus.py refuses a replacement that inherits an FX1 row it cannot
+    # take. What is still on you is the SIZE ITSELF: a module that declares
+    # `stock_instance_buffer` is refused outright, so if you want the row you
+    # must not use the allocator at all.
     #
     # FX1's DESCRIPTOR IS REPOINTED TOO. FX1_IDS (0x400d5f58) and FX2_IDS
     # (0x400d5fdc) are separate tables -- the DSP dispatch is shared, the
@@ -569,14 +576,32 @@ class Remix:
     # it inherits the stock effect's row and has both of FX1's tables
     # repointed in place, so a second row would list it twice.
     #
-    # ⚠️ NOT FOR A MODULE THAT USES THE HOST'S BUFFER ALLOCATOR. FX1 and FX2
-    # keep SEPARATE allocator tables at different sizes (measured, X:0x255 in
-    # both payloads): an FX2 slot is 16,384 words, an FX1 slot 3,072. Code
-    # that reads `x:>$213` and assumes the FX2 size overruns its FX1
-    # allocation by 13,312 words. Everything of ours uses FIXED bases at
-    # 0x4000 and up, which an FX1 allocation (0x1000..0x3fff) physically
-    # cannot reach, so nothing is currently exposed to it -- but a module
-    # that starts using the allocator would be.
+    # ⚠️ ONLY A BUFFER-FREE INSERT MAY TAKE ONE. `state.fx1_hazard()` is the
+    # single statement of why, read by both the remixer and build_bus.py, and
+    # it refuses three classes:
+    #
+    #   * A module that reads the host's allocator (`x:>$213`). FX1 and FX2
+    #     keep SEPARATE allocator tables at different sizes (measured, X:0x255
+    #     in both payloads): an FX2 slot is 16,384 words, an FX1 slot 3,072.
+    #     ⚠️ This is not theoretical and it is not new -- docs/DSP.md's "wrong
+    #     claim 1" is this exact failure, bisected on hardware: a 16K layout
+    #     at an FX1 base "runs to 0x53ff, through the other FX1 buffers and
+    #     into FX2 slot 0". NIMBUS LITE reads the allocator and IS exposed;
+    #     an earlier draft of this comment claimed nothing was, which was
+    #     wrong -- it had checked only the fixed-base modules.
+    #   * A module with FIXED buffers in the FX2 region (ChonVerb, Nimbus,
+    #     BongDelay). An FX1 instance still writes to Y:0x4000 and up, i.e.
+    #     into some other track's FX2 buffer. The hazard exists on FX2 too --
+    #     it is why Nimbus is documented "one per core" -- but an FX1 row
+    #     doubles the slots it can be reached from, a second instance on the
+    #     SAME track included.
+    #   * A bus SERVER, which is one per core by design (SPEC places one
+    #     engine per payload). A second instance on a core is the open
+    #     "duplicate instances corrupt audio after ~5.45 s" item.
+    #
+    # What is left is exactly the INSERT class: WarpFold, Ripple, Rungs,
+    # Streamz, BodeShift, Hello World -- and SEND, which is buffer-free
+    # (untested there, but nothing measured argues against it).
     fx1: tuple[str, ...] = ()
 
     def __post_init__(self):

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -37,7 +37,7 @@ class Kind(Enum):
                                 # code, no clone, no words -- its descriptor
                                 # and dispatch are already in the image; its
                                 # params are read FROM that descriptor for the
-                                # workbench and harness, never written back
+                                # remixer and harness, never written back
                                 # (tools/remix/stock.py is the whole list)
 
 
@@ -121,7 +121,7 @@ class Param:
     count: int | None = None           # value count; None leaves the donor's
     active: bool = False               # drawn at all (the enable bitmap)
     formatter: Formatter = Formatter.INHERIT
-    # Display-only, consumed by the workbench and never by the build (the
+    # Display-only, consumed by the remixer and never by the build (the
     # refhash gate proves it): one line saying what the knob DOES, and for a
     # select, what each value means. The unit's panel cannot show either, so
     # this is where a contributor answers "what is this?" once instead of in
@@ -563,7 +563,7 @@ class Remix:
     # move standalone against the stock image). What it does cost is CYCLES:
     # an FX1 effect runs on a track that is already running an FX2 one, so
     # the worst per-core load can gain four more copies of it. cycle_count.py
-    # prices that, and the workbench's Budget row is where to look first.
+    # prices that, and the remixer's Budget row is where to look first.
     #
     # ⚠️ A `replaces` MODULE IS ALREADY ON FX1 and must not be listed here:
     # it inherits the stock effect's row and has both of FX1's tables

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -549,6 +549,35 @@ class Remix:
     modules: tuple[str, ...]
     fallback: str                # module KEY that unimplemented ids alias to,
                                  # or NO_FALLBACK for the firmware's own NONE
+    # ---- which of them ALSO get a row on FX1 ------------------------------
+    # THE OTHER HALF OF "BOTH SLOTS", and it belongs to the REMIX rather than
+    # to the module: which menu an effect appears on is a composition choice,
+    # like the chooser order beside it, not a property of the code. The DSP
+    # dispatch is ONE table indexed by the raw id and shared by both menus,
+    # so a listed module's code ALREADY runs from FX1 -- what this adds is
+    # the panel side, which stock keeps in FX1's own tables.
+    #
+    # IT COSTS NO WORDS. Four bytes of cave per row, plus FX1's chooser list
+    # relocated into the cave (it ends at 0x400d608c with FX2's beginning at
+    # 0x400d6090, so it cannot grow in place -- tools/build_fx1.py proved the
+    # move standalone against the stock image). What it does cost is CYCLES:
+    # an FX1 effect runs on a track that is already running an FX2 one, so
+    # the worst per-core load can gain four more copies of it. cycle_count.py
+    # prices that, and the workbench's Budget row is where to look first.
+    #
+    # ⚠️ A `replaces` MODULE IS ALREADY ON FX1 and must not be listed here:
+    # it inherits the stock effect's row and has both of FX1's tables
+    # repointed in place, so a second row would list it twice.
+    #
+    # ⚠️ NOT FOR A MODULE THAT USES THE HOST'S BUFFER ALLOCATOR. FX1 and FX2
+    # keep SEPARATE allocator tables at different sizes (measured, X:0x255 in
+    # both payloads): an FX2 slot is 16,384 words, an FX1 slot 3,072. Code
+    # that reads `x:>$213` and assumes the FX2 size overruns its FX1
+    # allocation by 13,312 words. Everything of ours uses FIXED bases at
+    # 0x4000 and up, which an FX1 allocation (0x1000..0x3fff) physically
+    # cannot reach, so nothing is currently exposed to it -- but a module
+    # that starts using the allocator would be.
+    fx1: tuple[str, ...] = ()
 
     def __post_init__(self):
         if self.fallback != NO_FALLBACK and self.fallback not in self.modules:
@@ -557,3 +586,10 @@ class Remix:
                 f"the remix, so ids aliased to it would dispatch nowhere")
         if len(set(self.modules)) != len(self.modules):
             raise ValueError(f"remix {self.name!r}: duplicate module keys")
+        for k in self.fx1:
+            if k not in self.modules:
+                raise ValueError(
+                    f"remix {self.name!r}: fx1={k!r} is not in the remix, so "
+                    f"there is no descriptor for FX1's row to point at")
+        if len(set(self.fx1)) != len(self.fx1):
+            raise ValueError(f"remix {self.name!r}: duplicate fx1 keys")

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -388,6 +388,43 @@ def main():
                   f"{', '.join(_bus)}")
     print(f"  [PASS] every remix's fallback matches whether it has a bus")
 
+    # ---- FX1 rows (Remix.fx1) -------------------------------------------
+    # The schema half. The BUILD half -- the relocated list, FX1's own id and
+    # cursor tables, and stock's eleven rows unchanged and still first -- is
+    # tools/verify_menu.py, which needs a built image and so runs there.
+    for _bad_fx1, _why in ((("NOT IN IT",), "a key that is not in the remix"),
+                           (("WARPFOLD", "WARPFOLD"), "a duplicate key")):
+        try:
+            schema.Remix(name="_x", doc="_", modules=("WARPFOLD",),
+                         fallback=schema.NO_FALLBACK, fx1=_bad_fx1)
+            bad += 1
+            print(f"  [FAIL] Remix(fx1=...) accepted {_why}")
+        except ValueError:
+            print(f"  [PASS] Remix(fx1=...) refuses {_why}")
+    # A module of ours is FX2-only until a remix says otherwise, and then it
+    # is on both -- this is the derivation the workbench's menus column and
+    # every resource line read.
+    _wf = registry.modules()["WARPFOLD"]
+    if rig.menus(_wf) != (rig.FX2,):
+        bad += 1
+        print(f"  [FAIL] WarpFold is {rig.menus(_wf)} with no fx1 row")
+    elif rig.menus(_wf, {"WARPFOLD"}) != (rig.FX1, rig.FX2):
+        bad += 1
+        print(f"  [FAIL] WarpFold is {rig.menus(_wf, {'WARPFOLD'})} with one")
+    else:
+        print("  [PASS] an fx1 row moves a module from FX2 to FX1+FX2")
+    # A REPLACEMENT IS ALREADY ON FX1 and listing it again would duplicate
+    # the row; the build refuses it, and nothing shipped may do it.
+    for _n in registry.remix_names():
+        _r = registry.remix(_n)
+        for _k in _r.fx1:
+            _m = registry.modules()[_k]
+            if _m.is_stock or (_m.menu is not None and _m.menu.replaces):
+                bad += 1
+                print(f"  [FAIL] remix {_n!r} asks for an FX1 row for {_k}, "
+                      f"which already has one")
+    print("  [PASS] no remix asks for an FX1 row a module already has")
+
     # And the real thing: every shipped remix must be clean.
     for name in registry.remix_names():
         r = registry.remix(name)

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -413,7 +413,17 @@ def main():
             bad += 1
             print(f"  [FAIL] payload {_pay}: {_wrong} disagree with "
                   f"stock.WORDS")
-        else:
+        # ⚠️ AND EVERY SPAN KEY MUST BE A REAL STOCK KEY. `COMB` against the
+        # registry's `COMB FILTER` made `h` answer "it runs on the ColdFire"
+        # for an effect with 277 words of DSP code -- a silent miss, because
+        # a missing key looks exactly like an effect with no code.
+        _reg = {m.key for m in stock.MODULES}
+        _orphan = sorted(set(_sp) - _reg)
+        if _orphan:
+            bad += 1
+            print(f"  [FAIL] payload {_pay}: span keys not in the registry: "
+                  f"{_orphan}")
+        elif not _wrong:
             print(f"  [PASS] payload {_pay}: {len(_sp)} effects contiguous, "
                   f"P:0x{_lo:05x}..0x{_hi:05x} = {_hi - _lo:,} words")
     # And nothing shipped may harvest a non-contiguous set -- the build

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -434,7 +434,14 @@ def main():
     _sp = stock.p_spans("A")
     _fx1_all = {k for k in _sp
                 if registry.modules()[k].menu.fx2_id in stock.fx1_ids()}
-    _want = {"restock": (), "nimbuslite": ("PLATE REV", "SPRING REV")}
+    # The three that differ, and why -- a remix reaching this list by
+    # accident is the thing being guarded against.
+    _want = {"restock": (),                       # lists all fourteen
+             "nimbuslite": ("PLATE REV", "SPRING REV"),   # keeps DARK REV
+             # deliberately gives up two more, to put a non-reverb donor on
+             # the unit for the first time (docs/FLASHPLAN.md)
+             "fieldtest": ("FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
+                           "DARK REV")}
     for _n in registry.remix_names():
         _r = registry.remix(_n)
         _hv = stock.region_of(stock.harvested(

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -392,15 +392,24 @@ def main():
     # The schema half. The BUILD half -- the relocated list, FX1's own id and
     # cursor tables, and stock's eleven rows unchanged and still first -- is
     # tools/verify_menu.py, which needs a built image and so runs there.
-    for _bad_fx1, _why in ((("NOT IN IT",), "a key that is not in the remix"),
-                           (("WARPFOLD", "WARPFOLD"), "a duplicate key")):
-        try:
-            schema.Remix(name="_x", doc="_", modules=("WARPFOLD",),
-                         fallback=schema.NO_FALLBACK, fx1=_bad_fx1)
-            bad += 1
-            print(f"  [FAIL] Remix(fx1=...) accepted {_why}")
-        except ValueError:
-            print(f"  [PASS] Remix(fx1=...) refuses {_why}")
+    try:
+        schema.Remix(name="_x", doc="_", modules=("WARPFOLD",),
+                     fallback=schema.NO_FALLBACK, fx1=("WARPFOLD", "WARPFOLD"))
+        bad += 1
+        print("  [FAIL] Remix(fx1=...) accepted a duplicate key")
+    except ValueError:
+        print("  [PASS] Remix(fx1=...) refuses a duplicate key")
+    # A STOCK effect may be on the FX1 list without an FX2 row -- the two
+    # lists are independent -- so the schema deliberately does NOT require
+    # every fx1 key to be in `modules`. Pinned, because it was required for
+    # one day and that would have made a curated FX1 chooser impossible.
+    try:
+        schema.Remix(name="_x", doc="_", modules=("WARPFOLD",),
+                     fallback=schema.NO_FALLBACK, fx1=("FILTER", "WARPFOLD"))
+        print("  [PASS] an fx1 row may be a stock effect with no FX2 row")
+    except ValueError as e:
+        bad += 1
+        print(f"  [FAIL] Remix(fx1=...) refused a stock key: {e}")
     # A module of ours is FX2-only until a remix says otherwise, and then it
     # is on both -- this is the derivation the remixer's menus column and
     # every resource line read.
@@ -431,22 +440,39 @@ def main():
     print(f"  [PASS] {len(_want)} modules classified for an FX1 row "
           f"({sum(v is None for v in _want.values())} eligible)")
 
-    # A REPLACEMENT IS ALREADY ON FX1 and listing it again would duplicate
-    # the row; the build refuses it, and nothing shipped may do it.
+    # WHAT EVERY SHIPPED FX1 CHOOSER MAY HOLD. A stock effect must be one
+    # FX1 already lists (DELAY and the reverbs are FX2-only because they do
+    # not fit a 3,072-word FX1 allocation); a module of ours must have an FX2
+    # row -- that is where its descriptor clone comes from -- must not be a
+    # `replaces` (which already inherits an FX1 row) and must clear
+    # fx1_hazard.
+    from remix import stock as _stk
     for _n in registry.remix_names():
         _r = registry.remix(_n)
         for _k in _r.fx1:
-            _m = registry.modules()[_k]
-            if _m.is_stock or (_m.menu is not None and _m.menu.replaces):
+            _m = registry.modules().get(_k)
+            if _m is None or _m.menu is None:
                 bad += 1
-                print(f"  [FAIL] remix {_n!r} asks for an FX1 row for {_k}, "
-                      f"which already has one")
+                print(f"  [FAIL] remix {_n!r}: fx1={_k!r} is not an effect")
+                continue
+            if _m.is_stock:
+                if _m.menu.fx2_id not in _stk.fx1_ids():
+                    bad += 1
+                    print(f"  [FAIL] remix {_n!r}: stock {_k} is FX2-only")
+                continue
+            if _k not in _r.modules:
+                bad += 1
+                print(f"  [FAIL] remix {_n!r}: {_k} has no FX2 row, so there "
+                      f"is no descriptor clone for FX1 to point at")
+            if _m.menu.replaces:
+                bad += 1
+                print(f"  [FAIL] remix {_n!r}: {_k} replaces a stock effect "
+                      f"and already has its FX1 row")
             _why = state.fx1_hazard(_m)
             if _why:
                 bad += 1
-                print(f"  [FAIL] remix {_n!r} asks for an FX1 row for {_k}: "
-                      f"{_why}")
-    print("  [PASS] no remix asks for an FX1 row a module may not have")
+                print(f"  [FAIL] remix {_n!r}: {_k} on FX1 -- {_why}")
+    print("  [PASS] every shipped FX1 chooser holds only what FX1 can host")
 
     # And the real thing: every shipped remix must be clean.
     for name in registry.remix_names():

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -426,22 +426,31 @@ def main():
         elif not _wrong:
             print(f"  [PASS] payload {_pay}: {len(_sp)} effects contiguous, "
                   f"P:0x{_lo:05x}..0x{_hi:05x} = {_hi - _lo:,} words")
-    # And nothing shipped may harvest a non-contiguous set -- the build
-    # refuses it, and a remix that cannot build is not much of a remix.
+    # ⚠️ AND THE DERIVED HARVEST MUST REPRODUCE WHAT THE BUILD HAS ALWAYS
+    # DONE. "On neither chooser" gives every shipped remix exactly the three
+    # reverbs -- FX1 lists ten of the thirteen and the reverbs are FX2-only
+    # -- which is the whole reason removing the explicit field was safe.
+    # restock lists all fourteen and places nothing, so it gives up nothing.
+    _sp = stock.p_spans("A")
+    _fx1_all = {k for k in _sp
+                if registry.modules()[k].menu.fx2_id in stock.fx1_ids()}
+    _want = {"restock": (), "nimbuslite": ("PLATE REV", "SPRING REV")}
     for _n in registry.remix_names():
         _r = registry.remix(_n)
-        _sp = stock.p_spans("A")
-        _bad = [k for k in _r.harvest if k not in _sp]
-        if _bad:
+        _hv = stock.region_of(stock.harvested(
+            set(_r.modules) | set(_r.fx1 or _fx1_all)))
+        _exp = _want.get(_n, stock.CONSUMED)
+        if _n == "bothslots":
+            continue                     # its curated FX1 list gives it more
+        if tuple(_hv) != tuple(_exp):
             bad += 1
-            print(f"  [FAIL] remix {_n!r}: harvest={_bad} have no DSP code")
-            continue
-        _run = sorted(_sp[k] for k in _r.harvest)
-        if any(a + n != a2 for (a, n), (a2, _n) in zip(_run, _run[1:])):
+            print(f"  [FAIL] remix {_n!r} gives up {_hv}, expected {_exp}")
+        _run = sorted(_sp[k] for k in _hv)
+        if any(a + n != a2 for (a, n), (a2, _x) in zip(_run, _run[1:])):
             bad += 1
-            print(f"  [FAIL] remix {_n!r}: its harvested effects are not "
-                  f"contiguous")
-    print(f"  [PASS] every remix harvests a contiguous run")
+            print(f"  [FAIL] remix {_n!r}: its region is not contiguous")
+    print(f"  [PASS] every remix gives up a contiguous run, and the shipped "
+          f"ones give up exactly what they always did")
 
     # ---- FX1 rows (Remix.fx1) -------------------------------------------
     # The schema half. The BUILD half -- the relocated list, FX1's own id and

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -10,6 +10,7 @@ on nothing.
     python3 tools/remix/selftest.py
 """
 
+import os
 import pathlib
 import re
 import subprocess
@@ -441,7 +442,11 @@ def main():
              # deliberately gives up two more, to put a non-reverb donor on
              # the unit for the first time (docs/FLASHPLAN.md)
              "fieldtest": ("FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
-                           "DARK REV")}
+                           "DARK REV"),
+             # THREE runs on purpose -- the multi-run worked example. Its
+             # placement is checked for real below, not just its harvest.
+             "scattered": ("SPATIALIZER", "FLANGER", "CHORUS", "PLATE REV",
+                           "SPRING REV", "DARK REV", "COMB FILTER")}
     for _n in registry.remix_names():
         _r = registry.remix(_n)
         _hv = stock.region_of(stock.harvested(
@@ -467,6 +472,83 @@ def main():
             print(f"  [FAIL] remix {_n!r}: the runs do not cover {_hv}")
     print(f"  [PASS] every remix's given-up effects group into contiguous "
           f"runs, and the shipped ones give up exactly what they always did")
+
+    # ---- MULTI-RUN PLACEMENT, actually built --------------------------
+    # ⚠️ THE GROUPING ABOVE IS ARITHMETIC; THIS IS THE BUILD. Nothing else
+    # here would notice the placer quietly reverting to one bump cursor:
+    # `scattered` would still assemble, still pass every other check, and
+    # simply leave its two smaller runs empty -- which is exactly the defect
+    # this replaced (3 Sep 2026, "when I remove some reverb it only shows
+    # the free reverb space"). So: build it, and require that two modules
+    # landed in two DIFFERENT runs.
+    r = subprocess.run([sys.executable, "tools/build_bus.py"],
+                       cwd=ROOT, capture_output=True, text=True,
+                       env={**os.environ, "REMIX": "scattered",
+                            "XBUS": "1", "SPEC": "1"})
+    if r.returncode:
+        bad += 1
+        print(f"  [FAIL] remix 'scattered' does not build:\n"
+              f"{r.stdout[-600:]}{r.stderr[-400:]}")
+    else:
+        # ⚠️ PER PAYLOAD. The two payloads put the same effects at
+        # DIFFERENT addresses, so merging their run lines checks neither --
+        # and "one instance is one payload" is exactly how this codebase
+        # has been bitten before (docs/DSP.md s11).
+        _by_pay, _pay = {}, None
+        for line in r.stdout.splitlines():
+            m = re.match(r"-- payload (\w+) --", line.strip())
+            if m:
+                _pay = m.group(1)
+                _by_pay[_pay] = {"runs": [], "at": {}}
+            if _pay is None:
+                continue
+            m = re.match(r"\s+run \d+ P:0x([0-9a-f]+)\.\.0x([0-9a-f]+)", line)
+            if m:
+                _by_pay[_pay]["runs"].append((int(m.group(1), 16),
+                                              int(m.group(2), 16)))
+            m = re.match(r"\s{2}(STREAMZ|WARPFOLD)\s+P:0x([0-9a-f]+)", line)
+            if m:
+                _by_pay[_pay]["at"][m.group(1)] = int(m.group(2), 16)
+        if sorted(_by_pay) != ["A", "B"]:
+            bad += 1
+            print(f"  [FAIL] 'scattered': expected both payloads, saw "
+                  f"{sorted(_by_pay)}")
+        else:
+            _ok = True
+            for _p, _d in sorted(_by_pay.items()):
+                _rs, _at = _d["runs"], _d["at"]
+                _in = {k: next((i for i, (lo, hi) in enumerate(_rs)
+                                if lo <= a < hi), None)
+                       for k, a in _at.items()}
+                if len(_rs) != 3:
+                    bad += 1; _ok = False
+                    print(f"  [FAIL] 'scattered' payload {_p}: {len(_rs)} "
+                          f"runs, expected 3")
+                elif sorted(_at) != ["STREAMZ", "WARPFOLD"]:
+                    bad += 1; _ok = False
+                    print(f"  [FAIL] 'scattered' payload {_p}: placed "
+                          f"{sorted(_at)}, expected both modules")
+                elif None in _in.values():
+                    bad += 1; _ok = False
+                    print(f"  [FAIL] 'scattered' payload {_p}: a module "
+                          f"landed outside every run -- {_at} vs {_rs}")
+                elif len(set(_in.values())) < 2:
+                    bad += 1; _ok = False
+                    print(f"  [FAIL] 'scattered' payload {_p}: both modules "
+                          f"landed in the SAME run ({_in}) -- the placer is "
+                          f"not filling the smaller openings")
+                elif _in["STREAMZ"] != 0:
+                    # STREAMZ is 255 words and run 1 holds 261: first-fit
+                    # MUST take it. Anywhere else means the small opening
+                    # was skipped, which is the whole defect.
+                    bad += 1; _ok = False
+                    print(f"  [FAIL] 'scattered' payload {_p}: STREAMZ went "
+                          f"to run {_in['STREAMZ'] + 1}, not the 261-word "
+                          f"opening it fits")
+            if _ok:
+                print(f"  [PASS] 'scattered' fills 2 of its 3 non-contiguous "
+                      f"runs in BOTH payloads (STREAMZ into the 261-word "
+                      f"opening, WarpFold into the big run)")
 
     # ---- FX1 rows (Remix.fx1) -------------------------------------------
     # The schema half. The BUILD half -- the relocated list, FX1's own id and

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -413,6 +413,24 @@ def main():
         print(f"  [FAIL] WarpFold is {rig.menus(_wf, {'WARPFOLD'})} with one")
     else:
         print("  [PASS] an fx1 row moves a module from FX2 to FX1+FX2")
+    # ⚠️ ONLY A BUFFER-FREE INSERT MAY TAKE AN FX1 ROW. The measured reason
+    # is docs/DSP.md's "wrong claim 1": a 16K layout at an FX1 base runs
+    # through the other FX1 buffers and into FX2 slot 0. Pinned per module so
+    # a manifest that starts reading the allocator cannot quietly become
+    # eligible.
+    _want = {"NIMBUS LITE": "sizes its buffer", "NIMBUS": "fixed FX2",
+             "REVERB SERVER": "bus server", "DELAY SERVER": "bus server",
+             "WARPFOLD": None, "RIPPLE": None, "RUNGS": None,
+             "STREAMZ": None, "BODESHIFT": None, "HELLO WORLD": None}
+    for _k, _frag in _want.items():
+        _why = state.fx1_hazard(registry.modules()[_k])
+        if (_frag is None) != (_why is None) or (_frag and _frag not in _why):
+            bad += 1
+            print(f"  [FAIL] fx1_hazard({_k}) = {_why!r}, wanted "
+                  f"{_frag!r}")
+    print(f"  [PASS] {len(_want)} modules classified for an FX1 row "
+          f"({sum(v is None for v in _want.values())} eligible)")
+
     # A REPLACEMENT IS ALREADY ON FX1 and listing it again would duplicate
     # the row; the build refuses it, and nothing shipped may do it.
     for _n in registry.remix_names():
@@ -423,7 +441,12 @@ def main():
                 bad += 1
                 print(f"  [FAIL] remix {_n!r} asks for an FX1 row for {_k}, "
                       f"which already has one")
-    print("  [PASS] no remix asks for an FX1 row a module already has")
+            _why = state.fx1_hazard(_m)
+            if _why:
+                bad += 1
+                print(f"  [FAIL] remix {_n!r} asks for an FX1 row for {_k}: "
+                      f"{_why}")
+    print("  [PASS] no remix asks for an FX1 row a module may not have")
 
     # And the real thing: every shipped remix must be clean.
     for name in registry.remix_names():

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -205,7 +205,7 @@ def main():
         print("  [PASS] chonverb's manifest slots align with render_reverb")
 
     # ---- every drawn knob answers "what is this?" -----------------------
-    # The workbench shows Param.doc as the help line under the knob cursor,
+    # The remixer shows Param.doc as the help line under the knob cursor,
     # and a select's labels beside its value. A knob with neither is a knob
     # the operator has to reverse-engineer by ear, so hold the line: every
     # named, drawn param of every menu-bearing module carries a doc.
@@ -323,7 +323,7 @@ def main():
     else:
         print("  [SKIP] stock render harness: dsp_host or the stock image is missing")
 
-    # THE BUDGET'S TOTALS ARE NOT THE BUDGET'S TO DECIDE. The workbench
+    # THE BUDGET'S TOTALS ARE NOT THE BUDGET'S TO DECIDE. The remixer
     # states "N free of TOTAL" for the ColdFire cave, and the build reports
     # only what is LEFT of it -- so the total is written down in state.py and
     # would go stale silently the day the cave's bounds move. Pin it to
@@ -402,7 +402,7 @@ def main():
         except ValueError:
             print(f"  [PASS] Remix(fx1=...) refuses {_why}")
     # A module of ours is FX2-only until a remix says otherwise, and then it
-    # is on both -- this is the derivation the workbench's menus column and
+    # is on both -- this is the derivation the remixer's menus column and
     # every resource line read.
     _wf = registry.modules()["WARPFOLD"]
     if rig.menus(_wf) != (rig.FX2,):

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -18,7 +18,7 @@ import sys
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 
-from remix import ledger, state  # noqa: E402
+from remix import ledger, registry, schema, state  # noqa: E402
 from remix.schema import (CavePatch, Claims, DspSection, Kind, MenuEntry,  # noqa: E402
                           Module, Param, YBase)
 
@@ -143,7 +143,7 @@ def main():
     # The track model is DERIVED, so hold the derivation to the measured
     # facts: payload A serves TRACKS 5-8, B serves 1-4 (10 Aug 2026), an
     # insert runs anywhere, SYSTEM modules never sit on a track.
-    from remix import registry, rig
+    from remix import rig
     for mod in registry.modules().values():
         cat = rig.category(mod)
         tr = rig.track_range(mod)
@@ -348,6 +348,45 @@ def main():
         print(f"  [FAIL] state.CAVE_BYTES is {state.CAVE_BYTES:,} B but "
               f"build_bus's cave is "
               f"{_bounds['ZERO_RUN_END'] - _bounds['NEW_LIST']:,} B")
+
+    # THE NONE FALLBACK IS ONLY SAFE WITHOUT A BUS, and that is a refusal,
+    # not a convention -- an unassigned track then runs nothing at all, so
+    # nobody flips the rotation or clears the accumulators. dsp_host is
+    # single-core and can never reproduce the defect, so this check is the
+    # only thing standing between the two. See schema.NO_FALLBACK.
+    _probe = ROOT / "remixes/_selftest_nofb.py"
+    try:
+        _probe.write_text(
+            "from remix.schema import Remix\n\n"
+            "REMIX = Remix(name='_selftest_nofb', doc='scratch',\n"
+            "              modules=('WARPFOLD', 'SEND'), fallback='NONE')\n")
+        registry.remix("_selftest_nofb")
+        bad += 1
+        print("  [FAIL] fallback='NONE' was accepted beside SEND -- an "
+              "unassigned track would leave the bus unhousekept")
+    except SystemExit as e:
+        if "no bus participant" in str(e):
+            print("  [PASS] fallback='NONE' is refused beside a bus participant")
+        else:
+            bad += 1
+            print(f"  [FAIL] fallback='NONE' beside SEND was refused for the "
+                  f"wrong reason: {e}")
+    finally:
+        _probe.unlink(missing_ok=True)
+        for junk in (ROOT / "remixes/__pycache__").glob("_selftest_nofb*"):
+            junk.unlink(missing_ok=True)
+
+    # And the same rule read off the SHIPPED remixes, which is where it would
+    # actually go wrong: nothing may pair NO_FALLBACK with a bus module.
+    for _n in registry.remix_names():
+        _r = registry.remix(_n)
+        _bus = [k for k in _r.modules
+                if schema.on_the_bus(registry.modules()[k])]
+        if _r.fallback == schema.NO_FALLBACK and _bus:
+            bad += 1
+            print(f"  [FAIL] remix {_n!r} falls back to NONE but carries "
+                  f"{', '.join(_bus)}")
+    print(f"  [PASS] every remix's fallback matches whether it has a bus")
 
     # And the real thing: every shipped remix must be clean.
     for name in registry.remix_names():

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -11,13 +11,14 @@ on nothing.
 """
 
 import pathlib
+import re
 import subprocess
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 
-from remix import ledger  # noqa: E402
+from remix import ledger, state  # noqa: E402
 from remix.schema import (CavePatch, Claims, DspSection, Kind, MenuEntry,  # noqa: E402
                           Module, Param, YBase)
 
@@ -321,6 +322,32 @@ def main():
                   f"stock scratch?")
     else:
         print("  [SKIP] stock render harness: dsp_host or the stock image is missing")
+
+    # THE BUDGET'S TOTALS ARE NOT THE BUDGET'S TO DECIDE. The workbench
+    # states "N free of TOTAL" for the ColdFire cave, and the build reports
+    # only what is LEFT of it -- so the total is written down in state.py and
+    # would go stale silently the day the cave's bounds move. Pin it to
+    # build_bus's own constants by reading them out of the source: a total
+    # that is quietly wrong is exactly the kind of confident stale number
+    # this project keeps getting burned by.
+    _bb = (ROOT / "tools/build_bus.py").read_text()
+    _bounds = {}
+    for _name in ("NEW_LIST", "ZERO_RUN_END"):
+        _m = re.search(rf"^{_name} = (0x[0-9a-f]+)", _bb, re.M)
+        if _m:
+            _bounds[_name] = int(_m.group(1), 16)
+    if len(_bounds) != 2:
+        bad += 1
+        print("  [FAIL] could not read NEW_LIST/ZERO_RUN_END out of "
+              "build_bus.py -- the cave total cannot be pinned")
+    elif _bounds["ZERO_RUN_END"] - _bounds["NEW_LIST"] == state.CAVE_BYTES:
+        print(f"  [PASS] the cave total ({state.CAVE_BYTES:,} B) matches "
+              f"build_bus's own bounds")
+    else:
+        bad += 1
+        print(f"  [FAIL] state.CAVE_BYTES is {state.CAVE_BYTES:,} B but "
+              f"build_bus's cave is "
+              f"{_bounds['ZERO_RUN_END'] - _bounds['NEW_LIST']:,} B")
 
     # And the real thing: every shipped remix must be clean.
     for name in registry.remix_names():

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -452,12 +452,21 @@ def main():
         if tuple(_hv) != tuple(_exp):
             bad += 1
             print(f"  [FAIL] remix {_n!r} gives up {_hv}, expected {_exp}")
-        _run = sorted(_sp[k] for k in _hv)
-        if any(a + n != a2 for (a, n), (a2, _x) in zip(_run, _run[1:])):
+        # ⚠️ RUNS, NOT ONE RUN. Since 3 Sep 2026 a gap is two placeable
+        # openings rather than a refusal, so what has to hold is that the
+        # grouping is sound: every run internally contiguous, and the runs
+        # together covering exactly the harvested set.
+        _runs = stock.regions_of(_hv)
+        for _g in _runs:
+            _run = [_sp[k] for k in _g]
+            if any(a + n != a2 for (a, n), (a2, _x) in zip(_run, _run[1:])):
+                bad += 1
+                print(f"  [FAIL] remix {_n!r}: run {_g} is not contiguous")
+        if sorted(k for g in _runs for k in g) != sorted(_hv):
             bad += 1
-            print(f"  [FAIL] remix {_n!r}: its region is not contiguous")
-    print(f"  [PASS] every remix gives up a contiguous run, and the shipped "
-          f"ones give up exactly what they always did")
+            print(f"  [FAIL] remix {_n!r}: the runs do not cover {_hv}")
+    print(f"  [PASS] every remix's given-up effects group into contiguous "
+          f"runs, and the shipped ones give up exactly what they always did")
 
     # ---- FX1 rows (Remix.fx1) -------------------------------------------
     # The schema half. The BUILD half -- the relocated list, FX1's own id and

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -18,7 +18,7 @@ import sys
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 
-from remix import ledger, registry, schema, state  # noqa: E402
+from remix import ledger, registry, schema, state, stock  # noqa: E402
 from remix.schema import (CavePatch, Claims, DspSection, Kind, MenuEntry,  # noqa: E402
                           Module, Param, YBase)
 
@@ -387,6 +387,51 @@ def main():
             print(f"  [FAIL] remix {_n!r} falls back to NONE but carries "
                   f"{', '.join(_bus)}")
     print(f"  [PASS] every remix's fallback matches whether it has a bus")
+
+    # ---- dynamic donor regions (Remix.harvest) ---------------------------
+    # The property the whole idea rests on: the thirteen DSP effects are
+    # CONTIGUOUS in both payloads and their record sizes match what stock.py
+    # says they cost. Derived from the module map every run, so a firmware
+    # whose layout differs fails here rather than being written over.
+    for _pay in ("A", "B"):
+        try:
+            _sp = stock.p_spans(_pay)
+        except Exception as e:                       # noqa: BLE001
+            bad += 1
+            print(f"  [FAIL] payload {_pay}: no effect run found -- {e}")
+            continue
+        _run = sorted(_sp.values())
+        _lo, _hi = _run[0][0], _run[-1][0] + _run[-1][1]
+        _gap = [a for (a, n), (a2, _n) in zip(_run, _run[1:]) if a + n != a2]
+        if _gap:
+            bad += 1
+            print(f"  [FAIL] payload {_pay}: effect code is not contiguous")
+        _wrong = [k for k, (_a, n) in _sp.items()
+                  if k in stock.WORDS and stock.WORDS[k] != n
+                  and k != "PHASER"]
+        if _wrong:
+            bad += 1
+            print(f"  [FAIL] payload {_pay}: {_wrong} disagree with "
+                  f"stock.WORDS")
+        else:
+            print(f"  [PASS] payload {_pay}: {len(_sp)} effects contiguous, "
+                  f"P:0x{_lo:05x}..0x{_hi:05x} = {_hi - _lo:,} words")
+    # And nothing shipped may harvest a non-contiguous set -- the build
+    # refuses it, and a remix that cannot build is not much of a remix.
+    for _n in registry.remix_names():
+        _r = registry.remix(_n)
+        _sp = stock.p_spans("A")
+        _bad = [k for k in _r.harvest if k not in _sp]
+        if _bad:
+            bad += 1
+            print(f"  [FAIL] remix {_n!r}: harvest={_bad} have no DSP code")
+            continue
+        _run = sorted(_sp[k] for k in _r.harvest)
+        if any(a + n != a2 for (a, n), (a2, _n) in zip(_run, _run[1:])):
+            bad += 1
+            print(f"  [FAIL] remix {_n!r}: its harvested effects are not "
+                  f"contiguous")
+    print(f"  [PASS] every remix harvests a contiguous run")
 
     # ---- FX1 rows (Remix.fx1) -------------------------------------------
     # The schema half. The BUILD half -- the relocated list, FX1's own id and

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -20,6 +20,7 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from remix import ledger, registry  # noqa: E402
+from remix.schema import NO_FALLBACK, on_the_bus  # noqa: E402
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 DONOR_WORDS = 2724          # per payload; build_bus.py prints the live figure
@@ -78,10 +79,13 @@ class State:
         modules of ours. The honest starting point -- you add to what the box
         already does rather than to somebody else's selection.
 
-        Note this selection cannot BUILD as it stands and should not pretend
-        to: a remix must name a fallback for ids it does not implement, and
-        no stock effect is a safe one (it would PROCESS the unknown id). The
-        moment a module is added, SEND comes with it.
+        ⚠️ IT BUILDS, since 2 Sep 2026 -- to A 0/2724 · B 0/2724, not one
+        word placed, all three reverbs alive: the unit's own chooser rebuilt
+        from our tables. It could not, until the fallback stopped having to
+        be a module of ours; ids this selection does not implement now
+        resolve to the firmware's own NONE (schema.NO_FALLBACK), which is
+        what an unassigned track shows on a stock unit anyway. Until then
+        the bench opened on a selection it had to apologise for.
         """
         from remix import stock
         self.sel = {m.key for m in stock.MODULES}
@@ -173,13 +177,27 @@ class State:
         return [m for m in self.selected if m.menu is not None]
 
     def auto_fallback(self):
-        """The fallback to use when none is set explicitly. SEND is the safe
-        catch-all -- an unimplemented id aliased to it becomes a harmless dry
-        passthrough, not garbage -- so prefer it; if there is exactly one
-        menu-bearing module, it is the only choice. Otherwise there is no safe
-        automatic pick (any real effect would PROCESS the unknown id), so
-        return None and let problems() ask for an explicit choice.
+        """The fallback to use when none is set explicitly.
+
+        THE FIRMWARE'S OWN NONE, whenever this selection has no bus. An
+        unimplemented id then resolves to the descriptor a stock chooser
+        carries at row 0 and to the payload's null stub -- an unassigned
+        track is simply OFF, exactly as on an unmodified unit -- and it costs
+        no words. That is the honest answer for an insert collection, which
+        used to be made to carry SEND (215-250 words) for a bus client
+        nothing in the image reads. See schema.NO_FALLBACK, which is also
+        what refuses this beside a bus participant: with a server or a SEND
+        in the image, an unassigned track running nothing would leave the
+        rotation unflipped and the accumulators uncleared.
+
+        With a bus, SEND is the safe catch-all -- aliasing to it makes the
+        id a harmless dry passthrough rather than garbage -- so prefer it. If
+        there is exactly one menu-bearing module, it is the only choice.
+        Otherwise there is no safe automatic pick (any real effect would
+        PROCESS the unknown id), so return None and let problems() ask.
         """
+        if not any(on_the_bus(m) for m in self.selected):
+            return NO_FALLBACK
         for k in self.order:
             if self.mods[k].name == "send" and self.mods[k].menu is not None:
                 return k
@@ -190,7 +208,13 @@ class State:
     def eff_fallback(self):
         """What the build will actually use: the explicit choice if valid,
         else the intelligent default."""
-        if self.fallback and self.fallback in self.sel \
+        # NO_FALLBACK is not a module, so it is valid exactly when the
+        # selection still has no bus participant -- otherwise it falls
+        # through to the automatic pick, which will be SEND.
+        if self.fallback == NO_FALLBACK:
+            if not any(on_the_bus(m) for m in self.selected):
+                return NO_FALLBACK
+        elif self.fallback and self.fallback in self.sel \
                 and self.mods[self.fallback].menu is not None:
             return self.fallback
         return self.auto_fallback()

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -42,7 +42,10 @@ class State:
         self.cursor = 0
         self.words: dict[str, int] = {}      # key -> words, from a real build
         self.words_from = ""                 # which remix produced them
-        self.msg = "space toggles; w assembles for word counts; ? for keys"
+        # [(payload, used, free)] as the last build reported them. TWO
+        # regions, one per payload -- see problems().
+        self.regions: list[tuple[str, int, int]] = []
+        self.msg = "enter swaps · r hears it · ? for keys"
         # Per-MODULE knob values, so an effect's settings belong to the effect
         # rather than to a track. (The retired rig kept these per track, which
         # was the redundancy: one knob set per effect is what a remix means.)
@@ -193,14 +196,20 @@ class State:
             out.append("no fallback and none can be picked automatically "
                        "(no SEND, and several effects) — press f to choose "
                        "which effect unimplemented ids alias to")
-        # A module whose words we know, summed against the region it must fit.
-        known = [k for k in self.sel if k in self.words]
-        if known and len(known) == len([k for k in self.sel
-                                        if self.mods[k].dsp is not None]):
-            total = sum(self.words[k] for k in known)
-            if total > DONOR_WORDS:
-                out.append(f"{total} words exceeds the {DONOR_WORDS}-word "
-                           f"donor region by {total - DONOR_WORDS}")
+        # THE WORD BUDGET IS NOT CHECKED HERE, deliberately. It used to be:
+        # every module's words summed against ONE 2,724-word region. There
+        # are TWO -- one per payload -- and SPEC=1 puts each server on its
+        # own, so the sum is not a quantity the image has to fit. It read
+        # chongbong, the SHIPPING remix, as "5130 words exceeds the 2724-word
+        # donor region by 2406" when the truth was A 2650/74 free and B
+        # 2719/5 free. The check was latent while the words were only known
+        # after an explicit keypress; it became a permanent false alarm the
+        # moment the workbench started measuring on every change.
+        #
+        # The build is the authority and it refuses per payload ("payload B:
+        # RUNGS overruns the region (3599 > 2724 words)"), so an overrun
+        # arrives as a build failure with the payload named. measure() keeps
+        # the real per-payload numbers in self.regions.
         return out
 
     # ---- the one thing that needs a real build --------------------------
@@ -227,20 +236,28 @@ class State:
             if r.returncode != 0:
                 tail = (r.stdout + r.stderr).strip().splitlines()
                 return False, (tail[-1] if tail else "build failed")
-            words, free = {}, None
+            words, regions, payload = {}, [], None
             for line in r.stdout.splitlines():
                 m = re.match(r"\s{2}(\S.*?)\s+P:0x[0-9a-f]+\.\.0x[0-9a-f]+"
                              r"\s+\(\s*(\d+) words\)", line)
                 if m and m.group(1).strip() in self.mods:
                     words[m.group(1).strip()] = int(m.group(2))
-                m = re.search(r"used (\d+)\s+FREE (\d+)", line)
+                m = re.match(r"-- payload (\w+) --", line.strip())
                 if m:
-                    free = (int(m.group(1)), int(m.group(2)))
+                    payload = m.group(1)
+                # There is one of these PER PAYLOAD, each its own 2,724-word
+                # region. Keeping only the last was how the budget came to be
+                # reported as a single pool.
+                m = re.search(r"used (\d+)\s+FREE (\d+)", line)
+                if m and payload:
+                    regions.append((payload, int(m.group(1)),
+                                    int(m.group(2))))
             self.words.update(words)
             self.words_from = note
-            if free:
-                return True, (f"assembled: {free[0]} words used, "
-                              f"{free[1]} free in the donor region")
+            self.regions = regions
+            if regions:
+                return True, ("assembled: " + " · ".join(
+                    f"{n} {u}/{u + f}" for n, u, f in regions))
             return True, "assembled"
         finally:
             tmp.unlink(missing_ok=True)

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -43,8 +43,31 @@ class State:
         self.words: dict[str, int] = {}      # key -> words, from a real build
         self.words_from = ""                 # which remix produced them
         self.msg = "space toggles; w assembles for word counts; ? for keys"
-        self.load("chongbong" if "chongbong" in registry.remix_names()
-                  else (registry.remix_names() or [None])[0])
+        # Per-MODULE knob values, so an effect's settings belong to the effect
+        # rather than to a track. (The retired rig kept these per track, which
+        # was the redundancy: one knob set per effect is what a remix means.)
+        self.knobs: dict[str, dict[str, int]] = {}
+        self.loaded_name = ""
+        self.load_stock()
+
+    # ---- the default: an unmodified unit --------------------------------
+    def load_stock(self):
+        """The chooser an UNMODIFIED unit shows: every stock FX2 effect, no
+        modules of ours. The honest starting point -- you add to what the box
+        already does rather than to somebody else's selection.
+
+        Note this selection cannot BUILD as it stands and should not pretend
+        to: a remix must name a fallback for ids it does not implement, and
+        no stock effect is a safe one (it would PROCESS the unknown id). The
+        moment a module is added, SEND comes with it.
+        """
+        from remix import stock
+        self.sel = {m.key for m in stock.MODULES}
+        self.order = [m.key for m in stock.MODULES]
+        self.fallback = None
+        self.loaded_name = "stock"
+        self.msg = ("stock: the chooser an unmodified unit shows — "
+                    "add modules from the left")
 
     # ---- selection ----------------------------------------------------
     def load(self, name):
@@ -54,7 +77,19 @@ class State:
         self.sel = set(r.modules)
         self.order = list(r.modules)
         self.fallback = r.fallback
+        self.loaded_name = name
         self.msg = f"loaded remix {name!r}"
+
+    # ---- per-module knob values -----------------------------------------
+    def knobs_for(self, mod) -> dict[str, int]:
+        """This module's current knob values, seeded from its manifest
+        defaults the first time it is asked for. Manifest defaults are the
+        honest baseline -- a stale default polluted every shimmer measurement
+        until Round 12."""
+        from remix import rig
+        if mod.key not in self.knobs:
+            self.knobs[mod.key] = rig.default_knobs(mod)
+        return self.knobs[mod.key]
 
     def toggle(self, key):
         if key in self.sel:

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -39,6 +39,32 @@ BUILT_IMAGE = ROOT / "out/mainos_bus.bin"
 STOCK_ROOTS = {"PROJECT", "SYSTEM", "CONTROL", "MIDI"}
 
 
+def fx1_hazard(mod) -> str | None:
+    """Why this module must not take an FX1 row, or None if it may.
+
+    ONE STATEMENT, read by both the remixer (at the keystroke) and
+    build_bus.py (at the build), because the two drifting apart is how a UI
+    comes to offer something the build refuses.
+
+    ⚠️ An FX1 slot is 3,072 words and an FX2 slot is 16,384, and the trap is
+    not theoretical: docs/DSP.md's "wrong claim 1" is this exact failure,
+    bisected on hardware -- a 16K layout placed at an FX1 base "runs through
+    the other FX1 buffers and into FX2 slot 0".
+    """
+    from remix.schema import BusRole, YBase
+    claims = getattr(mod, "claims", None)
+    if mod.dsp is not None and mod.dsp.bus_role is BusRole.SERVER:
+        return "a bus server is one per core; an FX1 row is a second instance"
+    if claims is not None and claims.stock_instance_buffer:
+        return ("it sizes its buffer for an FX2 slot (16,384 words) and an "
+                "FX1 slot is 3,072")
+    if (claims is not None and claims.owns_fx2_buffers) or (
+            mod.dsp is not None and mod.dsp.ybase is not YBase.NEVER):
+        return ("its buffers are at fixed FX2 addresses, so an FX1 instance "
+                "writes into another track's buffer")
+    return None
+
+
 class State:
     def __init__(self):
         self.mods = registry.modules()
@@ -128,28 +154,40 @@ class State:
             self.knobs[mod.key] = rig.default_knobs(mod)
         return self.knobs[mod.key]
 
-    def toggle_fx1(self, key):
+    def toggle_fx1(self, key, name=None):
         """Give this module a row on FX1 as well, or take it away.
 
         -> a sentence for the status line. Refused rather than silently
         ignored where the build would refuse it, so the answer arrives at the
         keystroke instead of at the next rebuild.
+
+        `name` is what to CALL it: the caller passes the panel name, because
+        the module key ("REVERB SERVER") is not what the operator is looking
+        at ("ChonVerb") and this module must not import the shell.
         """
+        name = name or key
         mod = self.mods.get(key)
         if mod is None or mod.menu is None:
             return "this has no chooser row at all — nothing for FX1 to list"
         if key not in self.sel:
-            return f"add {key} to the image first, then 1 gives it FX1 too"
+            return f"add {name} to the image first, then 1 gives it FX1 too"
         if mod.is_stock:
             return "a stock effect's FX1 row is stock's own — this cannot add or remove one"
         if mod.menu.replaces:
-            return (f"{key} replaces stock {mod.menu.replaces}, so it "
+            return (f"{name} replaces stock {mod.menu.replaces}, so it "
                     f"already has that effect's FX1 row")
+        # ⚠️ ONLY A BUFFER-FREE INSERT CAN TAKE ONE, and the build refuses the
+        # rest for reasons worth arriving at the keystroke rather than at the
+        # next rebuild. See build_bus.py's fx1 block for the full statement.
+        why = fx1_hazard(mod)
+        if why:
+            return f"{name}: {why}"
         if key in self.fx1:
             self.fx1.discard(key)
-            return f"{key} is FX2 only again"
+            return f"{name} is FX2 only again"
         self.fx1.add(key)
-        return f"{key} gets a row on FX1 too — no words, but 4 more slots of cycles"
+        return (f"{name} gets a row on FX1 too — no words, but 4 more "
+                f"slots of cycles")
 
     def toggle(self, key):
         if key in self.sel:

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -44,6 +44,10 @@ class State:
         self.mods = registry.modules()
         self.keys = sorted(self.mods)
         self.sel: set[str] = set()
+        # WHICH OF THEM ALSO GET A ROW ON FX1 (schema.Remix.fx1). Part of the
+        # selection, not of a module: which menu an effect appears on is a
+        # composition choice, like the chooser order beside it.
+        self.fx1: set[str] = set()
         # Chooser ORDER. A remix's module list is ordered and that order is
         # the panel's row order, so the composer keeps it too -- the old set
         # alone wrote every saved remix alphabetically, which silently
@@ -95,6 +99,7 @@ class State:
         from remix import stock
         self.sel = {m.key for m in stock.MODULES}
         self.order = [m.key for m in stock.MODULES]
+        self.fx1 = set()
         self.fallback = None
         self.loaded_name = "stock"
         self.msg = ("stock: the chooser an unmodified unit shows — "
@@ -107,6 +112,7 @@ class State:
         r = registry.remix(name)
         self.sel = set(r.modules)
         self.order = list(r.modules)
+        self.fx1 = set(r.fx1)
         self.fallback = r.fallback
         self.loaded_name = name
         self.msg = f"loaded remix {name!r}"
@@ -122,10 +128,32 @@ class State:
             self.knobs[mod.key] = rig.default_knobs(mod)
         return self.knobs[mod.key]
 
+    def toggle_fx1(self, key):
+        """Give this module a row on FX1 as well, or take it away.
+
+        -> a sentence for the status line. Refused rather than silently
+        ignored where the build would refuse it, so the answer arrives at the
+        keystroke instead of at the next rebuild.
+        """
+        mod = self.mods.get(key)
+        if key not in self.sel or mod is None or mod.menu is None:
+            return "only an effect with a chooser row can have an FX1 one"
+        if mod.is_stock:
+            return "a stock effect's FX1 row is stock's own — this cannot add or remove one"
+        if mod.menu.replaces:
+            return (f"{key} replaces stock {mod.menu.replaces}, so it "
+                    f"already has that effect's FX1 row")
+        if key in self.fx1:
+            self.fx1.discard(key)
+            return f"{key} is FX2 only again"
+        self.fx1.add(key)
+        return f"{key} gets a row on FX1 too — no words, but 4 more slots of cycles"
+
     def toggle(self, key):
         if key in self.sel:
             self.sel.discard(key)
             self.order.remove(key)
+            self.fx1.discard(key)
             if self.fallback == key:
                 self.fallback = None
         else:
@@ -464,6 +492,11 @@ class State:
     def as_remix(self, name, doc):
         mods = ", ".join(f'"{k}"' for k in self.order)
         fb = f'"{self.eff_fallback}"' if self.eff_fallback else "None"
+        # Emitted only when there is one, so every remix written before FX1
+        # rows existed still round-trips byte-for-byte through save/load.
+        rows = [k for k in self.order if k in self.fx1]
+        fx1 = (f'    fx1=({", ".join(chr(34) + k + chr(34) for k in rows)},),\n'
+               if rows else "")
         return (f'"""{name} -- {doc}\n\n'
                 f'Written by the remix workbench. Edit freely: the docstring\n'
                 f'is the only thing here a human is expected to improve.\n'
@@ -474,4 +507,5 @@ class State:
                 f'    doc="{doc}",\n'
                 f'    modules=({mods},),\n'
                 f'    fallback={fb},\n'
+                f'{fx1}'
                 f')\n')

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -103,6 +103,9 @@ class State:
         # build takes CHORUS's module as well, so the size of the region is
         # a property of the build, not a constant of the firmware.
         self.regions: list[tuple[str, int, int, int]] = []
+        # (payload, base, words, used) per RUN -- empty when the harvested
+        # effects form one unbroken run, which is the common case.
+        self.runs: list[tuple[str, int, int, int]] = []
         # Which of PLATE/SPRING/DARK the last build LEFT ALONE, upper-cased
         # as the build names them. Empty until a build has reported.
         self.donors_kept: set[str] = set()
@@ -399,6 +402,7 @@ class State:
         stops being buildable: these numbers describe the image you HAD, and
         a budget that silently belongs to two edits ago is worse than none."""
         self.regions = []
+        self.runs = []
         self.cycles = None
         self.cave_free = None
         self.chooser_rows = None
@@ -437,7 +441,7 @@ class State:
             # forget_build() is the other half: when the parse yields
             # nothing, the fields go empty rather than stale.
             failed = r.returncode != 0
-            words, regions, payload = {}, [], None
+            words, regions, payload, runs = {}, [], None, []
             kept, saw_donor_line = set(), False
             cave_free = rows = None
             for line in r.stdout.splitlines():
@@ -462,6 +466,15 @@ class State:
                 # actually landed, so "are they gone" is a question only the
                 # placement can answer -- and the remixer used to assume
                 # the answer was always yes.
+                # ⚠️ ONE ENTRY PER RUN, and only when the region is split.
+                # The map needs to know WHICH opening a module went into --
+                # a single global cursor cannot say, and drawing one bracket
+                # across a gap claims ground the placer cannot use.
+                m = re.match(r"\s+run \d+ P:0x([0-9a-f]+)\.\.0x[0-9a-f]+"
+                             r"\s+(\d+) w\s+used (\d+)", line)
+                if m and payload:
+                    runs.append((payload, int(m.group(1), 16),
+                                 int(m.group(2)), int(m.group(3))))
                 m = re.search(r"KEPT STOCK: (\S+)", line)
                 if m:
                     kept |= {w.strip() for w in m.group(1).split("/")}
@@ -474,6 +487,7 @@ class State:
             self.words.update(words)
             self.words_from = note
             self.regions = regions
+            self.runs = runs
             # Both payloads report; a donor survives only if BOTH kept it.
             for line in r.stdout.splitlines():
                 if "donor ids" in line:

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -39,6 +39,15 @@ BUILT_IMAGE = ROOT / "out/mainos_bus.bin"
 STOCK_ROOTS = {"PROJECT", "SYSTEM", "CONTROL", "MIDI"}
 
 
+def stock_fx1_default() -> tuple[str, ...]:
+    """The FX1 chooser a stock unit shows, in ITS order, minus the NONE row
+    the build always emits. Read from the pristine image, never written
+    down."""
+    from remix import stock
+    by_id = {m.menu.fx2_id: m.key for m in stock.MODULES}
+    return tuple(by_id[i] for i in stock.fx1_order() if i in by_id)
+
+
 def fx1_hazard(mod) -> str | None:
     """Why this module must not take an FX1 row, or None if it may.
 
@@ -70,10 +79,11 @@ class State:
         self.mods = registry.modules()
         self.keys = sorted(self.mods)
         self.sel: set[str] = set()
-        # WHICH OF THEM ALSO GET A ROW ON FX1 (schema.Remix.fx1). Part of the
-        # selection, not of a module: which menu an effect appears on is a
-        # composition choice, like the chooser order beside it.
-        self.fx1: set[str] = set()
+        # THE FX1 CHOOSER, in its own row order (schema.Remix.fx1). A second
+        # list, not a flag on the first: FX1 and FX2 are two independent
+        # chooser lists and a remix composes both. Seeded from stock's ten,
+        # so an untouched selection saves `fx1=()` and writes nothing.
+        self.fx1: list[str] = []
         # Chooser ORDER. A remix's module list is ordered and that order is
         # the panel's row order, so the composer keeps it too -- the old set
         # alone wrote every saved remix alphabetically, which silently
@@ -125,7 +135,7 @@ class State:
         from remix import stock
         self.sel = {m.key for m in stock.MODULES}
         self.order = [m.key for m in stock.MODULES]
-        self.fx1 = set()
+        self.fx1 = list(stock_fx1_default())
         self.fallback = None
         self.loaded_name = "stock"
         self.msg = ("stock: the chooser an unmodified unit shows — "
@@ -138,7 +148,9 @@ class State:
         r = registry.remix(name)
         self.sel = set(r.modules)
         self.order = list(r.modules)
-        self.fx1 = set(r.fx1)
+        # `fx1=()` means "stock's, unchanged" -- so the pane shows stock's
+        # ten rather than an empty list, and saving it back writes `()` again.
+        self.fx1 = list(r.fx1) or list(stock_fx1_default())
         self.fallback = r.fallback
         self.loaded_name = name
         self.msg = f"loaded remix {name!r}"
@@ -169,10 +181,23 @@ class State:
         mod = self.mods.get(key)
         if mod is None or mod.menu is None:
             return "this has no chooser row at all — nothing for FX1 to list"
+        if mod.is_stock:
+            # A STOCK EFFECT NEEDS NO FX2 ROW TO SIT ON FX1: the two lists
+            # are independent. What it does need is for FX1 to be able to
+            # host it -- DELAY and the three reverbs are FX2-only because
+            # they do not fit a 3,072-word FX1 allocation.
+            from remix import stock
+            if mod.menu.fx2_id not in stock.fx1_ids():
+                return (f"{name} is FX2-only — it does not fit a 3,072-word "
+                        f"FX1 allocation, which is why stock never listed it "
+                        f"there")
+            if key in self.fx1:
+                self.fx1.remove(key)
+                return f"{name} is off the FX1 chooser"
+            self.fx1.append(key)
+            return f"{name} is back on the FX1 chooser"
         if key not in self.sel:
             return f"add {name} to the image first, then 1 gives it FX1 too"
-        if mod.is_stock:
-            return "a stock effect's FX1 row is stock's own — this cannot add or remove one"
         if mod.menu.replaces:
             return (f"{name} replaces stock {mod.menu.replaces}, so it "
                     f"already has that effect's FX1 row")
@@ -183,17 +208,23 @@ class State:
         if why:
             return f"{name}: {why}"
         if key in self.fx1:
-            self.fx1.discard(key)
-            return f"{name} is FX2 only again"
-        self.fx1.add(key)
-        return (f"{name} gets a row on FX1 too — no words, but 4 more "
+            self.fx1.remove(key)
+            return f"{name} is off the FX1 chooser"
+        self.fx1.append(key)
+        return (f"{name} joins the FX1 chooser — no words, but 4 more "
                 f"slots of cycles")
 
     def toggle(self, key):
         if key in self.sel:
             self.sel.discard(key)
             self.order.remove(key)
-            self.fx1.discard(key)
+            # ⚠️ ONLY FOR MODULES OF OURS. Their FX1 row points at the
+            # descriptor CLONE the FX2 row creates, so losing the FX2 row
+            # loses the FX1 one. A stock effect's FX1 row is independent --
+            # that is the whole asymmetry -- and taking it off the FX2
+            # chooser must not silently take it off FX1 as well.
+            if not self.mods[key].is_stock and key in self.fx1:
+                self.fx1.remove(key)
             if self.fallback == key:
                 self.fallback = None
         else:
@@ -532,11 +563,14 @@ class State:
     def as_remix(self, name, doc):
         mods = ", ".join(f'"{k}"' for k in self.order)
         fb = f'"{self.eff_fallback}"' if self.eff_fallback else "None"
-        # Emitted only when there is one, so every remix written before FX1
-        # rows existed still round-trips byte-for-byte through save/load.
-        rows = [k for k in self.order if k in self.fx1]
-        fx1 = (f'    fx1=({", ".join(chr(34) + k + chr(34) for k in rows)},),\n'
-               if rows else "")
+        # ⚠️ EMITTED ONLY WHEN IT DIFFERS FROM STOCK'S. `fx1=()` means "leave
+        # FX1 alone", and the build then writes not one byte -- which is what
+        # keeps every remix that predates FX1 composition byte-identical.
+        # An untouched chooser must therefore save as `()`, not as a
+        # spelled-out copy of stock's ten.
+        fx1 = ("" if tuple(self.fx1) == stock_fx1_default()
+               else '    fx1=('
+                    + ", ".join(f'"{k}"' for k in self.fx1) + ',),\n')
         return (f'"""{name} -- {doc}\n\n'
                 f'Written by the remixer. Edit freely: the docstring\n'
                 f'is the only thing here a human is expected to improve.\n'

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -144,8 +144,12 @@ class State:
         self.sel = {m.key for m in stock.MODULES}
         self.order = [m.key for m in stock.MODULES]
         self.fx1 = list(stock_fx1_default())
-        from remix.schema import DEFAULT_HARVEST
-        self.harvest = list(DEFAULT_HARVEST)
+        # ⚠️ NOTHING HARVESTED. An unmodified unit has every one of its 6,158
+        # words allocated -- each stock effect is using its own -- so a stock
+        # selection must show that, not a region already taken from the
+        # reverbs. Harvesting is the operator's choice and the first module
+        # added is what makes it necessary.
+        self.harvest = []
         self.fallback = None
         self.loaded_name = "stock"
         self.msg = ("stock: the chooser an unmodified unit shows — "
@@ -391,6 +395,14 @@ class State:
         if not self.menu_modules:
             out.append("no module with a menu entry: nothing would be "
                        "selectable on the panel")
+        # ⚠️ NOTHING TO PLACE INTO. On a stock chooser every word is a stock
+        # effect's, so adding a module of ours is the moment a choice has to
+        # be made about which one to give up. It arrives as a problem with a
+        # one-key fix rather than as a build failure.
+        if not self.harvest and [m for m in self.selected if m.dsp is not None]:
+            out.append("nothing is harvested, so there is nowhere to place "
+                       "your modules — x takes the three reverbs (2,724 "
+                       "words), or h takes whichever you would rather lose")
         if self.eff_fallback is None:
             out.append("no fallback and none can be picked automatically "
                        "(no SEND, and several effects) — press f to choose "
@@ -621,7 +633,7 @@ class State:
         from remix.schema import DEFAULT_HARVEST
         harvest = ("" if tuple(self.harvest) == DEFAULT_HARVEST
                    else '    harvest=('
-                        + ", ".join(f'"{k}"' for k in self.harvest) + ',),\n')
+                        + "".join(f'"{k}", ' for k in self.harvest) + '),\n')
         return (f'"""{name} -- {doc}\n\n'
                 f'Written by the remixer. Edit freely: the docstring\n'
                 f'is the only thing here a human is expected to improve.\n'

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -155,16 +155,21 @@ class State:
         return True
 
     def move(self, key, delta):
-        """Shift a selected module earlier (-1) or later (+1) in chooser order."""
+        """Shift a selected module earlier (-1) or later (+1) in chooser
+        order. -> its new 1-based chooser row, or None if it has none."""
         if key not in self.sel:
             self.msg = "select it first -- only selected modules have a row"
-            return
+            return None
         i = self.order.index(key)
         j = max(0, min(len(self.order) - 1, i + delta))
         self.order[i], self.order[j] = self.order[j], self.order[i]
+        # The ROW NUMBER as the pane prints it -- 1-based. This said
+        # "chooser row 1" for the row drawn as `2`, which is an invitation to
+        # doubt every other number here. The NAME is left to the caller: the
+        # panel name (`BongDelay`) lives in app.disp(), and this module must
+        # not import the shell.
         rows = [m.key for m in self.menu_modules]
-        self.msg = (f"{self.mods[key].name} -> chooser row {rows.index(key)}"
-                    if key in rows else "no menu entry: order is moot")
+        return rows.index(key) + 1 if key in rows else None
 
     @property
     def selected(self):

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -48,6 +48,10 @@ class State:
         # Which of PLATE/SPRING/DARK the last build LEFT ALONE, upper-cased
         # as the build names them. Empty until a build has reported.
         self.donors_kept: set[str] = set()
+        # Bytes left in the ColdFire cave region and rows in the chooser, as
+        # the last build reported them. None until one has.
+        self.cave_free: int | None = None
+        self.chooser_rows: int | None = None
         self.msg = "enter swaps · r hears it · ? for keys"
         # Per-MODULE knob values, so an effect's settings belong to the effect
         # rather than to a track. (The retired rig kept these per track, which
@@ -215,6 +219,15 @@ class State:
         # the real per-payload numbers in self.regions.
         return out
 
+    def forget_build(self):
+        """Drop everything only a build can know. Called when the selection
+        stops being buildable: these numbers describe the image you HAD, and
+        a budget that silently belongs to two edits ago is worse than none."""
+        self.regions = []
+        self.cave_free = None
+        self.chooser_rows = None
+        self.donors_kept = set()
+
     # ---- the one thing that needs a real build --------------------------
     def measure(self, note):
         """Assemble this selection and keep the words the build reports.
@@ -241,6 +254,7 @@ class State:
                 return False, (tail[-1] if tail else "build failed")
             words, regions, payload = {}, [], None
             kept, saw_donor_line = set(), False
+            cave_free = rows = None
             for line in r.stdout.splitlines():
                 m = re.match(r"\s{2}(\S.*?)\s+P:0x[0-9a-f]+\.\.0x[0-9a-f]+"
                              r"\s+\(\s*(\d+) words\)", line)
@@ -265,6 +279,12 @@ class State:
                 m = re.search(r"KEPT STOCK: (\S+)", line)
                 if m:
                     kept |= {w.strip() for w in m.group(1).split("/")}
+                m = re.search(r"(\d+) B of cave left", line)
+                if m:
+                    cave_free = int(m.group(1))
+                m = re.search(r"chooser list = (\d+) entries", line)
+                if m:
+                    rows = int(m.group(1))
             self.words.update(words)
             self.words_from = note
             self.regions = regions
@@ -276,6 +296,8 @@ class State:
                         kept = set()
                         break
             self.donors_kept = kept if saw_donor_line else set()
+            self.cave_free = cave_free
+            self.chooser_rows = rows
             if regions:
                 return True, ("assembled: " + " · ".join(
                     f"{n} {u}/{u + f}" for n, u, f in regions))

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -249,9 +249,18 @@ class State:
             r = subprocess.run([sys.executable, "tools/build_bus.py"],
                                cwd=ROOT, env=env, capture_output=True,
                                text=True)
-            if r.returncode != 0:
-                tail = (r.stdout + r.stderr).strip().splitlines()
-                return False, (tail[-1] if tail else "build failed")
+            # ⚠️ PARSE THE REPORT EVEN WHEN THE BUILD FAILED. Returning
+            # here left every build-derived number -- the donor budget, the
+            # cave, the rows, which reverbs survived -- holding the LAST
+            # SUCCESSFUL build's values, so a failed selection showed the
+            # budget of an image it was not. And the report is usually still
+            # informative: a chooser-row refusal happens after the region
+            # line is printed, so "726 used, 1998 free" is exactly the fact
+            # that tells you the failure is not about space.
+            #
+            # forget_build() is the other half: when the parse yields
+            # nothing, the fields go empty rather than stale.
+            failed = r.returncode != 0
             words, regions, payload = {}, [], None
             kept, saw_donor_line = set(), False
             cave_free = rows = None
@@ -298,6 +307,9 @@ class State:
             self.donors_kept = kept if saw_donor_line else set()
             self.cave_free = cave_free
             self.chooser_rows = rows
+            if failed:
+                tail = (r.stdout + r.stderr).strip().splitlines()
+                return False, (tail[-1] if tail else "build failed")
             if regions:
                 return True, ("assembled: " + " · ".join(
                     f"{n} {u}/{u + f}" for n, u, f in regions))

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -136,8 +136,10 @@ class State:
         keystroke instead of at the next rebuild.
         """
         mod = self.mods.get(key)
-        if key not in self.sel or mod is None or mod.menu is None:
-            return "only an effect with a chooser row can have an FX1 one"
+        if mod is None or mod.menu is None:
+            return "this has no chooser row at all — nothing for FX1 to list"
+        if key not in self.sel:
+            return f"add {key} to the image first, then 1 gives it FX1 too"
         if mod.is_stock:
             return "a stock effect's FX1 row is stock's own — this cannot add or remove one"
         if mod.menu.replaces:

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -110,6 +110,24 @@ class State:
         self.sel.add(key)
         self.order.insert(max(0, min(len(self.order), i)), key)
 
+    def swap(self, out_key, in_key):
+        """Replace one entry with another IN ITS OWN SLOT.
+
+        Composing an image is trading, not accumulating: the donor region is
+        2,724 words and the chooser is a list somebody has to scroll, so
+        putting something in generally means taking something out. Keeping
+        the position is the whole point -- the row number IS the panel slot.
+        """
+        if out_key not in self.sel or in_key in self.sel:
+            return False
+        i = self.order.index(out_key)
+        self.order[i] = in_key
+        self.sel.discard(out_key)
+        self.sel.add(in_key)
+        if self.fallback == out_key:
+            self.fallback = None
+        return True
+
     def move(self, key, delta):
         """Shift a selected module earlier (-1) or later (+1) in chooser order."""
         if key not in self.sel:

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -12,6 +12,7 @@ substitutions all affect the count and only the build knows them.
 
 from __future__ import annotations
 
+import json
 import os
 import pathlib
 import re
@@ -65,7 +66,11 @@ class State:
         # the last build reported them. None until one has.
         self.cave_free: int | None = None
         self.chooser_rows: int | None = None
-        self.msg = "enter swaps · r hears it · ? for keys"
+        # (worst per-core cycles, what our code may spend, the mix that
+        # produced it) -- tools/cycle_count.py against this selection.
+        self.cycles: tuple[int, int, dict] | None = None
+        # ⚠️ `enter` stopped swapping on 2 Sep 2026; this line did not.
+        self.msg = "enter adds · r hears it · ? for keys"
         # Per-MODULE knob values, so an effect's settings belong to the effect
         # rather than to a track. (The retired rig kept these per track, which
         # was the redundancy: one knob set per effect is what a remix means.)
@@ -265,6 +270,7 @@ class State:
         stops being buildable: these numbers describe the image you HAD, and
         a budget that silently belongs to two edits ago is worse than none."""
         self.regions = []
+        self.cycles = None
         self.cave_free = None
         self.chooser_rows = None
         self.donors_kept = set()
@@ -349,6 +355,24 @@ class State:
             self.donors_kept = kept if saw_donor_line else set()
             self.cave_free = cave_free
             self.chooser_rows = rows
+            # ---- CYCLES, the fifth scarce thing --------------------------
+            # It is the one that breaks AUDIO rather than the build: over
+            # budget the core does not refuse, it wedges (PLAN.md s2, "the
+            # wall is a CLIFF"). cycle_count.py is already remix-aware and
+            # costs 0.17 s, so it rides the same scratch remix rather than
+            # waiting for `make check` -- which is where this answer lived,
+            # behind a key, after the fact.
+            self.cycles = None
+            c = subprocess.run([sys.executable, "tools/cycle_count.py",
+                                "--json"], cwd=ROOT, env=env,
+                               capture_output=True, text=True)
+            if c.returncode == 0:
+                try:
+                    j = json.loads(c.stdout[c.stdout.index("{"):])
+                    self.cycles = (j["worst_core"], j["usable"],
+                                   j["worst_core_modules"])
+                except (ValueError, KeyError):
+                    pass
             if failed:
                 tail = (r.stdout + r.stderr).strip().splitlines()
                 return False, (tail[-1] if tail else "build failed")

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -24,7 +24,10 @@ from remix import ledger, registry  # noqa: E402
 from remix.schema import NO_FALLBACK, on_the_bus  # noqa: E402
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
-DONOR_WORDS = 2724          # per payload; build_bus.py prints the live figure
+# Per payload, for the DEFAULT harvest (the three reverbs). It is no longer a
+# constant of the image -- Remix.harvest decides the region -- so this is the
+# fallback for "no selection in hand"; ask stock.region_words(sel.harvest).
+DONOR_WORDS = 2724
 # The ColdFire cave: the firmware's zero run at 0x400d6b00..0x400d7c3c, which
 # is where EVERYTHING a remix plants on the ColdFire lives -- the chooser
 # list, the descriptor clones, the caves and the label formatters. The build
@@ -79,6 +82,11 @@ class State:
         self.mods = registry.modules()
         self.keys = sorted(self.mods)
         self.sel: set[str] = set()
+        # WHICH STOCK EFFECTS THIS SELECTION MAY PLACE INTO
+        # (schema.Remix.harvest). The donor region is a choice, not a place:
+        # any contiguous run of the thirteen DSP effects is placeable ground.
+        from remix.schema import DEFAULT_HARVEST
+        self.harvest: list[str] = list(DEFAULT_HARVEST)
         # THE FX1 CHOOSER, in its own row order (schema.Remix.fx1). A second
         # list, not a flag on the first: FX1 and FX2 are two independent
         # chooser lists and a remix composes both. Seeded from stock's ten,
@@ -136,6 +144,8 @@ class State:
         self.sel = {m.key for m in stock.MODULES}
         self.order = [m.key for m in stock.MODULES]
         self.fx1 = list(stock_fx1_default())
+        from remix.schema import DEFAULT_HARVEST
+        self.harvest = list(DEFAULT_HARVEST)
         self.fallback = None
         self.loaded_name = "stock"
         self.msg = ("stock: the chooser an unmodified unit shows — "
@@ -151,6 +161,7 @@ class State:
         # `fx1=()` means "stock's, unchanged" -- so the pane shows stock's
         # ten rather than an empty list, and saving it back writes `()` again.
         self.fx1 = list(r.fx1) or list(stock_fx1_default())
+        self.harvest = list(r.harvest)
         self.fallback = r.fallback
         self.loaded_name = name
         self.msg = f"loaded remix {name!r}"
@@ -165,6 +176,42 @@ class State:
         if mod.key not in self.knobs:
             self.knobs[mod.key] = rig.default_knobs(mod)
         return self.knobs[mod.key]
+
+    def toggle_harvest(self, key, name=None):
+        """Offer this stock effect's words to the placer, or take it back.
+
+        -> a sentence for the status line. The harvested set must stay
+        CONTIGUOUS -- a module of ours is one code stream, so a gap is not a
+        smaller region, it is two -- and refusing here rather than at the
+        build means the answer arrives at the keystroke.
+        """
+        from remix import stock
+        name = name or key
+        mod = self.mods.get(key)
+        if mod is None or not mod.is_stock:
+            return "only a stock effect's words can be harvested"
+        sp = stock.p_spans("A")
+        if key not in sp:
+            return f"{name} has no DSP code to take — it runs on the ColdFire"
+        want = [k for k in self.harvest if k != key] if key in self.harvest \
+            else self.harvest + [key]
+        if not want:
+            return ("something has to be harvested — with nothing to place "
+                    "into, no module of ours can go in the image")
+        run = sorted(sp[k] for k in want)
+        for (a, n), (a2, _n) in zip(run, run[1:]):
+            if a + n == a2:
+                continue
+            between = sorted(k for k, (ad, _w) in sp.items()
+                             if a + n <= ad < a2)
+            return (f"{name}: that would leave {', '.join(between)} in the "
+                    f"middle, and one module cannot span a gap")
+        self.harvest = [k for k, _v in sorted(
+            ((k, sp[k]) for k in want), key=lambda kv: kv[1])]
+        n_w = stock.region_words(tuple(self.harvest))
+        return (f"{name} is no longer harvested — {n_w:,} words to place into"
+                if key not in self.harvest else
+                f"{name} harvested — {n_w:,} words to place into")
 
     def toggle_fx1(self, key, name=None):
         """Give this module a row on FX1 as well, or take it away.
@@ -571,6 +618,10 @@ class State:
         fx1 = ("" if tuple(self.fx1) == stock_fx1_default()
                else '    fx1=('
                     + ", ".join(f'"{k}"' for k in self.fx1) + ',),\n')
+        from remix.schema import DEFAULT_HARVEST
+        harvest = ("" if tuple(self.harvest) == DEFAULT_HARVEST
+                   else '    harvest=('
+                        + ", ".join(f'"{k}"' for k in self.harvest) + ',),\n')
         return (f'"""{name} -- {doc}\n\n'
                 f'Written by the remixer. Edit freely: the docstring\n'
                 f'is the only thing here a human is expected to improve.\n'
@@ -582,4 +633,5 @@ class State:
                 f'    modules=({mods},),\n'
                 f'    fallback={fb},\n'
                 f'{fx1}'
+                f'{harvest}'
                 f')\n')

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -45,6 +45,9 @@ class State:
         # [(payload, used, free)] as the last build reported them. TWO
         # regions, one per payload -- see problems().
         self.regions: list[tuple[str, int, int]] = []
+        # Which of PLATE/SPRING/DARK the last build LEFT ALONE, upper-cased
+        # as the build names them. Empty until a build has reported.
+        self.donors_kept: set[str] = set()
         self.msg = "enter swaps · r hears it · ? for keys"
         # Per-MODULE knob values, so an effect's settings belong to the effect
         # rather than to a track. (The retired rig kept these per track, which
@@ -237,6 +240,7 @@ class State:
                 tail = (r.stdout + r.stderr).strip().splitlines()
                 return False, (tail[-1] if tail else "build failed")
             words, regions, payload = {}, [], None
+            kept, saw_donor_line = set(), False
             for line in r.stdout.splitlines():
                 m = re.match(r"\s{2}(\S.*?)\s+P:0x[0-9a-f]+\.\.0x[0-9a-f]+"
                              r"\s+\(\s*(\d+) words\)", line)
@@ -252,9 +256,26 @@ class State:
                 if m and payload:
                     regions.append((payload, int(m.group(1)),
                                     int(m.group(2))))
+                # WHICH DONORS SURVIVED, from the build rather than
+                # re-derived here. The three reverbs' code IS the donor
+                # region and the build nulls a donor id only where words
+                # actually landed, so "are they gone" is a question only the
+                # placement can answer -- and the workbench used to assume
+                # the answer was always yes.
+                m = re.search(r"KEPT STOCK: (\S+)", line)
+                if m:
+                    kept |= {w.strip() for w in m.group(1).split("/")}
             self.words.update(words)
             self.words_from = note
             self.regions = regions
+            # Both payloads report; a donor survives only if BOTH kept it.
+            for line in r.stdout.splitlines():
+                if "donor ids" in line:
+                    saw_donor_line = True
+                    if "KEPT STOCK:" not in line:
+                        kept = set()
+                        break
+            self.donors_kept = kept if saw_donor_line else set()
             if regions:
                 return True, ("assembled: " + " · ".join(
                     f"{n} {u}/{u + f}" for n, u, f in regions))

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -1,6 +1,6 @@
 """The composer's model: a module selection and what it costs to build.
 
-Extracted verbatim from the curses workbench (tools/remix/tui.py, retired by
+Extracted verbatim from the curses remixer (tools/remix/tui.py, retired by
 the track-centric app) so the Textual frontend and any headless caller share
 one model. Everything here is pure: no UI import, no terminal assumption.
 
@@ -94,7 +94,7 @@ class State:
         be a module of ours; ids this selection does not implement now
         resolve to the firmware's own NONE (schema.NO_FALLBACK), which is
         what an unassigned track shows on a stock unit anyway. Until then
-        the bench opened on a selection it had to apologise for.
+        the remixer opened on a selection it had to apologise for.
         """
         from remix import stock
         self.sel = {m.key for m in stock.MODULES}
@@ -287,7 +287,7 @@ class State:
         # donor region by 2406" when the truth was A 2650/74 free and B
         # 2719/5 free. The check was latent while the words were only known
         # after an explicit keypress; it became a permanent false alarm the
-        # moment the workbench started measuring on every change.
+        # moment the remixer started measuring on every change.
         #
         # The build is the authority and it refuses per payload ("payload B:
         # RUNGS overruns the region (3599 > 2724 words)"), so an overrun
@@ -361,7 +361,7 @@ class State:
                 # re-derived here. The three reverbs' code IS the donor
                 # region and the build nulls a donor id only where words
                 # actually landed, so "are they gone" is a question only the
-                # placement can answer -- and the workbench used to assume
+                # placement can answer -- and the remixer used to assume
                 # the answer was always yes.
                 m = re.search(r"KEPT STOCK: (\S+)", line)
                 if m:
@@ -482,7 +482,7 @@ class State:
         """
         tmp = ROOT / "remixes/_tui_scratch.py"
         tmp.write_text(self.as_remix("_tui_scratch",
-                                     "scratch selection from the workbench"))
+                                     "scratch selection from the remixer"))
         return "_tui_scratch"
 
     def scratch_cleanup(self):
@@ -500,7 +500,7 @@ class State:
         fx1 = (f'    fx1=({", ".join(chr(34) + k + chr(34) for k in rows)},),\n'
                if rows else "")
         return (f'"""{name} -- {doc}\n\n'
-                f'Written by the remix workbench. Edit freely: the docstring\n'
+                f'Written by the remixer. Edit freely: the docstring\n'
                 f'is the only thing here a human is expected to improve.\n'
                 f'"""\n\n'
                 f'from remix.schema import Remix\n\n'

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -82,11 +82,7 @@ class State:
         self.mods = registry.modules()
         self.keys = sorted(self.mods)
         self.sel: set[str] = set()
-        # WHICH STOCK EFFECTS THIS SELECTION MAY PLACE INTO
-        # (schema.Remix.harvest). The donor region is a choice, not a place:
-        # any contiguous run of the thirteen DSP effects is placeable ground.
-        from remix.schema import DEFAULT_HARVEST
-        self.harvest: list[str] = list(DEFAULT_HARVEST)
+        # ⚠️ THE HARVEST IS DERIVED, not held. See the `harvest` property.
         # THE FX1 CHOOSER, in its own row order (schema.Remix.fx1). A second
         # list, not a flag on the first: FX1 and FX2 are two independent
         # chooser lists and a remix composes both. Seeded from stock's ten,
@@ -144,12 +140,6 @@ class State:
         self.sel = {m.key for m in stock.MODULES}
         self.order = [m.key for m in stock.MODULES]
         self.fx1 = list(stock_fx1_default())
-        # ⚠️ NOTHING HARVESTED. An unmodified unit has every one of its 6,158
-        # words allocated -- each stock effect is using its own -- so a stock
-        # selection must show that, not a region already taken from the
-        # reverbs. Harvesting is the operator's choice and the first module
-        # added is what makes it necessary.
-        self.harvest = []
         self.fallback = None
         self.loaded_name = "stock"
         self.msg = ("stock: the chooser an unmodified unit shows — "
@@ -165,7 +155,6 @@ class State:
         # `fx1=()` means "stock's, unchanged" -- so the pane shows stock's
         # ten rather than an empty list, and saving it back writes `()` again.
         self.fx1 = list(r.fx1) or list(stock_fx1_default())
-        self.harvest = list(r.harvest)
         self.fallback = r.fallback
         self.loaded_name = name
         self.msg = f"loaded remix {name!r}"
@@ -181,41 +170,22 @@ class State:
             self.knobs[mod.key] = rig.default_knobs(mod)
         return self.knobs[mod.key]
 
-    def toggle_harvest(self, key, name=None):
-        """Offer this stock effect's words to the placer, or take it back.
+    @property
+    def harvest(self) -> list[str]:
+        """The stock effects this selection gives up, in address order.
 
-        -> a sentence for the status line. The harvested set must stay
-        CONTIGUOUS -- a module of ours is one code stream, so a gap is not a
-        smaller region, it is two -- and refusing here rather than at the
-        build means the answer arrives at the keystroke.
+        ⚠️ DERIVED FROM THE CHOOSERS, not toggled. Taking an effect off both
+        of the unit's menus IS the decision to give up its words -- "remove
+        from the chooser" and "harvest" were the same act described twice,
+        and the second one needed its own key, its own field and its own
+        contiguity rule. It reproduces every shipped remix exactly: FX1
+        lists ten of the thirteen and the three reverbs are FX2-only, so a
+        remix that lists none of them on FX2 harvests exactly those three,
+        which is what the build has always done.
         """
         from remix import stock
-        name = name or key
-        mod = self.mods.get(key)
-        if mod is None or not mod.is_stock:
-            return "only a stock effect's words can be harvested"
-        sp = stock.p_spans("A")
-        if key not in sp:
-            return f"{name} has no DSP code to take — it runs on the ColdFire"
-        want = [k for k in self.harvest if k != key] if key in self.harvest \
-            else self.harvest + [key]
-        if not want:
-            return ("something has to be harvested — with nothing to place "
-                    "into, no module of ours can go in the image")
-        run = sorted(sp[k] for k in want)
-        for (a, n), (a2, _n) in zip(run, run[1:]):
-            if a + n == a2:
-                continue
-            between = sorted(k for k, (ad, _w) in sp.items()
-                             if a + n <= ad < a2)
-            return (f"{name}: that would leave {', '.join(between)} in the "
-                    f"middle, and one module cannot span a gap")
-        self.harvest = [k for k, _v in sorted(
-            ((k, sp[k]) for k in want), key=lambda kv: kv[1])]
-        n_w = stock.region_words(tuple(self.harvest))
-        return (f"{name} is no longer harvested — {n_w:,} words to place into"
-                if key not in self.harvest else
-                f"{name} harvested — {n_w:,} words to place into")
+        return list(stock.region_of(
+            stock.harvested(set(self.order) | set(self.fx1))))
 
     def toggle_fx1(self, key, name=None):
         """Give this module a row on FX1 as well, or take it away.
@@ -400,9 +370,10 @@ class State:
         # be made about which one to give up. It arrives as a problem with a
         # one-key fix rather than as a build failure.
         if not self.harvest and [m for m in self.selected if m.dsp is not None]:
-            out.append("nothing is harvested, so there is nowhere to place "
-                       "your modules — x takes the three reverbs (2,724 "
-                       "words), or h takes whichever you would rather lose")
+            out.append("every stock effect is on a chooser, so there is "
+                       "nowhere to place your modules — x drops the three "
+                       "reverbs (2,724 words), or take off whichever you "
+                       "would rather lose")
         if self.eff_fallback is None:
             out.append("no fallback and none can be picked automatically "
                        "(no SEND, and several effects) — press f to choose "
@@ -630,10 +601,9 @@ class State:
         fx1 = ("" if tuple(self.fx1) == stock_fx1_default()
                else '    fx1=('
                     + ", ".join(f'"{k}"' for k in self.fx1) + ',),\n')
-        from remix.schema import DEFAULT_HARVEST
-        harvest = ("" if tuple(self.harvest) == DEFAULT_HARVEST
-                   else '    harvest=('
-                        + "".join(f'"{k}", ' for k in self.harvest) + '),\n')
+        # No `harvest=` line: it is derived from the two choosers, so
+        # writing it out would be a second copy of what `modules` and `fx1`
+        # already say -- and the first one to go stale.
         return (f'"""{name} -- {doc}\n\n'
                 f'Written by the remixer. Edit freely: the docstring\n'
                 f'is the only thing here a human is expected to improve.\n'
@@ -645,5 +615,4 @@ class State:
                 f'    modules=({mods},),\n'
                 f'    fallback={fb},\n'
                 f'{fx1}'
-                f'{harvest}'
                 f')\n')

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -285,6 +285,64 @@ class State:
             for junk in (ROOT / "remixes/__pycache__").glob("_tui_scratch*"):
                 junk.unlink(missing_ok=True)
 
+    def measure_every(self, note=None):
+        """Word counts for EVERY module of ours, not just the selection.
+
+        The build only reports what it PLACED, so a module you have not added
+        had no number and the pane said "build to measure" -- which is
+        circular: the cost is what you want to know BEFORE adding it. Each
+        module is assembled once beside SEND, which is what audition.py
+        already does for an insert, and one takes ~0.19 s.
+
+        Cached on disk against the newest module source, so it is paid once
+        per session and again only when something is edited.
+        """
+        import json
+        newest = 0.0
+        for f in (ROOT / "modules").rglob("*"):
+            if f.is_file() and "__pycache__" not in f.parts:
+                newest = max(newest, f.stat().st_mtime)
+        cache = ROOT / "out/_audition/words.json"
+        try:
+            have = json.loads(cache.read_text())
+            if have.get("stamp") == newest:
+                self.words.update(have["words"])
+                return
+        except Exception:                            # noqa: BLE001
+            pass
+        got = {}
+        for key, m in self.mods.items():
+            if m.is_stock or m.dsp is None or key in got:
+                continue
+            mods = (key,) if key == "SEND" else (key, "SEND")
+            tmp = ROOT / "remixes/_words.py"
+            tmp.write_text(
+                f'"""_words -- scratch: one module, to read its word count."""\n'
+                f'from remix.schema import Remix\n'
+                f'REMIX = Remix(name="_words", doc="one module", '
+                f'modules={mods!r}, fallback="SEND")\n')
+            try:
+                r = subprocess.run(
+                    [sys.executable, "tools/build_bus.py"], cwd=ROOT,
+                    env={**os.environ, "REMIX": "_words", "XBUS": "1",
+                         "SPEC": "1"}, capture_output=True, text=True)
+                for line in r.stdout.splitlines():
+                    mm = re.match(r"\s{2}(\S.*?)\s+P:0x[0-9a-f]+\.\.0x[0-9a-f]+"
+                                  r"\s+\(\s*(\d+) words\)", line)
+                    if mm and mm.group(1).strip() in self.mods:
+                        got[mm.group(1).strip()] = int(mm.group(2))
+            finally:
+                tmp.unlink(missing_ok=True)
+                for junk in (ROOT / "remixes/__pycache__").glob("_words*"):
+                    junk.unlink(missing_ok=True)
+        self.words.update(got)
+        try:
+            cache.parent.mkdir(parents=True, exist_ok=True)
+            cache.write_text(json.dumps({"stamp": newest, "words": got},
+                                        indent=2) + "\n")
+        except OSError:
+            pass
+
     # ---- scratch builds --------------------------------------------------
     def scratch_remix(self):
         """Write the live selection as the scratch remix and return its NAME,

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -23,6 +23,15 @@ from remix import ledger, registry  # noqa: E402
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 DONOR_WORDS = 2724          # per payload; build_bus.py prints the live figure
+# The ColdFire cave: the firmware's zero run at 0x400d6b00..0x400d7c3c, which
+# is where EVERYTHING a remix plants on the ColdFire lives -- the chooser
+# list, the descriptor clones, the caves and the label formatters. The build
+# reports what is LEFT of it, never the size, so the total is written down
+# here and pinned against build_bus's own NEW_LIST/ZERO_RUN_END by
+# tools/remix/selftest.py. Used is derived as CAVE_BYTES - free, which holds
+# for both list placements: a long chooser list moves the reported ceiling
+# down by exactly the 128 B the list then occupies.
+CAVE_BYTES = 0x400d7c3c - 0x400d6b00
 BUILT_IMAGE = ROOT / "out/mainos_bus.bin"
 # Stock top-level menu, to highlight what a patch adds (docs/MAINMENU.md).
 STOCK_ROOTS = {"PROJECT", "SYSTEM", "CONTROL", "MIDI"}
@@ -42,9 +51,12 @@ class State:
         self.cursor = 0
         self.words: dict[str, int] = {}      # key -> words, from a real build
         self.words_from = ""                 # which remix produced them
-        # [(payload, used, free)] as the last build reported them. TWO
-        # regions, one per payload -- see problems().
-        self.regions: list[tuple[str, int, int]] = []
+        # [(payload, total, used, free)] as the last build reported them.
+        # TWO regions, one per payload -- see problems(). The TOTAL is read
+        # from the build too rather than assumed to be DONOR_WORDS: a DEV
+        # build takes CHORUS's module as well, so the size of the region is
+        # a property of the build, not a constant of the firmware.
+        self.regions: list[tuple[str, int, int, int]] = []
         # Which of PLATE/SPRING/DARK the last build LEFT ALONE, upper-cased
         # as the build names them. Empty until a build has reported.
         self.donors_kept: set[str] = set()
@@ -275,10 +287,11 @@ class State:
                 # There is one of these PER PAYLOAD, each its own 2,724-word
                 # region. Keeping only the last was how the budget came to be
                 # reported as a single pool.
-                m = re.search(r"used (\d+)\s+FREE (\d+)", line)
+                m = re.search(r"\((\d+) words\)\s+used (\d+)\s+FREE (\d+)",
+                              line)
                 if m and payload:
                     regions.append((payload, int(m.group(1)),
-                                    int(m.group(2))))
+                                    int(m.group(2)), int(m.group(3))))
                 # WHICH DONORS SURVIVED, from the build rather than
                 # re-derived here. The three reverbs' code IS the donor
                 # region and the build nulls a donor id only where words
@@ -312,7 +325,7 @@ class State:
                 return False, (tail[-1] if tail else "build failed")
             if regions:
                 return True, ("assembled: " + " · ".join(
-                    f"{n} {u}/{u + f}" for n, u, f in regions))
+                    f"{n} {u}/{t}" for n, t, u, _f in regions))
             return True, "assembled"
         finally:
             tmp.unlink(missing_ok=True)

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -101,6 +101,15 @@ class State:
             self.sel.add(key)
             self.order.append(key)
 
+    def insert_at(self, key, i):
+        """Add a module at a CHOSEN position. Chooser order is the panel's row
+        order, so "which slot" is a real question and appending to the end is
+        only ever one answer to it."""
+        if key in self.sel:
+            return
+        self.sel.add(key)
+        self.order.insert(max(0, min(len(self.order), i)), key)
+
     def move(self, key, delta):
         """Shift a selected module earlier (-1) or later (+1) in chooser order."""
         if key not in self.sel:

--- a/tools/remix/stock.py
+++ b/tools/remix/stock.py
@@ -129,12 +129,39 @@ def _chooser_ids(addr: int, limit: int = 32) -> frozenset[int]:
     return frozenset(out)
 
 
+def _chooser_order(addr: int, limit: int = 32) -> tuple[int, ...]:
+    """The same ids IN ROW ORDER. Membership answers "is it on FX1"; order
+    answers "where", which is what a remixer composing the list needs."""
+    img = _image()
+    if img is None:
+        return ()
+
+    def rd32(a):
+        i = a - BASE
+        return int.from_bytes(img[i:i + 4], "big") if 0 <= i <= len(img) - 4 else 0
+
+    out, a = [], addr
+    for _ in range(limit):
+        ptr = rd32(a)
+        if not ptr:
+            break
+        out.append(rd32(ptr) & 0xff)    # the descriptor's own id word, P+0
+        a += 4
+    return tuple(out)
+
+
 def fx1_ids() -> frozenset[int]:
     """Effect ids the STOCK FX1 chooser lists, read from the pristine image."""
     global _fx1_ids
     if _fx1_ids is None:
         _fx1_ids = _chooser_ids(FX1_CHOOSER)
     return _fx1_ids
+
+
+def fx1_order() -> tuple[int, ...]:
+    """Those ids in stock's own row order, NONE (0x00) included at row 0 --
+    which is where the remixer's default FX1 chooser comes from."""
+    return _chooser_order(FX1_CHOOSER)
 
 
 def _params(desc_E: int, effect: str, key: str) -> tuple[Param, ...]:

--- a/tools/remix/stock.py
+++ b/tools/remix/stock.py
@@ -357,6 +357,42 @@ def p_spans(payload: str) -> dict[str, tuple[int, int]]:
 CONSUMED = ("PLATE REV", "SPRING REV", "DARK REV")
 
 
+def harvested(listed) -> frozenset[str]:
+    """Stock effects with DSP code that are on NEITHER chooser.
+
+    ⚠️ HARVESTING IS NOT A SEPARATE GESTURE. Taking an effect off both of the
+    unit's menus IS the decision to give it up -- there is no third thing to
+    remember and no second key. What it costs is only paid where our code
+    actually reaches: an unlisted effect the placer never gets to keeps its
+    algorithm and its dispatch, exactly as it always has.
+
+    ⚠️ BOTH choosers. An effect off FX2 but still on FX1 is still wanted, and
+    the DSP dispatch is one table shared by the menus -- overwriting its code
+    would take it off FX1 too.
+    """
+    return frozenset(k for k in p_spans("A") if k not in listed)
+
+
+def region_of(harvest) -> tuple[str, ...]:
+    """The largest CONTIGUOUS run of harvested effects, in address order.
+
+    A module of ours is one code stream, so it needs unbroken ground. The
+    effects outside the chosen run are not lost -- nothing is placed over
+    them, so they keep their code and simply have no chooser row.
+    """
+    sp = p_spans("A")
+    runs, cur = [], []
+    for a, k in sorted((sp[k][0], k) for k in harvest if k in sp):
+        if cur and sp[cur[-1]][0] + sp[cur[-1]][1] != a:
+            runs.append(cur)
+            cur = []
+        cur.append(k)
+    if cur:
+        runs.append(cur)
+    return tuple(max(runs, key=lambda g: sum(sp[k][1] for k in g),
+                     default=[]))
+
+
 def harvest_order(harvest=CONSUMED) -> tuple[str, ...]:
     """A harvested set in P-ADDRESS order, which is placement order.
 
@@ -382,22 +418,6 @@ def consumed_at(key: int | str, harvest=CONSUMED) -> int:
             return at
         at += WORDS[c]
     raise KeyError(key)
-
-
-def harvest_neighbours(harvest=CONSUMED) -> frozenset[str]:
-    """The effects that could JOIN a harvested run without breaking it.
-
-    A module of ours is one code stream, so the run has to stay contiguous:
-    only the effect immediately below the bottom of it and the one
-    immediately above the top can be added.
-    """
-    sp = p_spans("A")
-    run = sorted(sp[k] for k in harvest if k in sp)
-    if not run:
-        return frozenset(sp)
-    lo, (ha, hn) = run[0][0], run[-1]
-    return frozenset(k for k, (a, n) in sp.items()
-                     if a + n == lo or a == ha + hn)
 
 
 def region_words(harvest=CONSUMED) -> int:

--- a/tools/remix/stock.py
+++ b/tools/remix/stock.py
@@ -312,7 +312,7 @@ _P_ORDER = (("FILTER", (727,)), ("SPATIALIZER", (261,)), ("EQUALIZER", (282,)),
             ("PHASER", (157, 6, 6, 6, 32)), ("FLANGER", (289,)),
             ("CHORUS", (329,)), ("PLATE REV", (594,)), ("SPRING REV", (1063,)),
             ("DARK REV", (1067,)), ("COMPRESSOR", (180,)), ("LO-FI", (537,)),
-            ("DJ EQ", (345,)), ("COMB", (277,)))
+            ("DJ EQ", (345,)), ("COMB FILTER", (277,)))
 _spans: dict[str, dict[str, tuple[int, int]]] = {}
 
 
@@ -357,19 +357,53 @@ def p_spans(payload: str) -> dict[str, tuple[int, int]]:
 CONSUMED = ("PLATE REV", "SPRING REV", "DARK REV")
 
 
-def consumed_at(key: int | str) -> int:
-    """Words our modules may place before this donor's code is overwritten.
+def harvest_order(harvest=CONSUMED) -> tuple[str, ...]:
+    """A harvested set in P-ADDRESS order, which is placement order.
 
-    The region is contiguous and packed from PLATE upward, so PLATE goes
-    first and DARK survives longest. build_bus.py asserts the contiguity and
-    that the three sum to the region, so a drift here cannot pass quietly.
+    The region is packed from its lowest address upward, so the effect at the
+    bottom goes first and the one at the top survives longest. Written down
+    for the three reverbs until 3 Sep 2026; sorted from the image now,
+    because any run of effects can be harvested and nothing says a remix
+    lists them in address order.
+    """
+    sp = p_spans("A")
+    return tuple(sorted(harvest, key=lambda k: sp[k][0]))
+
+
+def consumed_at(key: int | str, harvest=CONSUMED) -> int:
+    """Words our modules may place before this effect's code is overwritten.
+
+    build_bus.py asserts the harvested run is contiguous and places from its
+    lowest address, so a drift here cannot pass quietly.
     """
     at = 0
-    for c in CONSUMED:
+    for c in harvest_order(harvest):
         if c == key:
             return at
         at += WORDS[c]
     raise KeyError(key)
+
+
+def harvest_neighbours(harvest=CONSUMED) -> frozenset[str]:
+    """The effects that could JOIN a harvested run without breaking it.
+
+    A module of ours is one code stream, so the run has to stay contiguous:
+    only the effect immediately below the bottom of it and the one
+    immediately above the top can be added.
+    """
+    sp = p_spans("A")
+    run = sorted(sp[k] for k in harvest if k in sp)
+    if not run:
+        return frozenset(sp)
+    lo, (ha, hn) = run[0][0], run[-1]
+    return frozenset(k for k, (a, n) in sp.items()
+                     if a + n == lo or a == ha + hn)
+
+
+def region_words(harvest=CONSUMED) -> int:
+    """The whole placeable region for a harvested set. 2,724 for the three
+    reverbs, which is the figure every document quoted as a constant."""
+    return sum(WORDS[k] for k in harvest)
 
 # The one stock row with nothing on the DSP to render.
 NO_DSP = frozenset({"DELAY"})

--- a/tools/remix/stock.py
+++ b/tools/remix/stock.py
@@ -292,6 +292,68 @@ MODULES = (
 # reached -- which is why they are listable at all. Nothing here decides
 # that; the build reports which survived and the remixer reads its answer
 # (state.measure). Kept as a tuple because the ORDER is the meaning.
+# ---- where each effect's CODE lives, per payload ---------------------------
+# The thirteen DSP effects are laid out CONTIGUOUSLY and every one of them is
+# self-contained: no control flow leaves its own span and nothing enters it
+# but its own dispatch entry (measured 3 Sep 2026, tools/dsp_reach.py over
+# both payloads; the one apparent exception is PLATE's `do #<$6,>$1267`,
+# whose operand is a loop END and therefore exclusive). That is what makes
+# any of them harvestable for its words, not just the three reverbs.
+#
+#   payload A  P:0x007d1..0x01fdf     payload B  P:0x00591..0x01d9f
+#   6,158 words each, same effects, same sizes, different bases.
+#
+# ⚠️ DERIVED FROM THE MODULE MAP, not written down. The record SIZES in P
+# order are the fingerprint, and PHASER is four records past its own -- its
+# true extent runs 41 words past what its record claims (docs/DSP.md s8), so
+# it is matched as a group. A firmware whose layout differs fails to match
+# and raises rather than handing back plausible addresses.
+_P_ORDER = (("FILTER", (727,)), ("SPATIALIZER", (261,)), ("EQUALIZER", (282,)),
+            ("PHASER", (157, 6, 6, 6, 32)), ("FLANGER", (289,)),
+            ("CHORUS", (329,)), ("PLATE REV", (594,)), ("SPRING REV", (1063,)),
+            ("DARK REV", (1067,)), ("COMPRESSOR", (180,)), ("LO-FI", (537,)),
+            ("DJ EQ", (345,)), ("COMB", (277,)))
+_spans: dict[str, dict[str, tuple[int, int]]] = {}
+
+
+def p_spans(payload: str) -> dict[str, tuple[int, int]]:
+    """{effect key: (P address, words)} for one payload's DSP effect code.
+
+    The run is found by matching the record-size fingerprint above, so the
+    addresses come from the image every time and a layout change is a
+    KeyError rather than a wrong write.
+    """
+    if payload in _spans:
+        return _spans[payload]
+    import sys as _sys, pathlib as _pl
+    _sys.path.insert(0, str(_pl.Path(__file__).resolve().parents[1]))
+    import dsp_modmap as dm
+    img = dm.IMG.read_bytes()
+    va, ln = [(v, l) for t, v, l in dm.PAYLOADS if t == payload][0]
+    mods, _b = dm.modules(img, va, ln)
+    recs = [(a, c) for sp, a, c, _o in sorted(mods, key=lambda m: m[1])
+            if sp == 0]
+    want = [n for _k, g in _P_ORDER for n in g]
+    sizes = [c for _a, c in recs]
+    for i in range(len(sizes) - len(want) + 1):
+        if sizes[i:i + len(want)] != want:
+            continue
+        out, j = {}, i
+        for key, group in _P_ORDER:
+            out[key] = (recs[j][0], sum(group))
+            j += len(group)
+        # Contiguity is the property the whole idea rests on -- assert it
+        # rather than trusting that adjacent records are adjacent addresses.
+        run = sorted(out.values())
+        for (a, n), (a2, _n2) in zip(run, run[1:]):
+            if a + n != a2:
+                raise ValueError(f"payload {payload}: effect code is not "
+                                 f"contiguous at P:0x{a:05x}+{n}")
+        _spans[payload] = out
+        return out
+    raise ValueError(f"payload {payload}: no run matches the effect layout")
+
+
 CONSUMED = ("PLATE REV", "SPRING REV", "DARK REV")
 
 

--- a/tools/remix/stock.py
+++ b/tools/remix/stock.py
@@ -223,11 +223,39 @@ MODULES = (
            "Stock Echo Freeze delay -- runs on the ColdFire, so it costs the "
            "DSP nothing; the row works as on a stock unit. No local render.",
            "Y"),
+    # ---- THE THREE REVERBS, listable since 2 Sep 2026 -------------------
+    # Their code IS the donor region, so they are the only stock rows whose
+    # availability depends on the rest of the selection: the build packs from
+    # PLATE upward and nulls a donor id ONLY where words actually landed
+    # (build_bus.py), so a light selection keeps the ones it never reached.
+    # It refuses a row whose words were taken, which is the guard that makes
+    # listing them safe.
+    #
+    # buffer=True is MEASURED, not assumed: all three read x:>$213 -- the
+    # host's bump allocator -- within the first ~25 words of their entry
+    # (PLATE 0x01018, SPRING 0x01267, DARK 0x01692; payload A disassembly,
+    # 2 Sep 2026), exactly like the four stock effects already flagged. So
+    # the ledger refuses them beside any module with fixed Y buffers, on the
+    # same grounds and with the same evidence.
+    _stock("PLATE REV", "plate", 0x14, 0x400d5594, b"PLTE", b"PLATE REV", 594,
+           "Stock plate reverb. Its 594 words are the FIRST of the donor "
+           "region, so it is the first row any module of ours takes.",
+           "T", buffer=True),
+    _stock("SPRING REV", "spring", 0x15, 0x400d5726, b"SPRG", b"SPRING REV",
+           1063,
+           "Stock spring reverb. 1,063 words, second in the donor region.",
+           "U", buffer=True),
+    _stock("DARK REV", "dark", 0x16, 0x400d58b8, b"DARK", b"DARK REV", 1067,
+           "Stock dark reverb. 1,067 words, last in the donor region -- so "
+           "it is the one a small selection is most likely to keep.",
+           "V", buffer=True),
 )
 
-# What every remix consumes, whether it lists anything or not: the three
-# reverbs whose code IS the donor region. Named here so the composer can
-# say so rather than leaving it to be inferred from a manifest comment.
+# The donor region, IN PLACEMENT ORDER. The build packs from PLATE upward,
+# so a selection loses them in this order and keeps the tail it never
+# reached -- which is why they are listable at all. Nothing here decides
+# that; the build reports which survived and the workbench reads its answer
+# (state.measure). Kept as a tuple because the ORDER is the meaning.
 CONSUMED = ("PLATE REV", "SPRING REV", "DARK REV")
 
 # The one stock row with nothing on the DSP to render.

--- a/tools/remix/stock.py
+++ b/tools/remix/stock.py
@@ -179,8 +179,17 @@ def _params(desc_E: int, effect: str, key: str) -> tuple[Param, ...]:
     return tuple(out)
 
 
+# key -> the words its DSP code occupies, from the payload module map. Only
+# the three donors' figures are load-bearing (the region is packed from PLATE
+# upward, so each survives while our modules stay under its offset); the rest
+# are recorded because the call sites already carried them and dropping them
+# on the floor is how a number goes stale unnoticed.
+WORDS: dict[str, int] = {}
+
+
 def _stock(key, name, fx2_id, desc, abbr, fullname, words, doc, char,
            buffer=False):
+    WORDS[key] = words
     return Module(
         name=name, key=key, kind=Kind.STOCK, doc=doc,
         menu=MenuEntry(fx2_id=fx2_id, donor_desc=desc, abbr=abbr,
@@ -257,6 +266,21 @@ MODULES = (
 # that; the build reports which survived and the workbench reads its answer
 # (state.measure). Kept as a tuple because the ORDER is the meaning.
 CONSUMED = ("PLATE REV", "SPRING REV", "DARK REV")
+
+
+def consumed_at(key: int | str) -> int:
+    """Words our modules may place before this donor's code is overwritten.
+
+    The region is contiguous and packed from PLATE upward, so PLATE goes
+    first and DARK survives longest. build_bus.py asserts the contiguity and
+    that the three sum to the region, so a drift here cannot pass quietly.
+    """
+    at = 0
+    for c in CONSUMED:
+        if c == key:
+            return at
+        at += WORDS[c]
+    raise KeyError(key)
 
 # The one stock row with nothing on the DSP to render.
 NO_DSP = frozenset({"DELAY"})

--- a/tools/remix/stock.py
+++ b/tools/remix/stock.py
@@ -373,24 +373,39 @@ def harvested(listed) -> frozenset[str]:
     return frozenset(k for k in p_spans("A") if k not in listed)
 
 
-def region_of(harvest) -> tuple[str, ...]:
-    """The largest CONTIGUOUS run of harvested effects, in address order.
+def regions_of(harvest) -> tuple[tuple[str, ...], ...]:
+    """Harvested effects grouped into CONTIGUOUS runs, in address order.
 
-    A module of ours is one code stream, so it needs unbroken ground. The
-    effects outside the chosen run are not lost -- nothing is placed over
-    them, so they keep their code and simply have no chooser row.
+    A module of ours is one code stream, so it must fit inside ONE run --
+    but different modules can sit in different runs, which is what
+    build_bus.py's placer does. So every harvested effect is placeable
+    ground, and the only cost of a gap is fragmentation: a module larger
+    than the biggest run has nowhere to go even when the total is ample.
+
+    Until 3 Sep 2026 this returned the LARGEST run alone and the rest were
+    given up for nothing -- visible in the remixer as "drop two effects,
+    free only the reverbs" (Sam, 3 Sep). A stranded run is now placeable.
     """
     sp = p_spans("A")
     runs, cur = [], []
     for a, k in sorted((sp[k][0], k) for k in harvest if k in sp):
         if cur and sp[cur[-1]][0] + sp[cur[-1]][1] != a:
-            runs.append(cur)
+            runs.append(tuple(cur))
             cur = []
         cur.append(k)
     if cur:
-        runs.append(cur)
-    return tuple(max(runs, key=lambda g: sum(sp[k][1] for k in g),
-                     default=[]))
+        runs.append(tuple(cur))
+    return tuple(runs)
+
+
+def region_of(harvest) -> tuple[str, ...]:
+    """Every harvested effect with DSP code, in address order.
+
+    Kept as the name the callers use for "the placeable set". It is no
+    longer a single run -- see regions_of() for the grouping the placer
+    needs.
+    """
+    return tuple(k for run in regions_of(harvest) for k in run)
 
 
 def harvest_order(harvest=CONSUMED) -> tuple[str, ...]:
@@ -409,8 +424,10 @@ def harvest_order(harvest=CONSUMED) -> tuple[str, ...]:
 def consumed_at(key: int | str, harvest=CONSUMED) -> int:
     """Words our modules may place before this effect's code is overwritten.
 
-    build_bus.py asserts the harvested run is contiguous and places from its
-    lowest address, so a drift here cannot pass quietly.
+    ⚠️ ONLY MEANINGFUL FOR A SINGLE RUN. It walks the harvested set as one
+    packed stream; since 3 Sep 2026 the placer fills each contiguous run
+    separately (regions_of), so with a gap this over-counts what precedes an
+    effect in the later run. Callers gate on len(regions_of(...)) < 2.
     """
     at = 0
     for c in harvest_order(harvest):

--- a/tools/remix/stock.py
+++ b/tools/remix/stock.py
@@ -97,6 +97,46 @@ def _image():
     return _img
 
 
+# ---- which MENU a stock effect appears on ----------------------------------
+# FX1 and FX2 are two slots on the same track, and stock gives them DIFFERENT
+# chooser lists: FX1 offers ten effects, FX2 offers those ten plus DELAY and
+# the three reverbs. That asymmetry is why taking the reverbs as donors cost
+# FX1 nothing -- they were never on its menu.
+#
+# Read from the pristine image rather than written down, so it cannot drift.
+# (Both stock lists open with a NONE row, id 0x00 -- which our rebuilt FX2
+# list drops. Noted 2 Sep 2026 from an outside report; see PLAN.)
+FX1_CHOOSER, FX2_CHOOSER = 0x400d6060, 0x400d6090
+_fx1_ids: frozenset[int] | None = None
+
+
+def _chooser_ids(addr: int, limit: int = 32) -> frozenset[int]:
+    img = _image()
+    if img is None:
+        return frozenset()
+
+    def rd32(a):
+        i = a - BASE
+        return int.from_bytes(img[i:i + 4], "big") if 0 <= i <= len(img) - 4 else 0
+
+    out, a = set(), addr
+    for _ in range(limit):
+        ptr = rd32(a)
+        if not ptr:
+            break
+        out.add(rd32(ptr) & 0xff)       # the descriptor's own id word, P+0
+        a += 4
+    return frozenset(out)
+
+
+def fx1_ids() -> frozenset[int]:
+    """Effect ids the STOCK FX1 chooser lists, read from the pristine image."""
+    global _fx1_ids
+    if _fx1_ids is None:
+        _fx1_ids = _chooser_ids(FX1_CHOOSER)
+    return _fx1_ids
+
+
 def _params(desc_E: int, effect: str, key: str) -> tuple[Param, ...]:
     """The twelve slots as the stock descriptor declares them, or () when
     the image is not on disk."""

--- a/tools/remix/stock.py
+++ b/tools/remix/stock.py
@@ -19,7 +19,7 @@ it is its list row and its cursor position, and nothing else.
 ITS KNOBS ARE READ FROM THE STOCK DESCRIPTOR, not declared: names, defaults,
 value counts and the enable bitmap come out of the pristine image
 (out/raw/section_3_MAIN_OS.bin, the same record the panel draws from), so
-the workbench shows a stock effect's real page-1/page-2 controls and
+the remixer shows a stock effect's real page-1/page-2 controls and
 `send_probe --set` can drive them by name. The build never writes these
 params back (a stock row is not cloned), and when the image is absent --
 a fresh clone before `make setup` -- the entry simply carries no params.
@@ -160,7 +160,7 @@ def _params(desc_E: int, effect: str, key: str) -> tuple[Param, ...]:
             continue
         # Two slots can share a panel label (FILTER draws Q on page 1 and a
         # 4-step Q select on page 2). knob_map() is name-keyed, so the later
-        # one gets its page number appended for the workbench and the
+        # one gets its page number appended for the remixer and the
         # harness; the panel itself is untouched (nothing here is written).
         if name in seen:
             name = name[:5] + b"2"
@@ -263,7 +263,7 @@ MODULES = (
 # The donor region, IN PLACEMENT ORDER. The build packs from PLATE upward,
 # so a selection loses them in this order and keeps the tail it never
 # reached -- which is why they are listable at all. Nothing here decides
-# that; the build reports which survived and the workbench reads its answer
+# that; the build reports which survived and the remixer reads its answer
 # (state.measure). Kept as a tuple because the ORDER is the meaning.
 CONSUMED = ("PLATE REV", "SPRING REV", "DARK REV")
 

--- a/tools/remix/stock_labels.json
+++ b/tools/remix/stock_labels.json
@@ -198,5 +198,24 @@
    "OFF",
    "ON"
   ]
+ },
+ "PLATE REV": {
+  "MIXF": [
+   "MIX",
+   "SEND"
+  ]
+ },
+ "SPRING REV": {
+  "TYPE": [
+   "1",
+   "2",
+   "3"
+  ]
+ },
+ "DARK REV": {
+  "MIXF": [
+   "MIX",
+   "SEND"
+  ]
  }
 }

--- a/tools/send_probe.py
+++ b/tools/send_probe.py
@@ -180,15 +180,27 @@ def entry_points(mem_path, fxid):
     init, proc = found.get(INIT_TAB + fxid), found.get(PROC_TAB + fxid)
     if init is None or proc is None:
         die(f"no dispatch entry for fx id 0x{fxid:02x} in {pathlib.Path(mem_path).name}")
-    # ⚠️ `proc == init + 1` USED TO BE THE TEST, and it was an accident of every
-    # init being a bare `rts`. It stopped being true on 17 Aug 2026 when the
-    # bus clients gained a rotation seed at init, and it failed as "implausible
-    # entry points" -- which reads like a stale dispatch table rather than a
-    # tool assumption. The real invariant is that proc follows init and init is
-    # SHORT: it seeds per-instance state, it does not process audio.
-    if not 0 < init < 0x20000 or not init < proc <= init + 64:
+    # ⚠️ THIS BOUND HAS BEEN WRONG TWICE, BOTH TIMES BY BEING FITTED TO THE
+    # EFFECTS THAT HAPPENED TO HAVE BEEN RENDERED. `proc == init + 1` was the
+    # first test, an accident of every init being a bare `rts`; it broke on
+    # 17 Aug 2026 when the bus clients gained a rotation seed. `init + 64`
+    # was the second, and it broke on 2 Sep 2026 the moment the three stock
+    # reverbs became renderable -- they seed a tank, so their init is real
+    # code. Both failed as "implausible entry points", which reads like a
+    # stale dispatch table rather than a tool assumption.
+    #
+    # MEASURED, every effect in the pristine image (payload A) plus ours:
+    #   ours, and stock DELAY        1
+    #   the other ten stock effects  5..32   (max CHORUS 32)
+    #   PLATE / SPRING / DARK REV    85 / 108 / 162
+    # So 256: comfortably past the real maximum, and still tight enough that
+    # a wrong table -- which gives a wild address or proc before init -- is
+    # caught. The invariant itself is unchanged: proc follows init, and init
+    # seeds per-instance state rather than processing audio.
+    _MAX_INIT = 256
+    if not 0 < init < 0x20000 or not init < proc <= init + _MAX_INIT:
         die(f"implausible entry points for 0x{fxid:02x}: init 0x{init:05x} "
-            f"proc 0x{proc:05x} (want init < proc <= init+64)")
+            f"proc 0x{proc:05x} (want init < proc <= init+{_MAX_INIT})")
     return init, proc
 
 

--- a/tools/stock_labels.py
+++ b/tools/stock_labels.py
@@ -12,9 +12,9 @@ Each is printed by the slot's "A" display formatter, a ColdFire function
 `fmt(char *buf, int value)` (docs/PARAM_PAGES.md section 7). So rather than
 hand-decode eleven formatters and keep the table honest by inspection, this
 runs each one on the emulated ColdFire (tools/emu_bringup.py's detour call,
-the same machine the workbench draws its screens with) for every legal
+the same machine the remixer draws its screens with) for every legal
 value and records what it wrote. The result is checked in as JSON because
-the emulator lives in the workbench's venv and the registry must load
+the emulator lives in the remixer's venv and the registry must load
 without it; `--check` (run by the selftest when unicorn is present) proves
 the JSON is still what the firmware prints.
 

--- a/tools/verify_labels.py
+++ b/tools/verify_labels.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Our mode selects print their WORDS on the unit, not their numbers.
+
+    python3 tools/verify_labels.py [remix]        (default: chongbong)
+
+PLAN §6's gate. `Param.labels` used to be authored, schema-checked and then
+never read -- the panel drew `1 2 3` where the manifest said FOLD RING BOTH.
+The build now plants a small ColdFire formatter per labelled select
+(tools/label_fmt.py) and registers it as that slot's "A" callback, so this
+asks the FIRMWARE what each one prints and compares it with the manifest.
+
+It is the same method tools/stock_labels.py uses for the stock selects: the
+words are PRINTED, not stored, so the only honest way to read them back is to
+call the formatter. Everything here runs on the emulated ColdFire -- no flash.
+
+Also checked: an OUT-OF-RANGE value. A part stores the raw byte, so a saved
+project can hand a select a value past its count; the formatter clamps to
+label 0 rather than indexing off the end of its table.
+"""
+import os
+import pathlib
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+BASE = 0x40000400
+CLONE_BASE, CLONE_STRIDE = 0x400d6b20, 0x1a0
+P_FMT_A = 0x0ca
+BUF = 0x47f00800                 # stock_labels' scratch: above the detour stack
+IMAGE = pathlib.Path("out/mainos_bus.bin")
+
+
+def main():
+    from remix import registry
+    name = sys.argv[1] if len(sys.argv) > 1 else "chongbong"
+    env = {**os.environ, "REMIX": name, "XBUS": "1", "SPEC": "1"}
+    r = subprocess.run([sys.executable, "tools/build_bus.py"],
+                       capture_output=True, text=True, env=env)
+    if r.returncode != 0:
+        tail = (r.stdout + r.stderr).strip().splitlines()
+        sys.exit(f"{name}: build failed: {tail[-1] if tail else '?'}")
+    img = IMAGE.read_bytes()
+
+    def rd32(a):
+        return int.from_bytes(img[a - BASE:a - BASE + 4], "big")
+
+    import emu_bringup as emu
+    boot = emu.boot(str(IMAGE))
+    uc = boot.uc
+    mods = registry.modules()
+    remix = registry.remix(name)
+    cloned = [k for k in remix.modules if not mods[k].is_stock
+              and mods[k].menu is not None]
+    fails, checked = [], 0
+    for ci, key in enumerate(cloned):
+        m = mods[key]
+        P = CLONE_BASE + ci * CLONE_STRIDE
+        for i, p in enumerate(m.params):
+            if not (p.active and p.labels):
+                continue
+            fmt = rd32(P + P_FMT_A + i * 4)
+            got = []
+            for v in range(len(p.labels)):
+                uc.mem_write(BUF, b"\0" * 32)
+                emu._call(uc, fmt, (BUF, v))
+                got.append(emu._cstr(uc, BUF, 16))
+            checked += 1
+            if tuple(got) != tuple(p.labels):
+                fails.append(f"{key} slot {i} {p.name.decode('latin1')}: "
+                             f"firmware prints {got}, manifest says "
+                             f"{list(p.labels)}")
+                continue
+            # A part stores the raw byte, so a value past the count is
+            # reachable from a saved project. It must clamp, not index off
+            # the end of the table into whatever follows the cave.
+            uc.mem_write(BUF, b"\0" * 32)
+            emu._call(uc, fmt, (BUF, 200))
+            over = emu._cstr(uc, BUF, 16)
+            if over != p.labels[0]:
+                fails.append(f"{key} slot {i} {p.name.decode('latin1')}: "
+                             f"value 200 printed {over!r}, not the clamped "
+                             f"{p.labels[0]!r}")
+                continue
+            print(f"  [PASS] {key:13} slot {i:<2} "
+                  f"{p.name.decode('latin1'):<5} prints {' | '.join(got)}")
+    for f in fails:
+        print(f"  [FAIL] {f}")
+    if not checked:
+        print(f"  [SKIP] {name} has no labelled selects")
+    print("OK" if not fails else f"{len(fails)} FAILED")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify_menu.py
+++ b/tools/verify_menu.py
@@ -56,6 +56,7 @@ FX1_CHOOSER = 0x400d6060
 FX1_ID2POS = 0x400d60d0                 # FX1's own cursor-row table
 FX1_LIST_REFS = [0x40037990, 0x40052706, 0x40059bd2]
 FX1_NONE = 0x400d4618
+FX1_ROWCOUNT_AT = 0x40059be6            # FX1's viewport literal
 
 # name -> (effect id, chooser position), derived from the SELECTED REMIX
 # (REMIX=<name> env, same default as the build) -- the image being verified
@@ -329,12 +330,14 @@ def main():
     _fx1_ids = {_MODS[k].menu.fx2_id for k in REMIX.fx1}
     _skip = set()
     for _eid in _fx1_ids:
-        for _t in (FX1_ID_LOOKUP, FX1_ID2POS):
-            _a = _t + _eid * 4 - BASE
-            _skip.update(range(_a, _a + 4))
+        _a = FX1_ID_LOOKUP + _eid * 4 - BASE
+        _skip.update(range(_a, _a + 4))
     if REMIX.fx1:
-        # The stock list is left where it is; the refs point elsewhere.
+        # The stock list is left where it is; the refs point elsewhere. The
+        # cursor table is rewritten WHOLE (every dropped id clamped to row
+        # 0), which the FX1 section above checks entry by entry.
         _skip.update(range(FX1_CHOOSER - BASE, FX1_CHOOSER - BASE + 0x40))
+        _skip.update(range(FX1_ID2POS - BASE, FX1_ID2POS - BASE + 0x80))
     for _eid in _rep_ids:
         _a = FX1_ID_LOOKUP + _eid * 4 - BASE
         _skip.update(range(_a, _a + 4))
@@ -364,11 +367,12 @@ def main():
     # list, and FX1's own id lookup must resolve each row to the SAME
     # descriptor the list does -- "a slot can draw a knob and publish
     # nothing" is what a disagreement between them looks like on the unit.
-    print("\n=== FX1 rows (Remix.fx1): list relocated, its three refs in "
-          "agreement, and FX1's own id and cursor tables written ===")
+    print("\n=== FX1 chooser (Remix.fx1): the list relocated and composed, "
+          "its three refs in agreement, the viewport sized to it, and FX1's "
+          "own id and cursor tables written ===")
     if not REMIX.fx1:
-        print("  --   this remix asks for none; the checks below prove FX1 "
-              "is byte-identical to stock")
+        print("  --   this remix composes no FX1 chooser; the checks above "
+              "prove FX1 is byte-identical to stock")
     else:
         _live = rd32(img, FX1_LIST_REFS[0])
         check(_live != FX1_CHOOSER,
@@ -377,35 +381,58 @@ def main():
         for _r in FX1_LIST_REFS:
             check(rd32(img, _r) == _live,
                   f"FX1 list-ref operand at 0x{_r:08x} == 0x{_live:08x}")
-        _stock_n = 0
-        while rd32(stock, FX1_CHOOSER + _stock_n * 4):
-            _stock_n += 1
-        _live_list, _i = [], 0
+        _list, _i = [], 0
         while rd32(img, _live + _i * 4):
-            _live_list.append(rd32(img, _live + _i * 4))
+            _list.append(rd32(img, _live + _i * 4))
             _i += 1
-        check(_live_list[:_stock_n] ==
-              [rd32(stock, FX1_CHOOSER + j * 4) for j in range(_stock_n)],
-              f"stock's {_stock_n} FX1 rows are unchanged and still first")
-        check(len(_live_list) == _stock_n + len(REMIX.fx1),
-              f"FX1 list is {_stock_n} + {len(REMIX.fx1)} = "
-              f"{_stock_n + len(REMIX.fx1)} rows (got {len(_live_list)})")
+        # ROW 0 IS THE FIRMWARE'S OWN NONE, always. It is how the slot is
+        # turned off, and a remix naming effects must not be able to lose it
+        # by omission.
+        check(_list[:1] == [FX1_NONE],
+              f"row 0 is the firmware's own NONE (0x{FX1_NONE:08x})")
+        check(len(_list) == len(REMIX.fx1) + 1,
+              f"FX1 list is NONE + {len(REMIX.fx1)} = {len(REMIX.fx1) + 1} "
+              f"rows (got {len(_list)})")
+        # THE VIEWPORT IS WHAT MAKES A SHORT LIST SAFE: the draw loop
+        # iterates this literal independently of the real length, so an
+        # unshrunk viewport over a short list reads past the terminator and
+        # renders raw memory as text.
+        _rows = int.from_bytes(img[FX1_ROWCOUNT_AT - BASE:
+                                   FX1_ROWCOUNT_AT - BASE + 2], "big")
+        _want = min(CHOOSER_ROWS, len(_list))
+        check(_rows == _want,
+              f"FX1 viewport row count == {_want} (got {_rows})"
+              + (" -- it scrolls" if len(_list) > CHOOSER_ROWS else ""))
+        _listed = set()
         for _n, _k in enumerate(REMIX.fx1):
-            _eid = _MODS[_k].menu.fx2_id
-            _pos = _stock_n + _n
+            _m = _MODS[_k]
+            _eid = _m.menu.fx2_id
+            _listed.add(_eid)
+            _pos = _n + 1                        # past NONE at row 0
             _ids = rd32(img, FX1_ID_LOOKUP + _eid * 4)
-            check(_ids != FX1_NONE and _ids == _live_list[_pos],
+            check(_ids != FX1_NONE and _ids == _list[_pos],
                   f"{_k}: FX1_IDS[0x{_eid:02x}] and FX1 list row {_pos} "
                   f"resolve to the same descriptor (0x{_ids:08x})")
             check(rd32(img, FX1_ID2POS + _eid * 4) == _pos,
                   f"{_k}: FX1's cursor table puts id 0x{_eid:02x} on row "
                   f"{_pos} -- without it the chooser opens on row 0")
-            # THE SAME DESCRIPTOR BOTH MENUS USE. FX1 and FX2 keep separate
-            # id tables; pointing them at different clones would draw two
-            # different pages for one effect.
-            check(_ids == rd32(img, FX2_IDS + _eid * 4),
-                  f"{_k}: FX1 and FX2 resolve id 0x{_eid:02x} to the SAME "
-                  f"descriptor, as stock does for the ten shared effects")
+            if not _m.is_stock:
+                # THE SAME DESCRIPTOR BOTH MENUS USE. FX1 and FX2 keep
+                # separate id tables; pointing them at different clones
+                # would draw two different pages for one effect.
+                check(_ids == rd32(img, FX2_IDS + _eid * 4),
+                      f"{_k}: FX1 and FX2 resolve id 0x{_eid:02x} to the "
+                      f"SAME descriptor, as stock does for the ten shared")
+        # ⚠️ AND EVERY OTHER ID IS CLAMPED TO ROW 0. A composed FX1 list can
+        # be SHORTER than stock's eleven, so a stale cursor position from an
+        # old project holding a dropped id would seed the chooser past the
+        # last row.
+        _stale = [i for i in range(0x20)
+                  if i not in _listed and rd32(img, FX1_ID2POS + i * 4)]
+        check(not _stale,
+              "every id this list drops has its cursor row clamped to 0"
+              + (f" -- {len(_stale)} still point past the list" if _stale
+                 else ""))
 
     for name, donor_E in (("SPRING", 0x400d5726), ("DARK", 0x400d58b8),
                            ("FILTER", 0x400d4772)):

--- a/tools/verify_menu.py
+++ b/tools/verify_menu.py
@@ -295,12 +295,37 @@ def main():
     print("\n=== FX1 untouched: its own id lookup and chooser list, and every "
           "donor's OWN descriptor bytes outside our clone caves, are "
           "byte-identical to the pristine image ===")
-    check(img[FX1_ID_LOOKUP - BASE:FX1_ID_LOOKUP - BASE + 0x80] ==
-          stock[FX1_ID_LOOKUP - BASE:FX1_ID_LOOKUP - BASE + 0x80],
-          "FX1 id lookup table (0x400d5f58, 32 entries) unchanged")
-    check(img[FX1_CHOOSER - BASE:FX1_CHOOSER - BASE + 0x40] ==
-          stock[FX1_CHOOSER - BASE:FX1_CHOOSER - BASE + 0x40],
-          "FX1 chooser list (0x400d6060, 15 entries) unchanged")
+    # A DECLARED REPLACEMENT owns its target's two FX1 entries and nothing
+    # else may move. Without a replacement in the remix these are exact
+    # equality, which is what they were written as -- the exception is
+    # enumerated from the manifests rather than loosened to a range, so an
+    # undeclared change to FX1 still fails.
+    _rep_ids = {m.menu.fx2_id for m in _MODS.values()
+                if m.menu is not None and m.menu.replaces
+                and m.key in REMIX.modules}
+    _skip = set()
+    for _eid in _rep_ids:
+        _a = FX1_ID_LOOKUP + _eid * 4 - BASE
+        _skip.update(range(_a, _a + 4))
+        _stock_P = next((m.menu.donor_desc + 0x38 for m in _MODS.values()
+                         if m.is_stock and m.menu.fx2_id == _eid), None)
+        for _o in range(0, 0x40, 4):
+            if int.from_bytes(stock[FX1_CHOOSER - BASE + _o:
+                                    FX1_CHOOSER - BASE + _o + 4], "big") == _stock_P:
+                _skip.update(range(FX1_CHOOSER - BASE + _o,
+                                   FX1_CHOOSER - BASE + _o + 4))
+
+    def _same(lo, ln, what):
+        bad = [i for i in range(lo, lo + ln)
+               if i not in _skip and img[i] != stock[i]]
+        check(not bad, what + (f" -- {len(bad)} byte(s) moved that no "
+                               f"replacement declared" if bad else ""))
+    _same(FX1_ID_LOOKUP - BASE, 0x80,
+          "FX1 id lookup table (0x400d5f58, 32 entries) unchanged"
+          + (" apart from declared replacements" if _rep_ids else ""))
+    _same(FX1_CHOOSER - BASE, 0x40,
+          "FX1 chooser list (0x400d6060, 15 entries) unchanged"
+          + (" apart from declared replacements" if _rep_ids else ""))
     for name, donor_E in (("SPRING", 0x400d5726), ("DARK", 0x400d58b8),
                            ("FILTER", 0x400d4772)):
         check(img[donor_E - BASE:donor_E - BASE + 0x192] ==

--- a/tools/verify_menu.py
+++ b/tools/verify_menu.py
@@ -38,6 +38,7 @@ import os, pathlib, sys
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
 from dsp_modmap import BASE  # noqa: E402
 from remix import registry as _reg  # noqa: E402
+from remix.schema import NO_FALLBACK as _NO_FALLBACK  # noqa: E402
 
 STOCK = pathlib.Path("out/raw/section_3_MAIN_OS.bin")
 BUILT = pathlib.Path("out/mainos_bus.bin")
@@ -52,6 +53,9 @@ ID2POS = 0x400d6150
 LIST_REFS = [0x400375f4, 0x40052496, 0x40059a42]
 FX1_ID_LOOKUP = 0x400d5f58
 FX1_CHOOSER = 0x400d6060
+FX1_ID2POS = 0x400d60d0                 # FX1's own cursor-row table
+FX1_LIST_REFS = [0x40037990, 0x40052706, 0x40059bd2]
+FX1_NONE = 0x400d4618
 
 # name -> (effect id, chooser position), derived from the SELECTED REMIX
 # (REMIX=<name> env, same default as the build) -- the image being verified
@@ -63,7 +67,13 @@ REMIX = _reg.remix(os.environ.get("REMIX") or _reg.DEFAULT_REMIX)
 _MODS = _reg.modules()
 _ORDER = [k for k in REMIX.modules if _MODS[k].menu is not None]
 EXPECT = {k: (_MODS[k].menu.fx2_id, i) for i, k in enumerate(_ORDER)}
-N_REAL = len(EXPECT)                    # no NONE entry any more
+# WITH NO FALLBACK the firmware's own NONE goes back at row 0, as a stock
+# unit has it, so the list is one longer than the modules and every position
+# shifts by one.
+_NONE_ROW = 1 if REMIX.fallback == _NO_FALLBACK else 0
+if _NONE_ROW:
+    EXPECT = {k: (i, p + 1) for k, (i, p) in EXPECT.items()}
+N_REAL = len(EXPECT) + _NONE_ROW
 # STOCK rows (tools/remix/stock.py): the build writes their list row and
 # cursor position only, so what is checked for them is that everything
 # else -- descriptor bytes, FX2_IDS entry -- is byte-identical to stock.
@@ -160,11 +170,20 @@ def main():
 
     print(f"\n=== id 0 (a fresh/unassigned track) is aliased to the remix's "
           f"fallback ({FALLBACK}), so every track degrades to it by default ===")
-    fb_p = rd32(img, FX2_IDS + EXPECT[FALLBACK][0] * 4)
+    # ⚠️ A REMIX WITH NO BUS NAMES NO MODULE AS ITS FALLBACK (schema.NO_FALLBACK)
+    # and gets the firmware's own NONE instead, restored at list row 0. This
+    # script assumed a module every time and died with a KeyError on `warped`
+    # and every other no-bus remix -- a traceback, not a failed check, so
+    # `REMIX=warped make verify` reported nothing at all. Found 3 Sep 2026.
+    if FALLBACK == _NO_FALLBACK:
+        fb_p, fb_pos = FX1_NONE, 0
+    else:
+        fb_p, fb_pos = rd32(img, FX2_IDS + EXPECT[FALLBACK][0] * 4), \
+            EXPECT[FALLBACK][1]
     check(rd32(img, FX2_IDS + NONE_ID * 4) == fb_p,
           f"FX2_IDS[0x00] == {FALLBACK}'s descriptor (0x{fb_p:08x})")
-    check(rd32(img, ID2POS + NONE_ID * 4) == EXPECT[FALLBACK][1],
-          f"ID2POS[0x00] == {FALLBACK}'s position ({EXPECT[FALLBACK][1]})")
+    check(rd32(img, ID2POS + NONE_ID * 4) == fb_pos,
+          f"ID2POS[0x00] == {FALLBACK}'s position ({fb_pos})")
 
     print("\n=== FUN_40052474: list[cursor] and FUN_4005996c/FUN_400326d4's "
           "independent FX2_IDS[id] lookup must resolve to the SAME "
@@ -292,7 +311,7 @@ def main():
                       f"{name}: p{i} count {cnt} is a KNOB, so both formatters "
                       f"are 0 (got 0x{f1:08x}/0x{f2:08x})")
 
-    print("\n=== FX1 untouched: its own id lookup and chooser list, and every "
+    print("\n=== FX1: its own id lookup and chooser list, and every "
           "donor's OWN descriptor bytes outside our clone caves, are "
           "byte-identical to the pristine image ===")
     # A DECLARED REPLACEMENT owns its target's two FX1 entries and nothing
@@ -303,7 +322,19 @@ def main():
     _rep_ids = {m.menu.fx2_id for m in _MODS.values()
                 if m.menu is not None and m.menu.replaces
                 and m.key in REMIX.modules}
+    # A REMIX MAY ALSO ASK FOR FX1 ROWS OUTRIGHT (Remix.fx1), which relocates
+    # the list and writes FX1's id and cursor tables. Those edits are checked
+    # in full below; the byte-equality sweep skips exactly the entries the
+    # remix declared, so an UNdeclared change to FX1 still fails.
+    _fx1_ids = {_MODS[k].menu.fx2_id for k in REMIX.fx1}
     _skip = set()
+    for _eid in _fx1_ids:
+        for _t in (FX1_ID_LOOKUP, FX1_ID2POS):
+            _a = _t + _eid * 4 - BASE
+            _skip.update(range(_a, _a + 4))
+    if REMIX.fx1:
+        # The stock list is left where it is; the refs point elsewhere.
+        _skip.update(range(FX1_CHOOSER - BASE, FX1_CHOOSER - BASE + 0x40))
     for _eid in _rep_ids:
         _a = FX1_ID_LOOKUP + _eid * 4 - BASE
         _skip.update(range(_a, _a + 4))
@@ -320,12 +351,62 @@ def main():
                if i not in _skip and img[i] != stock[i]]
         check(not bad, what + (f" -- {len(bad)} byte(s) moved that no "
                                f"replacement declared" if bad else ""))
+    _except = ([" apart from declared replacements"] if _rep_ids else []) \
+        + ([" apart from the rows this remix asked for"] if REMIX.fx1 else [])
+    _except = " and".join(_except)
     _same(FX1_ID_LOOKUP - BASE, 0x80,
-          "FX1 id lookup table (0x400d5f58, 32 entries) unchanged"
-          + (" apart from declared replacements" if _rep_ids else ""))
+          "FX1 id lookup table (0x400d5f58, 32 entries) unchanged" + _except)
     _same(FX1_CHOOSER - BASE, 0x40,
-          "FX1 chooser list (0x400d6060, 15 entries) unchanged"
-          + (" apart from declared replacements" if _rep_ids else ""))
+          "FX1 chooser list (0x400d6060, 11 entries) unchanged" + _except)
+    # ==== FX1 rows this remix asked for ==================================
+    # The same shape as the FX2 checks above, because it is the same
+    # mechanism one table along: three `lea` sites must agree on a relocated
+    # list, and FX1's own id lookup must resolve each row to the SAME
+    # descriptor the list does -- "a slot can draw a knob and publish
+    # nothing" is what a disagreement between them looks like on the unit.
+    print("\n=== FX1 rows (Remix.fx1): list relocated, its three refs in "
+          "agreement, and FX1's own id and cursor tables written ===")
+    if not REMIX.fx1:
+        print("  --   this remix asks for none; the checks below prove FX1 "
+              "is byte-identical to stock")
+    else:
+        _live = rd32(img, FX1_LIST_REFS[0])
+        check(_live != FX1_CHOOSER,
+              f"FX1 list relocated out of 0x{FX1_CHOOSER:08x} "
+              f"(to 0x{_live:08x}) -- it cannot grow in place")
+        for _r in FX1_LIST_REFS:
+            check(rd32(img, _r) == _live,
+                  f"FX1 list-ref operand at 0x{_r:08x} == 0x{_live:08x}")
+        _stock_n = 0
+        while rd32(stock, FX1_CHOOSER + _stock_n * 4):
+            _stock_n += 1
+        _live_list, _i = [], 0
+        while rd32(img, _live + _i * 4):
+            _live_list.append(rd32(img, _live + _i * 4))
+            _i += 1
+        check(_live_list[:_stock_n] ==
+              [rd32(stock, FX1_CHOOSER + j * 4) for j in range(_stock_n)],
+              f"stock's {_stock_n} FX1 rows are unchanged and still first")
+        check(len(_live_list) == _stock_n + len(REMIX.fx1),
+              f"FX1 list is {_stock_n} + {len(REMIX.fx1)} = "
+              f"{_stock_n + len(REMIX.fx1)} rows (got {len(_live_list)})")
+        for _n, _k in enumerate(REMIX.fx1):
+            _eid = _MODS[_k].menu.fx2_id
+            _pos = _stock_n + _n
+            _ids = rd32(img, FX1_ID_LOOKUP + _eid * 4)
+            check(_ids != FX1_NONE and _ids == _live_list[_pos],
+                  f"{_k}: FX1_IDS[0x{_eid:02x}] and FX1 list row {_pos} "
+                  f"resolve to the same descriptor (0x{_ids:08x})")
+            check(rd32(img, FX1_ID2POS + _eid * 4) == _pos,
+                  f"{_k}: FX1's cursor table puts id 0x{_eid:02x} on row "
+                  f"{_pos} -- without it the chooser opens on row 0")
+            # THE SAME DESCRIPTOR BOTH MENUS USE. FX1 and FX2 keep separate
+            # id tables; pointing them at different clones would draw two
+            # different pages for one effect.
+            check(_ids == rd32(img, FX2_IDS + _eid * 4),
+                  f"{_k}: FX1 and FX2 resolve id 0x{_eid:02x} to the SAME "
+                  f"descriptor, as stock does for the ten shared effects")
+
     for name, donor_E in (("SPRING", 0x400d5726), ("DARK", 0x400d58b8),
                            ("FILTER", 0x400d4772)):
         check(img[donor_E - BASE:donor_E - BASE + 0x192] ==

--- a/tools/verify_menu.py
+++ b/tools/verify_menu.py
@@ -38,6 +38,7 @@ import os, pathlib, sys
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
 from dsp_modmap import BASE  # noqa: E402
 from remix import registry as _reg  # noqa: E402
+from remix import rig as _rig  # noqa: E402
 from remix.schema import NO_FALLBACK as _NO_FALLBACK  # noqa: E402
 
 STOCK = pathlib.Path("out/raw/section_3_MAIN_OS.bin")
@@ -433,6 +434,46 @@ def main():
               "every id this list drops has its cursor row clamped to 0"
               + (f" -- {len(_stale)} still point past the list" if _stale
                  else ""))
+
+    # ==== the descriptor each module's id RESOLVES TO ======================
+    # ⚠️ THE FIELDS A CLONE INHERITS FROM ITS DONOR. A cloned descriptor is
+    # copied whole and then written over, so anything the build does not
+    # write stays the donor's -- and some of those fields outrank the ones it
+    # does write. A slot can carry the right count, default, name and enable
+    # bit and still draw as something else entirely, or as nothing at all:
+    # three of six page-2 slots drew wrong on the 17 Aug 2026 flash and every
+    # check then in place passed, because every field they checked was right.
+    #
+    # So the built descriptor is read BACK and compared to the manifest that
+    # asked for it. This lived in the remixer's UNIT pane for a day (3 Sep
+    # 2026) and does not belong there: it is a check, and a check belongs
+    # where a mismatch FAILS THE BUILD rather than where it has to be
+    # noticed in the corner of a pane.
+    print("\n=== every module's descriptor, read back out of the image: the "
+          "name and abbreviation the panel will print, and the twelve slot "
+          "names -- all fields a clone inherits from its donor ===")
+    for name in _ORDER:
+        mod = _MODS[name]
+        if mod.is_stock:
+            continue
+        got = _rig.drawn_as(mod.menu.fx2_id, img)
+        if got is None:
+            check(False, f"{name}: its id resolves to no descriptor")
+            continue
+        want_name = mod.menu.fullname.decode("latin1")
+        check(got["name"].startswith(want_name),
+              f"{name}: the panel prints {got['name']!r}, which starts with "
+              f"the declared {want_name!r} (the build tag follows it)")
+        check(got["abbr"] == mod.menu.abbr.decode("latin1"),
+              f"{name}: its abbreviation is "
+              f"{got['abbr']!r} == {mod.menu.abbr.decode('latin1')!r}")
+        want_slots = [p.name.decode("latin1") for p in mod.params
+                      if p.active and p.name]
+        drew = [x for x in got["slots"] if x]
+        check(drew == want_slots,
+              f"{name}: its {len(want_slots)} drawn slot names are the "
+              f"manifest's, in order"
+              + ("" if drew == want_slots else f" -- got {drew}"))
 
     for name, donor_E in (("SPRING", 0x400d5726), ("DARK", 0x400d58b8),
                            ("FILTER", 0x400d4772)):

--- a/tools/verify_menu.py
+++ b/tools/verify_menu.py
@@ -104,6 +104,9 @@ P_FMT1, P_FMT2, P_FMT3 = 0x0ca, 0x0fa, 0x12a
 # The enumerated-selector pair, taken from stock CHORUS.TAPS (count 5). Stock
 # uses all-zeros for a plain numeric knob.
 STEPPED_FMT = (0x4003c718, 0x40047254)
+# The ColdFire cave region (docs/PARAM_PAGES.md section 7): clones, the tempo
+# caves and PLAN §6's label formatters all live in here and nowhere else.
+CAVE_LO, CAVE_HI = 0x400d6b20, 0x400d7c3c
 TIME_FMT = 0x400d7080          # modules/tempo-sync/time_fmt.s cave (build_bus.py TIME_FMT_CAVE)
 
 
@@ -258,9 +261,24 @@ def main():
             f2 = rd32(img, P + P_FMT2 + i * 4)
             f3 = rd32(img, P + P_FMT3 + i * 4)
             if cnt < 128:
-                check((f1, f2) == STEPPED_FMT and f3 == 0,
+                # SINCE PLAN §6 the "A" callback may be one of our label
+                # caves instead of stock's 0x4003c718 -- that is the whole
+                # point: A decides WHAT IS PRINTED, and a select that prints
+                # ROOM/PLATE/BIG rather than 1/2/3 still has to be DRAWN as a
+                # select. So the invariant this check exists for is B and
+                # 0x12a, not A: B is the tick widget, and a non-zero 0x12a
+                # forces plain-knob drawing even with the right pair (which
+                # is the defect it was written for, 17 Aug 2026).
+                #
+                # A is still constrained -- stock's enumerated formatter or
+                # an address inside the cave region, never anything else.
+                # What each cave PRINTS is proven separately, by asking the
+                # emulated firmware: tools/verify_labels.py.
+                a_ok = f1 == STEPPED_FMT[0] or CAVE_LO <= f1 < CAVE_HI
+                check(a_ok and f2 == STEPPED_FMT[1] and f3 == 0,
                       f"{name}: p{i} count {cnt} is a SELECT, so it carries "
-                      f"the enumerated formatter pair and 0x12a=0 "
+                      f"the tick widget and 0x12a=0, with A either stock's "
+                      f"enumerated formatter or a label cave "
                       f"(got 0x{f1:08x}/0x{f2:08x}/0x{f3:08x})")
             elif name == "DELAY SERVER" and i == 0 and f1 == TIME_FMT:
                 # TIME's sticky-snap label formatter (modules/tempo-sync/time_fmt.s, 24 Aug

--- a/tools/verify_replaces.py
+++ b/tools/verify_replaces.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""No stock effect is hijacked by accident.
+
+    python3 tools/verify_replaces.py [remix ...]     (default: every remix)
+
+THE FAILURE THIS EXISTS FOR. The DSP dispatch tables are indexed by the raw
+effect id and SHARED BY BOTH MENUS, so a module carrying a stock effect's id
+replaces that effect wherever it is selected -- FX1 included -- and a remix
+that omits the module then aliases the id to the fallback, taking the stock
+effect away from FX1 too. Rungs sat on EQUALIZER's 0x0c and Nimbus on DJ EQ's
+0x0d from 29 Aug to 2 Sep 2026, in every local image. Every existing check
+passed: the modules built, dispatched, rendered and sounded correct. What was
+wrong was invisible from any one module's point of view.
+
+WHAT IS CHECKED, per remix, per payload, for every stock effect id:
+
+  * the module carrying it DECLARED it (MenuEntry.replaces naming that
+    effect), or
+  * the id is untouched -- FX2_IDS still points at the stock descriptor and
+    the dispatch entries still hold the pristine image's values.
+
+THE ONE LEGITIMATE EXCEPTION is a donor reverb whose words this selection
+took: PLATE/SPRING/DARK REV's code IS the donor region, so an id whose code
+was overwritten is repointed at the null stub. That is allowed, and ONLY
+that -- a donor id may be stock or the null stub, never anything else.
+
+Static checks run with no image: a declared replacement must name a real
+stock effect and carry that effect's id.
+"""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from remix import registry, stock  # noqa: E402
+
+BASE = 0x40000400
+FX2_IDS = 0x400d5fdc
+PRISTINE = pathlib.Path("out/raw/section_3_MAIN_OS.bin")
+# (tag, xtab, null init, null proc) -- build_bus.py's PAYLOADS
+PAYLOADS = (("A", 0x400e2345, 0x007c8, 0x007c9),
+            ("B", 0x400f5a10, 0x00588, 0x00589))
+DONOR_IDS = {0x14, 0x15, 0x16}
+
+
+def rd32(img, p):
+    return int.from_bytes(img[p - BASE:p - BASE + 4], "big")
+
+
+def rdw(img, p):
+    return int.from_bytes(img[p - BASE:p - BASE + 3], "little")
+
+
+def static_checks(fails):
+    """A declared replacement must name a real stock effect, on its id."""
+    for m in registry.modules().values():
+        rep = m.menu.replaces if m.menu is not None else None
+        if not rep:
+            continue
+        target = stock.BY_KEY.get(rep)
+        if target is None:
+            fails.append(f"{m.key}: replaces={rep!r}, which is not a stock "
+                         f"effect (have: {', '.join(sorted(stock.BY_KEY))})")
+        elif target.menu.fx2_id != m.menu.fx2_id:
+            fails.append(
+                f"{m.key}: replaces={rep!r} but carries id "
+                f"0x{m.menu.fx2_id:02x}; {rep} is 0x{target.menu.fx2_id:02x}")
+        else:
+            print(f"  [PASS] {m.key} declares it replaces {rep} "
+                  f"(id 0x{m.menu.fx2_id:02x})")
+
+
+def check_image(name, img, pristine, fails):
+    mods = registry.modules()
+    remix = registry.remix(name)
+    declared = {}
+    for key in remix.modules:
+        m = mods.get(key)
+        if m is not None and m.menu is not None and m.menu.replaces:
+            declared[m.menu.fx2_id] = m.key
+    for eff in stock.MODULES:
+        eid = eff.menu.fx2_id
+        if eid in declared:
+            continue                       # asked for, and checked statically
+        want_desc = eff.menu.donor_desc + 0x38
+        got_desc = rd32(img, FX2_IDS + eid * 4)
+        if got_desc != want_desc:
+            fails.append(
+                f"{name}: FX2_IDS[0x{eid:02x}] ({eff.key}) is "
+                f"0x{got_desc:08x}, not stock's 0x{want_desc:08x} -- nothing "
+                f"in this remix declared replaces={eff.key!r}")
+        for tag, xtab, nul_i, nul_p in PAYLOADS:
+            for slot, nul in ((eid, nul_i), (32 + eid, nul_p)):
+                got = rdw(img, xtab + slot * 3)
+                want = rdw(pristine, xtab + slot * 3)
+                if got == want:
+                    continue
+                if eid in DONOR_IDS and got == nul:
+                    continue               # its words were taken; see above
+                fails.append(
+                    f"{name}: payload {tag} dispatch[0x{eid:02x}] "
+                    f"({eff.key}) is 0x{got:05x}, not stock's 0x{want:05x}"
+                    + (f" (nor the null stub 0x{nul:05x})"
+                       if eid in DONOR_IDS else ""))
+
+
+def main():
+    if not PRISTINE.exists():
+        sys.exit(f"missing {PRISTINE} -- run 'make setup'")
+    pristine = PRISTINE.read_bytes()
+    fails: list[str] = []
+    static_checks(fails)
+    names = sys.argv[1:] or [n for n in registry.remix_names()
+                             if not n.startswith("_")]
+    out = pathlib.Path("out/mainos_bus.bin")
+    # ⚠️ EVERY BUILD HERE OVERWRITES THE SHIPPING ARTIFACT, and the checks
+    # that run after this one read it. verify_burn already had to say so in
+    # the Makefile; do it here instead, so the tool cleans up after itself
+    # rather than the caller having to know. (audition.py uses the same
+    # save-and-restore for its scratch builds.)
+    saved = out.read_bytes() if out.exists() else None
+    try:
+        run(names, out, pristine, fails)
+    finally:
+        if saved is not None:
+            out.write_bytes(saved)
+    print()
+    for f in fails:
+        print(f"  [FAIL] {f}")
+    print("OK" if not fails else f"{len(fails)} FAILED")
+    return 1 if fails else 0
+
+
+def run(names, out, pristine, fails):
+    import os
+    import subprocess
+    for name in names:
+        env = {**os.environ, "REMIX": name, "XBUS": "1", "SPEC": "1"}
+        r = subprocess.run([sys.executable, "tools/build_bus.py"],
+                           capture_output=True, text=True, env=env)
+        if r.returncode != 0:
+            tail = (r.stdout + r.stderr).strip().splitlines()
+            fails.append(f"{name}: build failed: {tail[-1] if tail else '?'}")
+            continue
+        before = len(fails)
+        check_image(name, out.read_bytes(), pristine, fails)
+        if len(fails) == before:
+            print(f"  [PASS] {name}: every stock id is stock's, or declared")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify_replaces.py
+++ b/tools/verify_replaces.py
@@ -19,6 +19,13 @@ WHAT IS CHECKED, per remix, per payload, for every stock effect id:
   * the id is untouched -- FX2_IDS still points at the stock descriptor and
     the dispatch entries still hold the pristine image's values.
 
+BOTH MENUS ARE CHECKED. FX1 resolves its own descriptors (FX1_IDS, and the
+chooser list it scrolls), so an id can be correct on FX2 and wrong on FX1 --
+which is the shape of the bug this file exists for. For a stock effect
+nobody declared, FX1's two tables must read back the pristine image's
+values; for a declared replacement, both must point at the module's clone
+(or be left alone when FX1 does not list that effect at all).
+
 THE ONE LEGITIMATE EXCEPTION is a donor reverb whose words this selection
 took: PLATE/SPRING/DARK REV's code IS the donor region, so an id whose code
 was overwritten is repointed at the null stub. That is allowed, and ONLY
@@ -35,6 +42,9 @@ from remix import registry, stock  # noqa: E402
 
 BASE = 0x40000400
 FX2_IDS = 0x400d5fdc
+FX1_IDS = 0x400d5f58
+FX1_LIST = 0x400d6060
+FX1_NONE = 0x400d4618
 PRISTINE = pathlib.Path("out/raw/section_3_MAIN_OS.bin")
 # (tag, xtab, null init, null proc) -- build_bus.py's PAYLOADS
 PAYLOADS = (("A", 0x400e2345, 0x007c8, 0x007c9),
@@ -48,6 +58,17 @@ def rd32(img, p):
 
 def rdw(img, p):
     return int.from_bytes(img[p - BASE:p - BASE + 3], "little")
+
+
+def _fx1_rows(pristine):
+    """Addresses of the FX1 chooser list's entries, from the pristine image
+    (the list is never relocated by build_bus -- a replacement rewrites a row
+    in place -- so the pristine addresses are the live ones)."""
+    out, a = [], FX1_LIST
+    while rd32(pristine, a) != 0 and len(out) < 32:
+        out.append(a)
+        a += 4
+    return out
 
 
 def static_checks(fails):
@@ -79,9 +100,40 @@ def check_image(name, img, pristine, fails):
             declared[m.menu.fx2_id] = m.key
     for eff in stock.MODULES:
         eid = eff.menu.fx2_id
-        if eid in declared:
-            continue                       # asked for, and checked statically
         want_desc = eff.menu.donor_desc + 0x38
+        fx1_slot = FX1_IDS + eid * 4
+        on_fx1 = rd32(pristine, fx1_slot) != FX1_NONE
+        if eid in declared:
+            # A declared replacement must have taken FX1 too, or FX1 would
+            # run its code under the stock effect's knob names.
+            if not on_fx1:
+                continue
+            got_id = rd32(img, fx1_slot)
+            got_row = [rd32(img, a) for a in _fx1_rows(pristine)
+                       if rd32(pristine, a) == want_desc]
+            if got_id == want_desc:
+                fails.append(
+                    f"{name}: FX1_IDS[0x{eid:02x}] still points at stock "
+                    f"{eff.key}, but {declared[eid]} replaces it -- FX1 would "
+                    f"run the module under stock's knob names")
+            if got_row and got_row[0] == want_desc:
+                fails.append(
+                    f"{name}: the FX1 chooser row for {eff.key} still points "
+                    f"at stock's descriptor, but {declared[eid]} replaces it")
+            if got_id != want_desc and (not got_row or got_row[0] != want_desc):
+                print(f"  [PASS] {name}: {declared[eid]} took {eff.key}'s FX1 "
+                      f"page as well as FX2's")
+            continue
+        if on_fx1:
+            for a in (fx1_slot,) + tuple(
+                    x for x in _fx1_rows(pristine)
+                    if rd32(pristine, x) == want_desc):
+                if rd32(img, a) != rd32(pristine, a):
+                    fails.append(
+                        f"{name}: FX1 table at 0x{a:08x} ({eff.key}) is "
+                        f"0x{rd32(img, a):08x}, not stock's "
+                        f"0x{rd32(pristine, a):08x} -- nothing declared "
+                        f"replaces={eff.key!r}")
         got_desc = rd32(img, FX2_IDS + eid * 4)
         if got_desc != want_desc:
             fails.append(

--- a/tools/verify_replaces.py
+++ b/tools/verify_replaces.py
@@ -98,6 +98,14 @@ def check_image(name, img, pristine, fails):
         m = mods.get(key)
         if m is not None and m.menu is not None and m.menu.replaces:
             declared[m.menu.fx2_id] = m.key
+    # WHAT THIS REMIX GIVES UP, derived from its two choosers exactly as the
+    # build derives it: an effect on neither is one it does not want, so its
+    # words are the region and its dispatch may legitimately be the null stub.
+    _sp = stock.p_spans("A")
+    _fx1_all = {k for k in _sp
+                if mods[k].menu.fx2_id in stock.fx1_ids()}
+    _given_up = set(stock.region_of(stock.harvested(
+        set(remix.modules) | set(remix.fx1 or _fx1_all))))
     for eff in stock.MODULES:
         eid = eff.menu.fx2_id
         want_desc = eff.menu.donor_desc + 0x38
@@ -124,7 +132,7 @@ def check_image(name, img, pristine, fails):
                 print(f"  [PASS] {name}: {declared[eid]} took {eff.key}'s FX1 "
                       f"page as well as FX2's")
             continue
-        if on_fx1:
+        if on_fx1 and eff.key not in _given_up:
             for a in (fx1_slot,) + tuple(
                     x for x in _fx1_rows(pristine)
                     if rd32(pristine, x) == want_desc):
@@ -146,13 +154,18 @@ def check_image(name, img, pristine, fails):
                 want = rdw(pristine, xtab + slot * 3)
                 if got == want:
                     continue
-                if eid in DONOR_IDS and got == nul:
+                # ⚠️ ANY EFFECT ON NEITHER CHOOSER MAY HAVE BEEN HARVESTED,
+                # not just the three reverbs. Which a remix gives up is
+                # derived from its two choosers (stock.harvested), so the
+                # null stub is legitimate for any of them -- and DONOR_IDS
+                # was the last place this file assumed the fixed three.
+                if got == nul and eff.key in _given_up:
                     continue               # its words were taken; see above
                 fails.append(
                     f"{name}: payload {tag} dispatch[0x{eid:02x}] "
                     f"({eff.key}) is 0x{got:05x}, not stock's 0x{want:05x}"
                     + (f" (nor the null stub 0x{nul:05x})"
-                       if eid in DONOR_IDS else ""))
+                       if eff.key in _given_up else ""))
 
 
 def main():


### PR DESCRIPTION
Two halves of one round: make the remixer usable by someone who has not read
the source, then give it the other effect slot.

## The other slot

**A module of ours can be listed on FX1** — `Remix.fx1=("WARPFOLD",)`, and
`1` toggles it on the highlighted row in `make remix`. It was never a
hardware limit: the DSP dispatch table is indexed by the raw id and SHARED
between the menus, so the code already ran from FX1 the moment FX1 selected
the id. What was missing was the panel side, because FX1's chooser list ends
at `0x400d608c` and FX2's begins four bytes later — so it relocates into the
cave, exactly as the FX2 list already does when it outgrows its own.

It belongs to the **remix**, not the module: which menu an effect appears on
is a composition choice, like the chooser order beside it.

⚠️ **FX1 has its own cursor table and the old experiment never wrote it.**
`FX1_ID2POS` = `0x400d60d0`, the exact analogue of FX2's `ID2POS`, found by
reading the four tables in address order (it is FX1's because DELAY and the
three reverbs are zero there where `ID2POS` gives them rows). Without it a
project holding one of our effects on FX1 opens the chooser on row 0.

**It costs no words and it is not free.** The bill is CYCLES: FX1 is four
more slots on the same four tracks, so an effect on both menus can double
the worst per-core load — WarpFold 4× → 8×, 404 → 808 of the 3,120 our code
may spend. `cycle_count.py` prices those slots now, which is why cycles
became the fifth row of the Budget strip.

Proof, in the order worth having: **refhash 26/26 bit-identical** (a remix
asking for no FX1 row writes no byte and prints no line); `verify_menu.py`
checks the relocated list, its three refs, stock's eleven rows unchanged and
still first, both id tables resolving to one descriptor, and the cursor row;
and the ColdFire emulator draws it with the firmware's own code —
`WarpFold78` as row 11 of a twelve-entry FX1 chooser, its own knobs on the
page. **UNFLASHED.** `remixes/bothslots.py` is the worked example and says so.

## The newcomer pass

- **80×24 did not degrade, it broke** — the UNIT pane got six columns and
  wrapped `Stock` / `· id` / `0x04` one token per line, both lists were cut
  mid-list with no way to reach the rest, and the Budget took nine of the
  twenty-four rows. Three widths now (three panes ≥118, sliding pairs ≥92,
  one pane below), a tab bar whenever they are not all on screen, lists that
  scroll with `↑ 6 more`, and a one-line Budget under 34 rows.
- **The flagship gesture dead-ended.** Adding a server leaves a selection
  that cannot build, and the key that fixes it was hidden — so it ended at
  `????  not built` with no visible way forward. `x fix it` is on the footer
  exactly when there is a fix. ⚠️ Textual's `check_action` reads `False` as
  *hidden* and `None` as *greyed*, which is backwards from the obvious
  reading and left the key showing when there was nothing to fix.
- **The ⚠ said it twice and outlived its fix** — seven rows of a
  forty-column pane, the first of them phrased as a second unresolved error.
- **`?` was silently clipped at ~60%**, double-wrapped every paragraph into
  an orphan, and closed with a **retracted claim** ("you cannot get the
  three reverbs back", untrue since 2 Sep). It scrolls, wraps once, and says
  what the build actually does.
- LOADED says what its own keys do (`enter removes · ←→ order · 1 FX1 row`),
  and a move reports the row number the pane prints — it said `chooser row 1`
  for the row drawn as `2`.

## Fixed on the way

`verify_menu.py` died with a **KeyError traceback, not a failed check**, on
any no-fallback remix: `REMIX=warped make verify` reported nothing at all.

## Dynamic donor regions

**A stock effect's words are given up by taking it off both choosers**, and
what you gave up is placeable ground — not a fixed 2,724-word "donor region"
that happened to be the three reverbs. `stock.p_spans()` derives every
effect's span from the module map by record-size fingerprint, so a firmware
whose layout differs raises rather than being written over. The thirteen DSP
effects are contiguous (6,158 words per payload) and each is self-contained,
so **any** run of them is ground.

⚠️ **And every run is placeable, not just the largest.** The build wrote one
contiguous stream, so it took the biggest run and discarded the rest —
harvesting EQ+Phaser (adjacent, 489 words) beside the reverbs (2,724) gave up
489 words nothing could ever be placed into. Caught from the budget map:
*"when I remove the modulation it shows free space. But when I remove some
reverb it only shows the free reverb space."* `regions_of()` groups the
harvest into runs and the placer first-fits each module into a run it fits.
`bothslots` goes 3,342 → 3,880 usable words.

A gap is still a **wall**: a module is one code stream and must fit one run,
so the budget names the largest opening beside the total and the map draws a
bracket per run instead of one across the intervening stock effects.

`remixes/scattered.py` is the worked example — three runs (261 / 3,342 /
277), two of them filled. Both its modules render **bit-identical** audio to
the same modules built into a single run, and selftest builds it and requires
two modules in two different runs **per payload** (verified to go red).

## A deterministic test project

Per-part FX ids are **project data** (`PART+0x009` / `+0x011`), so they
survive a flash and get resolved against the new image's tables — which is
why a freshly flashed unit still draws the old effect's controls. Not a
defect, and a prerequisite for testing anything: `ot_project.py testproj`
copies a project and lays out one effect per part across all eight tracks.
Eight PART records (5–8 are the RELOAD PART copies), checksum recomputed and
read back. Measured on a real project: 1,968 bytes changed across sixteen
banks, none outside the FX id fields.

`docs/FLASHPLAN.md` sequences three images for the 134 commits of untested
work. **Nothing here has been flashed.**

## Gates

`make check` OK (shipping remix and `scattered`) · `scripts/refhash.sh check`
**26/26 bit-identical** · `tools/remix/selftest.py` OK · `verify_menu` /
`verify_replaces` pass on `chongbong`, `warped`, `bothslots` and `scattered`.

⚠️ **UNFLASHED, all of it.** Harvesting a non-reverb has never run on
hardware, and no local test can reach a cross-core timing defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
