### PR TITLE
Rig tooling: floating caves, replacement-safe harvest, FX1 by name, sized FX1-only buffers

### DIFF
--- a/docs/DSP.md
+++ b/docs/DSP.md
@@ -857,8 +857,10 @@ because the hook runs after the copy. Still free on those terms:
 
 `modules/tempo-sync/tempo_cave.s` (56 bytes, `m68k-elf-as -mcpu=5407`, bytes pinned in
 `build_bus.py` and re-checked against a fresh assembly when the toolchain
-is present) sits at `0x400d7000` — inside the stock zero run
-`0x400d6b00..0x400d7c3c`, just past the menu clones. The hook replaces the
+is present) FLOATS: it is planted at the first 0x80-aligned address past the
+descriptor clones, inside the stock zero run `0x400d6b00..0x400d7c3c` —
+`0x400d7000` in the shipping image, whose three clones end exactly there
+(pinned until 3 Sep 2026, when a fourth clone ran into it). The hook replaces the
 three instructions at `0x40004d40` (`move.b 0xdbc(a0),d2 / ext.w d2 /
 move.w d2,0x38(a2)`) with `jsr cave` + two `nop`s; the cave replays them,
 then **only for FX2 id 6 or 7** stores `tempo24` to `+0x24` (`r6+$6`) and
@@ -882,7 +884,7 @@ but "steps on a free dial" felt wrong) — are in the history. 1/2T and 1/4.
 are not candidates (never fit the line below ~170 BPM).
 
 **The panel prints the division** (`modules/tempo-sync/time_fmt.s`, a second ColdFire cave
-at `0x400d7080` (moved 24 Aug when the tempo cave grew to 104 bytes; was `0x400d7040`), 288 bytes, registered as TIME's `A` formatter with `B=0` —
+floating behind the tempo cave — `0x400d7080` in the shipping image (moved 24 Aug when the tempo cave grew to 104 bytes; was `0x400d7040`), 288 bytes, registered as TIME's `A` formatter with `B=0` —
 stock DELAY TIME's shape): the same rule with the same integers, its own
 `last/held` in cave RAM (per panel), `"1/8"` etc. while held, else ms.
 `PARAM_PAGES.md` §7 has the formatter ABI. `verify_menu` allows exactly

--- a/docs/MIDI.md
+++ b/docs/MIDI.md
@@ -136,8 +136,9 @@ on the RE below.
 
 ## Status (24 Aug 2026) — note → interval ON THE UNIT (R57, tag 76), hardware-confirmed
 
-- **Cave v2** (`modules/tempo-sync/tempo_cave.s`, 104 bytes at `0x400d7000`; the TIME
-  formatter cave moved to `0x400d7080`): `r6+$8` = fader+1 (1 = fully B,
+- **Cave v2** (`modules/tempo-sync/tempo_cave.s`, 104 bytes, floating behind the
+  descriptor clones — `0x400d7000` in the shipping image; the TIME formatter
+  cave follows it, `0x400d7080` there): `r6+$8` = fader+1 (1 = fully B,
   128 = fully A, 0 = no cave), `r6+$9` = held note or 0. Bytes pinned in
   `build_bus.py`. ✅ assembled, ⬜ hardware.
 - **Note → PITCH interval** (`modules/bongdelay/delay_server.asm` after `pintend`): the

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -419,7 +419,9 @@ the worked example.
 ```python
 cf_patches=(CavePatch(
     label="my cave",
-    cave_addr=0x400d7100,
+    cave_addr=None,            # floats: first free 0x80-aligned address past
+                               # the clones and earlier caves; pin an int only
+                               # if the code is not position-independent
     pinned=MY_BYTES,
     source="modules/<name>/my_cave.s",
     hook_addr=0x400xxxxx,
@@ -431,6 +433,15 @@ The pattern is always the same: assert the hook site still holds the stock
 bytes, plant a `jsr` to the cave, and have the cave replay what it displaced
 before doing its own work. The installer is generic — contributing a cave
 needs no change to the build.
+
+**Caves float unless pinned** (3 Sep 2026). A remix with more than three
+descriptor clones used to run the clone block straight into the tempo cave
+pinned at `0x400d7000` — three clones end exactly there, so the shipping
+image had fit by arithmetic coincidence. `cave_addr=None` plants the cave at
+the first free address after whatever precedes it, rounded up to `0x80`,
+which reproduces the shipping image byte for byte and clears six clones.
+Only position-independent code may float: short branches and OS absolutes,
+no absolute reference to itself (both tempo-sync caves qualify).
 
 `pinned` is what actually gets written, so the build needs no m68k toolchain.
 When one *is* present the source is re-assembled and compared, so a source
@@ -641,7 +652,7 @@ classes are refused:
 | refused | why |
 |---|---|
 | a **stock** effect FX1 does not already list | DELAY and the three reverbs do not fit a 3,072-word FX1 allocation either — that is *why* stock keeps them off it |
-| a module that reads the allocator (`x:>$213`) | it sizes its buffer for an **FX2** slot, 16,384 words; an **FX1** slot is **3,072** |
+| a module that reads the allocator (`x:>$213`) **without saying how much it uses** | it sizes its buffer for an **FX2** slot, 16,384 words; an **FX1** slot is **3,072**. Declare `Claims(stock_instance_buffer=True, buffer_words=N)` with N ≤ 3,072 and the row is allowed; add `fx1_only=True` and it may also sit beside a server (see below) |
 | a module with **fixed** buffers in the FX2 region | an FX1 instance still writes to `Y:0x4000`+, i.e. into another track's FX2 buffer |
 | a bus **server** | one per core by design; an FX1 row is a second instance on the same core |
 
@@ -664,11 +675,37 @@ per track: FX1 instance *k* and FX2 instance *k* get different blocks, so the
 same effect on both slots of one track is two independent instances that
 happen to run in series.
 
-Also refused: a `replaces` module (it already has that effect's FX1 row — a
-second would list it twice), a stock effect (its FX1 row is stock's own
-business), and a key with no FX2 chooser row of its own (nothing for FX1's
-list to point at). `verify_menu.py` proves the rest, and asserts FX1 is
-byte-identical to stock in every remix that asks for nothing.
+**A `replaces` module is listed on FX1 by its own key** (since 3 Sep 2026):
+`fx1=("FILTER STATION", ...)`, never the stock key it replaces — the build
+refuses `fx1=("FILTER",)` beside a module that replaces FILTER, because
+that row would draw the stock name over our code. A composed list is
+rebuilt from scratch in the cave, so the stock row the replacement inherited
+cannot appear beside it (the old refusal, "would list it twice", was true
+of the in-place stock list and false of the composed one). With `fx1=()` the
+stock list stands and the replacement inherits its effect's row there, as
+before. Also refused: a stock effect FX1 never listed, and a key with no FX2
+chooser row of its own (nothing for FX1's list to point at).
+`verify_menu.py` proves the rest, `verify_replaces.py` walks the composed
+list for every declared replacement, and both assert FX1 is byte-identical
+to stock in every remix that asks for nothing.
+
+#### An FX1-ONLY allocator reader — `Claims(fx1_only=True)`
+
+An effect that needs a per-track delay line has exactly one safe place for
+it beside the servers: the **FX1** slot. Every FX2 slot is ChonVerb's tank
+on core 0 or BongDelay's line on tracks 3–4, which is why the ledger refuses
+every other allocator reader beside them. A module declaring
+`Claims(stock_instance_buffer=True, buffer_words=N, fx1_only=True)` (N ≤
+3,072) promises that it reads its base at **init** and, when the base is an
+FX2 slot (`>= 0x4000`), runs as a dry pass and **writes nothing** — so the
+ledger admits it beside a server, `fx1_hazard` admits it on FX1, and
+`send_probe` renders it as an FX1 instance (`-r7 1 -alloc 0`). The claim is
+a promise the module's render gate must prove: an FX2-slot render
+(`-alloc 1 -r7 2`) bit-exact dry at any setting, and `dsp_host`'s guard
+seeing no write above `0x3fff` on every FX1 base. ⚠️ FX1 bases are
+`0x1000 0x1c00 0x2800 0x3400` — only 1,024-aligned on two of the four — so
+modulo addressing over more than 1,024 words needs the linear-plus-mask
+idiom (`modules/nimbuslite/`), not an `m` register.
 
 #### What is actually different about FX1
 

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -209,11 +209,14 @@ menus can double the worst per-core load — WarpFold goes from `4×` to `8×`,
 it, which is why that row exists (`PLAN.md` §2 called this "the real ceiling
 is cycles ×4").
 
-**Only a buffer-free INSERT may take one**, and the UNIT pane says so where
-it applies rather than letting you find out from a refusal: `FX1  no row —
-and cannot take one: it sizes its buffer for an FX2 slot (16,384 words)`.
-An FX1 slot is **3,072** words; a module with **fixed** FX2 buffers would
-write into another track's; and a bus **server** is one per core. See
+**Only a buffer-free INSERT — or an allocator reader sized for FX1 — may
+take one**, and the UNIT pane says so where it applies rather than letting
+you find out from a refusal: `FX1  no row — and cannot take one: it sizes
+its buffer for an FX2 slot (16,384 words)`. An FX1 slot is **3,072** words;
+a module declaring `buffer_words` ≤ 3,072 fits, and one declaring
+`fx1_only` reads `FX1 ONLY: passes dry on FX2`; a module with **fixed** FX2
+buffers would write into another track's; and a bus **server** is one per
+core. See
 `docs/MODULES.md` for the measured reason — it is `docs/DSP.md`'s "wrong
 claim 1", bisected on hardware.
 
@@ -281,10 +284,11 @@ its id. Four bytes of cave per row, plus the relocated list.
 both menus can double the worst per-core load — WarpFold 4× → 8×, 404 → 808
 of the 3,120 our code may spend. The Budget's `cycles` row prices it.
 
-**Only a buffer-free INSERT of ours can take one**, and the UNIT pane says
-which cannot and why: `FX1  no row — and cannot take one: it sizes its
-buffer for an FX2 slot (16,384 words) and an FX1 slot is 3,072`. The three
-classes are in `docs/MODULES.md`, with the measured reason. The same
+**Only a buffer-free INSERT of ours, or one whose buffer is declared to fit
+an FX1 slot, can take one**, and the UNIT pane says which cannot and why:
+`FX1  no row — and cannot take one: it sizes its buffer for an FX2 slot
+(16,384 words) and an FX1 slot is 3,072`. A `replaces` module is listed by
+its own key. The classes are in `docs/MODULES.md`, with the measured reason. The same
 arithmetic is why stock keeps DELAY and the three reverbs off FX1 — they do
 not fit either, and the remixer refuses to list them there.
 

--- a/modules/tempo-sync/manifest.py
+++ b/modules/tempo-sync/manifest.py
@@ -61,7 +61,7 @@ MODULE = Module(
     cf_patches=(
         CavePatch(
             label="tempo cave",
-            cave_addr=0x400d7000,
+            cave_addr=None,          # floats: 0x400d7000 behind three clones
             pinned=TEMPO_CAVE_BYTES,
             source="modules/tempo-sync/tempo_cave.s",
             hook_addr=TEMPO_HOOK,
@@ -72,7 +72,7 @@ MODULE = Module(
         CavePatch(
             label="time_fmt cave",
             # Moved here 24 Aug 2026 when the tempo cave grew to 104 bytes.
-            cave_addr=0x400d7080,
+            cave_addr=None,          # floats: 0x400d7080 behind the tempo cave
             pinned=TIME_FMT_BYTES,
             source="modules/tempo-sync/time_fmt.s",
             # A (P+0x0ca) points at the cave and B (P+0x0fa) stays zero --

--- a/remixes/_floatcave.py
+++ b/remixes/_floatcave.py
@@ -1,0 +1,15 @@
+"""_floatcave -- scratch: FOUR descriptor clones plus tempo sync.
+
+Until 3 Sep 2026 this could not build: the clones end at 0x400d7000 with
+three of them, exactly where the tempo cave was pinned, and a fourth ran
+into it. The caves float now; this remix is the proof, and selftest builds
+it. FLANGER/CHORUS are off both choosers so WarpFold has words to land on.
+"""
+from remix.schema import Remix
+REMIX = Remix(
+    name="_floatcave",
+    doc="scratch: four clones + tempo sync (the caves must float)",
+    modules=("REVERB SERVER", "SEND", "WARPFOLD", "HELLO WORLD", "TEMPO SYNC"),
+    fallback="SEND",
+    fx1=("FILTER", "EQUALIZER", "DJ EQ", "PHASER", "COMPRESSOR", "LO-FI"),
+)

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -88,7 +88,7 @@ code: payload B's placed P words carry 0x38000 five times and 0x30000 zero
 times. The old docstring here claimed "exactly one occurrence", which was
 never true for the XBUS path.
 """
-import os, pathlib, re, subprocess, sys
+import dataclasses, os, pathlib, re, subprocess, sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
 from dsp_modmap import BASE, IMG, PAYLOADS, modules  # noqa: E402
@@ -1130,6 +1130,13 @@ def main():
         _plan = []
     _cave_top = cave_end            # caves start past the descriptor clones
     for _c, _b in _plan:
+        if _c.cave_addr is None:
+            # FLOATING (schema.CavePatch): first free address after what
+            # precedes it, rounded up to 0x80. With three clones this is
+            # 0x400d7000 then 0x400d7080 -- the addresses the shipping
+            # image pinned -- and with six it clears the clone block that
+            # used to run straight into them.
+            _c = dataclasses.replace(_c, cave_addr=(_cave_top + 0x7f) & ~0x7f)
         assert _c.cave_addr >= _cave_top, f"{_c.label} overlaps what precedes it"
         assert _c.cave_addr + len(_b) <= cave_limit, \
             "past the stock zero run (or into the long chooser list)"
@@ -1247,6 +1254,12 @@ def main():
             if _m is None:
                 sys.exit(f"fx1={_n!r}: no such effect")
             if _m.is_stock:
+                _rep = [k for k in ORDER if _MODS[k].menu is not None
+                        and _MODS[k].menu.replaces == _n]
+                if _rep:
+                    sys.exit(f"fx1={_n!r}: {_rep[0]} replaces it in this "
+                             f"remix, so its row would draw the stock name "
+                             f"over our code -- list {_rep[0]!r} instead")
                 if _m.menu.fx2_id not in stock_mod.fx1_ids():
                     sys.exit(f"fx1={_n!r}: stock does not list it on FX1, "
                              f"and it is FX2-only because it does not fit a "
@@ -1256,10 +1269,13 @@ def main():
             if _n not in ORDER:
                 sys.exit(f"fx1={_n!r}: it has no FX2 chooser row, so there "
                          f"is no descriptor clone for FX1 to point at")
-            if _m.menu.replaces:
-                sys.exit(f"fx1={_n!r}: it replaces stock {_m.menu.replaces}, "
-                         f"which already gives it that effect's FX1 row -- "
-                         f"listing it here would show it twice")
+            # A REPLACEMENT is listed by its own key. The composed list is
+            # rebuilt from scratch in the cave, so the stock row its id
+            # inherited (the in-place repoint above edits the STOCK list,
+            # which the three `lea` refs no longer point at) cannot show
+            # beside it. Until 3 Sep 2026 this exited as "would show it
+            # twice", which was true of the stock list and false of the
+            # composed one.
             _hz = fx1_hazard(_m)
             if _hz:
                 sys.exit(f"fx1={_n!r}: {_hz}")
@@ -1322,7 +1338,9 @@ def main():
             _eid = _m.menu.fx2_id
             if not _m.is_stock:
                 _slot = FX1_IDS + _eid * 4
-                if rd32(_slot) != FX1_NONE:
+                # A replacement's slot already holds its clone: the
+                # repoint above wrote it there in place of stock's.
+                if rd32(_slot) not in (FX1_NONE, clone_addr[_n]):
                     sys.exit(f"{_n}: FX1_IDS[0x{_eid:02x}] is "
                              f"0x{rd32(_slot):08x}, not NONE -- this id is "
                              f"already on FX1 and the row would be a "
@@ -2481,9 +2499,22 @@ mkgo:""",
         # ⚠️ PER RUN. One global cursor was right only while the region was
         # one run; with two, an effect in a run we never opened is untouched
         # however far the other run was packed.
-        kept = [d for d, (a, _n) in _hv.items() if not _written(a)]
+        _replaced = {_MODS[n].menu.replaces: n for n in CLONED_ORDER
+                     if _MODS[n].menu.replaces}
+        # (kept = harvested, unreached, and NOT replaced: a replaced effect's
+        # code may be untouched but its dispatch is ours, so it is not
+        # stock any more and must not be reported as kept.)
+        kept = [d for d, (a, _n) in _hv.items()
+                if not _written(a) and d not in _replaced]
+        # ⚠️ A REPLACED effect's dispatch is OURS, not the null stub's.
+        # A module with MenuEntry(replaces=...) carries the stock id and
+        # the placement above already wrote its entries there; its
+        # stock code is harvested ground like any other. This pass ran
+        # AFTER placement and, by span, nulled the very entry it had
+        # just written -- found by tracing on 3 Sep 2026, never hit
+        # because no shipped module replaced anything yet.
         for donor, (a, _n) in _hv.items():
-            if donor in kept:
+            if donor in kept or donor in _replaced:
                 continue
             eid = _MODS[donor].menu.fx2_id
             wrw_p(pp["xtab"] + eid * 3, pp["nul_i"])
@@ -2513,6 +2544,12 @@ mkgo:""",
                   + (f"stops at P:0x{cursor:05x} and never touched their code"
                      if len(runs) < 2 else
                      f"never reached into their runs"))
+        if any(d in _replaced for d in _hv):
+            # Its own clause, emitted only when a replacement is selected,
+            # so every existing report line stays byte-identical.
+            print("  REPLACED: " + ", ".join(
+                f"{_short[d]}->{_replaced[d]}" for d in _hv if d in _replaced)
+                + " -- dispatch is the replacement's, not the null stub")
         # A chooser row for a reverb whose words we just overwrote would
         # point at a live descriptor over dead code: the panel would draw
         # PLATE REV and the DSP would run ours. Refuse, loudly.

--- a/tools/cycle_count.py
+++ b/tools/cycle_count.py
@@ -122,7 +122,7 @@ FX2_SLOTS = 4           # per core: four tracks, one FX2 each
 FX1_SLOTS = 4
 
 
-def bank_worst(rows, mods, fx1=()):
+def bank_worst(rows, mods, fx1=(), stock_fx1_keys=()):
     """The worst per-core load the SELECTED remix can actually be asked for.
 
     Four FX2 slots on a core, and the modules that can occupy them are the
@@ -162,7 +162,13 @@ def bank_worst(rows, mods, fx1=()):
         # anything of ours; those tracks run stock, which this tool does not
         # price. Say so rather than inventing a number for them.
         pass
-    fx1_mods = [m for m in mods if m["key"] in fx1 and m["stem"] in cyc]
+    # ON FX1 = listed there by name, OR a replacement (MenuEntry.replaces)
+    # inheriting the stock row when the remix leaves stock's FX1 list
+    # alone: FILTER STATION on FILTER's id is on FX1 whether or not
+    # anyone typed it, so it is priced x4 like anything else there.
+    fx1_mods = [m for m in mods if m["stem"] in cyc
+                and (m["key"] in fx1
+                     or (not fx1 and m.get("replaces") in stock_fx1_keys))]
     if fx1_mods:
         picks += [max(fx1_mods, key=lambda m: cyc[m["stem"]])["stem"]] \
             * FX1_SLOTS
@@ -491,8 +497,24 @@ def main():
     from remix.schema import BusRole
     remix = registry.remix(os.environ.get("REMIX") or registry.DEFAULT_REMIX)
     mods = [dict(stem=pathlib.Path(m.dsp.asm).stem, key=m.key,
-                 server=(m.dsp.bus_role is BusRole.SERVER))
+                 server=(m.dsp.bus_role is BusRole.SERVER),
+                 replaces=(m.menu.replaces if m.menu is not None else None))
             for m in registry.selected(remix) if m.dsp is not None]
+    from remix import stock as _stock
+    _all = registry.modules()
+    _stock_fx1 = {k for k in _stock.MODULES_BY_KEY
+                  if _all[k].menu.fx2_id in _stock.fx1_ids()} \
+        if hasattr(_stock, "MODULES_BY_KEY") else \
+        {e.key for e in _stock.MODULES if e.menu.fx2_id in _stock.fx1_ids()}
+    # STOCK FILTER'S OWN LOAD IS INSIDE STOCK_SHARE: the 23 Aug budget was
+    # measured with four FILTERs running (192 each, CHIP.md s2). An image
+    # in which FILTER cannot run -- harvested off both choosers, or its
+    # id taken by a replacement -- gets those 768 back for our code.
+    _fx1_keys = set(remix.fx1) if remix.fx1 else _stock_fx1
+    _filter_listed = "FILTER" in set(remix.modules) | _fx1_keys
+    _filter_replaced = any(m["replaces"] == "FILTER" for m in mods)
+    filter_credit = 0 if (_filter_listed and not _filter_replaced) \
+        else 4 * 192
     rows = [measure(m["stem"]) for m in mods]
 
     if "--verify" in args:
@@ -503,7 +525,7 @@ def main():
             if not ok:
                 sys.exit("marker changed codegen -- the count is not trustworthy")
 
-    worst, picks = bank_worst(rows, mods, remix.fx1)
+    worst, picks = bank_worst(rows, mods, remix.fx1, _stock_fx1)
     # The legacy composition, and ONLY when the remix still carries the
     # modules it was measured with -- otherwise the comparison to the 7 Aug
     # hardware sweep is against a bank that shares nothing with it.
@@ -532,6 +554,9 @@ def main():
                               # rather than against core_total, and there
                               # must be one source for the figure.
                               usable=USABLE,
+                              # +768 when stock FILTER cannot run in
+                              # this image (see the printed line).
+                              filter_credit=filter_credit,
                               burn_spare_measured=BURN_SPARE,
                               bank_at_measure=BANK_AT_MEASURE,
                               core_total=CORE_TOTAL), indent=2))
@@ -571,8 +596,13 @@ def main():
     print(f"{'budget/core':{w}}  {CORE_TOTAL:>13}   (200 MIPS / 44.1 kHz)")
     print(f"{'usable by us':{w}}  {USABLE:>13}   measured 23 Aug 2026; stock takes "
           f"the other ~{STOCK_SHARE}")
-    print(f"{'headroom':{w}}  {USABLE - worst:>13}   against the worst core above"
-          + ("   *** OVER ***" if worst > USABLE else ""))
+    if filter_credit:
+        print(f"{'FILTER credit':{w}}  {filter_credit:>13}   stock FILTER cannot run "
+              f"in this image (harvested or replaced): its 4 x 192 inside "
+              f"stock's share come back to us (CHIP.md s2)")
+    _usable = USABLE + filter_credit
+    print(f"{'headroom':{w}}  {_usable - worst:>13}   against the worst core above"
+          + ("   *** OVER ***" if worst > _usable else ""))
     print(f"{'':{w}}  {'':>13}   ⚠️ the counter reads ~270 LOW on the reverb "
           f"(CHIP.md s2); the wall is a CLIFF")
     if bank is None:

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -371,7 +371,7 @@ If a selection ever patches the unit's top-level menu, the MAIN MENU appears und
 [bold]what an FX1 row costs[/]
 No words: the DSP dispatch table is indexed by the raw id and shared by both menus, so an effect's code already ran from FX1 the moment FX1 selected its id. It costs CYCLES — FX1 is four more slots on the same four tracks, so an effect on both menus can double the worst per-core load; watch the Budget's `cycles` row.
 
-Only a buffer-free INSERT of ours can take one, and the UNIT pane says which cannot and why: an FX1 buffer slot is 3,072 words against FX2's 16,384, a module with fixed FX2 buffers would write into another track's, and a bus server is one per core. The same three reasons are why stock keeps DELAY and the three reverbs off FX1 — they do not fit either.
+Only a buffer-free INSERT of ours, or one whose buffer is declared to fit an FX1 slot, can take one, and the UNIT pane says which cannot and why: an FX1 buffer slot is 3,072 words against FX2's 16,384, a module with fixed FX2 buffers would write into another track's, and a bus server is one per core. The same reasons are why stock keeps DELAY and the three reverbs off FX1 — they do not fit either. An FX1-ONLY module (it passes dry on FX2) says so on its resource line.
 
 ⚠️ The firmware's own NONE is always FX1 row 0 and is not shown here: it is how the slot is turned off, and no remix can lose it.
 
@@ -379,7 +379,7 @@ The `FX1+FX2` column in the library says which menus an effect CAN appear on, no
 
 It costs no words. The DSP dispatch table is indexed by the raw id and shared by both menus, so the code already ran from FX1 the moment FX1 selected the id; what `1` adds is the panel side. What it DOES cost is cycles: FX1 is four more slots on the same four tracks, so an effect on both menus can double the worst per-core load — watch the Budget's `cycles` row.
 
-Only a buffer-free INSERT can take one, and the UNIT pane says which cannot and why: an FX1 buffer slot is 3,072 words against FX2's 16,384, a module with fixed FX2 buffers would write into another track's, and a bus server is one per core. An effect that replaces a stock one is already on FX1 and says that instead.
+Only a buffer-free INSERT, or one whose buffer is declared to fit an FX1 slot, can take one, and the UNIT pane says which cannot and why: an FX1 buffer slot is 3,072 words against FX2's 16,384, a module with fixed FX2 buffers would write into another track's, and a bus server is one per core. An effect that replaces a stock one is listed here by its own name; with FX1 left stock it inherits that effect's row.
 
 [bold]a narrow terminal shows fewer panes[/]
 Under 118 columns the panes come in pairs that slide with the focus; under 92, one at a time. The tab bar at the top names all three and marks where you are. Lists longer than the pane scroll with the cursor and say so (`↑ 6 more`).

--- a/tools/remix/ledger.py
+++ b/tools/remix/ledger.py
@@ -94,6 +94,8 @@ def check(selected) -> list[str]:
     hooks: dict[int, str] = {}
     for m in selected:
         for c in m.cf_patches:
+            if c.cave_addr is None:      # floating: the build allocates
+                continue                 # it after everything pinned
             for start, length, owner, label in caves:
                 if _overlap(start, length, c.cave_addr, len(c.pinned)):
                     clash("ColdFire cave", f"{owner}'s {label}",
@@ -151,9 +153,14 @@ def check(selected) -> list[str]:
              if (getattr(m, "claims", None) is not None
                  and m.claims.owns_fx2_buffers)
              or (m.dsp is not None and m.dsp.ybase is not YBase.NEVER)]
+    # An FX1-ONLY allocator reader (Claims.fx1_only) is exempt: on an FX2
+    # slot it writes nothing, and on FX1 the allocator tops out at 0x3fff,
+    # below every buffer a module of ours pins. Its render gate proves
+    # the dry FX2 pass; the ledger takes the declaration.
     stocked = [m for m in selected
                if getattr(m, "claims", None) is not None
-               and m.claims.stock_instance_buffer]
+               and m.claims.stock_instance_buffer
+               and not m.claims.fx1_only]
     # ⚠️ THIS REFUSES AN FX2 CHOOSER ROW, NOT THE EFFECT. A stock effect left
     # out of a remix keeps its code, descriptor and dispatch, so the four
     # dual-menu ones are still on FX1 and still work -- and the collision

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -409,7 +409,12 @@ def resources(mod, words=None, fx1_rows=(), selected=True,
         # bill is CYCLES, and it is a big one: FX1 is four more slots on the
         # same four tracks, so listing an effect on both menus can double the
         # worst per-core load. The Budget's cycles row carries the number.
-        out.append("FX1  " + ("takes 1 of the 4 slots (3,072 words each)"
+        _fx1o = (getattr(mod, "claims", None) is not None
+                 and mod.claims.fx1_only)
+        out.append("FX1  " + ((f"takes 1 of the 4 slots ({mod.claims.buffer_words:,} "
+                               f"of 3,072 words) · FX1 ONLY: passes dry on FX2")
+                              if _fx1o else
+                              "takes 1 of the 4 slots (3,072 words each)"
                               if allocates else "no buffer")
                    + (" · a row costs no words, 4 slots of cycles"
                       if mod.key in fx1_rows else ""))

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -314,7 +314,17 @@ class CavePatch:
     """
 
     label: str                          # name used in the build report
-    cave_addr: int
+    # Where the cave is planted. None = FLOATING: the build places it at
+    # the first free address after whatever precedes it (the descriptor
+    # clones, then earlier caves), rounded up to 0x80. A cave may float
+    # only if its code is position-independent -- short branches and OS
+    # absolutes, no absolute reference to itself -- which both tempo-sync
+    # caves are. Pinned addresses stood until 3 Sep 2026, when a remix with
+    # more than three descriptor clones ran the clone block straight into
+    # the tempo cave at 0x400d7000: three clones end EXACTLY there, so the
+    # shipping image had fit by arithmetic coincidence. For that image the
+    # floating rule reproduces the old addresses byte for byte.
+    cave_addr: int | None                # None = floating; pass it explicitly
     pinned: bytes
     source: str | None = None           # .s re-assembled and compared
     hook_addr: int | None = None        # where the jsr is planted
@@ -372,6 +382,32 @@ class Claims:
     # (Falsifier: an effect reaching its base another way -- dsp_host's
     # -guard would show a stray write.)
     stock_instance_buffer: bool = False
+    # HOW MUCH of the allocator's buffer the module touches, from its base.
+    # None = "sized for an FX2 slot" (16,384 words), the stock reverbs'
+    # shape and the reason they are FX2-only. A module that declares
+    # buffer_words <= 3072 fits an FX1 slot and may take an FX1 row.
+    buffer_words: int | None = None
+    # FX1-ONLY BY DESIGN: the module reads its allocator base at init and,
+    # when the base is an FX2 slot (>= 0x4000), runs as a dry pass and
+    # WRITES NOTHING. That is what lets it sit beside a server: the FX2
+    # slots it would otherwise be handed are ChonVerb's tank and
+    # BongDelay's line, and the ledger refuses every other allocator
+    # reader beside them for exactly that reason. The claim is a promise
+    # the module's render gate must prove (an FX2-slot instance renders
+    # bit-exact dry and dsp_host's guard sees no write above 0x3fff).
+    fx1_only: bool = False
+
+    def __post_init__(self):
+        if self.buffer_words is not None and not self.stock_instance_buffer:
+            raise ValueError("buffer_words without stock_instance_buffer: "
+                             "only an allocator reader has a sized buffer")
+        if self.fx1_only:
+            if not self.stock_instance_buffer:
+                raise ValueError("fx1_only is for allocator readers -- a "
+                                 "buffer-free module runs on both menus")
+            if self.buffer_words is None or self.buffer_words > 3072:
+                raise ValueError("fx1_only needs buffer_words <= 3072: an "
+                                 "FX1 slot is 3,072 words (docs/DSP.md 10)")
 
 
 @dataclass(frozen=True)

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -621,15 +621,18 @@ def main():
                 if _m.menu.fx2_id not in _stk.fx1_ids():
                     bad += 1
                     print(f"  [FAIL] remix {_n!r}: stock {_k} is FX2-only")
+                _rep = [x for x in _r.modules if registry.modules()[x].menu is not None
+                        and registry.modules()[x].menu.replaces == _k]
+                if _rep:
+                    bad += 1
+                    print(f"  [FAIL] remix {_n!r}: fx1 lists stock {_k}, "
+                          f"which {_rep[0]} replaces -- list the "
+                          f"replacement")
                 continue
             if _k not in _r.modules:
                 bad += 1
                 print(f"  [FAIL] remix {_n!r}: {_k} has no FX2 row, so there "
                       f"is no descriptor clone for FX1 to point at")
-            if _m.menu.replaces:
-                bad += 1
-                print(f"  [FAIL] remix {_n!r}: {_k} replaces a stock effect "
-                      f"and already has its FX1 row")
             _why = state.fx1_hazard(_m)
             if _why:
                 bad += 1

--- a/tools/remix/state.py
+++ b/tools/remix/state.py
@@ -67,7 +67,9 @@ def fx1_hazard(mod) -> str | None:
     claims = getattr(mod, "claims", None)
     if mod.dsp is not None and mod.dsp.bus_role is BusRole.SERVER:
         return "a bus server is one per core; an FX1 row is a second instance"
-    if claims is not None and claims.stock_instance_buffer:
+    if (claims is not None and claims.stock_instance_buffer
+            and not (claims.buffer_words is not None
+                     and claims.buffer_words <= 3072)):
         return ("it sizes its buffer for an FX2 slot (16,384 words) and an "
                 "FX1 slot is 3,072")
     if (claims is not None and claims.owns_fx2_buffers) or (
@@ -222,9 +224,6 @@ class State:
             return f"{name} is back on the FX1 chooser"
         if key not in self.sel:
             return f"add {name} to the image first, then 1 gives it FX1 too"
-        if mod.menu.replaces:
-            return (f"{name} replaces stock {mod.menu.replaces}, so it "
-                    f"already has that effect's FX1 row")
         # ⚠️ ONLY A BUFFER-FREE INSERT CAN TAKE ONE, and the build refuses the
         # rest for reasons worth arriving at the keystroke rather than at the
         # next rebuild. See build_bus.py's fx1 block for the full statement.
@@ -512,7 +511,7 @@ class State:
             if c.returncode == 0:
                 try:
                     j = json.loads(c.stdout[c.stdout.index("{"):])
-                    self.cycles = (j["worst_core"], j["usable"],
+                    self.cycles = (j["worst_core"], j["usable"] + j.get("filter_credit", 0),
                                    j["worst_core_modules"])
                 except (ValueError, KeyError):
                     pass

--- a/tools/send_probe.py
+++ b/tools/send_probe.py
@@ -308,9 +308,16 @@ def run(mem, dur, tail, rev_params, send_params, verbose=False, amp=0.5,
         # own modules touch low X, so the default never mattered for them;
         # a stock render gets the hardware address.
         _tm = registry.by_id(SERVER_ID[tgt])
+        # An FX1-ONLY module (Claims.fx1_only) passes dry on an FX2 slot,
+        # so its render is an FX1 instance: state block 0x6100 and the
+        # allocator's first FX1 entry (Y:0x1000). Everything else renders
+        # as FX2 instance 1 (0x6200 / Y:0x4000), as it always has.
+        _fx1o = (_tm is not None and getattr(_tm, "claims", None) is not None
+                 and _tm.claims.fx1_only)
         cmd = [str(HOST), "-mem", str(mem),
                "-init", f"{ri:x}", "-proc", f"{rp:x}",
-               "-inst", "1", "-r7", "2", "-alloc", "1",
+               "-inst", "1", "-r7", "1" if _fx1o else "2",
+               "-alloc", "0" if _fx1o else "1",
                "-inmask", "1",                   # tone straight into the module
                *(["-audio", "0"] if _tm is not None and _tm.is_stock else []),
                "-blocks", str(blocks), "-in", str(src), "-out", str(out),

--- a/tools/verify_menu.py
+++ b/tools/verify_menu.py
@@ -119,7 +119,20 @@ STEPPED_FMT = (0x4003c718, 0x40047254)
 # The ColdFire cave region (docs/PARAM_PAGES.md section 7): clones, the tempo
 # caves and PLAN §6's label formatters all live in here and nowhere else.
 CAVE_LO, CAVE_HI = 0x400d6b20, 0x400d7c3c
-TIME_FMT = 0x400d7080          # modules/tempo-sync/time_fmt.s cave (build_bus.py TIME_FMT_CAVE)
+# TIME's sticky-snap formatter is the tempo-sync cave that registers itself
+# as DELAY SERVER slot 0. Its address FLOATS since 3 Sep 2026 (it sits
+# behind the descriptor clones, however many there are), so it is
+# recognised by its pinned bytes in the image rather than by a constant.
+def _time_fmt_cave():
+    _ts = _MODS.get("TEMPO SYNC")
+    if _ts is None:
+        return None
+    for _c in _ts.cf_patches:
+        _r = _c.registers_formatter
+        if _r is not None and _r.module == "DELAY SERVER" and _r.slot == 0:
+            return _c
+    return None
+TIME_FMT_CAVE = _time_fmt_cave()
 
 
 def main():
@@ -301,7 +314,10 @@ def main():
                       f"the tick widget and 0x12a=0, with A either stock's "
                       f"enumerated formatter or a label cave "
                       f"(got 0x{f1:08x}/0x{f2:08x}/0x{f3:08x})")
-            elif name == "DELAY SERVER" and i == 0 and f1 == TIME_FMT:
+            elif (name == "DELAY SERVER" and i == 0 and TIME_FMT_CAVE is not None
+                  and CAVE_LO <= f1 < CAVE_HI
+                  and img[f1 - BASE:f1 - BASE + len(TIME_FMT_CAVE.pinned)]
+                  == TIME_FMT_CAVE.pinned):
                 # TIME's sticky-snap label formatter (modules/tempo-sync/time_fmt.s, 24 Aug
                 # 2026): a knob with A = our cave and B = 0 -- stock DELAY
                 # TIME's own shape (A = 0x4003c718, B = 0).

--- a/tools/verify_replaces.py
+++ b/tools/verify_replaces.py
@@ -60,6 +60,22 @@ def rdw(img, p):
     return int.from_bytes(img[p - BASE:p - BASE + 3], "little")
 
 
+# The three `lea` operands the firmware reads the FX1 chooser list from
+# (build_bus.FX1_LIST_REFS). When a remix composes FX1 the list is rebuilt
+# in the cave and these are repointed, so the LIVE list is what they name.
+FX1_LIST_REFS = [0x40037990, 0x40052706, 0x40059bd2]
+
+
+def _live_fx1_list(img):
+    """Descriptor pointers of the FX1 chooser the built image actually
+    draws: the list its first `lea` names, walked to the terminator."""
+    out, a = [], rd32(img, FX1_LIST_REFS[0])
+    while rd32(img, a) != 0 and len(out) < 32:
+        out.append(rd32(img, a))
+        a += 4
+    return out
+
+
 def _fx1_rows(pristine):
     """Addresses of the FX1 chooser list's entries, from the pristine image
     (the list is never relocated by build_bus -- a replacement rewrites a row
@@ -128,9 +144,29 @@ def check_image(name, img, pristine, fails):
                 fails.append(
                     f"{name}: the FX1 chooser row for {eff.key} still points "
                     f"at stock's descriptor, but {declared[eid]} replaces it")
+            # A COMPOSED FX1 chooser is rebuilt in the cave, so the row a
+            # replacement inherited is whatever the composed list says:
+            # the clone if the remix listed the replacement by name, no
+            # row at all if it did not -- never stock's descriptor.
+            if remix.fx1:
+                _live = _live_fx1_list(img)
+                _clone = rd32(img, FX2_IDS + eid * 4)
+                if want_desc in _live:
+                    fails.append(
+                        f"{name}: the composed FX1 chooser still draws stock "
+                        f"{eff.key}'s row, but {declared[eid]} replaces it")
+                if (declared[eid] in remix.fx1) != (_clone in _live):
+                    fails.append(
+                        f"{name}: {declared[eid]} is "
+                        f"{'' if declared[eid] in remix.fx1 else 'not '}in "
+                        f"Remix.fx1 but its clone is "
+                        f"{'' if _clone in _live else 'not '}in the composed "
+                        f"FX1 list")
             if got_id != want_desc and (not got_row or got_row[0] != want_desc):
                 print(f"  [PASS] {name}: {declared[eid]} took {eff.key}'s FX1 "
-                      f"page as well as FX2's")
+                      f"page as well as FX2's"
+                      + (" and the composed chooser lists the clone"
+                         if remix.fx1 and declared[eid] in remix.fx1 else ""))
             continue
         if on_fx1 and eff.key not in _given_up:
             for a in (fx1_slot,) + tuple(


### PR DESCRIPTION
The tooling the BamSep26 rig needs before any station module exists. Design page: https://claude.ai/code/artifact/42670d67-7365-4c7d-bcc7-1786ba4331ce

- **Caves float** (`CavePatch.cave_addr=None`): six descriptor clones no longer overrun the pinned tempo caves; chongbong's addresses reproduce byte for byte. `remixes/_floatcave.py` is the four-clone proof.
- **A replacement keeps its dispatch**: the null-stub pass skips effects a selected module `replaces` (confirmed bug, never hit before). Reported as `REPLACED: FILTER->...`.
- **FX1 lists a replacement by its own key**; the stock key is refused beside it; `verify_replaces` checks the composed list.
- **`Claims(buffer_words, fx1_only)`**: a sized FX1-only allocator reader is admitted on FX1 and beside a server; `send_probe` renders it as an FX1 instance.
- **Cycle pricer**: an inherited FX1 row is priced ×4; stock FILTER's 768 are credited when FILTER cannot run.

Gates: `scripts/refhash.sh check` 26/26 bit-identical, `selftest`, `verify_replaces` (all remixes), `verify_menu` on bothslots/scattered/fieldtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)