### PR TITLE
BongDelay v5: pitched GRAIN over the delay lines, four grains per line; PITCH mode retired

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -211,7 +211,7 @@ core. Two consequences:
 
 The build report is the live ledger — `make bus` prints it. Current build
 (29 Aug 2026): **payload A used 2,650, FREE 74; payload B used 2,694,
-FREE 30.** The older "A 55 / B 1" figures in this file predated the freeze
+FREE 30 — and since GRAIN v4 (3 Sep 2026) B used 2,558, FREE 166.** The older "A 55 / B 1" figures in this file predated the freeze
 and roll work; both payloads are still effectively full, and new work needs
 a lever first.
 
@@ -247,13 +247,13 @@ choosing the same one. Measured this way:
 
 | remix | worst core | what fills it |
 |---|---|---|
-| chongbong | **2,398** | 1× delay + 3× send |
+| chongbong | **1,444** | 1× reverb + 3× send (was 2,432 with the v2 GRAIN delay: 1× delay + 3× send) |
 | mutables | **1,376** | 4× BodeShift (the dearest insert) |
 | nimbus | **1,308** | 4× Nimbus |
 | verbonly | **1,444** | 1× reverb + 3× send |
 
 against ~3,125 usable after stock's own ~1,410. Per-module: reverb 1,384,
-delay 2,338 (GRAIN worst path), Nimbus 327, BodeShift 344, Rungs 238,
+delay 1,255 (PITCH worst path since GRAIN v4, 3 Sep 2026; was 2,372 with the v2 GRAIN), Nimbus 327, BodeShift 344, Rungs 238,
 Streamz 154, WarpFold 101, Ripple 93, send 20.
 
 The old headline summed reverb + delay + sends onto one core — a load no

--- a/PLAN.md
+++ b/PLAN.md
@@ -19,8 +19,9 @@ What ships:
 - **ChonVerb** — an eight-line FDN reverb (ROOM/PLATE/BIG), shimmer, a gated
   mode, mid/side width, and a MOD speed select. Hosted on a track **5–8**
   (payload A / core 0); any track can send into it. `docs/REVERB.md`.
-- **BongDelay** — a multi-mode delay: CLEAN, PITCH (a once-per-repeat
-  harmoniser), GRAIN (a granular cloud), REVERSE — with tape-style
+- **BongDelay** — a multi-mode delay: CLEAN, GRAIN (a pitched granular
+  cloud, v5: Nimbus's readers, four per line, ±2 octaves on RATE; the
+  harmoniser since PITCH mode was retired 3 Sep 2026), REVERSE — with tape-style
   wow/flutter modulation (DPTH/RATE), drive (DRV, doubling as GRAIN's
   scatter depth) and a FREEZE hold available in **every** mode. (MODE still
   counts five positions; the former TAPE slot aliases CLEAN now that the
@@ -211,7 +212,7 @@ core. Two consequences:
 
 The build report is the live ledger — `make bus` prints it. Current build
 (29 Aug 2026): **payload A used 2,650, FREE 74; payload B used 2,694,
-FREE 30 — and since GRAIN v4 (3 Sep 2026) B used 2,558, FREE 166.** The older "A 55 / B 1" figures in this file predated the freeze
+FREE 30 — and since BongDelay v5 (3 Sep 2026, PITCH mode retired, GRAIN pitched) B used 2,401, FREE 323.** The older "A 55 / B 1" figures in this file predated the freeze
 and roll work; both payloads are still effectively full, and new work needs
 a lever first.
 
@@ -247,13 +248,13 @@ choosing the same one. Measured this way:
 
 | remix | worst core | what fills it |
 |---|---|---|
-| chongbong | **1,444** | 1× reverb + 3× send (was 2,432 with the v2 GRAIN delay: 1× delay + 3× send) |
+| chongbong | **1,817** | 1× delay (v5, pitched GRAIN) + 3× send (was 2,432 with the v2 GRAIN delay) |
 | mutables | **1,376** | 4× BodeShift (the dearest insert) |
 | nimbus | **1,308** | 4× Nimbus |
 | verbonly | **1,444** | 1× reverb + 3× send |
 
 against ~3,125 usable after stock's own ~1,410. Per-module: reverb 1,384,
-delay 1,255 (PITCH worst path since GRAIN v4, 3 Sep 2026; was 2,372 with the v2 GRAIN), Nimbus 327, BodeShift 344, Rungs 238,
+delay 1,757 (GRAIN v5, pitched, four per line, 3 Sep 2026; was 2,372 with the v2 GRAIN), Nimbus 327, BodeShift 344, Rungs 238,
 Streamz 154, WarpFold 101, Ripple 93, send 20.
 
 The old headline summed reverb + delay + sends onto one core — a load no

--- a/docs/MIDI.md
+++ b/docs/MIDI.md
@@ -136,6 +136,11 @@ on the RE below.
 
 ## Status (24 Aug 2026) — note → interval ON THE UNIT (R57, tag 76), hardware-confirmed
 
+⚠️ **v5 (3 Sep 2026, unflashed): the note drives GRAIN's continuous pitch**
+(2^((note−84)/12), ±24 semitones, MODE 1) — PITCH mode and its interval
+select are gone. `tools/verify_midi.py` checks the note against the RATE knob
+path (bit-identical at unison, spectral elsewhere). The cave is unchanged.
+
 - **Cave v2** (`modules/tempo-sync/tempo_cave.s`, 104 bytes, floating behind the
   descriptor clones — `0x400d7000` in the shipping image; the TIME formatter
   cave follows it, `0x400d7080` there): `r6+$8` = fader+1 (1 = fully B,

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -121,7 +121,7 @@ So the words are spent only by modules of ours, and a swap is only
 (322), or Hello World (27) + Ripple (347). Measured costs, payload A:
 Hello World 27, Streamz 255, WarpFold 322, Ripple 347, BodeShift 391,
 Nimbus 500, Rungs 880, Send 215, ChonVerb 2,411 (+24 LFO table), BongDelay
-2,469 (payload B).
+2,308 (payload B; 2,469 before GRAIN v4).
 
 **One trade is often not enough**, and the status line names the next one
 rather than leaving it to the build to refuse:

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -121,7 +121,7 @@ So the words are spent only by modules of ours, and a swap is only
 (322), or Hello World (27) + Ripple (347). Measured costs, payload A:
 Hello World 27, Streamz 255, WarpFold 322, Ripple 347, BodeShift 391,
 Nimbus 500, Rungs 880, Send 215, ChonVerb 2,411 (+24 LFO table), BongDelay
-2,308 (payload B; 2,469 before GRAIN v4).
+2,151 (payload B; 2,469 before BongDelay v5).
 
 **One trade is often not enough**, and the status line names the next one
 rather than leaving it to the build to refuse:

--- a/docs/VOICING.md
+++ b/docs/VOICING.md
@@ -2059,3 +2059,29 @@ material at matched settings.
 for: texture rather than pitch (no octave content now), the cloud morphing
 rather than stepping, no zipper at grain edges, and whether the 3.4 dB should
 go into the makeup law.
+
+## R64 — GRAIN v5: four per line, pitched, PITCH mode retired (3 Sep 2026)
+
+Sam heard v4's two-per-line cloud buzz at the grain rate with scatter up,
+and asked where GRAIN's pitch had gone: a four-position switch cannot be a
+pitch. So: four grains per line (v2's density), a continuous pitch on RATE
+(±2 octaves, 64 = unison; the latched MIDI note when one is held), and
+PITCH mode retired -- GRAIN at full density and zero scatter IS the
+harmoniser. MODE is CLEAN / GRAIN / REVRS; the PTCH switch is SIZE, in
+REVERSE's index order.
+
+Two defects found by measuring pitch rather than DC: Nimbus's read geometry
+plays an octave up at unity (955 Hz for 438 in -- the read moves with the
+head AND the phase), and dsp_host's boot garbage in the latched-note slot
+drove every local GRAIN render's pitch until the knob visibly did nothing.
+Both fixed; `modules/nimbus/README.md` carries the first as an open item.
+
+Numbers: delay 2,469 → 2,151 words (B FREE 323), 2,372 → 1,757 cycles.
+Pitch law measured to the grain-rate comb (see the module README's table);
+DC gate p-p 0; CLEAN/REVERSE/wow bit-identical to v3; density flat within
+1.3 dB from DPTH 32 up; v5 ~6 dB quieter than v3 on real material at
+matched settings (four decorrelated grains), a makeup decision for the ear.
+
+⬜ Ear pass pending (Sam): `out/ab/grain_v4/` -- `_v3` vs `_v5_r64_lm`
+(unison) and `_v5_r96_lm` (+12), glow_intro and guitar_dry.
+

--- a/docs/VOICING.md
+++ b/docs/VOICING.md
@@ -2031,3 +2031,31 @@ set keeps +7 at entry 7). Verified in the set table this session; the
 open-item note in the 30 Aug memory was stale. With this and R61, the
 delay quality pass's buildable items are done: what remains on the list
 is structural (REVERSE line length) or taste (a future ear round).
+
+## R63 — GRAIN v4: Nimbus's grain readers over the delay lines (3 Sep 2026)
+
+**The cycle lever for the BamSep26 rig, and a voicing change.** GRAIN's v2
+engine (eight lerped heads, per-grain rates, a rolled builder) was 1,385 of
+the delay's 2,372 worst-path cycles. v4 is Nimbus's engine over the delay
+lines: four unity-rate grains, two per line a half period apart, integer
+reads, one-multiply windows. `make cycles`: delay **2,372 → 1,255**, words
+2,469 → 2,308, payload B FREE 5 → 166. Core 1 is no longer the tight core.
+
+Kept: TIME as the read-back distance (it is still a granular DELAY), the R61
+density law and makeup, SPRAY on DRV, FREEZE, the shifted-output routing.
+PTCH becomes grain SIZE (23/46/93/186 ms), the same reading REVERSE gives it.
+Gone: the pitched grains (+12 / −19 / −12 / +5 / −5 / +7). v4.1 = a
+continuous grain PITCH on RATE, one rate for all four, Clouds-style.
+
+Measured: DC gate −124 dB (windows sum to exactly 1, a0 multiplier right);
+CLEAN/PITCH/TAPE/REVERSE/unknown-mode bit-identical to v3 (verify_delay
+against the v3 source, only the three GRAIN cases differ); density law
+−12.3/−8.7/−7.8/−8.0/−8.8 dBFS at DPTH 0/32/64/96/127 (sparse end 3.5 dB
+down: two grains per line); **v4 is 3.3–3.6 dB quieter than v3** on real
+material at matched settings.
+
+⬜ Ear pass pending (Sam): `out/ab/grain_v4/` — `glow_intro` and
+`guitar_dry`, `_v3` vs `_v4_lm` (v4 raised 3.45 dB to level-match). Listen
+for: texture rather than pitch (no octave content now), the cloud morphing
+rather than stepping, no zipper at grain edges, and whether the 3.4 dB should
+go into the makeup law.

--- a/modules/bongdelay/README.md
+++ b/modules/bongdelay/README.md
@@ -1,10 +1,10 @@
 # BongDelay
 
-A multi-mode delay — CLEAN, PITCH (a once-per-repeat harmoniser), GRAIN (a
-granular cloud: since v4, Nimbus's unity-rate grain readers over the delay
-lines) and REVERSE — with tape-style wow/flutter (DPTH/RATE), drive (DRV,
-doubling as GRAIN's scatter depth) and a FREEZE hold available in **every**
-mode. Its wet can be sent on into ChonVerb over the bus (`-VRB`),
+A multi-mode delay — CLEAN, GRAIN (a pitched granular cloud over the delay
+lines: Nimbus's grain readers, four per line, one continuous pitch) and
+REVERSE — with tape-style wow/flutter (DPTH/RATE), drive (DRV, doubling as
+GRAIN's scatter depth) and a FREEZE hold available in **every** mode. PITCH
+mode was retired in v5 (3 Sep 2026): GRAIN's pitch is the harmoniser now. Its wet can be sent on into ChonVerb over the bus (`-VRB`),
 which is the series topology the stock firmware has no path for.
 
 Hosted on payload B (core 1), which serves **tracks 1–4**.
@@ -22,50 +22,79 @@ label comes from the [`tempo-sync`](../tempo-sync/) module's formatter cave.
 hatch (`make render-delay`), which places it out of region in payload A.
 `DFRZAT=n` engages FREEZE after n blocks so a render can catch it mid-flight.
 
-## GRAIN v4 (3 Sep 2026) — Nimbus's readers over the delay lines
+## GRAIN v5 (3 Sep 2026) — Nimbus's readers over the delay lines, pitched; PITCH mode retired
 
-The v2 GRAIN was the delay's cost centre: eight lerped heads with per-grain
-rate accumulators and a rolled builder, priced at 1,385 cycles and the worst
-path of the whole engine. v4 is `modules/nimbus/`'s engine instead: four
-unity-rate grains, two per line at a half-period offset so each line's two
-triangle windows sum to exactly 1, integer reads, one multiply per window,
-a latch at each grain's own wrap. The delay's worst path is now PITCH's:
-**2,372 → 1,255 cycles** (`make cycles`), and the module shrank 2,469 → 2,308
-words (payload B FREE 5 → 166).
+The v2 GRAIN was the delay's cost centre (eight lerped heads, per-grain
+rates, a rolled builder: 1,385 of 2,372 worst-path cycles). v5 is
+`modules/nimbus/`'s engine over the delay lines with two things put back
+that the first cut (v4, the same day) lost by Sam's ear: **four overlapping
+grains per line** (two buzzed at the grain rate with scatter up) and
+**pitch** — one continuous rate for all eight grains, on the RATE knob, ±2
+octaves, 64 = unison. With that, PITCH mode was redundant (GRAIN at full
+density, scatter 0, RATE 96 is a granular +12 on the same non-cascading
+topology) and it is gone: **MODE is CLEAN / GRAIN / REVRS**, three positions.
+The PTCH switch is **SIZE** (46 / 93 / 23 ms, XTRM = 186 ms grains or 12 ms
+REVERSE segments — REVERSE's own order, one select for both modes).
 
-Knobs in GRAIN: TIME = position (read-back distance), PTCH = grain SIZE
-(23 / 46 / 93 / 186 ms — the select REVERSE already reads as a size), DRV =
-scatter depth (up to 4,095 samples), DPTH = density (the R61 full-dial law and
-makeup, kept verbatim), FREEZE holds the lines and the grains keep grazing
-them. ⚠️ The PTCH select still prints its PITCH-mode words (`+12 +7 -12 det`);
-per-mode labels are a rig backlog item.
+Knobs in GRAIN: TIME = position, SIZE = grain length, RATE = pitch, DRV =
+scatter depth (up to 4,095 samples), DPTH = density (R61 law and makeup),
+FREEZE holds the lines and the grains keep grazing them. A held MIDI note
+(the tempo cave's `r6+$9`, latched) replaces the RATE knob with
+2^((note−84)/12), ±24 semitones — the same law the retired mode drove.
 
-**What v4 gives up: the pitched grains.** Every grain plays at unity, so the
-+12 / −19 / −12 / +5 / −5 / +7 set is gone. The planned v4.1 puts a
-continuous grain PITCH on the RATE knob (free in GRAIN, since wow depth is
-density there): one rate for all four grains, Clouds-style, ~+100 cycles.
+**Cost:** delay 2,469 → **2,151 words** (payload B FREE 5 → **323**); worst
+path 2,372 → **1,757 cycles** (GRAIN, rolled: 345 words + 718 of roll).
 
-Measured (local, `make render-delay` hatch):
+**Two defects found on the way, both measured:**
 
-- **DC gate** — 0.25 FS DC through GRAIN at full density: −124 dB ripple in
-  the steady window, with scatter 0 and 64 and at the 186 ms grain. The two
-  windows per line sum to exactly 1, so the a0 multiplier is right (the trap
-  Nimbus found — see its header).
-- **Bit-identity** — CLEAN, PITCH, TAPE, REVERSE and the unknown-mode fallback
-  render bit-identical to v3 (`tools/verify_delay.py` against the v3 source);
-  only the three GRAIN cases differ, by design.
-- **Density law** — 0.5 FS tone, DPTH 0/32/64/96/127: −12.3 / −8.7 / −7.8 /
-  −8.0 / −8.8 dBFS. Flat within ~1 dB from 32 up; the sparse end is 3.5 dB
-  down (two grains per line now, so sparse is more silence). Peaks reach
-  1.0 FS at the sparse end on that tone: the +6 dB makeup headroom v3 had.
-- **Level vs v3** — at matched settings (DPTH 64, DRV 64, PTCH 1, FDBK 40)
-  v4 is 3.3–3.6 dB quieter on real material (`out/ab/grain_v4/`; the `_lm`
-  copies are v4 raised by 3.45 dB for a level-matched A/B). A voicing item:
-  the makeup law can absorb it once the ear pass says the texture is right.
+- **The grain read geometry played an octave up at "unity".** Nimbus's
+  `W − (base + s + G − phase)` moves with the write head AND the phase, so
+  the absolute read advances two samples per sample. Measured: 955 Hz out for
+  438 in, and 3× at +12. Invisible to the DC gate (rate has no DC signature).
+  Fixed with a `+ phase` term (unity = a fixed tap behind the head) and
+  per-sample distance clamps to `[2, 16383]`. The standalone Nimbus very
+  likely carries it — noted in its README, unverified there.
+- **The latched MIDI note slot is boot garbage in `dsp_host`**, so every
+  local GRAIN render ran its pitch from a garbage note until the RATE knob
+  visibly did nothing. The warm-up now clears `y:>$090a` (the build's
+  core-private census went 2 → 3 for a source with the clear).
 
-⬜ **Ear pass pending** (Sam): `out/ab/grain_v4/{glow_intro,guitar_dry}_{v3,v4_lm}.wav`.
+Measured (`make render-delay` hatch, 438 Hz tone, 93 ms grains, TIME 127):
+
+| RATE | measured | expected | note | measured | expected |
+|---|---|---|---|---|---|
+| 64 | 438.7 | 438 | 84 | = RATE 64, bit-identical | |
+| 96 | 869.4 | 876 | 96 | 869.4 | 876 |
+| 32 | 223.4 | 219 | 91 | 654.1 | 656 |
+| 48 | 309.5 | 310 | 72 | 223.4 | 219 |
+| 127 | 1709 | 1714 | 60 | 94 | 110 (see below) |
+
+Peaks are read off a comb at the grain rate (10.8 Hz at 93 ms), so ±1 line
+is the finder, not the engine. Below about −1.5 octaves the finder reads
+10–25 % low on both paths (RATE 16 → 137 for 155, note 60 → 94 for 110):
+**unverified** whether that is the engine or the measurement; a longer FFT
+on a lower tone would settle it. The pitch ceiling behaves as derived:
+186 ms grains at TIME 100 clamp RATE 127 to 2.5× (1106 Hz measured).
+
+- **DC gate** (0.25 FS DC, full density, unison): p-p 0 across scatter 0/64/127
+  and every size — four windows a quarter period apart sum to exactly 2.
+- **Bit-identity vs v3:** CLEAN in every case (defaults, PING 0/127, TIME
+  0/127, FDBK+TONE, split, MIX 0), REVERSE at both sizes, CLEAN with wow at
+  DPTH 100 and 127/FDBK 127, and the unknown-mode fallback — all identical
+  (`verify_delay` for CLEAN; REVERSE/wow by hand with the mode numbers mapped).
+- **Density law** (0.5 FS tone, DRV 64, 93 ms): −14.6 / −11.2 / −10.7 /
+  −11.3 / −12.0 dBFS at DPTH 0/32/64/96/127 — flat within 1.3 dB from 32 up,
+  sparse end 3.9 dB down. Peaks touch 0.86 FS at DPTH 32 (the +6 dB makeup
+  on a lone grain).
+- **Level vs v3** on real material at matched settings: v5 is ~6 dB quieter
+  (four decorrelated grains sum less coherently than their DC normalisation;
+  the `_lm` copies in `out/ab/grain_v4/` are level-matched). A voicing item.
+
+⬜ **Ear pass pending** (Sam): `out/ab/grain_v4/{glow_intro,guitar_dry}_v3.wav`
+vs `_v5_r64_lm.wav` (unison) and `_v5_r96_lm.wav` (+12).
 
 ## Open
 
-- GRAIN v4's ear pass, the −3.4 dB level offset, and v4.1 (PITCH on RATE).
+- GRAIN v5's ear pass and the level offset (a makeup decision).
+- Pitch accuracy below −1.5 octaves: finder or engine, unverified.
 - The delay return is ~4 dB quieter than the reverb at equal send.

--- a/modules/bongdelay/README.md
+++ b/modules/bongdelay/README.md
@@ -1,9 +1,10 @@
 # BongDelay
 
 A multi-mode delay — CLEAN, PITCH (a once-per-repeat harmoniser), GRAIN (a
-granular cloud) and REVERSE — with tape-style wow/flutter (DPTH/RATE), drive
-(DRV, doubling as GRAIN's scatter depth) and a FREEZE hold available in
-**every** mode. Its wet can be sent on into ChonVerb over the bus (`-VRB`),
+granular cloud: since v4, Nimbus's unity-rate grain readers over the delay
+lines) and REVERSE — with tape-style wow/flutter (DPTH/RATE), drive (DRV,
+doubling as GRAIN's scatter depth) and a FREEZE hold available in **every**
+mode. Its wet can be sent on into ChonVerb over the bus (`-VRB`),
 which is the series topology the stock firmware has no path for.
 
 Hosted on payload B (core 1), which serves **tracks 1–4**.
@@ -21,8 +22,50 @@ label comes from the [`tempo-sync`](../tempo-sync/) module's formatter cave.
 hatch (`make render-delay`), which places it out of region in payload A.
 `DFRZAT=n` engages FREEZE after n blocks so a render can catch it mid-flight.
 
+## GRAIN v4 (3 Sep 2026) — Nimbus's readers over the delay lines
+
+The v2 GRAIN was the delay's cost centre: eight lerped heads with per-grain
+rate accumulators and a rolled builder, priced at 1,385 cycles and the worst
+path of the whole engine. v4 is `modules/nimbus/`'s engine instead: four
+unity-rate grains, two per line at a half-period offset so each line's two
+triangle windows sum to exactly 1, integer reads, one multiply per window,
+a latch at each grain's own wrap. The delay's worst path is now PITCH's:
+**2,372 → 1,255 cycles** (`make cycles`), and the module shrank 2,469 → 2,308
+words (payload B FREE 5 → 166).
+
+Knobs in GRAIN: TIME = position (read-back distance), PTCH = grain SIZE
+(23 / 46 / 93 / 186 ms — the select REVERSE already reads as a size), DRV =
+scatter depth (up to 4,095 samples), DPTH = density (the R61 full-dial law and
+makeup, kept verbatim), FREEZE holds the lines and the grains keep grazing
+them. ⚠️ The PTCH select still prints its PITCH-mode words (`+12 +7 -12 det`);
+per-mode labels are a rig backlog item.
+
+**What v4 gives up: the pitched grains.** Every grain plays at unity, so the
++12 / −19 / −12 / +5 / −5 / +7 set is gone. The planned v4.1 puts a
+continuous grain PITCH on the RATE knob (free in GRAIN, since wow depth is
+density there): one rate for all four grains, Clouds-style, ~+100 cycles.
+
+Measured (local, `make render-delay` hatch):
+
+- **DC gate** — 0.25 FS DC through GRAIN at full density: −124 dB ripple in
+  the steady window, with scatter 0 and 64 and at the 186 ms grain. The two
+  windows per line sum to exactly 1, so the a0 multiplier is right (the trap
+  Nimbus found — see its header).
+- **Bit-identity** — CLEAN, PITCH, TAPE, REVERSE and the unknown-mode fallback
+  render bit-identical to v3 (`tools/verify_delay.py` against the v3 source);
+  only the three GRAIN cases differ, by design.
+- **Density law** — 0.5 FS tone, DPTH 0/32/64/96/127: −12.3 / −8.7 / −7.8 /
+  −8.0 / −8.8 dBFS. Flat within ~1 dB from 32 up; the sparse end is 3.5 dB
+  down (two grains per line now, so sparse is more silence). Peaks reach
+  1.0 FS at the sparse end on that tone: the +6 dB makeup headroom v3 had.
+- **Level vs v3** — at matched settings (DPTH 64, DRV 64, PTCH 1, FDBK 40)
+  v4 is 3.3–3.6 dB quieter on real material (`out/ab/grain_v4/`; the `_lm`
+  copies are v4 raised by 3.45 dB for a level-matched A/B). A voicing item:
+  the makeup law can absorb it once the ear pass says the texture is right.
+
+⬜ **Ear pass pending** (Sam): `out/ab/grain_v4/{glow_intro,guitar_dry}_{v3,v4_lm}.wav`.
+
 ## Open
 
-- GRAIN's density gate only subtracts energy, so sparse always costs level.
-  It needs makeup gain on the surviving grains, which does not exist yet.
+- GRAIN v4's ear pass, the −3.4 dB level offset, and v4.1 (PITCH on RATE).
 - The delay return is ~4 dB quieter than the reverb at equal send.

--- a/modules/bongdelay/delay_server.asm
+++ b/modules/bongdelay/delay_server.asm
@@ -204,25 +204,26 @@
 ;                       comes from $24/$25 -- PITCH or GRAIN. Replaces the
 ;                       per-sample MODE compare at the substitution point, so
 ;                       adding modes there costs nothing per sample
-;   r7+$34..$53         GRAIN grain table, 8 records of 4 words, INTERLEAVED
-;                       L0 R0 L1 R1 L2 R2 L3 R3 so that the builder walks it
-;                       straight through and each reader strides by 8:
-;                         +0 age_int, 0..2047       (rebuilt every sample)
-;                         +1 latched scatter        (PERSISTENT, see below)
-;                         +2 sample fraction, Q23   (rebuilt every sample)
-;                         +3 window gain / 2, Q23   (rebuilt every sample)
-;                       The field order IS the consumption order in both
-;                       loops, which is what lets every access be a plain
-;                       post-increment instead of an indexed read
-;   r7+$54/$55          this sample's scatter candidates, line L / line R --
-;                       two DISJOINT fields of one PRNG word, each scaled by
-;                       SPRAY. Per-line candidates are what keep L and R
-;                       decorrelated while they share ages and window gains
-;   r7+$56..$5b         GRAIN per-sample scratch (builder: age_fx / age_int /
-;                       frac / gain / smoothstep temp; reader: phase / t0;
-;                       $57 also carries the density MAKEUP coeff from the
-;                       hoist into the builder -- dead there until the
-;                       reader's t0 park)
+;   r7+$34..$37         GRAIN v4 latched scatter s0..s3, integers 0..4095
+;                       (PERSISTENT, latched at each grain's own wrap; cleared
+;                       by the warm-up like the PITCH offsets)
+;   r7+$38              GRAIN v4 mask G-1 (per block, from the PTCH select
+;                       read as SIZE: G = 1024 << idx)
+;   r7+$39              GRAIN v4 G/4, the grain-to-grain phase offset (per block)
+;   r7+$3a              GRAIN v4 window multiplier 2^(23-k) (per block)
+;   r7+$3b              GRAIN v4 read distance base lag + G + 1, lag =
+;                       min(TIME, 12287 - mask) (per block; the cap is what
+;                       keeps lag + scatter + G inside the line)
+;   r7+$3c              GRAIN v4 dens3 = DPTH knob >> 4, 0..7 (per block)
+;   r7+$3d              GRAIN v4 makeup coeff 1/2 + (7-dens3)/14, Q23 (per block)
+;   r7+$40..$43         GRAIN v4 window multiplier w0..w3, 2^(23-k) or 0 when
+;                       the grain was drawn muted (PERSISTENT, latched at the
+;                       wrap; cleared by the warm-up)
+;   r7+$3e/$3f, $44..$53  free since v4 (the v2 grain table's other fields)
+;   r7+$54              this sample's scatter candidate, 0..4095 (GRAIN v4)
+;   r7+$55              this sample's window-multiplier candidate (GRAIN v4)
+;   r7+$56..$5b         REVERSE per-sample scratch (GRAIN v4 no longer uses
+;                       them; v2's builder/reader scratch lived here)
 ;   r7+$5c              SPRAY depth, Q23 (per block, from the SPRAY knob)
 ;   r7+$5d              GRAIN per-grain age cursor (the builder's running age)
 ;   r7+$5e              REVERSE segment phase, 23-bit (persistent, masked on
@@ -857,19 +858,18 @@ dwarmz:
                                         ; what verify-delay bit-compares
         move    b,x:(r7+$32)            ; GRAIN base age
         move    b,x:(r7+$5e)            ; REVERSE segment phase
-; GRAIN's eight LATCHED SCATTERS (record +1 of each of the eight grains).
-; Only these persist -- every other field of the table is rewritten by the
-; builder before the readers touch it, every sample, so boot garbage there
-; cannot survive one sample. A garbage SCATTER would, and it subtracts
-; straight into a read address, so it is cleared like the PITCH offsets are.
-        move    b,x:(r7+$35)            ; L0
-        move    b,x:(r7+$39)            ; R0
-        move    b,x:(r7+$3d)            ; L1
-        move    b,x:(r7+$41)            ; R1
-        move    b,x:(r7+$45)            ; L2
-        move    b,x:(r7+$49)            ; R2
-        move    b,x:(r7+$4d)            ; L3
-        move    b,x:(r7+$51)            ; R3
+; GRAIN v4's PERSISTENT latches: four scatters and four window multipliers,
+; each re-latched at its own grain's wrap. A garbage scatter subtracts
+; straight into a read address and a garbage multiplier is a garbage window
+; for one grain-life, so both start at 0 like the PITCH offsets do.
+        move    b,x:(r7+$34)            ; scatter s0..s3
+        move    b,x:(r7+$35)
+        move    b,x:(r7+$36)
+        move    b,x:(r7+$37)
+        move    b,x:(r7+$40)            ; window multiplier w0..w3 (0 = muted)
+        move    b,x:(r7+$41)
+        move    b,x:(r7+$42)
+        move    b,x:(r7+$43)
         move    #>$123456,a             ; PRNG seed: any nonzero word (xorshift
         move    a,x:(r7+$18)            ; is dead at 0), fixed for determinism
         move    x:(r7+$15),a            ; reload count
@@ -1477,6 +1477,98 @@ plagok:
         add     x0,a                    ; min(TIME, 14335)
         move    a,x:(r7+$6e)            ; PLAGB, the pitch heads' lag base
 
+; ---- GRAIN v4 per-block decode (BongDelay v4, 3 Sep 2026) ----------------
+; Nimbus's grain family from the PTCH select, which GRAIN reads as a SIZE
+; exactly as REVERSE already does: G = 1024 << idx samples (23/46/93/186
+; ms), its mask, G/4 (the grain-to-grain offset) and the one-multiply window's
+; multiplier 2^(23-k) -- see modules/nimbus/nimbus_grain.asm's header for
+; why that is 2^(23-k) and not 2^(24-k) (the a0 trap). Per block, so the
+; sample loop pays nothing for the ladder.
+        move    x:(r7+$5f),a            ; SIZE index 0..3
+        move    #>$1,x0
+        cmp     x0,a
+        blt     gvs0
+        beq     gvs1
+        move    #>$2,x0
+        cmp     x0,a
+        beq     gvs2
+        move    #>$1fff,x0              ; idx 3: G = 8192 (186 ms)
+        move    x0,x:(r7+$38)
+        move    #>$800,x0
+        move    x0,x:(r7+$39)
+        move    #>$400,x0               ; 2^(23-13)
+        move    x0,x:(r7+$3a)
+        bra     gvsz
+gvs2:
+        move    #>$fff,x0               ; G = 4096 (93 ms)
+        move    x0,x:(r7+$38)
+        move    #>$400,x0
+        move    x0,x:(r7+$39)
+        move    #>$800,x0               ; 2^(23-12)
+        move    x0,x:(r7+$3a)
+        bra     gvsz
+gvs1:
+        move    #>$7ff,x0               ; G = 2048 (46 ms)
+        move    x0,x:(r7+$38)
+        move    #>$200,x0
+        move    x0,x:(r7+$39)
+        move    #>$1000,x0              ; 2^(23-11)
+        move    x0,x:(r7+$3a)
+        bra     gvsz
+gvs0:
+        move    #>$3ff,x0               ; G = 1024 (23 ms)
+        move    x0,x:(r7+$38)
+        move    #>$100,x0
+        move    x0,x:(r7+$39)
+        move    #>$2000,x0              ; 2^(23-10)
+        move    x0,x:(r7+$3a)
+gvsz:
+; the read distance base: lag + G + 1, with lag = min(TIME, 12287 - mask).
+; A grain reads W - (lag + s + G + 1 - phase): at least lag + s + 1 behind
+; the write and at most lag + s + G behind it, and s tops out at 4095, so
+; lag + 4095 + G must stay inside the 16,384-word line. ⚠️ THAT BOUND IS
+; LOAD-BEARING: past it a head reads across the write pointer, a full-scale
+; discontinuity once per grain. sub/tst, not cmp (the cmp-encodes-as-max
+; trap family).
+        move    x:(r7+$38),b            ; mask = G - 1
+        move    #>12287,a               ; 16383 - 4096
+        sub     b,a                     ; the lag cap for this G
+        move    a,x:(r7+$3b)            ; park the cap
+        move    x:(r7+$75),a            ; TIME
+        move    x:(r7+$3b),x0
+        sub     x0,a
+        tst     a
+        ble     gvlag                   ; TIME <= cap: keep it
+        clr     a                       ; over: excess -> 0, i.e. clamp
+gvlag:
+        add     x0,a                    ; min(TIME, cap)
+        move    x:(r7+$38),x0
+        add     x0,a                    ; + G - 1
+        add     #>$2,a                  ; + 2 = lag + G + 1
+        move    a,x:(r7+$3b)            ; the read distance base
+; density: dens3 = knob >> 4 (0..7) from the DPTH word ($2d = knob << 13),
+; the R61 full-dial law; and the level MAKEUP coeff = 1/2 + (7-dens3)/14 in
+; Q23 (R61, verbatim: flattens the gate's energy loss within ~1.2 dB; the top
+; of the ramp is $7FFFFF by construction, so the sum cannot wrap).
+        move    x:(r7+$2d),a
+        asr     #$11,a,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$3c)            ; dens3
+        move    #>7,b
+        sub     a,b                     ; 7 - dens3
+        move    b1,x0
+        move    x0,b
+        asl     #$14,b,b                ; (7-dens3) << 20 = n/8 in Q23
+        move    b1,x0
+        move    #>$492492,y1            ; 8/14 in Q23
+        mpy     x0,y1,b                 ; n/14 (x0,y1 -- a SIGNED encode)
+        move    #>$400000,x0
+        add     x0,b                    ; + 1/2
+        move    b1,x0
+        move    x0,b
+        move    b,x:(r7+$3d)            ; GRAIN makeup coeff, this block
+
 ; ---- rebuild both line pointers from saved phase --------------------------
 ; Same A2-clean discipline as dsp/reverb89.asm's phase reload: garbage with
 ; bit 23 set would sign-extend and saturate the following move a,rN to
@@ -1996,84 +2088,49 @@ pmode:
 ; stage-1 rule, so old projects' stored TAPE parts still play.)
 ; MODEFORK_MID -- alternative 3: GRAIN
 
-; ---- GRAIN: four overlapping grains per line, rolled (v2 stage 5) ---------
-; THE FLAGSHIP, and the honest answer to "it doesn't sound like a Microcosm":
-; density is the mechanism, not a better two-head shifter. PITCH's ear pass
-; established the framing this is built on -- a granular device is artifacts
-; made DENSE and APERIODIC until they read as texture, not a clean shifter.
-; So GRAIN is PITCH's machinery with twice the heads and an independent
-; random source position per grain, on a knob.
+; ---- GRAIN v4: Nimbus's grain readers over the delay lines (3 Sep 2026) --
+; The v2 stage-5 GRAIN was the delay's cost centre: eight lerped heads with
+; per-grain rate accumulators, a Tcc-chained interval draw and a rolled
+; builder priced at 548 words + 837 of roll surcharge -- 1,385 cycles, the
+; worst path of the whole engine, on the core that also has to fit the
+; BamSep26 stations. This is modules/nimbus/nimbus_grain.asm's engine
+; instead: four UNITY-RATE grains, two per line at a half-period offset so
+; each line's two triangle windows sum to exactly 1, integer reads (no
+; lerp -- unity rate has no sub-sample position), one multiply per window
+; and a branch-over-two-moves latch at each grain's own wrap. ~200 cycles.
 ;
-; N = 4, AND N MUST BE EVEN. With the full-overlap triangle window, grains
-; staggered by 1/N sum to: N=2 -> 1.0000, N=4 -> 2.0000 (both exactly flat,
-; because the grains pair up complementarily -- 0 with 2, 1 with 3), N=3 ->
-; 0.21 dB ripple, N=5 -> 0.03 dB. An ODD count puts a ripple AT THE GRAIN
-; RATE, which is a periodic amplitude modulation -- exactly the artifact
-; class stages 2b/2c existed to remove. Four it is, and each gain is HALVED
-; as it is built so the four sum to 1.0 and no partial sum can saturate on
-; its way through the accumulator.
+; What it keeps from v2: the density gate (a grain drawn muted at its wrap
+; stays silent for its life) and the R61 makeup law, the SPRAY scatter on
+; DRV, the PRNG (BongDelay's xorshift, which Nimbus copied verbatim), the
+; shifted-output substitution via $24/$25 and the $33 flag, and TIME as the
+; read-back distance -- so this is still a granular DELAY, reading TIME
+; behind the write head, not a Clouds on the input.
 ;
-; THE ROLL IS MANDATORY, not an optimization. PITCH spends 524 words on four
-; head evaluations; eight of them unrolled is ~1,048 words against payload
-; B's ~940 free -- it does not fit. Rolled, the body is emitted three times
-; (one builder, one reader per line) instead of eight. Precedent: the tank
-; roll and the LFO roll in modules/chonverb/reverb_server.asm.
+; What it gives up: the PITCHED grains. Every grain plays at unity, so the
+; +12 / -12 / -19 / +5 / -5 / +7 set is gone and PTCH is the grain SIZE here
+; (23/46/93/186 ms), as it already is for REVERSE. PITCH mode still
+; harmonises repeats. Sam's call at the ear pass (PLAN, the rig).
 ;
-; WHAT IS SHARED AND WHAT IS NOT. One base age serves all four grains, each
-; taking a fixed quarter-cycle offset, so a single advance moves the whole
-; cloud; the window gain, integer age and sample fraction depend only on that
-; age, so they are computed ONCE and used by both lines. What is per-line is
-; the SCATTER -- an independent random source offset per grain per line --
-; and that alone is what keeps L and R decorrelated. (A single scatter shared
-; by both lines would make the two channels identical up to the ping-pong
-; matrix, which is the mono trap this file's header already documents once.)
+; Knobs in GRAIN: TIME = position (lag), PTCH = SIZE, DRV = scatter depth
+; (SPRAY, up to 4095 samples), DPTH = density. FREEZE holds the lines and
+; the grains keep grazing them, forward, behind the frozen head.
 ;
-; OUTPUT ONLY, NEVER IN THE LOOP -- stage 2c, and it is not optional here: a
-; cascade would put every repeat through eight more splices, and compounding
-; is what an ear calls "machine". The result lands in $24/$25 exactly like
-; PITCH's, and the substitution below is mode-blind via the $33 flag.
+; ⚠️ THE WINDOW READS a0: phase * 2^(23-k) into the LOW word, sign-extended
+; back and folded with abs, is a triangle peaking at G/2 -- and the
+; multiplier is 2^(23-k), NOT 2^(24-k), because a0 exposes the fractional
+; left shift a1 hides (CLAUDE.md; found by Nimbus's DC gate). The gate that
+; pins it here: DC in must come back flat, because two triangles a half
+; period apart sum to exactly 1.
 ;
-; A `do` body must be BRANCH-FREE, so every conditional here is a Tcc --
-; already the house idiom, and the reason the scatter latch is `tmi`.
+; A grain's window multiplier is latched AT ITS WRAP as either 2^(23-k) or 0
+; (muted), so the density gate costs nothing per sample: a muted grain's
+; window is identically zero.
 ;
-; mpy orientation throughout: the possibly-negative operand (t1-t0, the tap)
-; is ALWAYS x0, the audited-signed `mpy x0,y1` form; y1 only ever carries a
-; fraction or a window gain, both non-negative.
+; mpy orientation: the signed operand (the line sample) is always x0, the
+; audited `mpy x0,y1` form; y1 only ever carries a window gain or a
+; multiplier, both non-negative.
 gmode:
-; ---- GRAIN, v2 stage 5e: the SCHEDULE and the RATE are separate ----------
-; Until now one accumulator drove both the window envelope and the read
-; position. That single fact forced three things at once, and Sam heard all
-; three: every grain shifted by the SAME interval and they all jumped
-; TOGETHER (a step in the whole layer, "jumping around in a not very musical
-; fashion"); UNISON WAS IMPOSSIBLE, because a rate of 1.0 means the age never
-; advances, so the grain never wraps and never re-scatters -- which is why
-; the interval set had no unison in it, and "mostly unison with occasional
-; shifts" is most of what makes a grain cloud sound musical rather than
-; arbitrary; and grain size was welded to the pitch ratio.
-;
-; So: a SCHEDULE phase ticks at a fixed rate and drives ONLY the envelope,
-; while each grain carries its OWN read-offset accumulator advancing at its
-; own rate. The cloud now morphs instead of stepping, and unison is a legal
-; draw.
-;
-; Record, 8 of them (L0 R0 L1 R1 ...), FOUR words -- exactly the 32 the old
-; table used, so this costs no r7 space (there is none):
-;   +0 rate delta, signed Q9 per sample   (PERSISTENT, latched at the wrap)
-;   +1 mute flag                          (PERSISTENT, latched at the wrap)
-;   +2 read offset, Q14.9                 (PERSISTENT, accumulates)
-;   +3 window gain / 2, Q23               (rebuilt every sample)
-; The field order is the BUILDER's access order, so every access is a plain
-; post-increment; the readers start at +2 and stride 8 with n4.
-;
-; RATE DELTAS are (1 - r) in Q9, because the read address is wr - lag and the
-; write pointer runs away at 1 sample/sample:
-;   unison r=1.0 -> 0      +12 r=2.0 -> -512
-;   +7     r=1.5 -> -256   -12 r=0.5 -> +256
-; A grain at +12 therefore traverses 2048 samples over its 2048-sample life,
-; which is why the offset RESETS to 2048 + scatter and why the lag ceiling
-; below subtracts 3072. ⚠️ That bound is load-bearing: LAG0 + 2048 + scatter
-; + 1024 must stay inside the 16384-word line, or a head reads across the
-; write pointer -- a full-scale discontinuity once per grain.
+; ---- PRNG advance: BongDelay's 23-bit xorshift 15/15/8 -------------------
         move    x:(r7+$18),a            ; state
         move    a1,x0
         asl     #$f,a,a
@@ -2091,461 +2148,189 @@ gmode:
         move    a1,x0
         move    x0,a                    ; A2 clean before the store
         move    a,x:(r7+$18)
-; ---- this sample's scatter candidates, SPRAY-scaled ---------------------
+; ---- this sample's scatter candidate: prng * SPRAY -> 0..4095 samples ----
         move    a,x0                    ; state, 0 .. ~1.0 (always positive)
-        move    x:(r7+$5c),y1           ; SPRAY
+        move    x:(r7+$5c),y1           ; SPRAY, Q23
         mpy     x0,y1,a                 ; both operands non-negative
-        asr     #$a,a,a
-        and     #>$1fff,a               ; 0..8191 samples (186 ms)
+        asr     #$b,a,a                 ; fraction -> integer samples
+        and     #>$fff,a                ; belt and braces: it IS 0..4095
         move    a1,x0
         move    x0,a
-        move    #>0,x0                  ; the SCATTER ALONE now -- the
-        add     x0,a                    ; reserve is added PER GRAIN below,
-        asl     #$9,a,a                 ; (4096 + scatter) in Q14.9. Also
-        move    a1,x0                   ; per-sample-constant, so the builder
-        move    x0,a                    ; no longer rebuilds it four times.
-        move    a,x:(r7+$54)            ; reset form, line L
-        move    x:(r7+$18),a
-        asl     #$b,a,a                 ; a DISJOINT field of the same word,
-        and     #>$7fffff,a             ; so no bit feeds both lines
-        move    a1,x0
-        move    x:(r7+$5c),y1
-        mpy     x0,y1,a
-        asr     #$a,a,a
-        and     #>$1fff,a
-        move    a1,x0
-        move    x0,a
-        move    #>0,x0                  ; the SCATTER ALONE now -- the
-        add     x0,a                    ; reserve is added PER GRAIN below,
-        asl     #$9,a,a                 ; (4096 + scatter) in Q14.9. Also
-        move    a1,x0                   ; per-sample-constant, so the builder
-        move    x0,a                    ; no longer rebuilds it four times.
-        move    a,x:(r7+$55)            ; reset form, line R
-; ---- the SCHEDULE: fixed rate, drives the envelope alone -----------------
-; 2^23 / 4096 = 2048 samples per grain (46 ms). Grain SIZE is now free to
-; become a parameter -- it is this constant and nothing else -- but page 2
-; has no spare slot, so it stays fixed until something is given up.
-        move    x:(r7+$32),a
-        move    #>$400,x0
-        add     x0,a
-        and     #>$7fffff,a
-        move    a1,x0
-        move    x0,a                    ; A2-clean; boot garbage dies here
-        move    a,x:(r7+$32)
-        move    a,x:(r7+$5d)            ; the builder's cursor
-; ---- GRAIN's lag base, from SPRAY ---------------------------------------
-        move    x:(r7+$5c),a            ; SPRAY, Q23
-        asr     #$a,a,a                 ; ~ its max scatter in samples
-        move    a1,x0
-        move    #>8190,a                ; 16382 - 8192 (a +12 grain's own
-        sub     x0,a                    ; grain's upward traversal)
-        move    a,x:(r7+$57)
-        move    x:(r7+$75),a            ; TIME
-        move    x:(r7+$57),x0
-        sub     x0,a
-        tst     a
-        ble     grcapok
-        clr     a
-grcapok:
-        add     x0,a
-        move    a,x:(r7+$56)            ; GRAIN's lag base, this sample
-; ---- HOISTED: the three per-sample draws (v2 stage 5f, optimisation) -----
-; These read ONLY per-sample-constant state -- the select index, the PRNG
-; word (advanced once above) and the DENS knob -- so all four builder
-; iterations were computing IDENTICAL values four times over. Lifting them is
-; therefore BIT-IDENTICAL, not merely equivalent, and the gate proves it.
-;
-; It is also correct for a second, independent reason worth writing down: the
-; four grains sit at exact quarter offsets of a schedule advancing $1000 per
-; sample, so their wraps are 512 samples apart and AT MOST ONE GRAIN WRAPS
-; PER SAMPLE. A single candidate is all that can ever be consumed.
-;
-; They live in REVERSE's per-block slots, which is sound for the same reason
-; GRAIN already borrows its scratch: the mode alternatives are mutually
-; exclusive within a sample, and REVERSE rebuilds these every block.
-; The select is the SET WIDTH, and entry 0 is +12 so that a mask of 0 --
-; select index 0 -- pins every grain to the octave. That is the fixed engine,
-; the nearest thing to what was ear-passed before the split, and it stays
-; reachable for comparison.
-;   index 0 -> mask 0: +12 only          index 1 -> mask 1: +12 / unison
-;   index 2,3 -> mask 3: +12 / unison / +7 / -12
-        move    x:(r7+$18),a            ; the interval-hold roll draw
-        asr     #$c,a,a                 ; bits 12-13: a field no other draw
-        and     #>$3,a                  ; touches (set 0-2, density 5-10)
-        move    a1,x0                   ; the AND leaves A2 stale, so the
-        move    x0,a                    ; value leaves through a1
-        move    a,x1                    ; park: 0 == re-pitch at this wrap.
-                                        ; x1, NOT y1 -- the builder's window
-                                        ; smoothstep clobbers y1 every pass.
-                                        ; p = 1/4, so a grain holds ~4 lives.
-        move    x:(r7+$5f),a            ; select index
-        move    #>$7,b                  ; index 3 -> the WIDE 8-entry set
-        tst     a
-        move    #>$0,x0
-        teq     x0,b                    ; index 0 -> fixed +12
-        move    #>$1,x0
-        cmp     x0,a
-        move    #>$1,x0
-        teq     x0,b                    ; index 1 -> +12 / unison
-        move    #>$2,x0
-        cmp     x0,a
-        move    #>$3,x0
-        teq     x0,b                    ; index 2 -> the shipping 4-entry set
-        move    b,x0
+        move    a,x:(r7+$54)
+; ---- this sample's window-multiplier candidate: 2^(23-k), or 0 if muted --
+; three PRNG bits against dens3 (the R61 law): muted when bits > dens3, so
+; dens3 = 7 never mutes and dens3 = 0 mutes seven grains in eight.
         move    x:(r7+$18),b
-        and     x0,b
-        move    b1,x0
-        move    x0,b                    ; A2-clean before the compares
-        move    #>$fffe00,a             ; 0 -> +12  (-512)
-        move    #>$1,x0
-        cmp     x0,b
-        move    #>$0,x0                 ; CLR is accumulator-only; a zero
-        teq     x0,a                    ; immediate is the register form
-                                        ; 1 -> UNISON (delta 0) -- impossible
-                                        ; before the split, and most of what
-                                        ; keeps the cloud musical
-        move    #>$2,x0
-        cmp     x0,b
-        move    #>$155,x0               ; 2 -> -19  (+341)
-        teq     x0,a
-        move    #>$3,x0
-        cmp     x0,b
-        move    #>$100,x0               ; 3 -> -12  (+256)
-        teq     x0,a
-        move    #>$4,x0
-        cmp     x0,b
-        move    #>$0,x0
-        teq     x0,a                    ; 4 -> UNISON again: 2/8, so the cloud
-                                        ; still sits mostly at pitch
-        move    #>$5,x0
-        cmp     x0,b
-        move    #>$ffff55,x0            ; 5 -> +5   (-171)
-        teq     x0,a
-        move    #>$6,x0
-        cmp     x0,b
-        move    #>$80,x0                ; 6 -> -5   (+128)
-        teq     x0,a
-        move    #>$7,x0
-        cmp     x0,b
-        move    #>$ffff00,x0            ; 7 -> +7   (-256)
-        teq     x0,a
-        move    a,x:(r7+$5e)            ; the candidate rate, this sample
-        move    x:(r7+$18),b            ; density: three PRNG bits vs DENS
         asr     #$5,b,b
         and     #>$7,b
-        move    b1,x0
-        move    x0,b
-        move    x:(r7+$2d),a            ; DENS (the WOW knob in GRAIN)
-        asr     #$11,a,a                ; $2d holds knob<<13; >>17 = knob>>4,
-                                        ; 0..7 across the FULL dial. The old
-                                        ; >>14 left knob>>1 vs a 3-bit draw:
-                                        ; every value >=15 saturated to full
-                                        ; density and the knob's whole range
-                                        ; lived in 0..14 (measured 31 Aug
-                                        ; 2026 -- flat 16..127, -7 dB at 0)
+        move    b1,x1                   ; bits, 0..7 (x1 is free in this mode)
+        clr     b                       ; the muted form, BEFORE the compare
+        move    x:(r7+$3c),a            ; dens3
+        sub     x1,a                    ; N SET == muted
+        move    x:(r7+$3a),x0           ; the live multiplier
+        tpl     x0,b                    ; not muted -> take it
+        move    b,x:(r7+$55)
+; ---- age advance, masked by G-1 (also swallows size changes) -------------
+        move    x:(r7+$32),a
+        add     #>$1,a
+        move    x:(r7+$38),x0
+        and     x0,a
         move    a1,x0
         move    x0,a
-        sub     b,a                     ; N SET == this grain stays silent
-        clr     b
-        move    #>$1,x0
-        tmi     x0,b                    ; b = 1 when muted
-        move    b,x:(r7+$60)            ; candidate mute, line L
-        move    x:(r7+$18),b            ; its own density draw, so L and R
-        asr     #$8,b,b                 ; gap independently
-        and     #>$7,b
-        move    b1,x0
-        move    x0,b
-        move    x:(r7+$2d),a
-        asr     #$11,a,a                ; same relaw as line L above
-        move    a1,x0
-        move    x0,a
-        sub     b,a
-        clr     b
-        move    #>$1,x0
-        tmi     x0,b
-        move    b,x:(r7+$61)            ; candidate mute, line R
-; ---- density MAKEUP: coeff = 1/2 + (7-dens3)/14, Q23 ---------------------
-; The gate mutes grains but nothing restored the level, so sparse always
-; cost energy (measured 31 Aug 2026: -0.4/-1.0/-1.9/-2.8/-3.8/-5.4/-7.1 dB
-; at dens3 6..0). This linear law flattens it within ~1.2 dB; the top of
-; the ramp is $7FFFFF by construction (7 * $492492 = $1FFFFFE, so the sum
-; cannot wrap), i.e. the cap is +6 dB and dens3=0 keeps a -1.1 dB residue.
-; Parked in $57, which is DEAD from the pre-hoist park above until the
-; reader parks t0 there -- after the builder (the only consumer) is done.
-; x1 (the parked roll draw) and y0 are NOT touched; y1 is builder-clobbered
-; every pass anyway and is loaded fresh at the consuming mpy.
-        move    x:(r7+$2d),a            ; knob<<13
-        asr     #$11,a,a                ; dens3, 0..7
-        move    a1,x0
-        move    x0,a
-        move    #>7,b
-        sub     a,b                     ; 7-dens3
-        move    b1,x0                   ; through b1: sub is safe but asl
-        move    x0,b                    ; below leaves B2 stale
-        asl     #$14,b,b                ; (7-dens3)<<20 = n/8 in Q23
-        move    b1,x0
-        move    #>$492492,y1            ; 8/14 in Q23
-        mpy     x0,y1,b                 ; n/14 (x0,y1 -- a SIGNED encode)
-        move    #>$400000,x0
-        add     x0,b                    ; + 1/2
-        move    b1,x0
-        move    x0,b
-        move    b,x:(r7+$57)            ; GRAIN makeup coeff, this sample
-
-; ---- BUILDER ------------------------------------------------------------
-        move    r7,a
-        move    #>$34,x0
-        add     x0,a
-        move    a,r4                    ; -> record L0
-        move    #>2,n4
-        do      #4,>grnbz
-; window gain from the SCHEDULE phase alone, scaled by the density makeup
-; coeff (1/2 at full density == the old fixed halving; four grains sum to
-; 2.0, so 1/2 is unity and the coeff tops out at 1.0 = +6 dB of makeup)
-        move    x:(r7+$5d),a
-        bsr     smoothw                 ; smoothstepped triangle (v6 roll --
-                                        ; y0's wrap flag is parked AFTER this
-                                        ; point, and smoothw never touches y0
-                                        ; anyway)
-        move    a1,x0                   ; window, >= 0
-        move    x:(r7+$57),y1           ; density makeup coeff (hoist)
-        mpy     x0,y1,a                 ; x0,y1 -- a SIGNED encode
-        move    a1,x0                   ; a1: the plain fractional product
-        move    x0,a
-        move    a,x:(r7+$59)            ; gain * coeff
-; ---- this grain's own wrap: prev = (phase - SSTEP) & mask ----------------
-        move    x:(r7+$5d),a
-        move    #>$400,x0
-        sub     x0,a
-        and     #>$7fffff,a
-        move    a1,x0                   ; prev (A1 only: the AND leaves A2
-                                        ; stale, so it leaves through a1)
-        move    x:(r7+$5d),a
-        sub     x0,a
+        move    a,x:(r7+$32)
+; ---- grain 0: line L, phase = age --------------------------------------
+        clr     b                       ; wet L accumulates in b
+        move    x:(r7+$32),a
+        tst     a
+        bne     gvga
+        move    x:(r7+$54),x0           ; wrap: latch this grain's scatter
+        move    x0,x:(r7+$34)
+        move    x:(r7+$55),x0           ; and its window multiplier (or 0)
+        move    x0,x:(r7+$40)
+gvga:
+        move    a,x1                    ; phase
+        move    a,x0
+        move    x:(r7+$40),y1
+        mpy     x0,y1,a                 ; a0 = wrap(2*phase/G), signed Q23
+        move    a0,x0
+        move    x0,a                    ; reloaded clean: A2 consistent
         abs     a
-        move    #>$400000,x0
-        sub     x0,a                    ; N SET == did NOT wrap
-        move    a,y0                    ; ⚠️ PARK THE FLAG AS A VALUE, in y0 --
-                                        ; free throughout the builder, and a
-                                        ; register restore is a word cheaper
-                                        ; than a memory one at every site. Eight
-                                        ; Tcc's below depend on it and the
-                                        ; arithmetic between them SETS the
-                                        ; condition codes -- the exact bug
-                                        ; stage 5d shipped and an ear caught.
-                                        ; Every one of them restores it first.
-; ---- the candidate rate for this grain, drawn from the SET ---------------
-; unison is IN the set and is drawn as often as anything else, which is what
-; keeps the cloud musical: most grains at pitch, some shifted.
-; ---- record: rate, mute, offset, gain -- L then R ------------------------
-        move    x1,a                    ; this sample's roll draw
-        tst     a                       ; Z SET == re-pitch on this wrap
-        move    #>$800000,x0            ; else force "did not wrap", so the
-        move    y0,a                    ; grain KEEPS its own current rate
-                                        ; (a MOVE leaves the flag alone)
-        tne     x0,a                    ; roll missed -> hold this pitch
-        tst     a                       ; sign = wrapped AND rolled
-        move    x:(r7+$5e),x0           ; candidate rate, hoisted
-        move    x:(r4),b                ; current rate
-        tpl     x0,b                    ; wrapped -> take the new one
-        move    b,x:(r4)+
-        move    b,x:(r7+$5a)            ; this grain's LIVE rate, for the
-                                        ; offset update two words along
-        move    y0,a
-        tst     a
-        move    x:(r7+$60),x0           ; candidate mute L, hoisted
-        move    x:(r4),b                ; current mute
-        tpl     x0,b                    ; wrapped -> take the new one
-        move    b,x:(r4)+
-        move    b,x:(r7+$5b)            ; the LIVE mute
-; offset: reset to (2048 + scatter) << 9 at the wrap, else += rate
-        move    x:(r7+$5a),a            ; this grain's rate delta
-        neg     a                       ; -delta: POSITIVE only for upshifts
-        move    #>$0,x0
-        tmi     x0,a                    ; a downshift reserves NOTHING
-        asl     #$d,a,a                 ; x8192 = (drift samples) << 9 at L=8192
-        move    a1,x0                   ; asl leaves A2 stale
-        move    x0,a
-        move    x:(r7+$54),x0           ; + (scatter << 9), hoisted
-        add     x0,a
-        move    a1,y1                   ; this grain's own RESET form
-        move    x:(r4),a                ; current offset
-        move    x:(r7+$5a),x0           ; this grain's live rate
-        add     x0,a                    ; the RUNNING form, in a
-        move    y1,x0                   ; the RESET form -- Tcc takes
-                                        ; a REGISTER source, never an accumulator
-        move    y0,b                    ; the parked wrap flag
-        tst     b                       ; N SET == did not wrap
-        tpl     x0,a                    ; wrapped -> reset
-        move    a,x:(r4)+
-; gain, zeroed when this grain is muted
-        clr     b
-        move    x:(r7+$5b),a            ; live mute
-        tst     a
-        move    x:(r7+$59),x0           ; gain/2
-        teq     x0,b                    ; mute==0 -> sounds
-        move    b,x:(r4)+
-; ---- the same four words for line R -------------------------------------
-        move    y0,a
-        tst     a
-        move    x:(r7+$5b),x0
-        move    x:(r4),b
-        move    x:(r7+$5a),x0           ; R shares the grain's RATE
-        tpl     x0,b
-        move    b,x:(r4)+
-        move    y0,a
-        tst     a
-        move    x:(r7+$61),x0           ; candidate mute R, hoisted
-        move    x:(r4),b
-        tpl     x0,b
-        move    b,x:(r4)+
-        move    b,x:(r7+$5b)
-        move    x:(r7+$5a),a            ; this grain's rate delta
-        neg     a                       ; -delta: POSITIVE only for upshifts
-        move    #>$0,x0
-        tmi     x0,a                    ; a downshift reserves NOTHING
-        asl     #$d,a,a                 ; x8192 = (drift samples) << 9 at L=8192
-        move    a1,x0                   ; asl leaves A2 stale
-        move    x0,a
-        move    x:(r7+$55),x0           ; + (scatter << 9), hoisted
-        add     x0,a
-        move    a1,y1                   ; this grain's own RESET form
-        move    x:(r4),a
-        move    x:(r7+$5a),x0
-        add     x0,a
-        move    y1,x0                   ; the RESET form
-        move    y0,b
-        tst     b
-        tpl     x0,a
-        move    a,x:(r4)+
-        clr     b
-        move    x:(r7+$5b),a
-        tst     a
-        move    x:(r7+$59),x0
-        teq     x0,b
-        move    b,x:(r4)+
-; ---- next grain: a quarter of the schedule further round -----------------
-        move    x:(r7+$5d),a
-        move    #>$200000,x0
-        add     x0,a
-        and     #>$7fffff,a
-        move    a1,x0
-        move    x0,a
-        move    a,x:(r7+$5d)
-grnbz:
-        nop
-; ---- READER, line L: offset at +2, gain at +3, stride 8 -----------------
-        move    r7,a
-        move    #>$36,x0
-        add     x0,a
-        move    a,r4
-        move    #>6,n4
-        clr     b
-        do      #4,>grnlz
-        move    x:(r4)+,x0              ; this grain's offset, Q14.9 -- it
-        move    x0,x:(r7+$5b)           ; carries BOTH the integer lag and the
-                                        ; lerp fraction now, because each grain
-                                        ; advances at its own rate and so has
-                                        ; its own sub-sample position. There is
-                                        ; no shared fraction any more.
-        move    x0,a
-        asr     #$9,a,a                 ; integer samples
-        move    a1,x0
-        move    x0,a                    ; A2-clean
-        move    a,x:(r7+$5a)
-        move    x:(r7+$5b),a
-        and     #>$1ff,a                ; the fractional part
-        asl     #$e,a,a                 ; -> Q23
-        move    a1,x0
-        move    x0,a
-        move    a,x:(r7+$5b)            ; park frac
+        move    a,y1                    ; window gain = |wrap(2*phase/G)|
+        move    x:(r7+$3b),a            ; lag + G + 1
+        move    x:(r7+$34),x0
+        add     x0,a                    ; + s
+        sub     x1,a                    ; - phase = dist
+        move    a,x0
         move    r1,a                    ; LineL write pointer
-        move    x:(r7+$56),x0           ; GRAIN's lag base
-        sub     x0,a
-        move    x:(r7+$5a),x0           ; this grain's integer offset
-        sub     x0,a
-        and     #>$3fff,a               ; read phase, t0
+        sub     x0,a                    ; W - dist
+        and     #>$3fff,a
         move    a1,x0
         move    x0,a
-        move    a,x:(r7+$5a)            ; park phase
         move    x:(r7+$31),x0           ; LineL base
         add     x0,a
         move    a,r5
-        move    y:(r5),a                ; t0
-        move    a,x:(r7+$57)            ; park t0
-        move    x:(r7+$5a),a
-        move    #>$1,x0
+        move    y:(r5),x0
+        mpy     x0,y1,a                 ; sample * window
+        add     a,b
+; ---- grain 2: line L, phase = age + G/2 ---------------------------------
+        move    x:(r7+$32),a
+        move    x:(r7+$39),x0
+        add     x0,a
+        add     x0,a
+        move    x:(r7+$38),x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a
+        tst     a
+        bne     gvgc
+        move    x:(r7+$54),x0
+        move    x0,x:(r7+$36)
+        move    x:(r7+$55),x0
+        move    x0,x:(r7+$42)
+gvgc:
+        move    a,x1
+        move    a,x0
+        move    x:(r7+$42),y1
+        mpy     x0,y1,a
+        move    a0,x0
+        move    x0,a
+        abs     a
+        move    a,y1
+        move    x:(r7+$3b),a
+        move    x:(r7+$36),x0
+        add     x0,a
+        sub     x1,a
+        move    a,x0
+        move    r1,a
         sub     x0,a
-        and     #>$3fff,a               ; one sample OLDER
+        and     #>$3fff,a
         move    a1,x0
         move    x0,a
         move    x:(r7+$31),x0
         add     x0,a
         move    a,r5
-        move    y:(r5),a                ; t1
-        move    x:(r7+$57),x0           ; t0
-        sub     x0,a                    ; t1 - t0, signed
-        move    a1,x0                   ; -> FIRST mpy operand
-        move    x:(r7+$5b),y1           ; frac, prepared above
-        mpy     x0,y1,a
-        move    x:(r7+$57),x0
-        add     x0,a                    ; tap = t0 + frac*(t1-t0)
-        move    a,x0                    ; LIMITING move
-        move    x:(r4)+,y1              ; this grain's window gain / 2
+        move    y:(r5),x0
         mpy     x0,y1,a
         add     a,b
-        move    (r4)+n4
-grnlz:
-        nop
-; +6 dB GRAIN MAKEUP (18 Aug 2026). Measured wet-only, GRAIN ran 14.2 dB
-; under CLEAN at Sam's settings (SPRA 64, set 3) -- the largest mode-switch
-; level jump in the box, mostly the 4-grain windowed sum's duty cycle. +6 is
-; the HEADROOM-SAFE first step, not the whole gap: at SPRA 0 all four grains
-; cluster coherently and can sum to ~4x a single tap, so closing the full 14
-; would rail exactly there. asl, not a mpy: A2-consistent, no new constant.
+; ---- wet L = (g0 + g2) * makeup * 2 ---------------------------------------
+; the two windows sum to 1, so at full density (coeff 1/2) this is unity;
+; the coeff tops out at 1.0 = +6 dB of makeup for the sparsest gate.
+        move    b,x0                    ; LIMITING move
+        move    x:(r7+$3d),y1           ; makeup coeff
+        mpy     x0,y1,b
         asl     #$1,b,b
         move    b,x:(r7+$24)            ; shifted OUTPUT tap L
-; ---- READER, line R -----------------------------------------------------
-        move    r7,a
-        move    #>$3a,x0
-        add     x0,a
-        move    a,r4
-        move    #>6,n4
+; ---- grain 1: line R, phase = age + G/4 ---------------------------------
         clr     b
-        do      #4,>grnrz
-        move    x:(r4)+,x0              ; this grain's offset, Q14.9 -- it
-        move    x0,x:(r7+$5b)           ; carries BOTH the integer lag and the
-                                        ; lerp fraction now, because each grain
-                                        ; advances at its own rate and so has
-                                        ; its own sub-sample position. There is
-                                        ; no shared fraction any more.
-        move    x0,a
-        asr     #$9,a,a                 ; integer samples
-        move    a1,x0
-        move    x0,a                    ; A2-clean
-        move    a,x:(r7+$5a)
-        move    x:(r7+$5b),a
-        and     #>$1ff,a                ; the fractional part
-        asl     #$e,a,a                 ; -> Q23
+        move    x:(r7+$32),a
+        move    x:(r7+$39),x0
+        add     x0,a
+        move    x:(r7+$38),x0
+        and     x0,a
         move    a1,x0
         move    x0,a
-        move    a,x:(r7+$5b)            ; park frac
-        move    r2,a
-        move    x:(r7+$56),x0
-        sub     x0,a
-        move    x:(r7+$5a),x0           ; this grain's integer offset
+        tst     a
+        bne     gvgb
+        move    x:(r7+$54),x0
+        move    x0,x:(r7+$35)
+        move    x:(r7+$55),x0
+        move    x0,x:(r7+$41)
+gvgb:
+        move    a,x1
+        move    a,x0
+        move    x:(r7+$41),y1
+        mpy     x0,y1,a
+        move    a0,x0
+        move    x0,a
+        abs     a
+        move    a,y1
+        move    x:(r7+$3b),a
+        move    x:(r7+$35),x0
+        add     x0,a
+        sub     x1,a
+        move    a,x0
+        move    r2,a                    ; LineR write pointer
         sub     x0,a
         and     #>$3fff,a
         move    a1,x0
         move    x0,a
-        move    a,x:(r7+$5a)
         move    x:(r7+$68),x0           ; LineR base
         add     x0,a
         move    a,r5
-        move    y:(r5),a
-        move    a,x:(r7+$57)
-        move    x:(r7+$5a),a
-        move    #>$1,x0
+        move    y:(r5),x0
+        mpy     x0,y1,a
+        add     a,b
+; ---- grain 3: line R, phase = age + 3G/4 --------------------------------
+        move    x:(r7+$32),a
+        move    x:(r7+$39),x0
+        add     x0,a
+        add     x0,a
+        add     x0,a
+        move    x:(r7+$38),x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a
+        tst     a
+        bne     gvgd
+        move    x:(r7+$54),x0
+        move    x0,x:(r7+$37)
+        move    x:(r7+$55),x0
+        move    x0,x:(r7+$43)
+gvgd:
+        move    a,x1
+        move    a,x0
+        move    x:(r7+$43),y1
+        mpy     x0,y1,a
+        move    a0,x0
+        move    x0,a
+        abs     a
+        move    a,y1
+        move    x:(r7+$3b),a
+        move    x:(r7+$37),x0
+        add     x0,a
+        sub     x1,a
+        move    a,x0
+        move    r2,a
         sub     x0,a
         and     #>$3fff,a
         move    a1,x0
@@ -2553,22 +2338,14 @@ grnlz:
         move    x:(r7+$68),x0
         add     x0,a
         move    a,r5
-        move    y:(r5),a
-        move    x:(r7+$57),x0
-        sub     x0,a
-        move    a1,x0
-        move    x:(r7+$5b),y1
-        mpy     x0,y1,a
-        move    x:(r7+$57),x0
-        add     x0,a
-        move    a,x0
-        move    x:(r4)+,y1
+        move    y:(r5),x0
         mpy     x0,y1,a
         add     a,b
-        move    (r4)+n4
-grnrz:
-        nop
-        asl     #$1,b,b                 ; +6 dB makeup, matching the L side
+; ---- wet R -------------------------------------------------------------
+        move    b,x0
+        move    x:(r7+$3d),y1
+        mpy     x0,y1,b
+        asl     #$1,b,b
         move    b,x:(r7+$25)            ; shifted OUTPUT tap R
         bra     pdone
 ; MODEFORK_MID -- alternative 4: REVERSE

--- a/modules/bongdelay/delay_server.asm
+++ b/modules/bongdelay/delay_server.asm
@@ -220,8 +220,10 @@
 ;                       the grain was drawn muted (PERSISTENT, latched at the
 ;                       wrap; cleared by the warm-up)
 ;   r7+$3e/$3f, $44..$53  free since v4 (the v2 grain table's other fields)
-;   r7+$54              this sample's scatter candidate, 0..4095 (GRAIN v4)
-;   r7+$55              this sample's window-multiplier candidate (GRAIN v4)
+;   r7+$58/$59          this sample's scatter / window-multiplier candidates
+;   r7+$19..$1f         GRAIN v5 per-sample parks: window, frac, t0, read
+;                       phase, s, wet L, wet R (the PITCH jitter slots until v5)
+;   r7+$5d              GRAIN v5 phase cursor (the reader's running phase)
 ;   r7+$56..$5b         REVERSE per-sample scratch (GRAIN v4 no longer uses
 ;                       them; v2's builder/reader scratch lived here)
 ;   r7+$5c              SPRAY depth, Q23 (per block, from the SPRAY knob)
@@ -247,7 +249,7 @@
 ;   r7+$68              LineR base = LineL base + 0x4000 (per block, for the
 ;                       per-sample manual wraps -- v2 spine)
 ;   r7+$69              MODE, MSB-aligned select (per block; 0 = CLEAN,
-;                       1 = PITCH -- stage 2; every other value runs CLEAN)
+;                       1 = GRAIN, 2 = REVERSE since v5; anything else = CLEAN)
 ;   r7+$6a/$6b          PITCH age step L / R, Q11.12 signed (per block, from
 ;                       the PTCH interval select; they differ only in DETUNE)
 ;   r7+$6c/$6d          PITCH head age L / R, Q11.12 (persistent, masked on
@@ -858,18 +860,42 @@ dwarmz:
                                         ; what verify-delay bit-compares
         move    b,x:(r7+$32)            ; GRAIN base age
         move    b,x:(r7+$5e)            ; REVERSE segment phase
-; GRAIN v4's PERSISTENT latches: four scatters and four window multipliers,
-; each re-latched at its own grain's wrap. A garbage scatter subtracts
+; GRAIN v5's PERSISTENT latches: eight scatters, eight window multipliers
+; and eight read advances, each re-latched at its own grain's wrap. A garbage scatter subtracts
 ; straight into a read address and a garbage multiplier is a garbage window
 ; for one grain-life, so both start at 0 like the PITCH offsets do.
-        move    b,x:(r7+$34)            ; scatter s0..s3
-        move    b,x:(r7+$35)
-        move    b,x:(r7+$36)
-        move    b,x:(r7+$37)
-        move    b,x:(r7+$40)            ; window multiplier w0..w3 (0 = muted)
-        move    b,x:(r7+$41)
-        move    b,x:(r7+$42)
-        move    b,x:(r7+$43)
+        move    b,x:(r7+$40)            ; GRAIN v5 records: s, w, acc x 4 grains x 2 lines
+        move    b,x:(r7+$41)            ; 
+        move    b,x:(r7+$42)            ; 
+        move    b,x:(r7+$43)            ; 
+        move    b,x:(r7+$44)            ; 
+        move    b,x:(r7+$45)            ; 
+        move    b,x:(r7+$46)            ; 
+        move    b,x:(r7+$47)            ; 
+        move    b,x:(r7+$48)            ; 
+        move    b,x:(r7+$49)            ; 
+        move    b,x:(r7+$4a)            ; 
+        move    b,x:(r7+$4b)            ; 
+        move    b,x:(r7+$4c)            ; 
+        move    b,x:(r7+$4d)            ; 
+        move    b,x:(r7+$4e)            ; 
+        move    b,x:(r7+$4f)            ; 
+        move    b,x:(r7+$50)            ; 
+        move    b,x:(r7+$51)            ; 
+        move    b,x:(r7+$52)            ; 
+        move    b,x:(r7+$53)            ; 
+        move    b,x:(r7+$54)            ; 
+        move    b,x:(r7+$55)            ; 
+        move    b,x:(r7+$56)            ; 
+        move    b,x:(r7+$57)            ; 
+        move    b,y:>$090a              ; the latched MIDI note starts at NONE.
+                                        ; ⚠️ Core-private Y is boot garbage in
+                                        ; dsp_host (measured 3 Sep 2026: every
+                                        ; local render ran GRAIN's pitch from a
+                                        ; garbage note, invisible until the knob
+                                        ; did nothing); the latch's HOLD semantics
+                                        ; survive a block, not a re-select, exactly
+                                        ; like every other persistent slot here
         move    #>$123456,a             ; PRNG seed: any nonzero word (xorshift
         move    a,x:(r7+$18)            ; is dead at 0), fixed for determinism
         move    x:(r7+$15),a            ; reload count
@@ -1108,7 +1134,7 @@ dwarmdone:
         move    a,x:(r7+$69)            ; MODE, this block (0 = CLEAN)
 
 ; ---- SHIFTED-OUTPUT flag: which modes replace the wet with $24/$25 --------
-; PITCH, GRAIN and REVERSE all leave their result in the shifted-output taps
+; GRAIN and REVERSE both leave their result in the shifted-output taps
 ; are substituted into the wet AFTER the lines are written (stage 2c, so
 ; nothing shifted can re-enter the feedback). Resolving "is this such a mode"
 ; ONCE PER BLOCK instead of at the substitution point makes that per-sample
@@ -1118,102 +1144,35 @@ dwarmdone:
 ; disturb it, and teq moves a CLEAN register in (never a hand-rolled mask).
         clr     a
         move    x:(r7+$69),b            ; MODE
-        move    #>$10000,x0             ; 1 << 16 = PITCH
+        move    #>$10000,x0             ; 1 << 16 = GRAIN
         cmp     x0,b
         move    #>$1,x0
         teq     x0,a
-        move    #>196608,x0             ; 3 << 16 = GRAIN. DECIMAL, DELIBERATELY:
-                                        ; in hex this immediate IS the payload-A
-                                        ; Y base literal, and build_bus.py's
-                                        ; blanket substitution would rewrite it
-                                        ; to the payload-B base -- i.e. to mode
-                                        ; 0x38. Same trap the census caught on
-                                        ; DMODE=3; writing this comment WITH the
-                                        ; hex spelled out trips the census too,
-                                        ; which is the cheapest possible reminder
-        cmp     x0,b
-        move    #>$1,x0
-        teq     x0,a
-        move    #>$40000,x0             ; 4 << 16 = REVERSE
+        move    #>$20000,x0             ; 2 << 16 = REVERSE
         cmp     x0,b
         move    #>$1,x0
         teq     x0,a
         move    a,x:(r7+$33)            ; nonzero = the wet comes from $24/$25
 
-; ---- PITCH interval select -> per-line age steps (v2 stage 2) -------------
-; Page-2 slot 9's companion field, r6+$d LOW bits -- ChonVerb's WIDTH/->DEL
-; idiom exactly (companion low-byte fields publish small counts; this one is
-; count 4). Decoded every block regardless of MODE (cheap, and keeps the
-; PITCH state warm across a MODE flip). The step is the head's age advance
-; per sample in Q13.10: age DECREASES by (rate-1) for an upshift, so
-;   +12 (rate 2.0)  -> step +$400 (1.0 sample/sample)
-;   +7  (rate 1.5)  -> step +$200 (0.5)
-;   -12 (rate 0.5)  -> step -$200 (age grows: the head falls behind)
-;   det (rate 1+-e) -> +-$9 = +-15.1 cents, L up / R down -- the one select
-;                      where the two lines' steps differ
-; Stored as full signed words; the per-sample update wraps with & $7fffff,
-; and two's complement subtraction is exact under that mask.
+; ---- SIZE select (the PTCH slot until v5): the raw index for GRAIN and ----
+; REVERSE, both of which read it as a SIZE. Page-2 slot 9's companion field,
+; r6+$d LOW bits (bits 8-15). Decoded every block regardless of MODE.
         move    x:(r6+$d),a
-        and     #>$7f00,a               ; slot 9's companion field: BITS 8-15, the
-        asr     #$8,a,a                 ; same place MODE's is -- see the note there
+        and     #>$7f00,a               ; slot 9's companion field: BITS 8-15
+        asr     #$8,a,a
 ; DINT_OVERRIDE
         move    a1,x0
-        move    x0,a                    ; A2-clean before the compares
-        move    a,x:(r7+$5f)            ; the RAW index, kept for REVERSE --
-                                        ; which reads this same select as a
-                                        ; segment SIZE. Stashing it here is
-                                        ; what avoids a second read of r6+$d,
-                                        ; and therefore a second copy of the
-                                        ; interval-override marker, which
-                                        ; build_bus.py refuses: it requires
-                                        ; EXACTLY ONE, and a marker spelled
-                                        ; out in a comment counts (the same
-                                        ; family as the base-literal census)
-        move    #>$1,x0
-        cmp     x0,a
-        beq     pint7
-        move    #>$2,x0
-        cmp     x0,a
-        beq     pintm12
-        move    #>$3,x0
-        cmp     x0,a
-        beq     pintdet
-        move    #>$1000,a               ; index 0 (and any garbage): +12
-        move    a,x:(r7+$6a)
-        move    a,x:(r7+$6b)
-        bra     pintend
-pint7:
-        move    #>$800,a                ; +7
-        move    a,x:(r7+$6a)
-        move    a,x:(r7+$6b)
-        bra     pintend
-pintm12:
-        move    #>$fff800,a             ; -12
-        move    a,x:(r7+$6a)
-        move    a,x:(r7+$6b)
-        bra     pintend
-pintdet:
-        move    #>$24,a                 ; detune: L up 15 cents
-        move    a,x:(r7+$6a)
-        move    #>$ffffdc,a             ; R down 15 cents
-        move    a,x:(r7+$6b)
-pintend:
+        move    x0,a                    ; A2-clean
+        move    a,x:(r7+$5f)            ; the RAW index, 0..3
 
-; ---- MIDI note -> PITCH interval (branch midi, 24 Aug 2026) ---------------
-; The ColdFire cave (modules/tempo-sync/tempo_cave.s v2) re-stores the host track's held
-; MIDI note into record halfword +0x2a = r6+$9 every frame (bits 8-15 after
-; the <<8, like every other published byte); 0 = released or no cave. The
-; OT's chromatic range is 72..96 with 84 = unison (the stock code p-locks
-; PTCH as 64+5*(note-84)), so interval = note-84, +-12. HOLD semantics: the
-; last note LATCHES in a core-private Y slot and the select above is overridden for as
-; long as any note has ever arrived -- a track that never sees MIDI behaves
-; exactly as before. Both scouts' facts: docs/midi_re_note.md.
-;   step = $1000 * (2^(n/12) - 1), computed by starting at r = 2^(13/12)/4
-;   and multiplying by 2^(-1/12) (97 - note) times: r = 2^(n/12)/4, and
-;   step = (r_word >> 9) - $1000. Error < 1 cent across the range (checked
-;   in python, 24 Aug). No table: R48-R50 died on an init-built Y table, and
-;   a P table needs an AGU register the block has no spare of. <= 25 mpys
-;   per block, per-block cost only. `do y0` is the shipped bus_zclr idiom.
+; ---- MIDI note -> latched note (branch midi, 24 Aug 2026; v5: GRAIN pitch) -
+; The ColdFire cave (modules/tempo-sync/tempo_cave.s v2) re-stores the host
+; track's held MIDI note into r6+$9 every frame (bits 8-15); 0 = released or
+; no cave. HOLD semantics: the last note LATCHES in a core-private Y slot for
+; as long as any note has ever arrived -- a track that never sees MIDI behaves
+; exactly as before. Since v5 the latched note drives GRAIN's continuous
+; pitch (2^((note-84)/12), the OT's 84 = unison) in place of the RATE knob;
+; the interval ladder it used to select died with PITCH mode.
         move    x:(r6+$9),a
         and     #>$7f00,a               ; the note, bits 8-15
         asr     #$8,a,a
@@ -1226,29 +1185,7 @@ pintend:
                                         ; (0) leaves it -- the moves between
                                         ; tst and tne do not touch the flags
         move    b,y:>$090a
-        tst     b
-        beq     qend                   ; no note ever -> the select stands
-        move    #>97,a
-        sub     b,a                     ; count = 97 - note = 13 - n
-        move    #>1,x0
-        cmp     x0,a
-        tlt     x0,a                    ; clamp 1..25 (belt and braces: the
-        move    #>25,x0                 ; chromatic map cannot exceed it)
-        cmp     x0,a
-        tgt     x0,a
-        move    a1,y0                   ; loop count
-        move    #>$43ce3e,a             ; 2^(13/12)/4
-        move    #>$78d0e0,y1            ; 2^(-1/12)
-        do      y0,>qmul
-        move    a,x0                    ; |a| < 1, immediate-loaded: clean
-        mpy     x0,y1,a                 ; SIGNED order (x0,y1) -- not mpysu
-qmul:
-        asr     #$9,a,a                 ; r_word >> 9 = 2^(n/12) * $1000
-        move    #>$1000,x0
-        sub     x0,a                    ; - 1.0 -> the age step
-        move    a,x:(r7+$6a)            ; both lines: the note is one
-        move    a,x:(r7+$6b)            ; interval, never a detune
-qend:
+        move    b,x:(r7+$6a)            ; this block's note for GRAIN (0 = none)
 
 ; ---- TAPE depths from the WOW knob (v2 stage 4) --------------------------
 ; Page-2 slot 6 is a KNOB field (the KNOB half of r6+$c, value<<16, 0..127),
@@ -1325,7 +1262,7 @@ qend:
 ; knob is DRV. knob<<16 IS d in Q1.23 (the MIX/PING trick). Y 0903h:
 ; same reasoning as the RATE increments above.
         move    x:(r7+$69),b            ; MODE
-        move    #>196608,x0             ; 3 << 16 = GRAIN. DECIMAL (base literal)
+        move    #>$10000,x0             ; 1 << 16 = GRAIN (v5 numbering)
         cmp     x0,b
         beq     drvz
         move    x:(r6+$e),a             ; p10 knob field
@@ -1461,29 +1398,14 @@ rlagok:
         add     x0,a                    ; min(TIME, cap)
         move    a,x:(r7+$62)            ; RLAG0, the reversed chunk's lag floor
 
-; ---- PITCH lag base: TIME clamped to keep lag + window + lerp in the line -
-; Max head lag = base + 8191 (age) + 1 (lerp's older neighbour); it must not
-; reach 16384 or the read wraps onto data written THIS lap. sub/branch, not
-; cmp (the cmp-encodes-as-max trap family: sub sets N and V properly).
-        move    x:(r7+$75),a            ; TIME, 64..16320
-        move    #>13311,x0              ; 16384 - 2048 - 1024 - 1 (window, the
-                                        ; grain jitter's max, and the lerp's
-                                        ; older neighbour)
-        sub     x0,a
-        tst     a
-        ble     plagok                  ; TIME <= cap: keep it
-        clr     a                       ; over: excess -> 0, i.e. clamp
-plagok:
-        add     x0,a                    ; min(TIME, 14335)
-        move    a,x:(r7+$6e)            ; PLAGB, the pitch heads' lag base
-
-; ---- GRAIN v4 per-block decode (BongDelay v4, 3 Sep 2026) ----------------
-; Nimbus's grain family from the PTCH select, which GRAIN reads as a SIZE
-; exactly as REVERSE already does: G = 1024 << idx samples (23/46/93/186
-; ms), its mask, G/4 (the grain-to-grain offset) and the one-multiply window's
-; multiplier 2^(23-k) -- see modules/nimbus/nimbus_grain.asm's header for
-; why that is 2^(23-k) and not 2^(24-k) (the a0 trap). Per block, so the
-; sample loop pays nothing for the ladder.
+; ---- GRAIN v5 per-block decode (BongDelay v5, 3 Sep 2026) ----------------
+; Nimbus's grain family from the SIZE select ($5f), in REVERSE's index order
+; so one select reads the same way in both modes: 0 = 46 ms (G 2048),
+; 1 = 93 ms (4096, the default), 2 = 23 ms (1024), 3 = 186 ms (8192). Per
+; size: the mask G-1, G/4 (grain-to-grain offset), the one-multiply window's
+; multiplier 2^(23-k) (modules/nimbus/nimbus_grain.asm: 2^(23-k), NOT
+; 2^(24-k) -- the a0 trap) and 2^(32-k), which turns the lag into the pitch
+; ceiling below with one mpy. Per block, so the loop pays nothing.
         move    x:(r7+$5f),a            ; SIZE index 0..3
         move    #>$1,x0
         cmp     x0,a
@@ -1498,40 +1420,48 @@ plagok:
         move    x0,x:(r7+$39)
         move    #>$400,x0               ; 2^(23-13)
         move    x0,x:(r7+$3a)
+        move    #>$80000,x0             ; 2^(32-13)
+        move    x0,x:(r7+$3f)
         bra     gvsz
 gvs2:
-        move    #>$fff,x0               ; G = 4096 (93 ms)
-        move    x0,x:(r7+$38)
-        move    #>$400,x0
-        move    x0,x:(r7+$39)
-        move    #>$800,x0               ; 2^(23-12)
-        move    x0,x:(r7+$3a)
-        bra     gvsz
-gvs1:
-        move    #>$7ff,x0               ; G = 2048 (46 ms)
-        move    x0,x:(r7+$38)
-        move    #>$200,x0
-        move    x0,x:(r7+$39)
-        move    #>$1000,x0              ; 2^(23-11)
-        move    x0,x:(r7+$3a)
-        bra     gvsz
-gvs0:
-        move    #>$3ff,x0               ; G = 1024 (23 ms)
+        move    #>$3ff,x0               ; idx 2: G = 1024 (23 ms)
         move    x0,x:(r7+$38)
         move    #>$100,x0
         move    x0,x:(r7+$39)
         move    #>$2000,x0              ; 2^(23-10)
         move    x0,x:(r7+$3a)
+        move    #>$400000,x0            ; 2^(32-10)
+        move    x0,x:(r7+$3f)
+        bra     gvsz
+gvs1:
+        move    #>$fff,x0               ; idx 1: G = 4096 (93 ms), the default
+        move    x0,x:(r7+$38)
+        move    #>$400,x0
+        move    x0,x:(r7+$39)
+        move    #>$800,x0               ; 2^(23-12)
+        move    x0,x:(r7+$3a)
+        move    #>$100000,x0            ; 2^(32-12)
+        move    x0,x:(r7+$3f)
+        bra     gvsz
+gvs0:
+        move    #>$7ff,x0               ; idx 0: G = 2048 (46 ms)
+        move    x0,x:(r7+$38)
+        move    #>$200,x0
+        move    x0,x:(r7+$39)
+        move    #>$1000,x0              ; 2^(23-11)
+        move    x0,x:(r7+$3a)
+        move    #>$200000,x0            ; 2^(32-11)
+        move    x0,x:(r7+$3f)
 gvsz:
-; the read distance base: lag + G + 1, with lag = min(TIME, 12287 - mask).
-; A grain reads W - (lag + s + G + 1 - phase): at least lag + s + 1 behind
-; the write and at most lag + s + G behind it, and s tops out at 4095, so
-; lag + 4095 + G must stay inside the 16,384-word line. ⚠️ THAT BOUND IS
-; LOAD-BEARING: past it a head reads across the write pointer, a full-scale
-; discontinuity once per grain. sub/tst, not cmp (the cmp-encodes-as-max
-; trap family).
+; the read distance base: lag + G + 2, with lag = min(TIME, 12286 - mask).
+; A grain at unity reads W - (lag + s + G + 2 - phase): at least lag + s + 2
+; behind the write head and at most lag + s + G + 1 behind it; s tops out at
+; 4095, so lag + 4095 + G + 1 must stay inside the 16,384-word line. ⚠️ THAT
+; BOUND IS LOAD-BEARING: past it a head reads across the write pointer, a
+; full-scale discontinuity once per grain. sub/tst, not cmp (the
+; cmp-encodes-as-max trap family).
         move    x:(r7+$38),b            ; mask = G - 1
-        move    #>12287,a               ; 16383 - 4096
+        move    #>12286,a               ; 16383 - 4096 - 1
         sub     b,a                     ; the lag cap for this G
         move    a,x:(r7+$3b)            ; park the cap
         move    x:(r7+$75),a            ; TIME
@@ -1541,11 +1471,153 @@ gvsz:
         ble     gvlag                   ; TIME <= cap: keep it
         clr     a                       ; over: excess -> 0, i.e. clamp
 gvlag:
-        add     x0,a                    ; min(TIME, cap)
+        add     x0,a                    ; min(TIME, cap) = lag
+        move    a,x:(r7+$3c)            ; park lag for the pitch ceiling
         move    x:(r7+$38),x0
         add     x0,a                    ; + G - 1
-        add     #>$2,a                  ; + 2 = lag + G + 1
+        add     #>$3,a                  ; + 3 = lag + G + 2
         move    a,x:(r7+$3b)            ; the read distance base
+; ---- GRAIN PITCH (v5): rstep, the grain's read advance per sample, Q9 ----
+; 512 = unity. From the RATE knob, +-2 octaves: r = 2^((RATE-64)/32), 64 =
+; unison, 96 = +12, 32 = -12. From a latched MIDI note when one has ever
+; arrived ($6a, the tempo cave's r6+$9): r = 2^((note-84)/12), clamped to
+; +-24 semitones -- the same law the retired PITCH mode drove from the note.
+; 2^f for f in [0,1) is a cubic, 1 + f(0.6931 + f(0.2402 + 0.0558 f)), error
+; < 0.2 cent; the octave part is a shift. Both paths meet at gvoct with
+; oct in a (-2..2, sign-extended) and f in x:(r7+$3d) (Q23).
+        move    x:(r7+$6a),a
+        tst     a
+        beq     gvknob
+; note path: st = note - 84 clamped to +-24; oct' = (st + 24) / 12 by ladder
+        move    #>84,x0
+        sub     x0,a                    ; st
+        move    #>$ffffe8,x0            ; -24
+        cmp     x0,a
+        tlt     x0,a
+        move    #>24,x0
+        cmp     x0,a
+        tgt     x0,a
+        add     x0,a                    ; st + 24, 0..48
+        move    a,x:(r7+$3d)            ; park (integer)
+        move    #>0,b                   ; oct'
+        move    #>12,x0
+        cmp     x0,a                    ; the ladder: subtract 12 while >= 12
+        blt     gvn0
+        sub     x0,a
+        move    #>1,b
+        cmp     x0,a
+        blt     gvn0
+        sub     x0,a
+        move    #>2,b
+        cmp     x0,a
+        blt     gvn0
+        sub     x0,a
+        move    #>3,b
+        cmp     x0,a
+        blt     gvn0
+        sub     x0,a
+        move    #>4,b
+gvn0:
+        asl     #$13,a,a                ; rem << 19 = rem/16 in Q23 (<= 0.69)
+        move    a1,x0
+        move    #>$555555,y1            ; 2/3
+        mpy     x0,y1,a                 ; rem/24
+        asl     #$1,a,a                 ; rem/12 = f, Q23
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$3d)            ; f, Q23
+        move    b,a
+        move    #>2,x0
+        sub     x0,a                    ; oct = oct' - 2
+        bra     gvoct
+gvknob:
+; knob path: e = RATE - 64 (-64..63); oct = e >> 5; f = (e & 31) << 18
+        move    x:(r6+$d),a             ; page-2 slot 8 KNOB field
+        and     #>$7f0000,a
+        move    a1,x0
+        move    x0,a
+        asr     #$10,a,a                ; the integer knob 0..127
+        move    #>64,x0
+        sub     x0,a                    ; e
+        move    a,x:(r7+$3d)            ; park e
+        and     #>$1f,a
+        asl     #$12,a,a                ; (e & 31) << 18 = f in Q23
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$49)            ; f, Q23 (park)
+        move    x:(r7+$3d),a
+        asr     #$5,a,a                 ; oct = e >> 5, -2..1 (arithmetic)
+        move    a1,x0
+        move    x0,a
+        move    x:(r7+$49),x0
+        move    x0,x:(r7+$3d)           ; f into its slot
+gvoct:
+        move    a,x:(r7+$49)            ; park oct
+; 2^f - 1 = f * (c1 + f * (c2 + c3 * f))
+        move    x:(r7+$3d),x0           ; f
+        move    #>$072470,y1            ; c3 = 0.0558
+        mpy     x0,y1,a
+        add     #>$1ebfce,a             ; + c2 = 0.2402
+        move    a,y1
+        mpy     x0,y1,a                 ; f * (c2 + c3 f)
+        add     #>$58b90c,a             ; + c1 = 0.6931
+        move    a,y1
+        mpy     x0,y1,a                 ; 2^f - 1, Q23, 0 .. 0.99
+        asr     #$e,a,a                 ; * 512 -> Q9 integer 0..511
+        move    a1,x0
+        move    x0,a
+        add     #>512,a                 ; rstep at oct 0: 512 .. 1023
+; the octave: shift by oct
+        move    a,x:(r7+$3e)
+        move    x:(r7+$49),a
+        tst     a
+        beq     gvrdone
+        move    #>1,x0
+        cmp     x0,a
+        beq     gvr1
+        move    #>2,x0
+        cmp     x0,a
+        beq     gvr2
+        move    #>$ffffff,x0            ; -1
+        cmp     x0,a
+        beq     gvrm1
+        move    x:(r7+$3e),a            ; -2
+        asr     #$2,a,a
+        bra     gvrst
+gvrm1:
+        move    x:(r7+$3e),a
+        asr     #$1,a,a
+        bra     gvrst
+gvr1:
+        move    x:(r7+$3e),a
+        asl     #$1,a,a
+        bra     gvrst
+gvr2:
+        move    x:(r7+$3e),a
+        asl     #$2,a,a
+gvrst:
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$3e)
+gvrdone:
+; ---- the pitch CEILING: a grain running faster than the write head needs
+; room in front of it. Its read starts lag + s + G + 2 behind the head and
+; closes on it by G*(r-1) over its life, so r - 1 <= 1 + lag/G keeps it
+; behind. rmax = 1024 + lag * 2^(9-k) via the per-size 2^(32-k) constant,
+; one mpy; rstep is clamped to it, so a short TIME on a long grain quietly
+; limits how far UP the pitch reaches (+12 always fits). The per-sample
+; distance clamps in the reader are the belt to this brace.
+        move    x:(r7+$3c),x0           ; lag (integer, 0..12285)
+        move    x:(r7+$3f),y1           ; 2^(32-k)
+        mpy     x0,y1,a                 ; a1 = lag * 2^(9-k)
+        move    a1,x0
+        move    x0,a
+        add     #>1024,a                ; rmax
+        move    a,x0
+        move    x:(r7+$3e),a
+        cmp     x0,a
+        tgt     x0,a                    ; rstep = min(rstep, rmax)
+        move    a,x:(r7+$3e)
 ; density: dens3 = knob >> 4 (0..7) from the DPTH word ($2d = knob << 13),
 ; the R61 full-dial law; and the level MAKEUP coeff = 1/2 + (7-dens3)/14 in
 ; Q23 (R61, verbatim: flattens the gate's energy loss within ~1.2 dB; the top
@@ -1554,7 +1626,7 @@ gvlag:
         asr     #$11,a,a
         move    a1,x0
         move    x0,a
-        move    a,x:(r7+$3c)            ; dens3
+        move    a,x:(r7+$3c)            ; dens3 (lag's park is consumed)
         move    #>7,b
         sub     a,b                     ; 7 - dens3
         move    b1,x0
@@ -1776,319 +1848,18 @@ gvlag:
 ; always runs; each MID..next is one mutually exclusive alternative, and the
 ; tool charges dispatch + the WORST alternative, never every engine summed.
         move    x:(r7+$69),a
-        move    #>$10000,x0             ; 1 << 16, MSB-aligned like the store
-        cmp     x0,a
-        beq     pmode
-        move    #>196608,x0             ; 3 << 16 = GRAIN (v2 stage 5). DECIMAL
-                                        ; for the base-literal reason above
+        move    #>$10000,x0             ; 1 << 16 = GRAIN (v5 numbering)
         cmp     x0,a
         beq     gmode
-        move    #>$40000,x0             ; 4 << 16 = REVERSE (v2 stage 6)
+        move    #>$20000,x0             ; 2 << 16 = REVERSE
         cmp     x0,a
         beq     rmode
         bra     pdone                   ; CLEAN, and every unknown value
-; MODEFORK_MID -- alternative 1: PITCH
+; MODEFORK_MID -- alternative 1: GRAIN
 
-; ---- PITCH: dual crossfaded lerp heads per line (v2 stage 2) --------------
-; The shimmer-v3 machinery (modules/chonverb/reverb_server.asm SHIMMER block) reading the
-; DELAY LINE ITSELF -- no separate shift buffer exists or fits; both line
-; buffers fill this server's entire half-window, and reading the line at
-; moving lag is the Microcosm-family topology anyway (GRAIN inherits exactly
-; this addressing). Per line:
-;
-;   age (Q11.12, persistent, wraps mod 2048 samples) advances by the
-;   interval step; head lag = PLAGB + age + JITTER, so an upshift's head
-;   slides TOWARD the write pointer, replaying material at rate
-;   (1 + step/4096). Head 1 runs half a window (1024 samples) behind head 0.
-;   Each head: FULL-OVERLAP complementary triangle window on AGE
-;   (t = 1024-|age-1024|), smoothstepped, times a LERPED line read (integer
-;   lag from age's top bits, Q23 fraction from its low 12 -- truncation is
-;   the floor that cost the first shimmer, lerp is mandatory). Smoothstep
-;   obeys s(g)+s(1-g)=1, so g0+g1 == 1 EXACTLY at every age: loop gain never
-;   exceeds FDBK and PITCH inherits CLEAN's stability bound.
-;
-;   FULL-OVERLAP WINDOW, 12 Aug 2026, replacing the shimmer trapezoid (ramp
-;   256, flat top, silent upper half). Measured on a 219.98 Hz sine, single
-;   generation, +12: the trapezoid's near-rectangular switching put splice
-;   sidebands every +-43.1 Hz at -18.7 dB with a slowly-decaying harmonic
-;   ladder (-27, -28, -33...) -- audibly "glitchy metallic" on a naked echo
-;   (the reverb wash hid the same machinery in shimmer). Full-overlap turns
-;   the switching waveform sinusoidal: higher orders collapsed 20-25 dB,
-;   first pair -18.7/-20.9 -> -26.0/-33.7. Ear (Sam): "bit better", still
-;   "robo".
-;
-;   ❌ WIDENING THE WINDOW IS RETRACTED, same day, by measurement AND ear.
-;   4x (2048 -> 8192, age Q13.10) was built on the theory that the residual
-;   pair was a lattice displacement that scales with window length. It is
-;   not: at EVERY window length the octave arrives as TWO EQUAL LINES a lap
-;   apart with nothing at 2f -- suppressed-carrier AM, i.e. the two heads
-;   (a half window = 93 ms apart on the line, so an arbitrary relative
-;   phase -- 158 deg for this tone) cancelling once per lap. Widening only
-;   moved the cancellation rate 43.1 -> 10.8 Hz, i.e. buzz -> flutter; Sam
-;   heard the 8192 build as "robo and fluttery" and it cost half the PITCH
-;   delay range. A ramp-width sweep at C=8192 (R=512/1024/2048/4096)
-;   confirmed the trade is 1-D and has no good point: envelope ripple
-;   6.3/10.3/12.6/13.5 dB against off-carrier energy -8.7/-10.3/-14.5/
-;   -35.6 dB. The defect is PERIODICITY, not window shape -- see the
-;   jitter block below.
-;
-; The shifted taps land in $79/$7a exactly where CLEAN's taps land, so
-; everything downstream -- TONE damping, the PING crossfeed, FDBK write-back,
-; MIX, the ->VERB send -- is one engine, mode-blind. Each REPEAT re-shifts:
-; the climbing-octave Crystal behaviour, on purpose (the reverb's shimmer
-; deliberately removed its cascade; a delay's discrete repeats are where a
-; climb IS the effect).
-;
-; mpy orientation throughout: the possibly-negative operand (tap, t1-t0) is
-; ALWAYS x0, the first operand of the audited-signed `mpy x0,y1` form; y1
-; only ever carries frac or a window gain, both strictly non-negative.
-pmode:
-; ---- grain jitter PRNG (v2 stage 2b) --------------------------------------
-; 23-bit xorshift, shifts 15/15/8: maximal period 8388607 (190 s of samples,
-; verified by simulation against the exact masked recurrence, along with a
-; flat distribution of the 10-bit field taken below). Every shift result is
-; re-cleaned through the a1->x0->a idiom because `and`/`eor` write A1 only
-; and leave A2 STALE -- the store trap. Advanced every sample; each head
-; LATCHES it at its own wrap, so the four grains scatter independently.
-        move    x:(r7+$18),a            ; state
-        move    a1,x0
-        asl     #$f,a,a
-        and     #>$7fffff,a
-        eor     x0,a                    ; x ^= (x << 15)
-        move    a1,x0
-        move    x0,a
-        asr     #$f,a,a                 ; state is always positive, so the
-        eor     x0,a                    ; arithmetic shift IS a logical one
-        move    a1,x0
-        move    x0,a
-        asl     #$8,a,a
-        and     #>$7fffff,a
-        eor     x0,a                    ; x ^= (x << 8)
-        move    a1,x0
-        move    x0,a                    ; A2 clean before the store
-        move    a,x:(r7+$18)
-        asr     #$d,a,a                 ; take the top 10 bits: 0..1023 samples
-        and     #>$3ff,a                ; of scatter (23 ms), the SPRAY depth
-        move    a1,x0                   ; GRAIN will put on a knob
-        move    x0,a
-        move    a,x:(r7+$21)            ; this sample's candidate offset
-; ---- Line L: age update ---------------------------------------------------
-        move    x:(r7+$6c),a            ; ageL, Q11.12
-        move    x:(r7+$6a),x0           ; stepL (signed)
-        sub     x0,a
-        and     #>$7fffff,a             ; wrap mod 2048 samples
-        move    a1,x0
-        move    x0,a                    ; A2-clean; boot garbage dies here
-        move    a,x:(r7+$6c)
-; ---- grain scatter: each head latches a new offset at ITS OWN wrap --------
-; The whole point of stage 2b. With a FIXED grain start the two heads sit a
-; half window (23 ms) apart on the line for ever, so for any steady partial
-; their relative phase is constant and they cancel on a metronome: measured,
-; the octave arrives as two equal lines one lap apart with nothing at 2f
-; (suppressed-carrier AM). Sam heard that as "robo" at a 43 Hz lap and
-; "fluttery" at 10.8 Hz -- the same defect at two rates, which is why no
-; window shape or length fixed it. Re-scattering each grain's source
-; position by 0..1023 samples makes the cancellation APERIODIC: the ear
-; stops tracking it as a machine and hears texture, which is what the
-; granular reference (PLAN 3.1) is actually made of.
-;
-; The jump is inaudible because a head's window gain is exactly 0 at its own
-; wrap -- so the full-overlap window is a PREREQUISITE for this, not just a
-; cleanup. GRAIN (stage 5) is this mechanism with more heads and the depth
-; on a SPRAY knob.
-        move    a,x:(r7+$22)            ; park age
-        move    x:(r7+$19),x0
-        sub     x0,a                    ; d = age - previous age
-        abs     a
-        move    #>$400000,x0
-        sub     x0,a                    ; |d| > half a cycle == this head just
-                                        ; wrapped; N set means it did NOT
-        move    x:(r7+$21),b            ; this sample's candidate offset
-        move    x:(r7+$1b),x0           ; the grain's current offset
-        tmi     x0,b                    ; no wrap -> keep it. Tcc, never a
-                                        ; hand-rolled mask (A2 staleness)
-        move    b,x:(r7+$1b)
-        move    x:(r7+$22),a
-        move    a,x:(r7+$19)           ; prevL0 := ageL0
-; head 1 runs half a window ahead, so it wraps half a lap later
-        move    #>$400000,x0
-        add     x0,a
-        and     #>$7fffff,a
-        move    a1,x0
-        move    x0,a                    ; A2 clean
-        move    a,x:(r7+$23)            ; park age
-        move    x:(r7+$1a),x0
-        sub     x0,a                    ; d = age - previous age
-        abs     a
-        move    #>$400000,x0
-        sub     x0,a                    ; |d| > half a cycle == this head just
-                                        ; wrapped; N set means it did NOT
-        move    x:(r7+$21),b            ; this sample's candidate offset
-        move    x:(r7+$1c),x0           ; the grain's current offset
-        tmi     x0,b                    ; no wrap -> keep it. Tcc, never a
-                                        ; hand-rolled mask (A2 staleness)
-        move    b,x:(r7+$1c)
-        move    x:(r7+$23),a
-        move    a,x:(r7+$1a)           ; prevL1 := ageL1
-        move    x:(r7+$22),a            ; ageL0 back for the heads below
-; ---- Line L, head 0: lerp read at lag PLAGB + age + scatter ---------------
-; (v7: both heads' read+window bodies live in phead; LineL's base is staged
-; once here for both calls -- staging touches only x0, and a still holds
-; age_fx.)
-        move    x:(r7+$31),x0           ; LineL base -> phead's staging slot
-        move    x0,x:(r7+$30)
-        move    a,x:(r7+$15)            ; park age_fx
-        asr     #$c,a,a                 ; age_int, 0..2047
-        move    a1,x0
-        move    x0,a
-        move    a,x:(r7+$6f)            ; park age_int
-        move    r1,a                    ; LineL write pointer
-        move    x:(r7+$6e),x0           ; PLAGB
-        sub     x0,a
-        move    x:(r7+$6f),x0           ; age_int
-        sub     x0,a
-        move    x:(r7+$1b),x0           ; this grain's scatter
-        bsr     phead                   ; lerped read + window (v7 roll):
-                                        ; out $17 = tap, $15 = g^2, y1 = 1-g
-        move    x:(r7+$15),x0
-        mpy     x0,y1,a                 ; g^2*(1-g)
-        asl     #$1,a,a
-        add     x0,a                    ; s = g^2 + 2*g^2*(1-g)
-        move    a1,y1                   ; g0
-        move    x:(r7+$17),x0           ; tap (signed) first
-        mpy     x0,y1,a
-        move    a,b                     ; b = head 0's contribution
-; ---- Line L, head 1: age + half a window, same machinery ------------------
-        move    x:(r7+$6c),a
-        move    #>$400000,x0            ; +1024 samples in Q11.12 (half the
-                                        ; window)
-        add     x0,a
-        and     #>$7fffff,a
-        move    a1,x0
-        move    x0,a                    ; age1_fx, clean
-        move    a,x:(r7+$15)
-        asr     #$c,a,a
-        move    a1,x0
-        move    x0,a
-        move    a,x:(r7+$6f)
-        move    r1,a
-        move    x:(r7+$6e),x0
-        sub     x0,a
-        move    x:(r7+$6f),x0
-        sub     x0,a
-        move    x:(r7+$1c),x0           ; this grain's scatter
-        bsr     phead                   ; ($30 still holds LineL's base)
-        move    x:(r7+$15),x0
-        mpy     x0,y1,a
-        asl     #$1,a,a
-        add     x0,a
-        move    a1,y1                   ; g1
-        move    x:(r7+$17),x0
-        mpy     x0,y1,a
-        add     b,a                     ; g0*tap0 + g1*tap1, g0+g1 ~= 1
-        move    a,x:(r7+$24)            ; shifted OUTPUT tap L -- NOT $79:
-                                        ; the loop's tap stays unshifted
-; ---- Line R: identical, on r2/base $68/age $6d/step $6b -------------------
-        move    x:(r7+$6d),a
-        move    x:(r7+$6b),x0
-        sub     x0,a
-        and     #>$7fffff,a
-        move    a1,x0
-        move    x0,a
-        move    a,x:(r7+$6d)
-        move    a,x:(r7+$22)            ; park age
-        move    x:(r7+$1d),x0
-        sub     x0,a                    ; d = age - previous age
-        abs     a
-        move    #>$400000,x0
-        sub     x0,a                    ; |d| > half a cycle == this head just
-                                        ; wrapped; N set means it did NOT
-        move    x:(r7+$21),b            ; this sample's candidate offset
-        move    x:(r7+$1f),x0           ; the grain's current offset
-        tmi     x0,b                    ; no wrap -> keep it. Tcc, never a
-                                        ; hand-rolled mask (A2 staleness)
-        move    b,x:(r7+$1f)
-        move    x:(r7+$22),a
-        move    a,x:(r7+$1d)           ; prevR0 := ageR0
-        move    #>$400000,x0
-        add     x0,a
-        and     #>$7fffff,a
-        move    a1,x0
-        move    x0,a
-        move    a,x:(r7+$23)            ; park age
-        move    x:(r7+$1e),x0
-        sub     x0,a                    ; d = age - previous age
-        abs     a
-        move    #>$400000,x0
-        sub     x0,a                    ; |d| > half a cycle == this head just
-                                        ; wrapped; N set means it did NOT
-        move    x:(r7+$21),b            ; this sample's candidate offset
-        move    x:(r7+$20),x0           ; the grain's current offset
-        tmi     x0,b                    ; no wrap -> keep it. Tcc, never a
-                                        ; hand-rolled mask (A2 staleness)
-        move    b,x:(r7+$20)
-        move    x:(r7+$23),a
-        move    a,x:(r7+$1e)           ; prevR1 := ageR1
-        move    x:(r7+$68),x0           ; LineR base -> phead's staging slot
-        move    x0,x:(r7+$30)           ; (once, for both R heads' calls)
-        move    x:(r7+$22),a            ; ageR0 back
-        move    a,x:(r7+$15)
-        asr     #$c,a,a
-        move    a1,x0
-        move    x0,a
-        move    a,x:(r7+$6f)
-        move    r2,a
-        move    x:(r7+$6e),x0
-        sub     x0,a
-        move    x:(r7+$6f),x0
-        sub     x0,a
-        move    x:(r7+$1f),x0           ; this grain's scatter
-        bsr     phead                   ; ($30 holds LineR's base)
-        move    x:(r7+$15),x0
-        mpy     x0,y1,a
-        asl     #$1,a,a
-        add     x0,a
-        move    a1,y1
-        move    x:(r7+$17),x0
-        mpy     x0,y1,a
-        move    a,b
-        move    x:(r7+$6d),a
-        move    #>$400000,x0
-        add     x0,a
-        and     #>$7fffff,a
-        move    a1,x0
-        move    x0,a
-        move    a,x:(r7+$15)
-        asr     #$c,a,a
-        move    a1,x0
-        move    x0,a
-        move    a,x:(r7+$6f)
-        move    r2,a
-        move    x:(r7+$6e),x0
-        sub     x0,a
-        move    x:(r7+$6f),x0
-        sub     x0,a
-        move    x:(r7+$20),x0           ; this grain's scatter
-        bsr     phead                   ; ($30 still holds LineR's base)
-        move    x:(r7+$15),x0
-        mpy     x0,y1,a
-        asl     #$1,a,a
-        add     x0,a
-        move    a1,y1
-        move    x:(r7+$17),x0
-        mpy     x0,y1,a
-        add     b,a
-        move    a,x:(r7+$25)            ; shifted OUTPUT tap R
-        bra     pdone
-; (alternative 2 was TAPE -- RETIRED 18 Aug 2026. Its wow/flutter machinery
-; moved into the always-run loop-tap read above: since stage 2c every mode
-; recirculates the same clean tap, so the modulation was never mode-shaped,
-; and once DPTH/RATE became knobs TAPE was CLEAN with the knobs up. Sam:
-; "tape wasn't offering much." Its MODE position falls through to CLEAN, the
-; stage-1 rule, so old projects' stored TAPE parts still play.)
-; MODEFORK_MID -- alternative 3: GRAIN
-
-; ---- GRAIN v4: Nimbus's grain readers over the delay lines (3 Sep 2026) --
+; ---- GRAIN v5: Nimbus's grain readers over the delay lines, PITCHED -------
+; (v4 the same day was unity-rate and two per line; v5 is four per line with
+; a continuous pitch on RATE, and PITCH mode is retired -- Sam, 3 Sep 2026.)
 ; The v2 stage-5 GRAIN was the delay's cost centre: eight lerped heads with
 ; per-grain rate accumulators, a Tcc-chained interval draw and a rolled
 ; builder priced at 548 words + 837 of roll surcharge -- 1,385 cycles, the
@@ -2106,14 +1877,16 @@ pmode:
 ; read-back distance -- so this is still a granular DELAY, reading TIME
 ; behind the write head, not a Clouds on the input.
 ;
-; What it gives up: the PITCHED grains. Every grain plays at unity, so the
-; +12 / -12 / -19 / +5 / -5 / +7 set is gone and PTCH is the grain SIZE here
-; (23/46/93/186 ms), as it already is for REVERSE. PITCH mode still
-; harmonises repeats. Sam's call at the ear pass (PLAN, the rig).
+; What changed against v2: the per-grain interval SET is gone -- every grain
+; runs at the one pitch RATE (or the MIDI note) says, continuously, +-2
+; octaves -- and PITCH mode is retired with it: GRAIN at full density, scatter
+; 0 IS a granular pitch shifter on the same non-cascading topology. The
+; select is the grain SIZE (46/93/23/186 ms, REVERSE's own index order).
 ;
-; Knobs in GRAIN: TIME = position (lag), PTCH = SIZE, DRV = scatter depth
-; (SPRAY, up to 4095 samples), DPTH = density. FREEZE holds the lines and
-; the grains keep grazing them, forward, behind the frozen head.
+; Knobs in GRAIN: TIME = position (lag), SIZE = grain length, RATE = pitch
+; (64 = unison), DRV = scatter depth (SPRAY, up to 4095 samples), DPTH =
+; density. FREEZE holds the lines and the grains keep grazing them behind the
+; frozen head.
 ;
 ; ⚠️ THE WINDOW READS a0: phase * 2^(23-k) into the LOW word, sign-extended
 ; back and folded with abs, is a triangle peaking at G/2 -- and the
@@ -2156,7 +1929,7 @@ gmode:
         and     #>$fff,a                ; belt and braces: it IS 0..4095
         move    a1,x0
         move    x0,a
-        move    a,x:(r7+$54)
+        move    a,x:(r7+$58)
 ; ---- this sample's window-multiplier candidate: 2^(23-k), or 0 if muted --
 ; three PRNG bits against dens3 (the R61 law): muted when bits > dens3, so
 ; dens3 = 7 never mutes and dens3 = 0 mutes seven grains in eight.
@@ -2169,7 +1942,7 @@ gmode:
         sub     x1,a                    ; N SET == muted
         move    x:(r7+$3a),x0           ; the live multiplier
         tpl     x0,b                    ; not muted -> take it
-        move    b,x:(r7+$55)
+        move    b,x:(r7+$59)
 ; ---- age advance, masked by G-1 (also swallows size changes) -------------
         move    x:(r7+$32),a
         add     #>$1,a
@@ -2178,177 +1951,252 @@ gmode:
         move    a1,x0
         move    x0,a
         move    a,x:(r7+$32)
-; ---- grain 0: line L, phase = age --------------------------------------
         clr     b                       ; wet L accumulates in b
-        move    x:(r7+$32),a
-        tst     a
-        bne     gvga
-        move    x:(r7+$54),x0           ; wrap: latch this grain's scatter
-        move    x0,x:(r7+$34)
-        move    x:(r7+$55),x0           ; and its window multiplier (or 0)
-        move    x0,x:(r7+$40)
-gvga:
-        move    a,x1                    ; phase
-        move    a,x0
-        move    x:(r7+$40),y1
+; ---- READER, line L: four grains, ROLLED (v5) ----------------------------
+; Records of THREE words at r7+$40: s (latched scatter), w (window
+; multiplier, 0 = muted), acc (read advance, Q14.9). Every latch is a Tcc
+; reading the ONE `tst` of this grain's phase, with nothing but moves between
+; them (the GRAIN 5d trap); the `add` that advances acc comes AFTER the last
+; of them. Phase walks $5d by G/4 per trip; the wet sum lives in x:(r7+$1e)
+; because b is the latch register inside the body.
+        move    r7,a
+        move    #>$40,x0
+        add     x0,a
+        move    a,r4
+        move    #>$ffffff,m4
+        move    x:(r7+$32),x0
+        move    x0,x:(r7+$5d)           ; cursor = age (grain 0's phase)
+        clr     a
+        move    a,x:(r7+$1e)
+        do      #4,>gvlz
+        move    x:(r7+$5d),a            ; this grain's phase
+        tst     a                       ; Z SET == its wrap
+        move    a,x1                    ; phase, kept for the distance
+        move    x:(r7+$58),x0           ; candidate scatter
+        move    x:(r4),b
+        teq     x0,b
+        move    b,x:(r4)+               ; s
+        move    b,x:(r7+$1d)            ; park s
+        move    x:(r7+$59),x0           ; candidate multiplier (0 = muted)
+        move    x:(r4),b
+        teq     x0,b
+        move    b,x:(r4)+               ; w
+        move    b,y1                    ; w, the window multiplier
+        move    #>$0,x0
+        move    x:(r4),b
+        teq     x0,b                    ; acc restarts at the wrap
+        move    x:(r7+$3e),x0           ; rstep
+        add     x0,b                    ; acc += rstep
+        move    b,x:(r4)+               ; -> the next record
+        move    a,x0                    ; phase
         mpy     x0,y1,a                 ; a0 = wrap(2*phase/G), signed Q23
         move    a0,x0
         move    x0,a                    ; reloaded clean: A2 consistent
         abs     a
-        move    a,y1                    ; window gain = |wrap(2*phase/G)|
-        move    x:(r7+$3b),a            ; lag + G + 1
-        move    x:(r7+$34),x0
+        move    a,x:(r7+$19)            ; park the window gain
+        move    b,a                     ; acc
+        and     #>$1ff,a                ; the fraction
+        asl     #$e,a,a                 ; -> Q23
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$1a)            ; park frac
+        move    b,a
+        asr     #$9,a,a                 ; integer samples advanced
+        move    a1,x0
+        move    x:(r7+$3b),a            ; lag + G + 2
+        sub     x0,a                    ; - advance
+        move    x:(r7+$1d),x0
         add     x0,a                    ; + s
-        sub     x1,a                    ; - phase = dist
+        add     x1,a                    ; + phase = dist. ⚠️ THE PHASE TERM IS
+                                        ; WHAT MAKES UNITY A FIXED TAP: W moves
+                                        ; one sample per sample, so a distance
+                                        ; that does not grow with the phase
+                                        ; reads at 1 + r, an octave up at
+                                        ; "unity" (measured 3 Sep 2026: 955 Hz
+                                        ; for 438 in). Nimbus's geometry has the
+                                        ; same term missing -- see its README.
+        move    #>$2,x0
+        cmp     x0,a                    ; never the head's own slot ...
+        tlt     x0,a
+        move    #>$3fff,x0
+        cmp     x0,a                    ; ... and never past the line's end
+        tgt     x0,a                    ; (a low pitch on a long grain pins
+                                        ; at the oldest sample: a flat spot,
+                                        ; not a wrap)
         move    a,x0
-        move    r1,a                    ; LineL write pointer
+        move    r1,a                ; line L write pointer
         sub     x0,a                    ; W - dist
         and     #>$3fff,a
         move    a1,x0
         move    x0,a
-        move    x:(r7+$31),x0           ; LineL base
+        move    a,x:(r7+$1c)            ; park the read phase
+        move    x:(r7+$31),x0     ; line L base
         add     x0,a
         move    a,r5
-        move    y:(r5),x0
-        mpy     x0,y1,a                 ; sample * window
-        add     a,b
-; ---- grain 2: line L, phase = age + G/2 ---------------------------------
-        move    x:(r7+$32),a
-        move    x:(r7+$39),x0
-        add     x0,a
-        add     x0,a
-        move    x:(r7+$38),x0
-        and     x0,a
-        move    a1,x0
-        move    x0,a
-        tst     a
-        bne     gvgc
-        move    x:(r7+$54),x0
-        move    x0,x:(r7+$36)
-        move    x:(r7+$55),x0
-        move    x0,x:(r7+$42)
-gvgc:
-        move    a,x1
-        move    a,x0
-        move    x:(r7+$42),y1
-        mpy     x0,y1,a
-        move    a0,x0
-        move    x0,a
-        abs     a
-        move    a,y1
-        move    x:(r7+$3b),a
-        move    x:(r7+$36),x0
-        add     x0,a
-        sub     x1,a
-        move    a,x0
-        move    r1,a
-        sub     x0,a
+        move    y:(r5),a                ; t0
+        move    a,x:(r7+$1b)
+        move    x:(r7+$1c),a
+        add     #>$1,a                  ; one sample NEWER
         and     #>$3fff,a
         move    a1,x0
         move    x0,a
         move    x:(r7+$31),x0
         add     x0,a
         move    a,r5
-        move    y:(r5),x0
+        move    y:(r5),a                ; t1
+        move    x:(r7+$1b),x0
+        sub     x0,a                    ; t1 - t0, signed
+        move    a1,x0                   ; -> FIRST mpy operand
+        move    x:(r7+$1a),y1           ; frac
         mpy     x0,y1,a
-        add     a,b
-; ---- wet L = (g0 + g2) * makeup * 2 ---------------------------------------
-; the two windows sum to 1, so at full density (coeff 1/2) this is unity;
-; the coeff tops out at 1.0 = +6 dB of makeup for the sparsest gate.
-        move    b,x0                    ; LIMITING move
-        move    x:(r7+$3d),y1           ; makeup coeff
-        mpy     x0,y1,b
-        asl     #$1,b,b
-        move    b,x:(r7+$24)            ; shifted OUTPUT tap L
-; ---- grain 1: line R, phase = age + G/4 ---------------------------------
-        clr     b
-        move    x:(r7+$32),a
+        move    x:(r7+$1b),x0
+        add     x0,a                    ; tap = t0 + frac*(t1-t0)
+        move    a,x0                    ; LIMITING move
+        move    x:(r7+$19),y1           ; window gain
+        mpy     x0,y1,a
+        move    x:(r7+$1e),b
+        add     b,a
+        move    a,x:(r7+$1e)       ; wet L +=
+        move    x:(r7+$5d),a            ; next grain: a quarter further round
         move    x:(r7+$39),x0
         add     x0,a
         move    x:(r7+$38),x0
         and     x0,a
         move    a1,x0
         move    x0,a
-        tst     a
-        bne     gvgb
-        move    x:(r7+$54),x0
-        move    x0,x:(r7+$35)
-        move    x:(r7+$55),x0
-        move    x0,x:(r7+$41)
-gvgb:
-        move    a,x1
-        move    a,x0
-        move    x:(r7+$41),y1
-        mpy     x0,y1,a
-        move    a0,x0
-        move    x0,a
-        abs     a
-        move    a,y1
-        move    x:(r7+$3b),a
-        move    x:(r7+$35),x0
+        move    a,x:(r7+$5d)
+gvlz:
+        nop
+; ---- wet L = sum of four * makeup --------------------------------------
+; four windows at quarter offsets sum to exactly 2, so the makeup coeff's
+; 1/2 at full density is unity and its 1.0 top is +6 dB for the sparsest
+; gate -- the v2 arithmetic, kept.
+        move    x:(r7+$1e),x0
+        move    x:(r7+$3d),y1           ; makeup coeff
+        mpy     x0,y1,b
+        move    b,x:(r7+$24)            ; shifted OUTPUT tap L
+; ---- READER, line R: four grains, ROLLED (v5) ----------------------------
+; Records of THREE words at r7+$4c: s (latched scatter), w (window
+; multiplier, 0 = muted), acc (read advance, Q14.9). Every latch is a Tcc
+; reading the ONE `tst` of this grain's phase, with nothing but moves between
+; them (the GRAIN 5d trap); the `add` that advances acc comes AFTER the last
+; of them. Phase walks $5d by G/4 per trip; the wet sum lives in x:(r7+$1f)
+; because b is the latch register inside the body.
+        move    r7,a
+        move    #>$4c,x0
         add     x0,a
-        sub     x1,a
+        move    a,r4
+        move    #>$ffffff,m4
+        move    x:(r7+$32),x0
+        move    x0,x:(r7+$5d)           ; cursor = age (grain 0's phase)
+        clr     a
+        move    a,x:(r7+$1f)
+        do      #4,>gvrz
+        move    x:(r7+$5d),a            ; this grain's phase
+        tst     a                       ; Z SET == its wrap
+        move    a,x1                    ; phase, kept for the distance
+        move    x:(r7+$58),x0           ; candidate scatter
+        move    x:(r4),b
+        teq     x0,b
+        move    b,x:(r4)+               ; s
+        move    b,x:(r7+$1d)            ; park s
+        move    x:(r7+$59),x0           ; candidate multiplier (0 = muted)
+        move    x:(r4),b
+        teq     x0,b
+        move    b,x:(r4)+               ; w
+        move    b,y1                    ; w, the window multiplier
+        move    #>$0,x0
+        move    x:(r4),b
+        teq     x0,b                    ; acc restarts at the wrap
+        move    x:(r7+$3e),x0           ; rstep
+        add     x0,b                    ; acc += rstep
+        move    b,x:(r4)+               ; -> the next record
+        move    a,x0                    ; phase
+        mpy     x0,y1,a                 ; a0 = wrap(2*phase/G), signed Q23
+        move    a0,x0
+        move    x0,a                    ; reloaded clean: A2 consistent
+        abs     a
+        move    a,x:(r7+$19)            ; park the window gain
+        move    b,a                     ; acc
+        and     #>$1ff,a                ; the fraction
+        asl     #$e,a,a                 ; -> Q23
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$1a)            ; park frac
+        move    b,a
+        asr     #$9,a,a                 ; integer samples advanced
+        move    a1,x0
+        move    x:(r7+$3b),a            ; lag + G + 2
+        sub     x0,a                    ; - advance
+        move    x:(r7+$1d),x0
+        add     x0,a                    ; + s
+        add     x1,a                    ; + phase = dist. ⚠️ THE PHASE TERM IS
+                                        ; WHAT MAKES UNITY A FIXED TAP: W moves
+                                        ; one sample per sample, so a distance
+                                        ; that does not grow with the phase
+                                        ; reads at 1 + r, an octave up at
+                                        ; "unity" (measured 3 Sep 2026: 955 Hz
+                                        ; for 438 in). Nimbus's geometry has the
+                                        ; same term missing -- see its README.
+        move    #>$2,x0
+        cmp     x0,a                    ; never the head's own slot ...
+        tlt     x0,a
+        move    #>$3fff,x0
+        cmp     x0,a                    ; ... and never past the line's end
+        tgt     x0,a                    ; (a low pitch on a long grain pins
+                                        ; at the oldest sample: a flat spot,
+                                        ; not a wrap)
         move    a,x0
-        move    r2,a                    ; LineR write pointer
-        sub     x0,a
+        move    r2,a                ; line R write pointer
+        sub     x0,a                    ; W - dist
         and     #>$3fff,a
         move    a1,x0
         move    x0,a
-        move    x:(r7+$68),x0           ; LineR base
+        move    a,x:(r7+$1c)            ; park the read phase
+        move    x:(r7+$68),x0     ; line R base
         add     x0,a
         move    a,r5
-        move    y:(r5),x0
-        mpy     x0,y1,a
-        add     a,b
-; ---- grain 3: line R, phase = age + 3G/4 --------------------------------
-        move    x:(r7+$32),a
-        move    x:(r7+$39),x0
-        add     x0,a
-        add     x0,a
-        add     x0,a
-        move    x:(r7+$38),x0
-        and     x0,a
-        move    a1,x0
-        move    x0,a
-        tst     a
-        bne     gvgd
-        move    x:(r7+$54),x0
-        move    x0,x:(r7+$37)
-        move    x:(r7+$55),x0
-        move    x0,x:(r7+$43)
-gvgd:
-        move    a,x1
-        move    a,x0
-        move    x:(r7+$43),y1
-        mpy     x0,y1,a
-        move    a0,x0
-        move    x0,a
-        abs     a
-        move    a,y1
-        move    x:(r7+$3b),a
-        move    x:(r7+$37),x0
-        add     x0,a
-        sub     x1,a
-        move    a,x0
-        move    r2,a
-        sub     x0,a
+        move    y:(r5),a                ; t0
+        move    a,x:(r7+$1b)
+        move    x:(r7+$1c),a
+        add     #>$1,a                  ; one sample NEWER
         and     #>$3fff,a
         move    a1,x0
         move    x0,a
         move    x:(r7+$68),x0
         add     x0,a
         move    a,r5
-        move    y:(r5),x0
+        move    y:(r5),a                ; t1
+        move    x:(r7+$1b),x0
+        sub     x0,a                    ; t1 - t0, signed
+        move    a1,x0                   ; -> FIRST mpy operand
+        move    x:(r7+$1a),y1           ; frac
         mpy     x0,y1,a
-        add     a,b
+        move    x:(r7+$1b),x0
+        add     x0,a                    ; tap = t0 + frac*(t1-t0)
+        move    a,x0                    ; LIMITING move
+        move    x:(r7+$19),y1           ; window gain
+        mpy     x0,y1,a
+        move    x:(r7+$1f),b
+        add     b,a
+        move    a,x:(r7+$1f)       ; wet R +=
+        move    x:(r7+$5d),a            ; next grain: a quarter further round
+        move    x:(r7+$39),x0
+        add     x0,a
+        move    x:(r7+$38),x0
+        and     x0,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$5d)
+gvrz:
+        nop
 ; ---- wet R -------------------------------------------------------------
-        move    b,x0
+        move    x:(r7+$1f),x0
         move    x:(r7+$3d),y1
         mpy     x0,y1,b
-        asl     #$1,b,b
         move    b,x:(r7+$25)            ; shifted OUTPUT tap R
         bra     pdone
-; MODEFORK_MID -- alternative 4: REVERSE
+; MODEFORK_MID -- alternative 2: REVERSE
 
 ; ---- REVERSE: windowed backward reads (v2 stage 6) -----------------------
 ; The cheapest mode left, and cheap only BECAUSE the crossfade machinery
@@ -3057,67 +2905,3 @@ smoothw:
         add     x0,a                    ; s = g^2*(3-2g)
         rts
 
-; ---- phead: one PITCH head -- lerped line read + smoothstep window --------
-; (v7 roll, 23 Aug 2026.) The identical 45-instruction body appeared FOUR
-; times (head 0/1 x Line L/R), 62 words each: the single biggest repeat the
-; n-gram scan ever found in either server. Rolled to unblock verify_burn's
-; plain-layout fit (the burn sweep re-measures the cycle ceiling, which is
-; the live constraint again) -- the shipping payloads bank the rest.
-; In: a = write pointer minus PLAGB minus age_int, with this head's SCATTER
-; staged in x0 (the first sub consumes it); $15 = age_fx (frac source),
-; $6f = age_int; the line base staged in $30 (modtap's convention -- per
-; LINE, not per head: nothing between the two heads' calls touches it).
-; Out: a1 (via a,y1 at the tail's last move) = 1-g staged for the caller's
-; smoothstep finish; $17 = the lerped tap; $15 = g^2. Clobbers x0/y1/r5 and
-; $16. b IS PRESERVED -- head 0's contribution rides it through head 1's
-; call. Cycle cost: bsr+rts per head, and PITCH's fork path stays under
-; GRAIN's, so the priced worst path is unchanged.
-phead:
-        sub     x0,a
-        and     #>$3fff,a               ; read phase (t0, the newer neighbour)
-        move    a1,x0
-        move    x0,a                    ; A2-clean
-        move    a,x:(r7+$16)            ; park phase
-        move    x:(r7+$30),x0           ; line base, staged by the caller
-        add     x0,a
-        move    a,r5
-        move    y:(r5),a                ; t0
-        move    a,x:(r7+$17)            ; park t0
-        move    x:(r7+$16),a
-        move    #>$1,x0
-        sub     x0,a
-        and     #>$3fff,a               ; phase-1, wrapped: one sample OLDER
-        move    a1,x0
-        move    x0,a
-        move    x:(r7+$30),x0
-        add     x0,a
-        move    a,r5
-        move    y:(r5),a                ; t1
-        move    x:(r7+$17),x0           ; t0
-        sub     x0,a                    ; t1 - t0, signed
-        move    a1,x0                   ; -> FIRST mpy operand
-        move    x:(r7+$15),a            ; age_fx
-        and     #>$fff,a                ; sample fraction, Q12 (a2 already 0)
-        asl     #$b,a,a                 ; -> Q23
-        move    a1,y1                   ; frac
-        mpy     x0,y1,a                 ; frac*(t1-t0), signed
-        move    x:(r7+$17),x0
-        add     x0,a                    ; tap = t0 + frac*(t1-t0)
-        move    a,x:(r7+$17)            ; park tap (t0 dead)
-; window: full-overlap triangle t = 1024 - |age-1024|, smoothstepped
-        move    x:(r7+$6f),a            ; age_int
-        move    #>1024,x0
-        sub     x0,a
-        abs     a
-        neg     a
-        add     x0,a                    ; t = 1024 - |age-1024|, 0..1024
-        asl     #$d,a,a                 ; g = t/1024, Q23; t=1024 -> 2^23,
-                                        ; exact in the 56-bit acc
-        move    a,x0                    ; LIMITING move: 2^23 clips $7fffff
-        move    a,y1                    ; smoothstep s = g^2*(3-2g), zero-slope
-        mpy     x0,y1,a                 ; g^2       joins at both ends
-        move    a,x:(r7+$15)            ; park g^2 (age_fx dead)
-        move    #>$7fffff,a
-        sub     x0,a
-        move    a,y1                    ; 1-g
-        rts

--- a/modules/bongdelay/manifest.py
+++ b/modules/bongdelay/manifest.py
@@ -1,4 +1,4 @@
-"""BongDelay -- a multi-mode delay: CLEAN, PITCH, GRAIN, REVERSE.
+"""BongDelay -- a multi-mode delay: CLEAN, GRAIN (pitched), REVERSE.
 
 Hosted on payload B (core 1), which serves TRACKS 1-4. Any track can send
 into it, and its wet can be sent on into ChonVerb over the bus (-VRB) -- the
@@ -25,7 +25,7 @@ MODULE = Module(
     name="bongdelay",
     key="DELAY SERVER",
     kind=Kind.DSP_EFFECT,
-    doc="Multi-mode delay: CLEAN/PITCH/GRAIN/REVERSE, tape wow, drive, freeze.",
+    doc="Multi-mode delay: CLEAN / pitched GRAIN cloud / REVERSE, tape wow, drive, freeze.",
     menu=MenuEntry(
         fx2_id=0x06,
         donor_desc=0x400d5726,        # SPRING REV
@@ -60,34 +60,21 @@ MODULE = Module(
         Param(b"DPTH", 48, 128, active=True, formatter=_PLAIN,
               doc="tape wow depth; 0 = none - GRAIN: density, full dial, "
                   "level-flat (R61)"),
-        # ⚠️ Position 2 is DEAD ON PURPOSE, and the numbering is load-bearing.
-        # TAPE was retired 18 Aug 2026 (its wow/flutter became the global
-        # DPTH/RATE knobs, so TAPE was CLEAN with the knobs up) and its slot
-        # was KEPT rather than closed up, because a part stores the raw value:
-        # renumbering would turn every saved GRAIN (3) into REVERSE.
-        #
-        # It is labelled CLEAN, plainly, because that is what it RUNS. Two
-        # earlier labels were both worse: "(tape)" named a mode that does not
-        # exist, and "(CLEAN)" carried an editorial aside in a field that can
-        # only hold a value's NAME -- the parentheses read as a defect rather
-        # than as a footnote. Since PLAN §6 the unit prints these words too,
-        # so the list reads CLEAN PITCH CLEAN GRAIN REVRS: two positions that
-        # do the same thing, which is the truth and needs no explaining.
-        Param(b"MODE", 0, 5, active=True, formatter=_STEP,
-              labels=("CLEAN", "PITCH", "CLEAN", "GRAIN", "REVRS"),
-              doc="engine select; 2 is the retired TAPE slot and runs CLEAN "
-                  "(kept: parts store raw)"),
+        # v5 (3 Sep 2026): three real positions, nothing dead. The parts that
+        # stored PITCH (1) get GRAIN, which is its harmoniser now; the stamper
+        # writes fresh defaults for a replaced/renumbered effect anyway (plan A6).
+        Param(b"MODE", 0, 3, active=True, formatter=_STEP,
+              labels=("CLEAN", "GRAIN", "REVRS"),
+              doc="engine select: CLEAN, GRAIN (pitched cloud, v5), REVERSE"),
         # RATE 64 IS LOAD-BEARING: exactly 1x, the pre-knob modulation speed.
         # The DPTH=0 bypass gate only holds with the law exact here.
         Param(b"RATE", 64, 128, active=True, formatter=_PLAIN,
-              doc="wow LFO speed; 64 = exactly 1x (the DPTH=0 bypass law)"),
-        # PTCH is triple-meaning: the PITCH interval, GRAIN's grain SIZE
-        # (since v4, 3 Sep 2026) and REVERSE's segment size -- which is why
-        # its count stays 4.
-        Param(b"PTCH", 1, 4, active=True, formatter=_STEP,
-              labels=("+12", "+7", "-12", "det"),
-              doc="PITCH: interval - REVERSE: seg 46/93/23/12 ms, default 1 "
-                  "= 93 musical (R62) - GRAIN: size 23/46/93/186 ms (v4)"),
+              doc="wow LFO speed, 64 = 1x - GRAIN: pitch, +-2 oct, 64 = unison (v5)"),
+        # SIZE (the PTCH slot until v5): GRAIN's grain length and REVERSE's
+        # segment, one select read the same way by both. Count stays 4.
+        Param(b"SIZE", 1, 4, active=True, formatter=_STEP,
+              labels=("46MS", "93MS", "23MS", "XTRM"),
+              doc="segment/grain size 46/93/23 ms; XTRM = 12 ms REVERSE, 186 ms GRAIN"),
         # DRV is drive in every mode but GRAIN, where the same byte is the
         # scatter depth. 0 = exact bypass, which outranks a scatter taste
         # that gets played by hand anyway.

--- a/modules/bongdelay/manifest.py
+++ b/modules/bongdelay/manifest.py
@@ -81,12 +81,13 @@ MODULE = Module(
         # The DPTH=0 bypass gate only holds with the law exact here.
         Param(b"RATE", 64, 128, active=True, formatter=_PLAIN,
               doc="wow LFO speed; 64 = exactly 1x (the DPTH=0 bypass law)"),
-        # PTCH is triple-meaning: the PITCH interval, GRAIN's set width, and
-        # REVERSE's segment size -- which is why its count stays 4.
+        # PTCH is triple-meaning: the PITCH interval, GRAIN's grain SIZE
+        # (since v4, 3 Sep 2026) and REVERSE's segment size -- which is why
+        # its count stays 4.
         Param(b"PTCH", 1, 4, active=True, formatter=_STEP,
               labels=("+12", "+7", "-12", "det"),
               doc="PITCH: interval - REVERSE: seg 46/93/23/12 ms, default 1 "
-                  "= 93 musical (R62) - GRAIN: width"),
+                  "= 93 musical (R62) - GRAIN: size 23/46/93/186 ms (v4)"),
         # DRV is drive in every mode but GRAIN, where the same byte is the
         # scatter depth. 0 = exact bypass, which outranks a scatter taste
         # that gets played by hand anyway.

--- a/modules/nimbus/README.md
+++ b/modules/nimbus/README.md
@@ -58,3 +58,17 @@ on-unit reconfirm.
 
 - Voicing: grain density is fixed at four. Clouds' texture/diffusion stage
   and pitch-shifted grains are both out of scope for v1.
+
+## ⚠️ Open (found 3 Sep 2026, from BongDelay v5): the grains may play an octave UP
+
+BongDelay v5 took this engine's read geometry -- a grain reads
+`W - (POSbase + s + G + 1 - phase)` -- and measured it with a tone: at
+"unity" the output was **2x the input frequency**. The write head `W` moves
+one sample per sample and `phase` grows one per sample, so the absolute read
+position advances at TWO samples per sample: unity relative to the moving
+head is an octave up in absolute terms. The DC gate cannot see rate, which
+is why it passed. In FREEZE the head is still, so frozen clouds play at
+unity, which is the case that was listened to. **Unverified here** (this
+module was not re-rendered); the fix in the delay is a `+ phase` term in the
+distance so unity is a fixed tap behind the head. Falsifier: a tone through
+this module at MIX=127 with FRZE=0 reads back at its own frequency.

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -1787,9 +1787,14 @@ mkgo:""",
             # + 4 for the sticky-snap state: last knob + held division,
             # load + store each (24 Aug 2026)
             n_want += 4 if "y:>$0908" in src else 0
-            # + 2 for the MIDI branch (24 Aug 2026): latched note $090a,
-            # load + store
-            n_want += 2 if "y:>$090a" in src else 0
+            # + 3 for the MIDI branch (24 Aug 2026): latched note $090a,
+            # load + store, and since 3 Sep 2026 the warm-up's clear (the
+            # emulator's core-private Y is boot garbage, and a garbage
+            # note drove GRAIN's pitch in every local render)
+            # (2 for a source without the warm-up clear, so verify_delay can
+            # still build a pre-v5 reference)
+            n_want += (3 if "note starts at NONE" in src else 2) \
+                if "y:>$090a" in src else 0
             if name == "DELAY SERVER" and n_priv != n_want:
                 sys.exit(f"XBUS: {name} expected exactly {n_want} core-private "
                          f"$09xx refs (RATE/DRV state"

--- a/tools/verify_delay.py
+++ b/tools/verify_delay.py
@@ -281,16 +281,17 @@ def main():
     if "; DMODE_OVERRIDE" in cand_src:
         clean_ref = render(ref_mem, dp(), source=source)
         MODES = [
-            ("PITCH +12", 1, 0, dp()),
-            ("PITCH detune (L/R steps differ)", 1, 3, dp()),
-            ("TAPE WOW=100", 2, None, dp(WOW=100)),
-            ("TAPE WOW=127 FDBK=127 (deep wobble + loop saturation)", 2, None,
-             dp(WOW=127, FDBK=127)),
-            ("GRAIN SPRAY=0 (every grain on the same read)", 3, 0, dp(SPRAY=0)),
-            ("GRAIN SPRAY=127 (full scatter)", 3, 0, dp(SPRAY=127)),
-            ("GRAIN rolling intervals (select 1)", 3, 1, dp(SPRAY=90)),
-            ("REVERSE size 4096 (93 ms, the line's ceiling)", 4, 0, dp()),
-            ("REVERSE size 512 (stutter) at TIME=127", 4, 3, dp(TIME=127)),
+            # v5 numbering (3 Sep 2026): 1 = GRAIN, 2 = REVERSE; PITCH mode is
+            # retired and its harmoniser lives in GRAIN's continuous pitch.
+            # DINT drives the SIZE select (the PTCH slot until v5).
+            ("GRAIN unison SPRAY=0 (every grain on the same read)", 1, 1, dp(SPRAY=0)),
+            ("GRAIN unison SPRAY=127 (full scatter)", 1, 1, dp(SPRAY=127)),
+            ("GRAIN +12 on RATE, 23 ms grains", 1, 2, dp(SPRAY=60, RATE=96)),
+            ("GRAIN -12 on RATE, 186 ms grains (the distance clamp)", 1, 3,
+             dp(SPRAY=90, RATE=32)),
+            ("GRAIN sparse (DENS 0) at 93 ms", 1, 1, dp(SPRAY=64, WOW=0)),
+            ("REVERSE size 4096 (93 ms, the line's ceiling)", 2, 1, dp()),
+            ("REVERSE size 512 (stutter) at TIME=127", 2, 3, dp(TIME=127)),
         ]
         for label, dmode, dint, params in MODES:
             if dmode > shared_modes - 1:
@@ -318,9 +319,9 @@ def main():
         # ---- unknown MODE must fall back to CLEAN --------------------------
         # DMODE=5, not 3: 3 is GRAIN now, and a fallback case aimed at a mode
         # that EXISTS proves nothing. Keep this above the highest engine.
-        dm_mem, _, _ = build(args.candidate, "cand_dmode7", dmode=7)
+        dm_mem, _, _ = build(args.candidate, "cand_dmode5", dmode=5)
         d = render(dm_mem, dp(), source=source)
-        check("DMODE=7 (nonexistent mode) degrades to CLEAN, bit-identical",
+        check("DMODE=5 (nonexistent mode) degrades to CLEAN, bit-identical",
               d == clean_ref)
     else:
         print("  [ -- ] mode cases skipped: candidate has no "

--- a/tools/verify_midi.py
+++ b/tools/verify_midi.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""Local verification of the MIDI branch's two DSP paths (24 Aug 2026):
-note -> BongDelay PITCH interval (r6+$9). dsp_host has no ColdFire cave,
-so the word is forced with the DNOTE= build override and the result compared
-with the knob select that should produce the same thing.
+"""Local verification of the MIDI note path (24 Aug 2026; v5 3 Sep 2026):
+note -> BongDelay GRAIN pitch (r6+$9, latched). dsp_host has no ColdFire
+cave, so the word is forced with the DNOTE= build override and the result
+compared with the RATE knob, which drives the same 2^x law.
 
   EXACT (bit-identical):
-    no note (DNOTE=0)          == the PTCH select      (nothing changes)
-  WITHIN 15 CENTS OF THE SELECT PATH, 30 of nominal (spectral peak of the wet, the heads decorrelate so a
-  waveform diff is meaningless):
-    note 96 ~ +12, note 91 ~ +7, note 72 ~ -12, note 84 ~ unison (CLEAN's pitch)
+    no note (DNOTE=0)  == RATE 64         (nothing changes)
+    note 84 (unison)   == RATE 64         (f = 0 on both paths)
+  WITHIN 40 CENTS OF NOMINAL (the grain-rate comb), 15 of the knob path (spectral peak of the wet):
+    note 96 ~ +12 (RATE 96), note 91 ~ +7, note 72 ~ -12 (RATE 32)
 
 Slow (8 DEV builds + renders, ~1 min); not part of make check.
 """
@@ -69,17 +69,35 @@ def same(a, b):
     return read(a)[0] == read(b)[0]
 
 
-P = ("--dmode", "1", "--dptch", "0")
-sel12 = render("sel_p12", {}, *P)
-check("DNOTE=0 == PTCH select (no note ever: unchanged)", same(sel12, render("note0", {"DNOTE": "0"}, *P)))
-clean = render("clean", {}, "--dmode", "0")
-
-uni = peak_hz(clean)
-for note, want, ref in ((96, 1200, sel12), (91, 700, render("sel_p7", {}, "--dmode", "1", "--dptch", "1")),
-                        (72, -1200, render("sel_m12", {}, "--dmode", "1", "--dptch", "2")), (84, 0, clean)):
-    got = 1200 * math.log2(peak_hz(render(f"note{note}", {"DNOTE": str(note)}, *P)) / uni)
-    refc = 1200 * math.log2(peak_hz(ref) / uni)
-    check(f"note {note} -> {want:+5d} cents", abs(got - want) < 30 and abs(got - refc) < 15,
-          f"got {got:+.1f}, select path {refc:+.1f}")
+# v5 (3 Sep 2026): the note drives GRAIN's continuous pitch (MODE 1), the
+# same law the RATE knob uses -- so the knob path is the reference, and two
+# of the cases are BIT-IDENTICAL rather than spectral: no note ever == the
+# knob, and note 84 (the OT's unison) == RATE 64, because both feed the same
+# 2^x arithmetic with f = 0.
+G = ("--set", "MODE=1", "--set", "DPTH=127", "--set", "DRV=0", "--set", "FDBK=0",
+     "--set", "PING=0", "--set", "TIME=127", "--set", "SIZE=1")
+knob64 = render("knob64", {}, *G, "--set", "RATE=64")
+check("DNOTE=0 == the RATE knob (no note ever: unchanged)",
+      same(knob64, render("note0", {"DNOTE": "0"}, *G, "--set", "RATE=64")))
+check("note 84 (unison) == RATE 64, bit-identical (one 2^x law, f = 0)",
+      same(knob64, render("note84", {"DNOTE": "84"}, *G, "--set", "RATE=64")))
+clean = render("clean", {}, "--set", "MODE=0", "--set", "DPTH=0", "--set", "FDBK=0",
+               "--set", "PING=0", "--set", "TIME=127")
+uni = peak_hz(clean, 80, 3000)
+for note, want, rate in ((96, 1200, 96), (91, 700, None), (72, -1200, 32)):
+    got = 1200 * math.log2(peak_hz(render(f"note{note}", {"DNOTE": str(note)}, *G,
+                                          "--set", "RATE=64"), 80, 3000) / uni)
+    detail = f"got {got:+.1f}"
+    # 40 cents of NOMINAL: the peak is read off a comb at the grain rate
+    # (10.8 Hz at 93 ms), so a line's worth of error is the finder's, and
+    # -12 at 219 Hz reads 223 (+33 cents) on both paths. The 15-cent
+    # agreement with the knob path is the gate that is about the engine.
+    ok = abs(got - want) < 40
+    if rate is not None:
+        refc = 1200 * math.log2(peak_hz(render(f"rate{rate}", {}, *G, "--set",
+                                               f"RATE={rate}"), 80, 3000) / uni)
+        ok = ok and abs(got - refc) < 15
+        detail += f", RATE={rate} knob path {refc:+.1f}"
+    check(f"note {note} -> {want:+5d} cents", ok, detail)
 print(f"{fails} check(s) failed" if fails else "all MIDI checks passed")
 sys.exit(1 if fails else 0)


### PR DESCRIPTION
Plan step 2, after Sam's design pass. GRAIN is Nimbus's grain readers over the delay lines: four grains per line, one continuous pitch on RATE (±2 oct, 64 = unison; the held MIDI note when there is one). PITCH mode is retired, so MODE is **CLEAN / GRAIN / REVRS** and the PTCH switch is **SIZE**.

- Delay **2,469 → 2,151 words** (payload B FREE 323); worst path **2,372 → 1,757** cycles.
- Two defects found by measuring pitch instead of DC: Nimbus's read geometry plays an **octave up at unity** (fixed here; open item on the standalone Nimbus), and `dsp_host`'s boot garbage in the latched-note slot (warm-up clears it).
- CLEAN in every `verify_delay` case, REVERSE at both sizes, CLEAN with wow and the unknown-mode fallback: bit-identical to v3. DC gate flat. Pitch law measured to the grain-rate comb. `verify_midi` rewritten for GRAIN pitch and green.
- v5 is ~6 dB quieter than v3 at matched settings (decorrelated grains): makeup is an ear decision.

⬜ Ear pass pending: `out/ab/grain_v4/{glow_intro,guitar_dry}_v3.wav` vs `_v5_r64_lm.wav` (unison) and `_v5_r96_lm.wav` (+12). `make remix` → BongDelay → MODE GRAIN also auditions it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)