### PR TITLE
BamSep26: the three stations and the rig remix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,8 @@ verify: ## Verify the ColdFire menu edits, module ledger (+ burn probe when it f
 	python3 tools/label_fmt.py
 	@$(PY) tools/verify_labels.py $(REMIX) 2>/dev/null || \
 	  echo "  [SKIP] label check against the firmware: no .venv (make emu-setup)"
+	@$(PY) tools/verify_modenames.py $(REMIX) 2>/dev/null || \
+	  echo "  [SKIP] per-mode knob names: no .venv, or this remix has none"
 	REMIX=$(REMIX) python3 tools/verify_menu.py
 	python3 tools/verify_burn.py
 

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ verify: ## Verify the ColdFire menu edits, module ledger (+ burn probe when it f
 	  echo "  [SKIP] label check against the firmware: no .venv (make emu-setup)"
 	@$(PY) tools/verify_modenames.py $(REMIX) 2>/dev/null || \
 	  echo "  [SKIP] per-mode knob names: no .venv, or this remix has none"
+	@$(PY) tools/verify_menushortcut.py $(REMIX) 2>/dev/null || \
+	  echo "  [SKIP] menu shortcut: no .venv, or this remix has none"
 	REMIX=$(REMIX) python3 tools/verify_menu.py
 	python3 tools/verify_burn.py
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -212,7 +212,7 @@ core. Two consequences:
 
 The build report is the live ledger — `make bus` prints it. Current build
 (29 Aug 2026): **payload A used 2,650, FREE 74; payload B used 2,694,
-FREE 30 — and since BongDelay v5 (3 Sep 2026, PITCH mode retired, GRAIN pitched) B used 2,401, FREE 323.** The older "A 55 / B 1" figures in this file predated the freeze
+FREE 30 — and since BongDelay v5 (3 Sep 2026, PITCH mode retired, GRAIN pitched) B used 2,404, FREE 320 (v5.1: 2,154 words).** The older "A 55 / B 1" figures in this file predated the freeze
 and roll work; both payloads are still effectively full, and new work needs
 a lever first.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -671,6 +671,31 @@ is the slice of that road worth having.
 
 ---
 
+### 6b. Per-mode knob NAMES — DONE 3 Sep 2026, emulator-proven
+
+**A MODE select now renames the knobs around it.** BongDelay's MDEP/MRAT read
+SCAT/DENS in GRAIN, and the modulation station's FDBK/DLY read RES and
+RING/PTCH in PHSR and COMB. `ModeView` in the manifest is the single
+declaration; the remixer's UNIT pane follows it, `send_probe --set` accepts
+the aliases, and `tools/mode_names.py` emits a MODE formatter that rewrites
+the descriptor's 6-byte name fields (`E+0x4e`) before printing its own word.
+
+No new hook: PLAN §6's formatter cave is already called with the value when
+the page draws that slot. `tools/verify_modenames.py` (in `make check`) calls
+each formatter on the emulated ColdFire and reads the names back — 12 checks
+on the rig, including that a mode which does not rename a slot RESTORES its
+own name, and that an out-of-range value clamps to mode 0.
+
+⚠️ Inferred, not measured: the rename lands on the next redraw if the panel
+draws names before formatting MODE, and the descriptor is shared by every
+track running that effect. ⚠️ 84 bytes of cave left on the rig.
+
+⬜ **Per-mode DEFAULTS are the other half and are NOT on the unit.** The
+remixer applies them the moment MODE changes; doing it on the box means
+writing the part's parameter bytes when the encoder moves, which nothing here
+does live (`ot_project.py` writes parts offline, on a card). That is the next
+ColdFire job, and it wants the part-write path PLAN §4 started decoding.
+
 ### 6. On-device labels for the mode selects — DONE 2 Sep 2026
 
 **Every stepped select now prints its words on the unit.** WarpFold's MODE

--- a/docs/MAINMENU.md
+++ b/docs/MAINMENU.md
@@ -299,3 +299,65 @@ teardown) and the two `0x46c7d8d8` readers — plus everything
 (`PTR_FUN_400bb7f0` etc.) covers. None of it blocks the two-write table
 extension in §5 or the §7 shortcut; authoring a *new* screen of your own is
 the part that still costs real decode work.
+
+## 9. The global edit screen: the four unknowns, measured (3 Sep 2026)
+
+Sam's actual ask, once §4b landed: *"I missed that it would still be on the
+track, that was the whole point"*. A shortcut removes the hunting; it does not
+remove the coupling. What CAN move is where you edit from -- §6's bespoke list
+screen, whose setters call the stock parameter writer for the host track. Four
+things had to be known before that could be priced. Three are now known.
+
+### 9a. Relocating the menu-state table ✅ EASY
+
+`0x400cbdac` is named by exactly **three `lea` immediates** -- `0x40064bd2`,
+`0x40064e34`, `0x400650e6`, all `lea 0x400cbdac,%aN` -- and by no pointer
+cell. Extending it is therefore the same relocate-and-repoint move the build
+already performs for the FX1 chooser list: copy 16 x 0x14 bytes to a cave,
+append a 17th, patch three 4-byte operands.
+
+Read out of booted RAM, the entries confirm the layout
+`{on_enter, on_exit, draw, key_handler, encoder_handler}` and that **a NULL
+member is skipped** (`tstl %a0 / beqs / jsr %a0@`), so an unused handler can
+be left zero. State 0 is all zeros but is unreachable: id 0 is the action
+path, which is why §3's "all 15 occupied" stands.
+
+### 9b. Where the values live ✅ BOTH SOURCES LOCATED
+
+- **The staged page**, which is what the panel draws:
+  `0x46C7D244 + slot * 0x14` (`FUN_400326d4` builds it;
+  `docs/midi_re_cc.md` already knew `0x46c7d244[2*slot+1] = 0x14` as the
+  redraw marker). Only valid for the page currently staged -- so a global
+  screen cannot read it without staging the page it is trying to avoid.
+- **The Part**, which is what the writer commits to and therefore the
+  authoritative store: `*(0x46c82456) + part * 6322 + 0x8EDA2 + track` is the
+  per-track id byte (`0x100b14cf` is the current part), with the parameter
+  bytes in the same record. A global screen reads and writes here.
+
+### 9c. The `flat` index 🟡 PARTLY
+
+`FUN_40054cd8(track, flat, value)` decomposes `flat` **by six**: two `rems.l
+#6` give slot = flat mod 6 and page = flat / 6, and the page is handed to
+`FUN_40031da4(track, kind)` -- the same resolver the [FX2] key path uses. So
+`flat = page * 6 + slot`, which page index means FX2 page 1 and page 2 is
+NOT yet confirmed.
+
+⚠️ **And it cannot be confirmed in the emulator as it stands**: the machine
+boots to DEMO with no CF card, so `*(0x46c82456)` is 0 and the current part
+and track bytes are 0. Anything that touches Part storage has no storage to
+touch. **This is the real limit on the feature's local testability** -- the
+draw half can be proven locally, the write half cannot, until either a
+project is faked in RAM or the harness learns to mount a card image.
+
+### 9d. The encoder handler's ABI 🟡 SHAPE ONLY
+
+Every stock encoder handler examined (states 3 and 4, `0x400658f0` and
+`0x40065c98`) opens identically: push `%a2` and `%d2`, then `%sp@(12)` ->
+`%a2` and `%sp@(16)` -> `%d2`. So it is two stack arguments after the usual
+prologue. **Which is the encoder index and which is the delta is unsettled**:
+the same value is used as a pointer base (`pea %a2@(56)`) and compared
+against a small integer a few instructions later, which is either a
+re-load this reading missed or a desynchronised stream. Not guessed at --
+`CLAUDE.md`'s standing rule about r2 inventing plausible code applies to any
+disassembly read past the point where it stops making sense.
+

--- a/docs/MAINMENU.md
+++ b/docs/MAINMENU.md
@@ -110,6 +110,37 @@ holds a pointer back to the descriptor. ✅ Resolved (31 Aug 2026): it is the
 nav engine reads and writes; it persists across menu close (the menu
 remembers its position), which is stock behavior.
 
+## 4b. BUILT: `modules/menushortcut/` — CONTROL > REVERB / DELAY ✅ (3 Sep 2026)
+
+**Two rows, emulator-walked, unflashed.** `modules/menushortcut/manifest.py`
+copies CONTROL's six rows into a cave, appends REVERB and DELAY, repoints the
+rows pointer at `0x400cbd6c` and bumps the count at `0x400cbd54` to 8 — the
+§5 move, applied to CONTROL rather than the root for the reason §7 gives.
+Both writes assert the stock bytes first.
+
+The action (`menu_shortcut.s`, 92 bytes, assembled and pinned) is §7's
+sketch with one change: **the track is not hardcoded.** It scans the eight
+per-track FX2 id bytes at `0x80000ecc` for its server's id — 7 ChonVerb,
+6 BongDelay — and selects whichever track hosts it, so the row follows the
+project rather than assuming T5. If that address is wrong the scan simply
+never matches and the handler opens the current track's page: a wrong
+screen, not a crash, which is why it scans rather than trusting.
+
+⚠️ The cave is PINNED at `0x400d24d0`, the unclaimed 2,064-byte zero run §5
+names, **not** in the clone/label region — the BamSep26 rig leaves 84 bytes
+there and this cave is 300. `build_bus.py` allows a cave outside that window;
+it still refuses one whose target is not free.
+
+`tools/verify_menushortcut.py` (in `make check`) checks the table statically,
+boots the image and walks the menu out of RAM with the firmware's own layout
+— both rows resolve with their labels, id 0 (the action path) and actions in
+the cave — and calls the REVERB action with MIDI mode set, where it must
+return having touched nothing.
+
+⬜ What no local test can reach: whether closing the menu from inside an
+action and then selecting a track lands on the FX2 page. That is §7's ~65%
+and the flash is the test.
+
 ## 5. Why this matters: adding a fifth top-level entry is two writes ✅
 
 **The root row array `0x400cc698` has exactly ONE reference in the whole

--- a/docs/MIDI.md
+++ b/docs/MIDI.md
@@ -138,8 +138,8 @@ on the RE below.
 
 ⚠️ **v5 (3 Sep 2026, unflashed): the note drives GRAIN's continuous pitch**
 (2^((note−84)/12), ±24 semitones, MODE 1) — PITCH mode and its interval
-select are gone. `tools/verify_midi.py` checks the note against the RATE knob
-path (bit-identical at unison, spectral elsewhere). The cave is unchanged.
+select are gone. `tools/verify_midi.py` checks the note against the PTCH knob
+path (page 1 since v5.1; bit-identical at unison, spectral elsewhere). The cave is unchanged.
 
 - **Cave v2** (`modules/tempo-sync/tempo_cave.s`, 104 bytes, floating behind the
   descriptor clones — `0x400d7000` in the shipping image; the TIME formatter

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -227,6 +227,33 @@ is not when it lands — HELLO WORLD arrived on `0x17` and was moved to `0x1b`,
 `0x17` having become Rungs's on 2 Sep 2026. `make modules` prints what is
 claimed today.
 
+## A STATION: an insert that is also a bus client
+
+The BamSep26 stations (`modules/filterstation/` is the first) are per-track
+inserts that also SEND: page-1 →DEL / →VRB knobs, the processed mono added
+into both accumulators. What that takes, beyond the insert contract:
+
+- `Harness(bus_client=True)` on a `Kind.DSP_EFFECT`, so the registry treats
+  the image as having a bus (`fallback="SEND"`, never NONE), and the build
+  relocates the module's `$9xx` scratch literals under XBUS exactly as
+  SEND's — **without** the housekeeping gate, because
+- **a station never housekeeps.** It carries SEND's split-offset block, the
+  `; ROTINIT` / `; ROTLATCH` markers (substituted per payload, keyed on
+  `r7_latch_slot=0x69`), the knob-gated registration and the per-sample
+  writer — but not the election. An FX1 instance on track 5 runs BEFORE that
+  track's FX2 instance, and position 0 housekeeps unconditionally, so an
+  electing FX1 participant would flip the rotation twice in the first block
+  and leave core 1's private tracking one step behind forever. The price is
+  16 samples less bus latency for a station on core 0 (it adds into the
+  buffer written last block, which is read next block); nothing is lost.
+- The layout alphabet is exhausted (A–W, Y, Z), so stations take DIGITS as
+  `layout_char`. `send_probe --feed 1 --set 1:-VRB=100` feeds the tone to
+  the station's own track and drives its knob; `LETTER:NAME=VAL` drives any
+  live slot. The registration gate is: a second instance with its send at
+  zero must not move the server's level (the N/(N+1) trap).
+- Every slot the sample loop touches sits **below `$40`**: the module's
+  README records why.
+
 ## Keeping STOCK effects in the chooser
 
 Every image replaces the FX2 chooser wholesale, and until 2 Sep 2026 that

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -227,6 +227,53 @@ is not when it lands — HELLO WORLD arrived on `0x17` and was moved to `0x1b`,
 `0x17` having become Rungs's on 2 Sep 2026. `make modules` prints what is
 claimed today.
 
+## PER-MODE KNOB NAMES AND DEFAULTS -- `ModeView`
+
+A multi-mode effect reuses its knobs, and a panel that prints one name for
+both meanings is telling the operator the wrong thing half the time.
+BongDelay's MDEP is the tape modulation depth in CLEAN and the grain scatter
+in GRAIN; its MRAT is the rate and the density. Declare the difference:
+
+```python
+mode_slot=7,                       # which slot carries the MODE select
+mode_views=(
+    ModeView(mode=0, defaults={0: 40, 1: 60}),          # CLEAN
+    ModeView(mode=1, names={6: b"SCAT", 8: b"DENS"},    # GRAIN
+             defaults={0: 36, 6: 40, 8: 127}),
+),
+```
+
+Both maps are SPARSE and both are optional. `names` renames a slot for that
+mode -- four characters, the field's width. `defaults` is where the OTHER
+knobs should land when the operator arrives at this mode.
+
+**What each half drives:**
+
+| | the remixer | the unit |
+|---|---|---|
+| `names` | the UNIT pane's rows follow the current MODE (`Module.knob_map_in`), and `send_probe --set SCAT=40` resolves the alias | ✅ `tools/mode_names.py` emits a MODE formatter that REWRITES the descriptor's name fields before printing its own word |
+| `defaults` | applied the moment MODE changes | ⬜ not yet: it needs a write into the part, which nothing here does live |
+
+**How the unit half works, and why it needs no new hook.** A descriptor
+carries its twelve parameter names as 12 x 6 bytes at `E+0x4e`
+(`docs/PARAM_PAGES.md`), and our clones are ordinary writable RAM. PLAN §6
+already gives every stepped select a formatter cave that the panel calls as
+`fmt(buf, value)` **with the value in hand**, so the rename rides in there:
+no per-frame writer, no decode of which track is selected, no read of the
+part. `tools/verify_modenames.py` (in `make check`) calls each MODE formatter
+on the emulated ColdFire and reads the names back out of the clone.
+
+⚠️ **Two limits, both inferred rather than measured.** The rename lands on
+the draw AFTER the one that formats MODE, if the panel draws names first --
+invisible when you turn the encoder, since that redraws. And the descriptor
+is shared by every track running that effect, so two tracks in different
+modes have one set of names between them: the one drawn last.
+
+⚠️ **The names are not free.** Each mode's block is 8 bytes per renamed slot
+plus a terminator, in a cave that had 84 bytes to spare on the shipping rig.
+Rename a slot whose MEANING changes; a knob that is merely unused in a mode
+keeps its name and says so in its `doc`.
+
 ## A STATION: an insert that is also a bus client
 
 The BamSep26 stations (`modules/filterstation/` is the first) are per-track

--- a/docs/REMIXER.md
+++ b/docs/REMIXER.md
@@ -121,7 +121,7 @@ So the words are spent only by modules of ours, and a swap is only
 (322), or Hello World (27) + Ripple (347). Measured costs, payload A:
 Hello World 27, Streamz 255, WarpFold 322, Ripple 347, BodeShift 391,
 Nimbus 500, Rungs 880, Send 215, ChonVerb 2,411 (+24 LFO table), BongDelay
-2,151 (payload B; 2,469 before BongDelay v5).
+2,154 (payload B; 2,469 before BongDelay v5).
 
 **One trade is often not enough**, and the status line names the next one
 rather than leaving it to the build to refuse:

--- a/docs/VOICING.md
+++ b/docs/VOICING.md
@@ -2085,3 +2085,16 @@ matched settings (four decorrelated grains), a makeup decision for the ear.
 ⬜ Ear pass pending (Sam): `out/ab/grain_v4/` -- `_v3` vs `_v5_r64_lm`
 (unison) and `_v5_r96_lm` (+12), glow_intro and guitar_dry.
 
+### R64 addendum — v5.1, the knob map done in one pass (3 Sep 2026)
+
+Sam, rightly: the mode change had been patched knob by knob (RATE meant
+pitch AND wow speed, DPTH meant density AND wow depth in GRAIN). One pass,
+one meaning per knob per mode: IN retired (the host's own send is its FX1
+station), PTCH on page 1 in its place, MDEP = mod depth / GRAIN scatter,
+MRAT = mod rate / GRAIN density, DRV = drive in every mode, GRAIN with a
+fixed gentle wow. Measured after: CLEAN bit-identical to v3; pitch on PTCH
+438/869/223 Hz at 64/96/32; density on MRAT −15.1 → −12.0 dBFS (0 → 127);
+scatter on MDEP −7.1 (coherent) → −11.8 dBFS; DC gate p-p 0. The Nimbus
+comparison stands: Sam's Nimbus was the octave-up one, so PTCH 96 is the
+sound he knew, MDEP 40, MRAT 127, SIZE 93MS, TIME 36, FDBK 40, PING 127.
+

--- a/modules/bongdelay/README.md
+++ b/modules/bongdelay/README.md
@@ -22,6 +22,34 @@ label comes from the [`tempo-sync`](../tempo-sync/) module's formatter cave.
 hatch (`make render-delay`), which places it out of region in payload A.
 `DFRZAT=n` engages FREEZE after n blocks so a render can catch it mid-flight.
 
+## The knob map since v5.1 (3 Sep 2026) — one meaning per knob per mode
+
+Sam's redesign, done in one pass after a day of piecemeal fixes: IN is
+retired (the host track's own send into the delay is its FX1 station's
+→DEL, or SEND on FX1), GRAIN's pitch moves onto the scene page in its place,
+and the two tape-modulation knobs are named for what they are.
+
+| | CLEAN | GRAIN | REVERSE |
+|---|---|---|---|
+| **page 1** TIME · FDBK · TONE · PING · →VRB | the same everywhere | | |
+| **PTCH** (page 1, was IN) | no effect | pitch, ±2 oct, 64 = unison; a held MIDI note overrides | no effect |
+| MDEP | tape mod depth | **scatter** | tape mod depth |
+| MODE | CLEAN | GRAIN | REVRS |
+| MRAT | tape mod rate, 64 = 1× | **density** | tape mod rate |
+| SIZE | unused | grain size | segment |
+| DRV | drive | drive | drive |
+| FRZE | freeze | freeze | freeze |
+
+GRAIN carries a **fixed gentle wow** (knob 12's worth at exactly 1×) that no
+knob touches: the grains read the lines the repeats recirculate through, and
+at MDEP 127 they used to wobble by ±254 samples ("modulating heavily"). The
+per-mode label cave on the backlog will print SCAT / DENS in GRAIN. The IN
+arithmetic is still in the loop, pinned to exactly zero (bit-identical to
+every IN=0 render); removing it is a cycle trim.
+
+⚠️ Old parts store IN's value in slot 5, which is PTCH now: the project
+stamper (plan A6) writes fresh defaults.
+
 ## GRAIN v5 (3 Sep 2026) — Nimbus's readers over the delay lines, pitched; PITCH mode retired
 
 The v2 GRAIN was the delay's cost centre (eight lerped heads, per-grain
@@ -36,10 +64,10 @@ topology) and it is gone: **MODE is CLEAN / GRAIN / REVRS**, three positions.
 The PTCH switch is **SIZE** (46 / 93 / 23 ms, XTRM = 186 ms grains or 12 ms
 REVERSE segments — REVERSE's own order, one select for both modes).
 
-Knobs in GRAIN: TIME = position, SIZE = grain length, RATE = pitch, DRV =
-scatter depth (up to 4,095 samples), DPTH = density (R61 law and makeup),
-FREEZE holds the lines and the grains keep grazing them. A held MIDI note
-(the tempo cave's `r6+$9`, latched) replaces the RATE knob with
+Knobs in GRAIN (v5.1 names): TIME = position, SIZE = grain length, PTCH =
+pitch (page 1), MDEP = scatter (up to 4,095 samples), MRAT = density (R61 law
+and makeup), DRV = drive, FREEZE holds the lines and the grains keep grazing
+them. A held MIDI note (the tempo cave's `r6+$9`, latched) replaces PTCH with
 2^((note−84)/12), ±24 semitones — the same law the retired mode drove.
 
 **Cost:** delay 2,469 → **2,151 words** (payload B FREE 5 → **323**); worst
@@ -61,9 +89,9 @@ path 2,372 → **1,757 cycles** (GRAIN, rolled: 345 words + 718 of roll).
 
 Measured (`make render-delay` hatch, 438 Hz tone, 93 ms grains, TIME 127):
 
-| RATE | measured | expected | note | measured | expected |
+| PTCH | measured | expected | note | measured | expected |
 |---|---|---|---|---|---|
-| 64 | 438.7 | 438 | 84 | = RATE 64, bit-identical | |
+| 64 | 438.7 | 438 | 84 | = PTCH 64, bit-identical | |
 | 96 | 869.4 | 876 | 96 | 869.4 | 876 |
 | 32 | 223.4 | 219 | 91 | 654.1 | 656 |
 | 48 | 309.5 | 310 | 72 | 223.4 | 219 |

--- a/modules/bongdelay/delay_server.asm
+++ b/modules/bongdelay/delay_server.asm
@@ -267,11 +267,10 @@
 ;   r7+$73              FDBK coefficient (per block)
 ;   r7+$74              PING amount (per block)
 ;   r7+$75              TIME, integer sample count (per block)
-;   r7+$76              IN -- this track's OWN send level into the delay
-;                       (per block, raw knob used directly as Q1.23). Was
-;                       MIX; v3 stage 1 made the host track a return, so
-;                       there is no dry left to cross-fade and the knob
-;                       became the host's counterpart of send_client's p0
+;   r7+$76              IN -- pinned to 0 since v5.1 (3 Sep 2026): slot 5 is
+;                       PTCH now and the host's own send is its FX1 client.
+;                       The IN arithmetic is still in the loop (x0 = exactly
+;                       zero contribution); removing it is a cycle trim
 ;   r7+$77/$78          TONE filter state, line L / R (persistent)
 ;   r7+$79/$7a          scratch: dL/dR, raw taps (per sample)
 ;   r7+$7b/$7c          scratch: fL/fR, damped taps == this sample's wet
@@ -723,13 +722,9 @@ bus_mine:
 ; Tcc needs an accumulator, so it takes b and the base is RE-LOADED below
 ; rather than "still live". Costs one word; the version that trusted the old
 ; comment indexed the table at address 0 or 1, a wild Y read.
-        move    #>$1,x0                 ; the "one more client" increment
-        clr     b                       ; b = 0 -- BEFORE the tst below
-        move    x:(r6+$5),a             ; IN (p5 since the 18 Aug swap), read
-                                        ;  from the knob directly: the per-block
-                                        ;  decode runs AFTER this block
-        tst     a                       ; Z set == IN is 0 == not sending
-        tne     x0,b                    ; sending -> b = 1
+        clr     b                       ; b = 0: IN is retired (v5.1), the host
+                                        ; never counts itself -- its own send
+                                        ; is an FX1 client like any other
         move    y:(r5),a                ; clients that wrote the buffer we read
         add     b,a                     ; ... plus ourselves, if sending
         and     #>$7,a                  ; masked: boot garbage cannot index wild
@@ -1111,8 +1106,12 @@ dwarmdone:
 ; NEITHER FLASHED. The matrix now has an IN-nonzero render so a dead IN can
 ; never again pass silently -- verify_bus alone cannot see it because every
 ; default render has IN at 0.
-        move    x:(r6+$5),x0
-        move    x0,x:(r7+$76)           ; IN, 0 .. ~0.99
+; v5.1 (3 Sep 2026): IN IS RETIRED. Slot 5 is PTCH, GRAIN's pitch; the host
+; track's own send into the delay is its FX1 station's ->DEL (or SEND on
+; FX1). The IN machinery below is kept and pinned to 0 -- bit-identical to
+; every IN=0 render, and a cycle trim for later rather than a risk now.
+        clr     a
+        move    a,x:(r7+$76)            ; IN = 0, always
 
 ; ---- MODE: engine select, page-2 slot 7 ($c bits 8-15) -- v2 spine --------
 ; Same field, same extract, same MSB-aligned convention as ChonVerb's MODE
@@ -1214,6 +1213,17 @@ dwarmdone:
                                         ; 8-15; on $b nothing shared the word
         move    a1,x0
         move    x0,a                    ; A2-clean
+; ---- v5.1: GRAIN carries a FIXED GENTLE wow (Sam, 3 Sep 2026) ------------
+; MDEP is scatter there, so the depth cannot come from the knob; and the
+; grains read the same lines the repeats recirculate through, so DPTH 127
+; had them wobbling by +-254 samples ("modulating heavily"). Knob 12's worth,
+; ~+-24 samples at 1x: a tape's breath rather than a wobble.
+        move    x:(r7+$69),b            ; MODE
+        move    #>$10000,x0             ; 1 << 16 = GRAIN
+        cmp     x0,b
+        bne     wowlive
+        move    #>$18000,a              ; 12 << 13
+wowlive:
         move    a,x:(r7+$2d)            ; WOWD
         asr     #$3,a,a
         move    a1,x0
@@ -1231,8 +1241,14 @@ dwarmdone:
 ; XBUS): r7 is full, and the server-role lock guarantees ONE delay per bank,
 ; so the shared words have one writer.
         move    x:(r6+$d),a
-        and     #>$7f0000,a             ; RATE knob field
+        and     #>$7f0000,a             ; MRAT knob field
         move    a1,x0
+        move    x:(r7+$69),b            ; v5.1: in GRAIN MRAT is density and the
+        move    #>$10000,x0             ; mod rate is fixed at exactly 1x (64),
+        cmp     x0,b                    ; the DPTH=0 bypass law's own value.
+        move    #>$400000,x0            ; 64 << 16 -- a move between the cmp
+        teq     x0,a                    ; and the Tcc is fine; Tcc's DESTINATION
+        move    a1,x0                   ; is an accumulator, never a register
         move    #>$130,y1
         mpy     x0,y1,a                 ; wow inc = $98 * val/64
 ; ⚠️ 0901h-0904h: CORE-PRIVATE Y, and the ZERO-PADDED SPELLING IS LOAD-BEARING.
@@ -1256,21 +1272,11 @@ dwarmdone:
         mpy     x0,y1,a                 ; flutter inc = $56d * val/64
         move    a,y:>$0902
 
-; ---- DRIVE amount: p10 in every mode but GRAIN --------------------------
-; GRAIN's p10 is SPRA (scatter), the established multi-meaning pattern -- so
-; in GRAIN, d is pinned 0 and the grains run undriven; everywhere else the
-; knob is DRV. knob<<16 IS d in Q1.23 (the MIX/PING trick). Y 0903h:
-; same reasoning as the RATE increments above.
-        move    x:(r7+$69),b            ; MODE
-        move    #>$10000,x0             ; 1 << 16 = GRAIN (v5 numbering)
-        cmp     x0,b
-        beq     drvz
+; ---- DRIVE amount: p10, EVERY mode (v5.1: scatter moved to MDEP, so the ---
+; grains read a driven line like the repeats do). knob<<16 IS d in Q1.23
+; (the MIX/PING trick). Y 0903h: same reasoning as the RATE increments above.
         move    x:(r6+$e),a             ; p10 knob field
         and     #>$7f0000,a
-        bra     drvw
-drvz:
-        clr     a
-drvw:
         move    a,x:(r7+$83)            ; d -> r7 (18 Aug 2026, probe V0/V127:
                                         ; d via Y read INSIDE the bsr callee
                                         ; measured dead on hardware -- crest
@@ -1317,17 +1323,15 @@ drvw:
         teq     x0,b                    ; running -> re-arm
         move    b,y:>$0904
 
-; ---- SPRAY: GRAIN scatter depth (v2 stage 5) ------------------------------
-; Page-2 slot 10's KNOB field -- the SAME WORD as FRZE, whose select is its
-; low byte, which is why the two masks here are disjoint and neither reads
-; the other's field. knob<<16 already IS value/128 in Q1.23, so it is used
+; ---- SPRAY: GRAIN scatter depth (v2 stage 5; on MDEP since v5.1) ----------
+; Page-2 slot 6's KNOB field (r6+$c, the word MODE's select shares). knob<<16 already IS value/128 in Q1.23, so it is used
 ; directly as a multiplier with no mpy to build it (the MIX/PING trick).
 ; SPRAY=0 puts every grain on the same read position -- four heads in a
 ; cluster, the most coherent and least granular end -- and 127 gives the
 ; full 0..1015-sample scatter. Decoded every block regardless of MODE, like
 ; PTCH and FRZE; harmless in the modes that never read it.
-        move    x:(r6+$e),a
-        and     #>$7f0000,a             ; knob field only
+        move    x:(r6+$c),a             ; MDEP's knob field: SCATTER in GRAIN
+        and     #>$7f0000,a             ; (v5.1 -- the mod depth is fixed there)
         move    a1,x0
         move    x0,a                    ; A2-clean (AND cleans A1 only)
         move    a,x:(r7+$5c)            ; SPRAY, 0 .. ~0.992 as Q23
@@ -1532,8 +1536,8 @@ gvn0:
         bra     gvoct
 gvknob:
 ; knob path: e = RATE - 64 (-64..63); oct = e >> 5; f = (e & 31) << 18
-        move    x:(r6+$d),a             ; page-2 slot 8 KNOB field
-        and     #>$7f0000,a
+        move    x:(r6+$5),a             ; PTCH: page-1 slot 5 (IN until v5.1),
+        and     #>$7f0000,a             ; a plain knob, val << 16
         move    a1,x0
         move    x0,a
         asr     #$10,a,a                ; the integer knob 0..127
@@ -1622,8 +1626,9 @@ gvrdone:
 ; the R61 full-dial law; and the level MAKEUP coeff = 1/2 + (7-dens3)/14 in
 ; Q23 (R61, verbatim: flattens the gate's energy loss within ~1.2 dB; the top
 ; of the ramp is $7FFFFF by construction, so the sum cannot wrap).
-        move    x:(r7+$2d),a
-        asr     #$11,a,a
+        move    x:(r6+$d),a             ; MRAT's knob field: DENSITY in GRAIN
+        and     #>$7f0000,a             ; (v5.1 -- the mod rate is fixed there)
+        asr     #$14,a,a                ; knob >> 4 = dens3, 0..7
         move    a1,x0
         move    x0,a
         move    a,x:(r7+$3c)            ; dens3 (lag's park is consumed)

--- a/modules/bongdelay/manifest.py
+++ b/modules/bongdelay/manifest.py
@@ -53,13 +53,13 @@ MODULE = Module(
         # every real sender.
         Param(b"-VRB", 0, active=True, formatter=_PLAIN,
               doc="wet send into ChonVerb over the bus -- delay into reverb in series"),
-        # IN sits bottom-right to match the reverb's IN (the 18 Aug swap).
-        Param(b"IN", 0, active=True, formatter=_PLAIN,
-              doc="this track's own send into the delay; 0 = off (and off the bus)"),
+        # PTCH sits where IN did (v5.1, 3 Sep 2026): the host's own send is its
+        # FX1 station's ->DEL now, and GRAIN's pitch belongs on the scene page.
+        Param(b"PTCH", 64, active=True, formatter=_PLAIN,
+              doc="GRAIN pitch, +-2 oct, 64 = unison (a held MIDI note overrides); idle in other modes"),
         # ---- page 2 -------------------------------------------------------
-        Param(b"DPTH", 48, 128, active=True, formatter=_PLAIN,
-              doc="tape wow depth; 0 = none - GRAIN: density, full dial, "
-                  "level-flat (R61)"),
+        Param(b"MDEP", 48, 128, active=True, formatter=_PLAIN,
+              doc="tape mod (wow) depth; 0 = none - GRAIN: scatter, how far apart the grains read"),
         # v5 (3 Sep 2026): three real positions, nothing dead. The parts that
         # stored PITCH (1) get GRAIN, which is its harmoniser now; the stamper
         # writes fresh defaults for a replaced/renumbered effect anyway (plan A6).
@@ -68,8 +68,8 @@ MODULE = Module(
               doc="engine select: CLEAN, GRAIN (pitched cloud, v5), REVERSE"),
         # RATE 64 IS LOAD-BEARING: exactly 1x, the pre-knob modulation speed.
         # The DPTH=0 bypass gate only holds with the law exact here.
-        Param(b"RATE", 64, 128, active=True, formatter=_PLAIN,
-              doc="wow LFO speed, 64 = 1x - GRAIN: pitch, +-2 oct, 64 = unison (v5)"),
+        Param(b"MRAT", 64, 128, active=True, formatter=_PLAIN,
+              doc="tape mod (wow) rate, 64 = 1x - GRAIN: density, full dial, level-flat (R61)"),
         # SIZE (the PTCH slot until v5): GRAIN's grain length and REVERSE's
         # segment, one select read the same way by both. Count stays 4.
         Param(b"SIZE", 1, 4, active=True, formatter=_STEP,
@@ -79,7 +79,7 @@ MODULE = Module(
         # scatter depth. 0 = exact bypass, which outranks a scatter taste
         # that gets played by hand anyway.
         Param(b"DRV", 0, 128, active=True, formatter=_PLAIN,
-              doc="drive on the repeats; in GRAIN it is the scatter depth; 0 = bypass"),
+              doc="drive on the repeats, every mode; 0 = bypass"),
         Param(b"FRZE", 0, 2, active=True, formatter=_STEP,
               labels=("RUN", "HOLD"),
               doc="freeze the line as a loop -- loop length = TIME"),

--- a/modules/bongdelay/manifest.py
+++ b/modules/bongdelay/manifest.py
@@ -15,7 +15,7 @@ cave that prints the tempo division while the DSP's sticky snap holds one,
 installed by the tempo-sync patch and registered over slot 0 afterwards.
 """
 
-from remix.schema import (BusRole, Claims, YBase, DspSection, Formatter, Harness, Kind,
+from remix.schema import (ModeView, BusRole, Claims, YBase, DspSection, Formatter, Harness, Kind,
                           MenuEntry, Module, Param)
 
 _PLAIN = Formatter.PLAIN
@@ -83,6 +83,24 @@ MODULE = Module(
         Param(b"FRZE", 0, 2, active=True, formatter=_STEP,
               labels=("RUN", "HOLD"),
               doc="freeze the line as a loop -- loop length = TIME"),
+    ),
+    # ---- what each MODE renames and re-defaults (v5.1, 3 Sep 2026) --------
+    # MDEP and MRAT are the tape modulation depth and rate in CLEAN and
+    # REVERSE, and the grain scatter and density in GRAIN; PTCH is the grain
+    # pitch and idle elsewhere. The panel printed one name for both meanings
+    # until this table existed.
+    mode_slot=7,
+    mode_views=(
+        ModeView(mode=0,                        # CLEAN
+                 defaults={0: 40, 1: 60, 2: 100, 3: 127, 5: 64,
+                           6: 48, 8: 64, 10: 0}),
+        ModeView(mode=1,                        # GRAIN
+                 names={6: b"SCAT", 8: b"DENS"},   # PTCH is PTCH in every mode
+                 defaults={0: 36, 1: 40, 2: 100, 3: 127, 5: 64,
+                           6: 40, 8: 127, 9: 1, 10: 0}),
+        ModeView(mode=2,                        # REVERSE
+                 defaults={0: 40, 1: 60, 2: 100, 3: 127, 5: 64,
+                           6: 48, 8: 64, 9: 1, 10: 0}),
     ),
     dsp=DspSection(
         asm="modules/bongdelay/delay_server.asm",

--- a/modules/charstation/README.md
+++ b/modules/charstation/README.md
@@ -1,0 +1,80 @@
+# CHARACTER STATION
+
+The second BamSep26 station: everything that dirties or tightens a track, in
+one insert, **replacing stock LO-FI** (id 0x1c) on both menus and in every
+saved part that chose LO-FI. Design page:
+https://claude.ai/code/artifact/42670d67-7365-4c7d-bcc7-1786ba4331ce
+
+| page 1 | DRV · FOLD · CRSH · COMP · →DEL · →VRB |
+|---|---|
+| page 2 | MIX · SAT (TAPE TUBE FUZZ BUS) · RING · CMOD (COMP GLUE TRNS) · WDTH · SRR (OFF /2 /4 /8) |
+
+Chain, fixed: **crush → fold/ring → saturate → compress → width → mix**.
+Distortion before dynamics, so the compressor is a tool on a dirty signal
+rather than a fader for the dirt.
+
+- **CRSH / SRR** are LO-FI's pair: a bit mask built once per block (0..21 bits
+  cleared) and a sample-and-hold of 2, 4 or 8.
+- **FOLD / RING** are WarpFold's wavefolder and its parabolic carrier.
+- **SAT** is BongDelay's `w − w³/3` with four characters, and since the
+  branchless pass they are **four per-block coefficients** — `neg` (TUBE's
+  asymmetry: the negative half scaled 0.75 before the curve), `pre`/`post`
+  (BUS drives at half and doubles back — the gentlest knee, for a master) and
+  a symmetric `clip` (FUZZ at ±0.6; 1.0 elsewhere never bites, since
+  |sat(w)| ≤ 2/3).
+- **COMP / CMOD** is one feedforward detector on the mono key with a gain
+  applied to both channels, so it cannot pump the image. COMP is fast 4:1,
+  GLUE slow and soft-kneed (the master setting), TRNS a transient shaper —
+  and the gain is **one branchless expression**, because TRNS sets the
+  compressor's threshold to 1.0 and the other modes set the boost flag to 0.
+- **WDTH** is mid/side: 64 untouched, 0 mono, 127 double sides. With BUS +
+  GLUE + WDTH this is the master chain on T8's FX1.
+- **→DEL / →VRB** make it a bus client on the filter station's terms:
+  knob-gated registration, and it never housekeeps.
+
+⚠️ **The detector reads `x:(r7+$32)`, the KEY**, which is the station's own
+input today. The →KEY bus send on the backlog writes another track's there
+and nothing else changes — that is the whole sidechain-ducking path.
+
+## Measured (3 Sep 2026, local)
+
+- **833 words** (payload A, 866 on B), **405 cycles/sample**. ⚠️ The pricer's
+  worst case — seven of these on one core beside the reverb — is **331 over**
+  the 3,120 + 768 FILTER credit. Sam's layout runs one or two. Trims if it
+  must come down: drop RING (~12), a single `chsatur` call by rolling the two
+  channels (~13), the TUBE asymmetry (~10 per channel).
+- `tools/verify_charstation.py`, **22 gates, all PASS**: defaults bit-exact;
+  MIX=0 bit-exact with every stage driven; CRSH=110 collapses a ramp to 144
+  wet levels against 4,500; SRR holds the wet exactly 2/4/8 samples; all four
+  SAT characters unity small-signal at DRV=0 and bounded at DRV=127; FOLD
+  folds a monotonic ramp; RING at DC has ~zero mean; COMP reduces the loud
+  signal 6.1 dB more than the quiet one and is exactly unity at 0; TRNS
+  boosts an onset 8% above the steady state; WDTH 0 is mono and 64 is exact.
+- Menu: `verify_menu`, `verify_replaces` (it took LO-FI's FX1 page and the
+  composed chooser lists the clone) and `verify_labels` (all three selects
+  print their words on the emulated firmware) pass on `stations`.
+
+## What the gates cost to get right (all four were real bugs)
+
+- **A patch batch that aborted before writing** left five arithmetic fixes
+  unapplied while a sixth had landed, so the compressor stored a full-scale
+  gain that the multiply site doubled: **every knob read +6 dB**. Found by
+  measuring a DC input through an identity chain — ratio 1.951 — not by
+  reading.
+- **The transient shaper took `max` with the fast follower**, so the slow one
+  could never lag and the difference was identically zero. The knob did
+  nothing, and the gate that would have caught it was comparing two bypass
+  renders.
+- **Two gates were measuring the wrong thing**: the crush cannot be read off
+  the output word (the cubic refills the low bits, and the mix carries 1/128
+  of the un-quantised dry), and SRR holds the *wet*, not the output.
+- **`ch_sat` is a prefix of `ch_satr`**, so every branch resolved to garbage —
+  `dsp_asm` matches labels by prefix (CLAUDE.md). Labels here are `chsatur`,
+  `chsatr1`, `chsatr2`, none a prefix of another.
+
+## Open
+
+- Voicing: nothing has been heard yet. Every law here — the drive taper, the
+  four characters' constants, the two compressor timings, the 12 ms transient
+  window — is a first guess.
+- ⚠️ UNFLASHED.

--- a/modules/charstation/char_station.asm
+++ b/modules/charstation/char_station.asm
@@ -1,0 +1,743 @@
+; ---------------------------------------------------------------------------
+; CHARACTER STATION -- crush, fold, ring, saturate, compress, width, sends.
+;
+; Insert contract (modules/ripple/ripple_svf.asm): frames in place at
+; x:(r0)/x:(r0+n0), knobs from r6, state in this instance's r7 block. PLUS
+; the bus-client contract from modules/send/send_client.asm, exactly as
+; modules/filterstation/ carries it: the PROCESSED mono goes into both
+; accumulators, registration is gated on each send knob, and the station
+; NEVER HOUSEKEEPS (an FX1 instance runs before its track's FX2 one, so an
+; electing station would double-flip the rotation -- see filterstation's
+; header for the full argument).
+;
+; ---- the chain, fixed order ----------------------------------------------
+;   held  = SRR ? (hold each sample 2/4/8) : x          SRR
+;   q     = quantise(held, bits)                        CRSH
+;   f     = fold(q * (1 + 7*FOLD/128))                  FOLD
+;   r     = f * carrier                                 RING (0 = skip)
+;   s     = saturate(r * (1 + 3*DRV/128))               DRV, SAT
+;   c     = s * gain(env)                                COMP, CMOD
+;   w     = width(c)                                     WDTH
+;   out   = x + MIX*(w - x)                              MIX
+; Distortion BEFORE dynamics: a compressor after the dirt is a tool, before
+; it is a fader for the dirt.
+;
+; ---- the compressor ------------------------------------------------------
+; A feedforward peak detector on the mono sum, one-pole attack and release,
+; then a gain curve applied to both channels -- so it cannot pump the image.
+;   env  = max(|key| , env*rel) with attack smoothing on the way up
+;   over  = env - thr, positive part only            (thr per CMOD)
+;   gr/2  = 0.5 - over*slope*COMP/2                  (linear-in-amplitude,
+;                                                     which IS a soft knee in
+;                                                     dB and needs no log)
+;   TRNS  = fast - slow followers: gr rides ABOVE 1 on transients, so the
+;           knob adds attack. Its gr is 1 + (fast-slow)*COMP, and BOTH
+;           gains are stored HALVED: a y1 operand is a fraction, so a gain
+;           above 1 would wrap. Doubled back in the accumulator's guard bits.
+; ⚠️ THE DETECTOR READS x:(r7+$32), the KEY. Today the station writes its own
+; input there; the ->KEY bus send on the backlog writes another track's, and
+; nothing else changes.
+;
+; ---- r7 slots -------------------------------------------------------------
+;   $14 $65..$69   bus bookkeeping, SEND's layout ($69 = this block's offset)
+;   per block:
+;   $20 m (MIX)   $21 fold gain/8   $22 drive gain/4   $23 crush mask
+;   $24 carrier step  $25 srr mask  $26 comp amount    $27 thr
+;   $28 slope     $29 sat mode      $2a cmod           $2b width side gain
+;   $2c width mid gain  $2d attack coeff   $2e release coeff  $2f bypass
+;   $30 ->DEL level     $31 ->VRB level
+;   per sample / persistent (ALL BELOW $40 -- an r7 displacement past 63
+;   assembles to the two-word long form, which cost the filter station 30
+;   words before it was found):
+;   $19 held L (PERSISTENT)      $1a held R (PERSISTENT)
+;   $1b srr counter (PERSISTENT) $1c carrier phase (PERSISTENT)
+;   $1d env fast (PERSISTENT)    $1e env slow (PERSISTENT, TRNS only)
+;   $1f gr this sample           $32 key    $33 dry L park   $34 dry R park
+;   $35 scratch (wet L)          $36 scratch (wet R)
+;
+; CYCLES_FORWARD_BRANCHES -- the SRR hold and the RING gate are the only
+; branches left in the sample loop, both forward and both skipping work, so
+; the word span is the worst-case cycle count (tools/cycle_count.py). The
+; saturation character and the compressor mode are per-block COEFFICIENTS
+; for exactly this reason: a dispatch inside the loop cannot be priced.
+;
+; Every mpy is `mpy x0,y1` (the audited-signed encoding) except the send
+; taps, which are SEND's `mpy x1,y1` / `mpy x1,y0` with a non-negative level
+; second. Every Tcc reads the ONE compare above it with nothing but moves
+; between (the flag-clobber trap).
+; ---------------------------------------------------------------------------
+
+init:
+; ROTINIT
+        rts
+
+proc:
+; ===========================================================================
+; BUS: split-aware frame offset, verbatim from modules/send/send_client.asm
+; ===========================================================================
+        move    a,x:(r7+$14)
+        clr     a
+        move    a,x:(r7+$67)
+        move    x:(r7+$14),a
+        tst     a
+        bne     ch_a1
+        move    #>$1,a
+        move    a,x:(r7+$65)
+        move    n7,a
+        and     #>$f,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$66)
+        bra     ch_offok
+ch_a1:
+        move    x:(r7+$65),a
+        and     #>$ff,a
+        move    a1,x0
+        move    x0,a
+        move    #>$1,x0
+        cmp     x0,a
+        bne     ch_offok
+        clr     a
+        move    a,x:(r7+$65)
+        move    x:(r7+$66),a
+        and     #>$f,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$67)
+ch_offok:
+; ---- resolve this block's write offset (per payload) -> r7+$69, r1, r2 ---
+; ROTLATCH
+        move    a,x0
+        move    #>$901,a
+        add     x0,a
+        move    x:(r7+$67),b
+        add     b,a
+        move    a,r1                    ; REVERB ACC[write] + frame offset
+        move    #>$961,a
+        add     x0,a
+        add     b,a
+        move    a,r2                    ; DELAY  ACC[write] + frame offset
+        move    #>$ffffff,m1
+        move    #>$ffffff,m2
+; ---- register, once per block, per bus, ONLY IF SENDING (r6+4 / r6+5) ----
+        move    x:(r7+$67),a
+        tst     a
+        bne     ch_cntz
+        move    x:(r7+$69),a
+        asr     #$4,a,a
+        move    a1,x0
+        move    x0,a
+        move    #>$9c3,x0
+        add     x0,a
+        move    a,r3
+        move    #>$ffffff,m3
+        move    #>$1,x0
+        clr     b
+        move    x:(r6+$5),a             ; ->VRB level
+        tst     a
+        tne     x0,b
+        move    y:(r3),a
+        add     b,a
+        move    a,y:(r3)
+        move    #4,n3
+        move    (r3)+n3
+        clr     b
+        move    x:(r6+$4),a             ; ->DEL level
+        tst     a
+        tne     x0,b
+        move    y:(r3),a
+        add     b,a
+        move    a,y:(r3)
+ch_cntz:
+        move    x:(r6+$4),x0
+        move    x0,x:(r7+$30)           ; ->DEL
+        move    x:(r6+$5),x0
+        move    x0,x:(r7+$31)           ; ->VRB
+
+; ===========================================================================
+; PER-BLOCK KNOB DECODE
+; ===========================================================================
+; MIX: page-2 slot 6, the KNOB field of r6+$c (the word SAT's select shares)
+        move    x:(r6+$c),a
+        and     #>$7f0000,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$20)            ; m
+; fold gain/8 = (1 + 7*FOLD/128)/8 = 1/8 + FOLD*(7/1024)   -- WarpFold's law,
+; pre-divided by 8 so the fold's (v+1)/2 arithmetic keeps its guard bits.
+        move    x:(r6+$1),x0            ; the knob word IS FOLD/128 in Q23
+        move    #>$700000,y1            ; 7/8
+        mpy     x0,y1,a                 ; (7/8)*(FOLD/128)
+        add     #>$100000,a             ; + 1/8 -> gain/8, 0.125 .. 0.992
+        move    a,x:(r7+$21)            ; gq
+; drive gain/4 = (1 + 3*DRV/128)/4 = 1/4 + DRV*(3/512)
+        move    x:(r6+$0),x0            ; the knob word IS DRV/128 in Q23
+        move    #>$600000,y1            ; 3/4
+        mpy     x0,y1,a                 ; (3/4)*(DRV/128)
+        add     #>$200000,a             ; + 1/4 -> gain/4, 0.25 .. 0.992
+        move    a,x:(r7+$22)            ; gd
+; CRSH -> a bit MASK, built ONCE PER BLOCK (the per-sample cost is then one
+; AND). The knob picks how many low bits are cleared, 0..21; the mask is
+; $ffffff shifted left that many times, and the shift runs in a `do` loop
+; here rather than a `rep` per sample.
+; bits = 21 * knob / 128. The knob word IS knob/128 in Q23, so the product
+; with 21/128 is 21*knob/2^14 as a fraction; one asr #16 of the accumulator
+; leaves the plain integer.
+        move    x:(r6+$2),x0
+        move    #>$150000,y1            ; 21/128
+        mpy     x0,y1,a
+        asr     #$10,a,a                ; -> the integer, 0..20
+        move    a1,x0
+        move    x0,a
+        move    #>21,x0
+        cmp     x0,a
+        tgt     x0,a                    ; belt and braces: never past 21
+        move    a,y0                    ; bits to drop, 0..21 -- the do count
+        tst     a                       ; (tst takes an ACCUMULATOR, never a
+        move    #>$ffffff,a             ; register; a move does not disturb it)
+        beq     ch_mskz                 ; knob 0: the all-ones mask, unshifted
+        do      y0,>ch_mskl
+        asl     #$1,a,a
+        move    a1,x0                   ; asl leaves A2 stale every trip
+        move    x0,a
+ch_mskl:
+        nop
+ch_mskz:
+        move    a,x:(r7+$23)            ; the mask: AND clears the low bits
+; RING: carrier step, WarpFold's squared taper; 0 = OFF (a step of 0 leaves
+; the phase still, and the per-sample gate below skips the multiply)
+        move    x:(r6+$d),a
+        and     #>$7f0000,a
+        move    a1,x0
+        move    x0,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a                 ; RING^2
+        move    a,x0
+        move    #>$5a0000,y1            ; ~2.95 kHz at full knob
+        mpy     x0,y1,a
+        move    a,x:(r7+$24)            ; carrier step
+; SRR (slot 11 select of r6+$e): hold mask 0 / 1 / 3 / 7
+        move    x:(r6+$e),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     ch_srr2
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     ch_srr4
+        move    #>$30000,x0
+        cmp     x0,a
+        beq     ch_srr8
+        clr     a                       ; OFF, and anything unexpected
+        bra     ch_srrz
+ch_srr2:
+        move    #>$1,a
+        bra     ch_srrz
+ch_srr4:
+        move    #>$3,a
+        bra     ch_srrz
+ch_srr8:
+        move    #>$7,a
+ch_srrz:
+        move    a,x:(r7+$25)            ; srr mask
+; COMP amount, straight from the knob
+        move    x:(r6+$3),x0
+        move    x0,x:(r7+$26)
+; CMOD (slot 9 select of r6+$d): threshold, slope, attack and release
+        move    x:(r6+$d),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     ch_cglue
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     chcmtr
+        clr     a                       ; COMP: fast 4:1
+        move    a,x:(r7+$2a)            ; trns flag = 0
+        move    #>$199999,x0            ; thr 0.2
+        move    x0,x:(r7+$27)
+        move    #>$600000,x0            ; slope 0.75 (4:1-ish in amplitude)
+        move    x0,x:(r7+$28)
+        move    #>$100000,x0            ; attack ~0.5 ms
+        move    x0,x:(r7+$2d)
+        move    #>$008000,x0            ; release ~90 ms
+        move    x0,x:(r7+$2e)
+        bra     ch_cdone
+ch_cglue:
+        clr     a                       ; GLUE: slow, soft, 2:1
+        move    a,x:(r7+$2a)            ; trns flag = 0
+        move    #>$0ccccd,x0            ; thr 0.1 -- it works earlier
+        move    x0,x:(r7+$27)
+        move    #>$400000,x0            ; slope 0.5
+        move    x0,x:(r7+$28)
+        move    #>$020000,x0            ; attack ~8 ms: lets transients through
+        move    x0,x:(r7+$2d)
+        move    #>$002000,x0            ; release ~350 ms
+        move    x0,x:(r7+$2e)
+        bra     ch_cdone
+chcmtr:
+        move    #>$7fffff,a             ; TRNS: the two-follower difference
+        move    a,x:(r7+$2a)            ; trns flag = 1
+        move    a,x:(r7+$27)            ; threshold 1.0: the compressor half of
+                                        ; the expression below can never fire,
+                                        ; which is what makes it branchless
+        clr     a
+        move    a,x:(r7+$28)            ; slope 0
+        move    #>$200000,x0            ; fast follower
+        move    x0,x:(r7+$2d)
+        move    #>$004000,x0            ; slow follower
+        move    x0,x:(r7+$2e)
+ch_cdone:
+; SAT character (slot 7 select of r6+$c) -> FOUR COEFFICIENTS, so the sample
+; loop has no branch in it at all: neg (what the negative half is scaled by
+; before the curve -- TUBE's asymmetry), pre and post around the curve (BUS
+; drives it half and doubles back, the gentlest knee) and a symmetric clip
+; (FUZZ's hard half; 1.0 elsewhere never bites, since |sat(w)| <= 2/3).
+; neg / pre / post are stored HALVED and doubled back in the accumulator's
+; guard bits, the same discipline as the width and compressor gains: a y1
+; operand is a fraction and post reaches 2.0.
+        move    #>$400000,x0            ; the defaults: neg 1, pre 1, post 1
+        move    x0,x:(r7+$37)
+        move    x0,x:(r7+$38)
+        move    x0,x:(r7+$39)
+        move    #>$7fffff,x0            ; clip 1.0 -- never bites
+        move    x0,x:(r7+$3a)
+        move    #>$800000,x0            ; -1.0
+        move    x0,x:(r7+$3b)
+        move    x:(r6+$c),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     ch_stube
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     ch_sfuzz
+        move    #>$30000,x0
+        cmp     x0,a
+        beq     ch_sbus
+        bra     ch_sdone                ; TAPE: the curve alone
+ch_stube:
+        move    #>$300000,x0            ; neg = 0.75: the positive half is
+        move    x0,x:(r7+$37)           ; driven harder, so even harmonics
+        bra     ch_sdone
+ch_sfuzz:
+        move    #>$266666,x0            ; clip +0.6
+        move    x0,x:(r7+$3a)
+        move    #>$d9999a,x0            ; clip -0.6
+        move    x0,x:(r7+$3b)
+        bra     ch_sdone
+ch_sbus:
+        move    #>$200000,x0            ; pre = 0.5 ...
+        move    x0,x:(r7+$38)
+        move    #>$7fffff,x0            ; ... post = 2.0
+        move    x0,x:(r7+$39)
+ch_sdone:
+; WDTH -> mid and side gains. 64 = (1, 1); 0 = (1, 0) mono; 127 = (1, ~2).
+; side gain = WDTH/64, mid stays 1 -- widening only touches the difference,
+; so a mono source is untouched at every setting.
+        move    x:(r6+$e),a
+        and     #>$7f0000,a
+        move    a1,x0
+        move    x0,a
+; ⚠️ STORED HALVED. A y1 operand is a FRACTION, and a side gain of WDTH/64
+; tops out near 2.0, which would wrap the word. The knob's own value IS
+; WDTH/128, so it is stored as-is and the product is doubled back in the
+; accumulator's guard bits. 64 -> 0.5 -> x2 = exactly 1.0, i.e. untouched.
+        move    a,x:(r7+$2b)            ; side gain / 2
+; ---- BYPASS: the defaults are a bit-exact passthrough ---------------------
+; DRV 0, FOLD 0, CRSH 0, COMP 0, MIX 127, RING 0, WDTH 64, SRR OFF. Every
+; part that ever chose LO-FI runs this after the flash, so the neutral block
+; copies nothing and only does the sends.
+        clr     b
+        move    b,x:(r7+$2f)
+        move    x:(r6+$0),a             ; DRV
+        tst     a
+        bne     ch_live
+        move    x:(r6+$1),a             ; FOLD
+        tst     a
+        bne     ch_live
+        move    x:(r6+$2),a             ; CRSH
+        tst     a
+        bne     ch_live
+        move    x:(r6+$3),a             ; COMP
+        tst     a
+        bne     ch_live
+        move    x:(r7+$24),a            ; carrier step (RING)
+        tst     a
+        bne     ch_live
+        move    x:(r7+$25),a            ; srr mask
+        tst     a
+        bne     ch_live
+        move    x:(r7+$2b),a            ; side gain/2: 64 -> exactly 0.5
+        move    #>$400000,x0
+        cmp     x0,a
+        bne     ch_live
+        bra     ch_bypass
+ch_live:
+
+; ===========================================================================
+; THE SAMPLE LOOP
+; ===========================================================================
+        move    #>$1,n0
+        do      n7,>ch_end
+; ---- park the dry, and take the key (the mono sum) ------------------------
+        move    x:(r0),a
+        move    a,x:(r7+$33)
+        move    x:(r0+n0),x0
+        move    x0,x:(r7+$34)
+        add     x0,a
+        asr     #$1,a,a
+        move    a,x:(r7+$32)            ; key = mono in (the ->KEY hook)
+; ---- SRR: hold the pair for 2/4/8 samples ---------------------------------
+        move    x:(r7+$25),a            ; mask
+        tst     a
+        beq     ch_nosrr
+        move    x:(r7+$1b),b            ; counter
+        add     #>$1,b
+        move    b1,x0
+        move    x0,b
+        move    b,x:(r7+$1b)
+        and     x0,a                    ; counter & mask
+        move    a1,x0
+        move    x0,a
+        tst     a
+        bne     ch_hold                 ; not a fresh sample: reuse the held
+        move    x:(r0),x0               ; fresh: latch this pair
+        move    x0,x:(r7+$19)
+        move    x:(r0+n0),x0
+        move    x0,x:(r7+$1a)
+ch_hold:
+        move    x:(r7+$19),x0           ; the held pair drives the chain
+        move    x0,x:(r7+$33)
+        move    x:(r7+$1a),x0
+        move    x0,x:(r7+$34)
+ch_nosrr:
+; ---- CRSH: one AND per channel with the per-block mask -------------------
+; ⚠️ AND leaves A2 STALE and the next store would saturate (CLAUDE.md), so
+; each value leaves through a1 into a clean register first.
+        move    x:(r7+$23),x0           ; mask
+        move    x:(r7+$33),a
+        and     x0,a
+        move    a1,x1
+        move    x1,x:(r7+$33)
+        move    x:(r7+$34),a
+        and     x0,a
+        move    a1,x1
+        move    x1,x:(r7+$34)
+; ---- FOLD: WarpFold's wrap-and-reflect, both channels --------------------
+        move    x:(r7+$33),x0
+        move    x:(r7+$21),y1           ; gq = gain/8
+        mpy     x0,y1,a                 ; v/8
+        asl     #$2,a,a                 ; v/2
+        move    #>$400000,x1
+        add     x1,a                    ; (v+1)/2
+        move    a1,x1                   ; s = wrap(...), raw A1: the fold
+        move    x1,a                    ; clean re-load, A2 consistent
+        abs     a
+        move    #>$400000,b
+        sub     b,a                     ; |s| - 0.5
+        asl     #$1,a,a                 ; fold in [-1,1)
+        move    a,x:(r7+$35)            ; wet L
+        move    x:(r7+$34),x0
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    #>$400000,x1
+        add     x1,a
+        move    a1,x1
+        move    x1,a
+        abs     a
+        move    #>$400000,b
+        sub     b,a
+        asl     #$1,a,a
+        move    a,x:(r7+$36)            ; wet R
+; ---- RING: one carrier, both channels ------------------------------------
+        move    x:(r7+$24),a            ; step
+        tst     a
+        beq     ch_noring
+        move    x:(r7+$1c),b            ; phase
+        move    a,x0
+        move    b,a
+        add     x0,a
+        move    a1,x0                   ; p = wrapped phase
+        move    x0,x:(r7+$1c)
+        move    x0,a
+        abs     a
+        move    #>$800000,y1            ; -1.0
+        add     y1,a                    ; |p| - 1
+        neg     a                       ; t = 1 - |p|
+        move    a,y1
+        mpy     x0,y1,a                 ; p*t
+        asl     #$2,a,a                 ; carrier = 4*p*t
+        move    a,y0                    ; held for both channels
+        move    x:(r7+$35),x0
+        mpy     y0,x0,a                 ; wet * carrier (signed order)
+        move    a,x:(r7+$35)
+        move    x:(r7+$36),x0
+        mpy     y0,x0,a
+        move    a,x:(r7+$36)
+ch_noring:
+; ---- SATURATE: drive, the curve, the character -- BRANCHLESS ------------
+; Both channels take the identical path: scale the negative half by `neg`
+; (one tst + one Tcc, nothing between them), apply `pre`, run the cubic,
+; apply `post`, clamp to +-clip. The character lives in those four per-block
+; words, so `make cycles` can price this loop -- a branch in a sample loop
+; makes words != cycles and the counter refuses the module outright.
+        move    x:(r7+$35),x0           ; L, post-fold/ring ($33 is the PRE-fold
+                                        ; park -- reading it here threw the fold
+                                        ; and the ring away, 3 Sep 2026)
+        move    x:(r7+$22),y1           ; gd = gain/4
+        mpy     x0,y1,a
+        asl     #$2,a,a                 ; driven
+        move    a,x:(r7+$35)            ; LIMITING store: the clip IS the drive
+        move    x:(r7+$35),x0
+        move    x:(r7+$37),y1           ; neg / 2
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        move    a,x1                    ; the softened form
+        move    x:(r7+$35),a
+        tst     a                       ; sign of w -- nothing between this
+        tmi     x1,a                    ; and the Tcc (the flag trap)
+        move    a,x0
+        move    x:(r7+$38),y1           ; pre / 2
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        move    a,x:(r7+$35)
+        bsr     chsatur
+        move    a,x0
+        move    x:(r7+$39),y1           ; post / 2
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        move    x:(r7+$3a),x0           ; +clip
+        cmp     x0,a
+        tgt     x0,a
+        move    x:(r7+$3b),x0           ; -clip
+        cmp     x0,a
+        tlt     x0,a
+        move    a,x:(r7+$35)            ; saturated L
+        move    x:(r7+$36),x0           ; R, the identical path
+        move    x:(r7+$22),y1
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    a,x:(r7+$36)
+        move    x:(r7+$36),x0
+        move    x:(r7+$37),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        move    a,x1
+        move    x:(r7+$36),a
+        tst     a
+        tmi     x1,a
+        move    a,x0
+        move    x:(r7+$38),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        move    x:(r7+$35),x1           ; park L across chsatur's use of $35
+        move    a,x:(r7+$35)
+        bsr     chsatur
+        move    a,x0
+        move    x:(r7+$39),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        move    x:(r7+$3a),x0
+        cmp     x0,a
+        tgt     x0,a
+        move    x:(r7+$3b),x0
+        cmp     x0,a
+        tlt     x0,a
+        move    a,x:(r7+$36)            ; saturated R
+        move    x1,x:(r7+$35)           ; L back from its park
+; ---- COMPRESS: one detector, one gain, both channels ---------------------
+; env_fast: attack toward |key|, release by the coefficient.
+        move    x:(r7+$32),a            ; key
+        abs     a
+        move    a,x1                    ; |key|
+        move    x:(r7+$1d),x0           ; env fast
+        move    x:(r7+$2e),y1           ; release
+        mpy     x0,y1,a                 ; decayed
+        cmp     x1,a                    ; nothing between this and the Tcc
+        tlt     x1,a                    ; env = max(|key|, decayed)
+        move    a,x:(r7+$1d)
+; gr/2 = 0.5 - (compress - boost)/2, where ONE of the two terms is always
+; zero by construction: the compressor half needs env above the threshold,
+; and TRNS sets that threshold to 1.0; the boost half is multiplied by the
+; trns flag, which is 0 in the other two modes. No branch, so the loop stays
+; priceable.
+        move    x:(r7+$27),x0           ; thr
+        sub     x0,a                    ; env - thr
+        move    #>$0,x0
+        tmi     x0,a                    ; below it: nothing
+        move    a,x0
+        move    x:(r7+$28),y1           ; slope
+        mpy     x0,y1,a                 ; the compression term
+        move    a,x1
+; the slow follower, and the boost term (fast - slow) * trns flag
+        move    x:(r7+$1d),a            ; fast env
+        move    x:(r7+$1e),b            ; slow env
+        sub     b,a                     ; fast - slow, either sign
+        asr     #$1,a,a
+        move    a,x0
+        move    #>$004000,y1            ; k ~ 1/512: ~12 ms, slow enough that
+                                        ; a transient is 12 ms of headroom
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a                     ; slow'
+        move    a,x:(r7+$1e)
+        move    x:(r7+$1d),a
+        move    x:(r7+$1e),x0
+        sub     x0,a                    ; fast - slow, >= 0 while it lags
+        move    #>$0,x0
+        tmi     x0,a                    ; never negative
+        move    a,x0
+        move    x:(r7+$2a),y1           ; trns flag: 1 in TRNS, 0 elsewhere
+        mpy     x0,y1,a                 ; the boost term
+        move    a,x0
+        move    x1,a                    ; compression - boost
+        sub     x0,a
+        move    a,x0
+        move    x:(r7+$26),y1           ; COMP amount
+        mpy     x0,y1,a
+        asr     #$1,a,a                 ; halved: gr is a y1 fraction and TRNS
+        neg     a                       ; drives it above 1
+        add     #>$400000,a             ; gr/2
+        move    #>$0,x0
+        tmi     x0,a                    ; never invert
+ch_grz:
+        move    a,x:(r7+$1f)            ; gr / 2
+        move    x:(r7+$35),x0
+        move    x:(r7+$1f),y1           ; gr / 2
+        mpy     x0,y1,a
+        asl     #$1,a,a                 ; ... doubled back in the guard bits
+        move    a,x:(r7+$35)
+        move    x:(r7+$36),x0
+        move    x:(r7+$1f),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        move    a,x:(r7+$36)
+; ---- WIDTH: mid stays, side scales ---------------------------------------
+        move    x:(r7+$35),a            ; L
+        move    x:(r7+$36),x0           ; R
+        add     x0,a
+        asr     #$1,a,a
+        move    a,x1                    ; mid
+        move    x:(r7+$35),a
+        sub     x0,a
+        asr     #$1,a,a
+        move    a,x0                    ; side
+        move    x:(r7+$2b),y1           ; side gain / 2
+        mpy     x0,y1,a
+        asl     #$1,a,a                 ; the halving undone in the guard bits
+        move    a,y0                    ; scaled side
+        move    x1,a
+        add     y0,a                    ; mid + side
+        move    a,x:(r7+$35)
+        move    x1,a
+        sub     y0,a                    ; mid - side
+        move    a,x:(r7+$36)
+; ---- MIX and write back --------------------------------------------------
+        move    x:(r7+$35),a
+        move    x:(r0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1           ; m
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)
+        move    x:(r7+$36),a
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+; ---- the sends: the PROCESSED mono, 3 bits of bus headroom ---------------
+        move    x:(r0),a
+        move    x:(r0+n0),x0
+        add     x0,a
+        asr     #$1,a,a
+        move    a,x1
+        move    x:(r7+$30),y1           ; ->DEL
+        mpy     x1,y1,a                 ; SEND's order: the level is >= 0
+        asr     #$3,a,a
+        move    y:(r2),b
+        add     b,a
+        move    a,y:(r2)+
+        move    x:(r7+$31),y0           ; ->VRB
+        mpy     x1,y0,a
+        asr     #$3,a,a
+        move    y:(r1),b
+        add     b,a
+        move    a,y:(r1)+
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+ch_end:
+        nop
+        rts
+
+; ===========================================================================
+; BYPASS LOOP: frames untouched, sends only
+; ===========================================================================
+ch_bypass:
+        move    x:(r7+$31),y0
+        move    x:(r7+$30),y1
+        move    #>$1,n0
+        do      n7,>ch_byz
+        move    x:(r0),a
+        move    x:(r0+n0),x0
+        add     x0,a
+        asr     #$1,a,a
+        move    a,x1
+        mpy     x1,y1,a
+        asr     #$3,a,a
+        move    y:(r2),b
+        add     b,a
+        move    a,y:(r2)+
+        mpy     x1,y0,a
+        asr     #$3,a,a
+        move    y:(r1),b
+        add     b,a
+        move    a,y:(r1)+
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+ch_byz:
+        nop
+        rts
+
+; ---------------------------------------------------------------------------
+; chsatur -- BongDelay's loop-saturation curve, sat = w - w^3/3.
+; In:  x:(r7+$35) = w (already limited by its store).  Out: a = sat.
+; Unity small-signal by construction, monotonic, |out| bounded -- the same
+; argument modules/bongdelay/delay_server.asm's satdrv makes, which is why
+; this can sit in front of a compressor without adding gain.
+; bsr, not jsr: dsp_asm implements only the relative b-forms.
+; ---------------------------------------------------------------------------
+chsatur:
+        move    x:(r7+$35),x0           ; w
+        move    x0,y1
+        mpy     x0,y1,b                 ; w^2
+        move    b,y1                    ; limiting move: w^2 <= 1
+        mpy     x0,y1,b                 ; w^3
+        move    b,x0
+        move    #>$2aaaab,y1            ; 1/3
+        mpy     x0,y1,b                 ; w^3/3
+        move    x:(r7+$35),a            ; w
+        move    b,x0
+        sub     x0,a                    ; sat
+        rts

--- a/modules/charstation/manifest.py
+++ b/modules/charstation/manifest.py
@@ -1,0 +1,96 @@
+"""CHARACTER STATION -- everything that dirties or tightens, and a bus sender.
+
+The second BamSep26 station. A per-track INSERT that REPLACES stock LO-FI
+(id 0x1c, both menus, and every saved part that chose LO-FI):
+
+  * CRUSH -- sample-rate reduction (hold N samples) and bit depth, LO-FI's
+    own pair, on one knob each way (CRSH = bits, SRR = the rate divider);
+  * FOLD + RING -- WarpFold's wavefolder and its parabolic carrier, so the
+    fold and the ring mod are here rather than needing a second insert;
+  * SATURATE -- BongDelay's satdrv curve (w - w^3/3, unity small-signal) in
+    four flavours: TAPE (the curve alone), TUBE (asymmetric: positive half
+    driven harder), FUZZ (hard clip after the curve) and BUS (soft, gentle,
+    for the master);
+  * COMPRESS -- a feedforward peak compressor with three characters: COMP
+    (fast, 4:1), GLUE (slow attack and release, 2:1, soft knee -- the
+    mastering setting) and TRNS (a transient shaper: the difference of two
+    followers, so the knob adds attack rather than removing it);
+  * WIDTH -- mid/side width, 64 = untouched, 0 = mono, 127 = 2x side. This
+    is what makes the station a master chain on T8's FX1;
+  * ->DEL / ->VRB -- the station is a BUS CLIENT, exactly as the filter
+    station is: knob-gated registration, no housekeeping.
+
+Chain order is fixed: crush -> fold/ring -> saturate -> compress -> width.
+Distortion before dynamics is the order that makes a compressor useful on a
+dirty signal rather than a fader for the dirt.
+
+DEFAULTS ARE A BIT-EXACT PASSTHROUGH (DRV 0, FOLD 0, CRSH 0, COMP 0, MIX
+127, RING 0, WDTH 64, SRR OFF, sends 0), because a part that stored LO-FI
+runs this after the flash. ⚠️ A part's STORED bytes are stock LO-FI's --
+the stamper (plan A6) writes ours.
+
+The compressor's detector reads a KEY that is the station's own input today;
+the ->KEY bus send on the backlog swaps in another track's, which is the
+only change needed for sidechain ducking.
+"""
+
+from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
+                          MenuEntry, Module, Param, YBase)
+
+_PLAIN = Formatter.PLAIN
+_STEP = Formatter.STEPPED
+
+MODULE = Module(
+    name="charstation",
+    key="CHARACTER STATION",
+    kind=Kind.DSP_EFFECT,
+    doc="BamSep26 station: crush, fold/ring, saturation, compressor, width, sends.",
+    menu=MenuEntry(
+        fx2_id=0x1c,
+        replaces="LO-FI",
+        donor_desc=0x400d58b8,        # DARK REV: 12 active slots, selects 7/9/11
+        abbr=b"CHAR",
+        fullname=b"Character",
+        build_tag=True,
+    ),
+    params=(
+        # ---- page 1: the performance surface, scene/CC-reachable -----------
+        Param(b"DRV", 0, active=True, formatter=_PLAIN,
+              doc="saturation amount; 0 = clean, the curve is unity small-signal"),
+        Param(b"FOLD", 0, active=True, formatter=_PLAIN,
+              doc="wavefolder drive, 1x..8x into the fold; 0 = no folding"),
+        Param(b"CRSH", 0, active=True, formatter=_PLAIN,
+              doc="bit depth: 0 = 24 bits, 127 = about 3; the quantiser is mid-tread"),
+        Param(b"COMP", 0, active=True, formatter=_PLAIN,
+              doc="compression amount; 0 = no gain reduction at any level"),
+        Param(b"-DEL", 0, active=True, formatter=_PLAIN,
+              doc="send the processed signal onto the DELAY bus; 0 = not a client"),
+        Param(b"-VRB", 0, active=True, formatter=_PLAIN,
+              doc="send the processed signal onto the REVERB bus; 0 = not a client"),
+        # ---- page 2: knob / select / knob / select / knob / select ----------
+        Param(b"MIX", 127, 128, active=True, formatter=_PLAIN,
+              doc="dry/wet across the whole chain; 0 = exact passthrough"),
+        Param(b"SAT", 0, 4, active=True, formatter=_STEP,
+              labels=("TAPE", "TUBE", "FUZZ", "BUS"),
+              doc="saturation character; BUS is the gentle one for a master chain"),
+        Param(b"RING", 0, 128, active=True, formatter=_PLAIN,
+              doc="ring-mod carrier, ~5 Hz..3 kHz; 0 = off (no carrier at all)"),
+        Param(b"CMOD", 0, 3, active=True, formatter=_STEP,
+              labels=("COMP", "GLUE", "TRNS"),
+              doc="COMP fast 4:1 - GLUE slow soft-knee 2:1 (the master) - TRNS transient shaper"),
+        Param(b"WDTH", 64, 128, active=True, formatter=_PLAIN,
+              doc="mid/side width: 64 = untouched, 0 = mono, 127 = double the sides"),
+        Param(b"SRR", 0, 4, active=True, formatter=_STEP,
+              labels=("OFF", "/2", "/4", "/8"),
+              doc="sample-rate reduction: hold each sample 2, 4 or 8 times"),
+    ),
+    dsp=DspSection(
+        asm="modules/charstation/char_station.asm",
+        priority=13,                  # after the filter station
+        bus_role=BusRole.NONE,        # an insert that also WRITES the bus
+        ybase=YBase.NEVER,
+        r7_latch_slot=0x69,           # ROTLATCH parks this block's offset here
+        gate_label=None,              # no housekeeping: a station never elects
+    ),
+    harness=Harness(layout_char="2", is_server=False, bus_client=True),
+)

--- a/modules/filterstation/README.md
+++ b/modules/filterstation/README.md
@@ -35,7 +35,7 @@ on FILTER's stored values sent at 64 through a closed, resonant filter).
 ## Measured (3 Sep 2026, local)
 
 - **983 words** (payload A; 1,016 on B with the tracked-rotation body), placed
-  by `remixes/_fs.py`. **339 cycles/sample** (`make cycles`): every
+  by `remixes/stations.py`. **339 cycles/sample** (`make cycles`): every
   r7-indexed access is two words in this assembler, and the loop is ~250
   instructions with two filters, the routing mix, the peak tracker and both
   sends. Stock FILTER is 192 for one filter. Seven of these on one core is
@@ -47,7 +47,7 @@ on FILTER's stored values sent at 64 through a closed, resonant filter).
   LSB low); BASE 100 kills DC through the pair (4 LSB); WDTH 30 takes 55 dB
   off 8 kHz; RING at DC = 2·DC² to 5 LSB; VOWEL A vs I differ by 8.7 dB at
   1.1 kHz; every knob at both extremes renders. All PASS.
-- **Registration** (`send_probe` on the `_fs` bus dump, tone fed to the
+- **Registration** (`send_probe` on the `stations` bus dump, tone fed to the
   station's track only, `--amp 0.05` so the reverb stays linear):
 
   ```
@@ -58,7 +58,7 @@ on FILTER's stored values sent at 64 through a closed, resonant filter).
   ```
 - Menu: `verify_menu`, `verify_replaces` (FX1 page taken, composed chooser
   lists the clone) and `verify_labels` (the three selects print their words
-  on the emulated firmware) all pass on `_fs`.
+  on the emulated firmware) all pass on `stations`.
 
 ## Open
 

--- a/modules/filterstation/README.md
+++ b/modules/filterstation/README.md
@@ -1,0 +1,72 @@
+# FILTER STATION
+
+The first BamSep26 station: two filters, four routings, one modulation and
+two bus sends in one insert, **replacing stock FILTER** (id 0x04) on both
+menus and in every saved part that chose FILTER. Design page:
+https://claude.ai/code/artifact/42670d67-7365-4c7d-bcc7-1786ba4331ce
+
+| page 1 | FREQ · RES · BASE · WDTH · →DEL · →VRB |
+|---|---|
+| page 2 | DRV · MODE (LP BP HP NTCH VOWL) · DPTH · ROUT (SER PAR RING FM) · RATE · SRC (ENV LFO BOTH) |
+
+Filter A is Ripple's driven Chamberlin SVF with NOTCH (lp + hp) and a VOWEL
+mode (five formant pairs morphed by FREQ: A's band-pass at F1, filter B as a
+band at F2, routing forced PAR). Filter B is the base/width pair: two
+cascaded one-poles of HP at BASE and two of LP at WDTH. Routing: SER (A into
+B), PAR, RING (2·A·B), FM (B's output modulates A's cutoff multiplicatively,
+one sample late). Modulation: one bipolar DPTH onto A's cutoff from a
+block-peak envelope follower (instant attack, RATE = release), an LFO
+(RATE = ~0.08–9 Hz), or half of each.
+
+**It is a bus client.** The processed mono is sent onto both buses with
+SEND's exact writer, registering only when a send is non-zero, and it
+**never housekeeps**: the rotation election is the FX2 participants'
+business, so an FX1 station on track 5 cannot double-flip the rotation
+with its own FX2 (see the engine header for the argument, and the one-block
+latency difference it accepts).
+
+**Defaults are a bit-exact passthrough**, because after the flash every
+part that ever chose FILTER runs this on FX1. ⚠️ A part's STORED bytes are
+stock FILTER's, not these defaults — DEC=64 lands on →VRB — which is what
+the project stamper (plan A6) exists to rewrite; the registration gate
+below reproduced exactly that scenario by accident (a second instance run
+on FILTER's stored values sent at 64 through a closed, resonant filter).
+
+## Measured (3 Sep 2026, local)
+
+- **983 words** (payload A; 1,016 on B with the tracked-rotation body), placed
+  by `remixes/_fs.py`. **339 cycles/sample** (`make cycles`): every
+  r7-indexed access is two words in this assembler, and the loop is ~250
+  instructions with two filters, the routing mix, the peak tracker and both
+  sends. Stock FILTER is 192 for one filter. Seven of these on one core is
+  at the cliff by the pricer; four on FX1 plus three SENDs beside the reverb
+  is 1,384 + 1,356 + 60.
+- `tools/verify_filterstation.py` (needs the audition dump): defaults
+  bit-exact on a full-scale ramp; LP 12.9 dB/oct between 2 and 4 kHz at
+  FREQ 30; HP and BP at DC → 0 (−2 / −1 LSB); NOTCH and LP at DC → DC (5
+  LSB low); BASE 100 kills DC through the pair (4 LSB); WDTH 30 takes 55 dB
+  off 8 kHz; RING at DC = 2·DC² to 5 LSB; VOWEL A vs I differ by 8.7 dB at
+  1.1 kHz; every knob at both extremes renders. All PASS.
+- **Registration** (`send_probe` on the `_fs` bus dump, tone fed to the
+  station's track only, `--amp 0.05` so the reverb stays linear):
+
+  ```
+  --layout R1  --feed 1  --set 1:-VRB=100                       -24.8 dBFS
+  --layout R1L --feed 1L --set 1:-VRB=100 + L neutral, L:-VRB=0  -24.8 dBFS  (silent client: no dilution)
+  --layout R1L --feed 1L --set 1:-VRB=100 + L:-VRB=100           -20.6 dBFS  (two senders, +4.2 dB)
+  --layout R1  --feed 1  --set 1:-VRB=0                          silence
+  ```
+- Menu: `verify_menu`, `verify_replaces` (FX1 page taken, composed chooser
+  lists the clone) and `verify_labels` (the three selects print their words
+  on the emulated firmware) all pass on `_fs`.
+
+## Open
+
+- Voicing: nothing has been heard yet. The coefficient laws (cutoff taper,
+  base/width corners, LFO rate range, release times, FM depth 0.25) are
+  first guesses.
+- Cycles: 339 is dear. Candidates if it must come down: drop RING (~10),
+  a single-pole base/width (~40), block-rate FM.
+- The layout alphabet lists this station under both `1` and `L` (stock
+  FILTER's letter) because both map to id 0x04 — harmless, cosmetic.
+- ⚠️ UNFLASHED. The FX1-participant bus case is flash 4's claim (v).

--- a/modules/filterstation/filter_station.asm
+++ b/modules/filterstation/filter_station.asm
@@ -1,0 +1,796 @@
+; ---------------------------------------------------------------------------
+; FILTER STATION -- two filters, four routings, one modulation, two sends.
+;
+; Insert contract (modules/ripple/ripple_svf.asm): frames in place at
+; x:(r0)/x:(r0+n0), knobs from r6, state in this instance's r7 block. PLUS
+; the bus-client contract from modules/send/send_client.asm: the PROCESSED
+; frames are summed to mono and added into the REVERB and DELAY accumulators
+; at this block's write offset, and the instance registers in the per-block
+; client count -- ONLY when its send knob is non-zero.
+;
+; ---- signal ---------------------------------------------------------------
+;   x_d  = clip(x * gain)                                  DRV
+;   A    = SVF(x_d, f, damp): lp / bp / hp taps            FREQ RES MODE
+;   wetA = kLP*lp + kBP*bp + kHP*hp                        (MODE, per block)
+;   yB   = sel ? wetA : x                                  (ROUT, per block)
+;   B    = LP2_wdth( HP2_base( yB ) )                      BASE WDTH
+;   out  = kA*wetA + kB*B + kR*(2*wetA*B)                  (ROUT, per block)
+;   f    = fA + kFM*B_prev  (clamped)                      (FM only)
+;   fA   = law( FREQ + (DPTH-64)/64 * mod )                mod: ENV/LFO/BOTH
+; NOTCH is kLP = kHP = 1 (lp + hp = x - damp*bp). VOWEL is BP at F1 with B
+; a band at F2, routing forced PAR, F1/F2 morphed across five formants.
+;
+; ---- NO HOUSEKEEPING, by design ------------------------------------------
+; The election (SEND's bus_dohk) is for FX2 participants. An FX1 instance on
+; track 5 runs BEFORE that track's FX2 instance, and position 0 (r7 = 0x6200)
+; housekeeps unconditionally -- so an FX1 participant that also elected would
+; flip the rotation TWICE in the first block, which leaves core 1's private
+; tracking one step behind forever (the R25 metallic). This station reads the
+; rotation and writes; it never flips. On core 0 its contribution therefore
+; lands in the buffer written LAST block (it runs before the flip), which is
+; read one block sooner than everyone else's -- 16 samples less bus latency
+; and nothing lost: that buffer was cleared two blocks ago and is read next.
+;
+; ---- r7 slots -------------------------------------------------------------
+;   $14 $65..$69   bus bookkeeping, SEND's layout ($69 = this block's offset)
+;   $20 fA (per block, post-modulation)   $21 damp          $22 g4 (gain/4)
+;   $23 kLP  $24 kBP  $25 kHP              $26 kA  $27 kB  $28 kR  $29 sel
+;   $2a cHP  $2b cLP  $2c kFM              $2d bypass flag
+;   $2e ->DEL level  $2f ->VRB level (per block copies of r6+4/5)
+;   $31 LFO phase (PERSISTENT, masked)     $32 env (PERSISTENT, clamped)
+;   $34/$35 SVF lp/bp L   $36/$37 SVF lp/bp R                 (PERSISTENT)
+;   $38..$3b B poles L: hp1 hp2 lp1 lp2    $3c..$3f R         (PERSISTENT)
+;   $19/$1a B_out previous sample L/R (the FM source)         (PERSISTENT)
+;   $1b wetA  $1c f this sample  $1d x / yB park  $1e peak (this block, so
+;   at decode time LAST block's)  $1f f ceiling (per block)
+;   $46 fall  $47 lfo inc  $49 lfo / frac park  $4a..$4d VOWEL picks
+;   ⚠️ EVERY SLOT THE SAMPLE LOOP TOUCHES IS BELOW $40: an r7-indexed move
+;   with a displacement past 63 takes the two-word long form, and the loop
+;   priced 30 words dearer with these at $40..$4f (3 Sep 2026). Per-block
+;   slots may sit high; per-sample ones may not.
+; Persistent states are bounded by the limited stores or masked on use;
+; nothing here ever becomes an address except the bus pointers, which come
+; masked from ROTLATCH exactly as SEND's do.
+;
+; Every mpy is `mpy x0,y1` (the known-signed encoding) except the send taps,
+; which are SEND's `mpy x1,y1` / `mpy x1,y0` with a non-negative level in the
+; second operand -- the one condition under which that order is safe. The FM
+; clamp and the env max are cmp + ONE Tcc with nothing between (the flag
+; trap).
+; ---------------------------------------------------------------------------
+
+init:
+; ROTINIT
+        rts
+
+proc:
+; ===========================================================================
+; BUS: split-aware frame offset, verbatim from modules/send/send_client.asm
+; ===========================================================================
+        move    a,x:(r7+$14)
+        clr     a
+        move    a,x:(r7+$67)
+        move    x:(r7+$14),a
+        tst     a
+        bne     fs_a1
+        move    #>$1,a
+        move    a,x:(r7+$65)
+        move    n7,a
+        and     #>$f,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$66)
+        bra     fs_offok
+fs_a1:
+        move    x:(r7+$65),a
+        and     #>$ff,a
+        move    a1,x0
+        move    x0,a
+        move    #>$1,x0
+        cmp     x0,a
+        bne     fs_offok
+        clr     a
+        move    a,x:(r7+$65)
+        move    x:(r7+$66),a
+        and     #>$f,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$67)
+fs_offok:
+; ---- resolve this block's write offset (per payload) -> r7+$69, r1, r2 ---
+; ROTLATCH
+        move    a,x0
+        move    #>$901,a
+        add     x0,a
+        move    x:(r7+$67),b
+        add     b,a
+        move    a,r1                    ; REVERB ACC[write] + frame offset
+        move    #>$961,a
+        add     x0,a
+        add     b,a
+        move    a,r2                    ; DELAY  ACC[write] + frame offset
+        move    #>$ffffff,m1
+        move    #>$ffffff,m2
+; ---- register, once per block, per bus, ONLY IF SENDING (r6+4 / r6+5) ----
+        move    x:(r7+$67),a
+        tst     a
+        bne     fs_cntz
+        move    x:(r7+$69),a
+        asr     #$4,a,a
+        move    a1,x0
+        move    x0,a
+        move    #>$9c3,x0
+        add     x0,a
+        move    a,r3
+        move    #>$ffffff,m3
+        move    #>$1,x0
+        clr     b
+        move    x:(r6+$5),a             ; ->VRB level
+        tst     a
+        tne     x0,b
+        move    y:(r3),a
+        add     b,a
+        move    a,y:(r3)
+        move    #4,n3
+        move    (r3)+n3
+        clr     b
+        move    x:(r6+$4),a             ; ->DEL level
+        tst     a
+        tne     x0,b
+        move    y:(r3),a
+        add     b,a
+        move    a,y:(r3)
+fs_cntz:
+        move    x:(r6+$4),x0
+        move    x0,x:(r7+$2e)           ; ->DEL
+        move    x:(r6+$5),x0
+        move    x0,x:(r7+$2f)           ; ->VRB
+
+; ===========================================================================
+; PER-BLOCK KNOB DECODE
+; ===========================================================================
+; damp = 0.992 - RES * 0.969   (Ripple's law)
+        move    x:(r6+$1),x0
+        move    #>$7c0000,y1
+        mpy     x0,y1,a
+        neg     a
+        add     #>$7f0000,a
+        move    a,x:(r7+$21)
+; g4 = 0.25 + DRV * 0.75  (page-2 slot 6 KNOB field of r6+$c)
+        move    x:(r6+$c),a
+        and     #>$7f0000,a
+        move    a1,x0
+        move    x0,a
+        move    a,x0
+        move    #>$600000,y1
+        mpy     x0,y1,a
+        add     #>$200000,a
+        move    a,x:(r7+$22)
+; cHP = BASE^2 * 0.5 ;  cLP = WDTH^2 * 0.75 + 0.002  (one-pole coefficients)
+        move    x:(r6+$2),x0
+        move    x:(r6+$2),y1
+        mpy     x0,y1,a
+        move    a,x0
+        move    #>$400000,y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$2a)
+        move    x:(r6+$3),x0
+        move    x:(r6+$3),y1
+        mpy     x0,y1,a
+        move    a,x0
+        move    #>$600000,y1
+        mpy     x0,y1,a
+        add     #>$4189,a
+        move    a,x:(r7+$2b)
+; RATE (slot 10 KNOB of r6+$e): lfo inc = RATE^2 * $7000 + $100 per block
+; (~0.08..9 Hz); fall = $7fe000 - RATE * $1e00 (~370 ms .. ~3 ms release)
+        move    x:(r6+$e),a
+        and     #>$7f0000,a
+        move    a1,x0
+        move    x0,a
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a
+        move    a,x0
+        move    #>$7000,y1
+        mpy     x0,y1,a
+        add     #>$100,a
+        move    a,x:(r7+$47)            ; lfo inc
+        move    x:(r6+$e),a
+        and     #>$7f0000,a
+        move    a1,x0
+        move    x0,a
+        move    a,x0
+        move    #>$f0000,y1
+        mpy     x0,y1,a                 ; RATE * $1e00 in Q23
+        neg     a
+        add     #>$7fe000,a
+        move    a,x:(r7+$46)            ; fall
+
+; ---- LFO: phase += inc, triangle -> bipolar Q23 ---------------------------
+        move    x:(r7+$31),a
+        move    x:(r7+$47),x0
+        add     x0,a
+        and     #>$7fffff,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$31)
+        move    #>$400000,x0
+        sub     x0,a
+        abs     a                       ; 0 .. $400000
+        move    #>$200000,x0
+        sub     x0,a
+        asl     #$1,a,a                 ; -0.5 .. +0.5 -> -1 .. +1
+        move    a,x:(r7+$49)            ; lfo, bipolar
+
+; ---- ENV: env = max(last block's peak, env * fall) ------------------------
+        move    x:(r7+$1e),x1           ; last block's peak
+        move    x:(r7+$32),x0
+        move    x:(r7+$46),y1
+        mpy     x0,y1,a                 ; env * fall
+        cmp     x1,a                    ; nothing between this and the Tcc
+        tlt     x1,a                    ; env = max(peak, release)
+        move    a,x:(r7+$32)
+        clr     a
+        move    a,x:(r7+$1e)            ; this block's peak starts at 0
+
+; ---- SRC (slot 11 select of r6+$e): mod = env | lfo | (env+lfo)/2 ---------
+        move    x:(r6+$e),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     fs_slfo
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     fs_sboth
+        move    x:(r7+$32),a            ; ENV (and anything unexpected)
+        bra     fs_smod
+fs_slfo:
+        move    x:(r7+$49),a
+        bra     fs_smod
+fs_sboth:
+        move    x:(r7+$32),a
+        move    x:(r7+$49),x0
+        add     x0,a
+        asr     #$1,a,a
+fs_smod:
+; ---- DPTH (slot 8 KNOB of r6+$d): depth = (DPTH - 64)/64, bipolar ---------
+        move    a,x1                    ; mod
+        move    x:(r6+$d),a
+        and     #>$7f0000,a
+        move    a1,x0
+        move    x0,a
+        move    #>$400000,x0
+        sub     x0,a                    ; (DPTH-64)/128
+        asl     #$1,a,a                 ; (DPTH-64)/64, -1 .. +1
+        move    a,x0
+        move    x1,y1
+        mpy     x0,y1,a                 ; depth * mod  (x0 signed, y1 signed)
+        move    x:(r6+$0),x0            ; FREQ
+        add     x0,a                    ; FREQm
+        move    #>$0,x0
+        tmi     x0,a                    ; clamp below at 0
+        move    #>$7f0000,x0
+        cmp     x0,a
+        tgt     x0,a                    ; clamp above at 127/128
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a                 ; FREQm^2
+        move    a,x0
+        move    #>$7df3b6,y1            ; 0.984
+        mpy     x0,y1,a
+        add     #>$6f69,a               ; + 0.0034
+        move    a,x:(r7+$20)            ; fA
+
+; ---- ROUT (slot 9 select of r6+$d): sel, kA, kB, kR, kFM -------------------
+        clr     a
+        move    a,x:(r7+$29)            ; sel = 0
+        move    a,x:(r7+$26)            ; kA
+        move    a,x:(r7+$27)            ; kB
+        move    a,x:(r7+$28)            ; kR
+        move    a,x:(r7+$2c)            ; kFM
+        move    x:(r6+$d),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     fs_rpar
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     fs_rring
+        move    #>$30000,x0
+        cmp     x0,a
+        beq     fs_rfm
+        move    #>$1,x0                 ; SER (and anything unexpected):
+        move    x0,x:(r7+$29)           ; B is fed A, out = B
+        move    #>$7fffff,x0
+        move    x0,x:(r7+$27)
+        bra     fs_rdone
+fs_rpar:
+        move    #>$400000,x0            ; PAR: out = (A + B) / 2
+        move    x0,x:(r7+$26)
+        move    x0,x:(r7+$27)
+        bra     fs_rdone
+fs_rring:
+        move    #>$7fffff,x0            ; RING: out = 2 * A * B
+        move    x0,x:(r7+$28)
+        bra     fs_rdone
+fs_rfm:
+        move    #>$7fffff,x0            ; FM: out = A, f modulated by B
+        move    x0,x:(r7+$26)
+        move    #>$200000,x0            ; kFM = 0.25
+        move    x0,x:(r7+$2c)
+fs_rdone:
+
+; ---- MODE (slot 7 select of r6+$c): tap coefficients; VOWEL overrides -----
+        clr     a
+        move    a,x:(r7+$23)
+        move    a,x:(r7+$24)
+        move    a,x:(r7+$25)
+        move    #>$7fffff,x0
+        move    x:(r6+$c),a
+        and     #>$ff00,a
+        move    a1,x1
+        move    x1,a
+        asl     #$8,a,a                 ; mode << 16
+        move    #>$10000,x1
+        cmp     x1,a
+        beq     fs_mbp
+        move    #>$20000,x1
+        cmp     x1,a
+        beq     fs_mhp
+        move    #>$30000,x1
+        cmp     x1,a
+        beq     fs_mntch
+        move    #>$40000,x1
+        cmp     x1,a
+        beq     fs_mvowl
+        move    x0,x:(r7+$23)           ; LP, and anything unexpected
+        bra     fs_mdone
+fs_mbp:
+        move    x0,x:(r7+$24)
+        bra     fs_mdone
+fs_mhp:
+        move    x0,x:(r7+$25)
+        bra     fs_mdone
+fs_mntch:
+        move    x0,x:(r7+$23)
+        move    x0,x:(r7+$25)
+        bra     fs_mdone
+fs_mvowl:
+; ---- VOWEL: A = band-pass at F1, B = a band at F2, routing forced PAR; ----
+; F1 (an SVF f) and F2 (a one-pole c) morph across A E I O U with FREQ:
+; idx = FREQ >> 5 (0..3) picks the pair, frac = (FREQ & 31)/32 interpolates.
+; Constants are 2*sin(pi*F/44100) and 1-exp(-2*pi*F/44100) in Q23 for
+; A 730/1090, E 530/1840, I 270/2290, O 570/840, U 300/870 Hz.
+        move    x0,x:(r7+$24)           ; kBP = 1
+        clr     a
+        move    a,x:(r7+$29)            ; sel = 0
+        move    a,x:(r7+$28)
+        move    a,x:(r7+$2c)
+        move    #>$400000,x0            ; PAR
+        move    x0,x:(r7+$26)
+        move    x0,x:(r7+$27)
+        move    x:(r6+$0),a
+        asr     #$10,a,a
+        and     #>$1f,a                 ; FREQ & 31
+        asl     #$12,a,a                ; -> frac, Q23
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$49)            ; frac (the lfo park is dead by now)
+        move    x:(r6+$0),a
+        asr     #$15,a,a                ; idx = FREQ >> 5, 0..3
+        move    a1,x0
+        move    x0,a
+        move    #>$1,x0
+        cmp     x0,a
+        blt     fs_v0
+        beq     fs_v1
+        move    #>$2,x0
+        cmp     x0,a
+        beq     fs_v2
+        move    #>$0a6466,x0            ; idx 3: O -> U
+        move    x0,x:(r7+$4a)
+        move    #>$05787d,x0
+        move    x0,x:(r7+$4b)
+        move    #>$0e7015,x0
+        move    x0,x:(r7+$4c)
+        move    #>$0eec14,x0
+        move    x0,x:(r7+$4d)
+        bra     fs_vint
+fs_v2:
+        move    #>$04ec75,x0            ; idx 2: I -> O
+        move    x0,x:(r7+$4a)
+        move    #>$0a6466,x0
+        move    x0,x:(r7+$4b)
+        move    #>$23a244,x0
+        move    x0,x:(r7+$4c)
+        move    #>$0e7015,x0
+        move    x0,x:(r7+$4d)
+        bra     fs_vint
+fs_v1:
+        move    #>$09a9cc,x0            ; idx 1: E -> I
+        move    x0,x:(r7+$4a)
+        move    #>$04ec75,x0
+        move    x0,x:(r7+$4b)
+        move    #>$1d8496,x0
+        move    x0,x:(r7+$4c)
+        move    #>$23a244,x0
+        move    x0,x:(r7+$4d)
+        bra     fs_vint
+fs_v0:
+        move    #>$0d4e94,x0            ; idx 0: A -> E
+        move    x0,x:(r7+$4a)
+        move    #>$09a9cc,x0
+        move    x0,x:(r7+$4b)
+        move    #>$12695e,x0
+        move    x0,x:(r7+$4c)
+        move    #>$1d8496,x0
+        move    x0,x:(r7+$4d)
+fs_vint:
+; v = a + frac * (b - a), both tables
+        move    x:(r7+$4b),a
+        move    x:(r7+$4a),x0
+        sub     x0,a
+        move    a,x0                    ; b - a (signed)
+        move    x:(r7+$49),y1           ; frac
+        mpy     x0,y1,a
+        move    x:(r7+$4a),x0
+        add     x0,a
+        move    a,x:(r7+$20)            ; fA = F1 (no modulation in VOWEL)
+        move    x:(r7+$4d),a
+        move    x:(r7+$4c),x0
+        sub     x0,a
+        move    a,x0
+        move    x:(r7+$49),y1
+        mpy     x0,y1,a
+        move    x:(r7+$4c),x0
+        add     x0,a
+        move    a,x:(r7+$2a)            ; cHP = F2
+        move    a,x:(r7+$2b)            ; cLP = F2: a band around F2
+fs_mdone:
+
+        move    #>$7d0e56,x0            ; the SVF's stable f ceiling, staged for
+        move    x0,x:(r7+$1f)           ; the loop's FM clamp (1-word loads there)
+
+; ---- BYPASS: the defaults are a bit-exact passthrough ---------------------
+; FREQ 127, RES 0, BASE 0, WDTH 127, DRV 0, DPTH 64, MODE LP, ROUT SER. Every
+; part that ever chose stock FILTER runs this on FX1 after the flash, so the
+; neutral block copies nothing and only does the sends.
+        clr     b
+        move    b,x:(r7+$2d)
+        move    x:(r6+$0),a
+        move    #>$7f0000,x0
+        cmp     x0,a
+        bne     fs_live
+        move    x:(r6+$1),a
+        tst     a
+        bne     fs_live
+        move    x:(r6+$2),a
+        tst     a
+        bne     fs_live
+        move    x:(r6+$3),a
+        cmp     x0,a
+        bne     fs_live
+        move    x:(r6+$c),a             ; DRV knob field AND the MODE select
+        and     #>$7fff00,a
+        move    a1,x0
+        move    x0,a
+        tst     a
+        bne     fs_live
+        move    x:(r6+$d),a             ; DPTH knob field AND the ROUT select
+        and     #>$7fff00,a
+        move    a1,x0
+        move    x0,a
+        move    #>$400000,x0
+        cmp     x0,a
+        bne     fs_live
+        bra     fs_bypass
+fs_live:
+
+; ===========================================================================
+; THE SAMPLE LOOP
+; ===========================================================================
+        move    #>$1,n0
+        do      n7,>fs_end
+; ---- input peak for the envelope follower (mono, pre-filter) --------------
+        move    x:(r0),a
+        move    x:(r0+n0),x0
+        add     x0,a
+        asr     #$1,a,a
+        abs     a
+        move    x:(r7+$1e),x0
+        cmp     x0,a
+        tlt     x0,a
+        move    a,x:(r7+$1e)
+; ===================== channel L =====================
+        move    x:(r0),x0
+        move    x0,x:(r7+$1d)           ; park x
+; FM: f = clamp(fA + kFM * B_prev)
+        move    x:(r7+$19),x0           ; B_prev L
+        move    x:(r7+$2c),y1           ; kFM (0 unless ROUT = FM)
+        mpy     x0,y1,a                 ; kFM * B, +-0.25
+        move    a,x0
+        move    x:(r7+$20),y1           ; fA
+        mpy     x0,y1,a                 ; fA * kFM * B: MULTIPLICATIVE FM,
+        move    x:(r7+$20),x0           ; so f stays positive by construction
+        add     x0,a                    ; f = fA * (1 + kFM * B)
+        move    x:(r7+$1f),x0           ; 0.977, the SVF's stable ceiling
+        cmp     x0,a
+        tgt     x0,a
+        move    a,x:(r7+$1c)            ; f this sample
+; drive
+        move    x:(r7+$1d),x0
+        move    x:(r7+$22),y1           ; g4
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    a,x1                    ; x_d, the limiter IS the drive clip
+; SVF A: lp += f*bp
+        move    x:(r7+$35),x0           ; bp
+        move    x:(r7+$1c),y1           ; f
+        mpy     x0,y1,a
+        move    x:(r7+$34),b
+        add     b,a
+        move    a,x:(r7+$34)            ; lp'
+        move    a,b
+; hp = x_d - lp' - damp*bp
+        move    x:(r7+$21),y1           ; damp
+        mpy     x0,y1,a                 ; damp*bp (x0 still bp)
+        neg     a
+        sub     b,a
+        add     x1,a                    ; hp
+        move    a,x0                    ; hp, limited -- the resonance clamp
+        move    a,y0                    ; park hp
+; bp += f*hp
+        move    x:(r7+$1c),y1
+        mpy     x0,y1,a
+        move    x:(r7+$35),b
+        add     b,a
+        move    a,x:(r7+$35)            ; bp'
+; wetA = kBP*bp' + kHP*hp + kLP*lp'
+        move    a,x0
+        move    x:(r7+$24),y1
+        mpy     x0,y1,a
+        move    y0,x0
+        move    x:(r7+$25),y1
+        mpy     x0,y1,b
+        add     b,a
+        move    x:(r7+$34),x0
+        move    x:(r7+$23),y1
+        mpy     x0,y1,b
+        add     b,a
+        move    a,x:(r7+$1b)            ; wetA
+        move    a,x1
+; yB = sel ? wetA : x
+        move    x:(r7+$29),b
+        tst     b
+        move    x:(r7+$1d),a
+        tne     x1,a
+        move    a,x:(r7+$1d)            ; yB
+; B: two HP poles (HP = in - LP2(in)) at cHP
+        move    x:(r7+$38),b            ; h1
+        sub     b,a                     ; yB - h1
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$2a),y1           ; cHP
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a                     ; h1'
+        move    a,x:(r7+$38)
+        move    x:(r7+$39),b            ; h2
+        sub     b,a                     ; h1' - h2
+        asr     #$1,a,a
+        move    a,x0
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a                     ; h2'
+        move    a,x:(r7+$39)
+        move    a,x0
+        move    x:(r7+$1d),a
+        sub     x0,a                    ; hp2 = yB - h2'
+        move    a,x:(r7+$1d)            ; park hp2
+; two LP poles at cLP
+        move    x:(r7+$3a),b            ; l1
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$2b),y1           ; cLP
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$3a)
+        move    x:(r7+$3b),b            ; l2
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$3b)            ; B_out = l2'
+        move    a,x:(r7+$19)            ; B_prev for next sample's FM
+; out = kA*wetA + kB*B + kR*(2*wetA*B)
+        move    a,x0                    ; B_out
+        move    x:(r7+$27),y1           ; kB
+        mpy     x0,y1,a
+        move    x:(r7+$1b),y1           ; wetA (signed x signed: the known-
+        mpy     x0,y1,b                 ; signed order)
+        asl     #$1,b,b
+        move    b,x0
+        move    x:(r7+$28),y1           ; kR
+        mpy     x0,y1,b
+        add     b,a
+        move    x:(r7+$1b),x0           ; wetA
+        move    x:(r7+$26),y1           ; kA
+        mpy     x0,y1,b
+        add     b,a
+        move    a,x:(r0)                ; out L (limited)
+; ===================== channel R =====================
+        move    x:(r0+n0),x0
+        move    x0,x:(r7+$1d)
+        move    x:(r7+$1a),x0           ; B_prev R
+        move    x:(r7+$2c),y1           ; kFM (0 unless ROUT = FM)
+        mpy     x0,y1,a                 ; kFM * B, +-0.25
+        move    a,x0
+        move    x:(r7+$20),y1           ; fA
+        mpy     x0,y1,a                 ; fA * kFM * B: MULTIPLICATIVE FM,
+        move    x:(r7+$20),x0           ; so f stays positive by construction
+        add     x0,a                    ; f = fA * (1 + kFM * B)
+        move    x:(r7+$1f),x0           ; 0.977, the SVF's stable ceiling
+        cmp     x0,a
+        tgt     x0,a
+        move    a,x:(r7+$1c)            ; f this sample
+        move    x:(r7+$1d),x0
+        move    x:(r7+$22),y1
+        mpy     x0,y1,a
+        asl     #$2,a,a
+        move    a,x1
+        move    x:(r7+$37),x0           ; bp R
+        move    x:(r7+$1c),y1
+        mpy     x0,y1,a
+        move    x:(r7+$36),b
+        add     b,a
+        move    a,x:(r7+$36)
+        move    a,b
+        move    x:(r7+$21),y1
+        mpy     x0,y1,a
+        neg     a
+        sub     b,a
+        add     x1,a
+        move    a,x0
+        move    a,y0
+        move    x:(r7+$1c),y1
+        mpy     x0,y1,a
+        move    x:(r7+$37),b
+        add     b,a
+        move    a,x:(r7+$37)
+        move    a,x0
+        move    x:(r7+$24),y1
+        mpy     x0,y1,a
+        move    y0,x0
+        move    x:(r7+$25),y1
+        mpy     x0,y1,b
+        add     b,a
+        move    x:(r7+$36),x0
+        move    x:(r7+$23),y1
+        mpy     x0,y1,b
+        add     b,a
+        move    a,x:(r7+$1b)
+        move    a,x1
+        move    x:(r7+$29),b
+        tst     b
+        move    x:(r7+$1d),a
+        tne     x1,a
+        move    a,x:(r7+$1d)
+        move    x:(r7+$3c),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$2a),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$3c)
+        move    x:(r7+$3d),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$3d)
+        move    a,x0
+        move    x:(r7+$1d),a
+        sub     x0,a
+        move    a,x:(r7+$1d)
+        move    x:(r7+$3e),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$2b),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$3e)
+        move    x:(r7+$3f),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$3f)
+        move    a,x:(r7+$1a)
+        move    a,x0
+        move    x:(r7+$27),y1
+        mpy     x0,y1,a
+        move    x:(r7+$1b),y1
+        mpy     x0,y1,b
+        asl     #$1,b,b
+        move    b,x0
+        move    x:(r7+$28),y1
+        mpy     x0,y1,b
+        add     b,a
+        move    x:(r7+$1b),x0
+        move    x:(r7+$26),y1
+        mpy     x0,y1,b
+        add     b,a
+        move    a,x:(r0+n0)             ; out R
+; ---- the sends: the PROCESSED mono, 3 bits of bus headroom, both buses ----
+        move    x:(r0),a
+        move    x:(r0+n0),x0
+        add     x0,a
+        asr     #$1,a,a
+        move    a,x1                    ; mono
+        move    x:(r7+$2e),y1           ; ->DEL level
+        mpy     x1,y1,a                 ; SEND's order: level (2nd) >= 0
+        asr     #$3,a,a
+        move    y:(r2),b
+        add     b,a
+        move    a,y:(r2)+
+        move    x:(r7+$2f),y0           ; ->VRB level
+        mpy     x1,y0,a
+        asr     #$3,a,a
+        move    y:(r1),b
+        add     b,a
+        move    a,y:(r1)+
+        move    #>$2,n0                 ; LONG immediates, deliberately: the
+        move    (r0)+n0                 ; short form `move #2,n0` assembled and
+        move    #>$1,n0                 ; stepped ONE word per frame (3 Sep 2026)
+fs_end:
+        nop
+        rts
+
+; ===========================================================================
+; BYPASS LOOP: frames untouched, sends only (SEND's loop, verbatim shape)
+; ===========================================================================
+fs_bypass:
+        move    x:(r7+$2f),y0           ; ->VRB level
+        move    x:(r7+$2e),y1           ; ->DEL level
+        move    #>$1,n0
+        do      n7,>fs_byz
+        move    x:(r0),a                ; frames untouched: the bypass IS the
+        move    x:(r0+n0),x0            ; bit-exact passthrough
+        add     x0,a
+        asr     #$1,a,a
+        move    a,x1
+        mpy     x1,y1,a
+        asr     #$3,a,a
+        move    y:(r2),b
+        add     b,a
+        move    a,y:(r2)+
+        mpy     x1,y0,a
+        asr     #$3,a,a
+        move    y:(r1),b
+        add     b,a
+        move    a,y:(r1)+
+        move    #>$2,n0                 ; LONG immediates, deliberately: the
+        move    (r0)+n0                 ; short form `move #2,n0` assembled and
+        move    #>$1,n0                 ; stepped ONE word per frame (3 Sep 2026)
+fs_byz:
+        nop
+        rts

--- a/modules/filterstation/manifest.py
+++ b/modules/filterstation/manifest.py
@@ -1,0 +1,95 @@
+"""FILTER STATION -- two filters in one insert, and a bus sender.
+
+The first BamSep26 station. A per-track INSERT that REPLACES stock FILTER
+(id 0x04, both menus, and every saved part that chose FILTER), built the way
+the Digitakt II / Digitone II pair a multimode filter with a base/width
+filter -- plus the Sherman-filterbank moves that fit in twelve slots:
+
+  * filter A -- Ripple's driven Chamberlin SVF: LP / BP / HP / NOTCH, and a
+    VOWEL mode (five formant pairs morphed by FREQ, A's band-pass at F1 and
+    filter B as a band at F2);
+  * filter B -- a base/width pair: two cascaded one-poles of HP at BASE and
+    two of LP at WDTH (12 dB/oct each side);
+  * routing -- SER (A into B), PAR (A + B), RING (A x B), FM (B's output
+    modulates A's cutoff at audio rate, one sample late);
+  * modulation -- one bipolar DPTH onto A's cutoff, from an envelope follower
+    (block-peak, instant attack, RATE = release), an LFO (RATE = speed), or
+    both;
+  * ->DEL / ->VRB -- the station is a BUS CLIENT: the processed signal is
+    sent onto both buses, page 1, scene-lockable. It registers only when a
+    send is non-zero (the N/(N+1) dilution trap) and NEVER HOUSEKEEPS: the
+    election is the FX2 participants' business, so an FX1 station on track 5
+    cannot double-flip the rotation with its own FX2.
+
+DEFAULTS ARE A BIT-EXACT PASSTHROUGH (FREQ 127, RES 0, BASE 0, WDTH 127,
+DRV 0, DPTH 64, LP, SER, sends 0): the engine detects that block and copies
+nothing, because after the flash every part that ever chose FILTER runs
+this on FX1. ⚠️ A part's STORED bytes are stock FILTER's, not these defaults
+(DEC=64 lands on ->VRB): the project stamper writes ours (plan A6).
+
+Every mpy is `mpy x0,y1`, the audited-signed form; every clip is the store
+limiter. Cycles: the whole loop is straight-line and priced by `make cycles`.
+"""
+
+from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
+                          MenuEntry, Module, Param, YBase)
+
+_PLAIN = Formatter.PLAIN
+_STEP = Formatter.STEPPED
+
+MODULE = Module(
+    name="filterstation",
+    key="FILTER STATION",
+    kind=Kind.DSP_EFFECT,
+    doc="BamSep26 station: dual filter (SVF + base/width), LFO/env, SER/PAR/RING/FM, sends.",
+    menu=MenuEntry(
+        fx2_id=0x04,
+        replaces="FILTER",            # stock FILTER's id: both menus, every part
+        donor_desc=0x400d58b8,        # DARK REV: 12 active slots, selects on 7/9/11
+        abbr=b"FLTS",
+        fullname=b"FilterStn",
+        build_tag=True,
+    ),
+    params=(
+        # ---- page 1: the performance surface, scene/CC-reachable -----------
+        Param(b"FREQ", 127, active=True, formatter=_PLAIN,
+              doc="filter A cutoff, ~24 Hz..7.2 kHz squared taper; in VOWEL the vowel A-E-I-O-U"),
+        Param(b"RES", 0, active=True, formatter=_PLAIN,
+              doc="filter A resonance, up to Q~30"),
+        Param(b"BASE", 0, active=True, formatter=_PLAIN,
+              doc="filter B high-pass corner (12 dB/oct); 0 = open"),
+        Param(b"WDTH", 127, active=True, formatter=_PLAIN,
+              doc="filter B low-pass corner above BASE (12 dB/oct); 127 = open"),
+        Param(b"-DEL", 0, active=True, formatter=_PLAIN,
+              doc="send the processed signal onto the DELAY bus; 0 = not a client"),
+        Param(b"-VRB", 0, active=True, formatter=_PLAIN,
+              doc="send the processed signal onto the REVERB bus; 0 = not a client"),
+        # ---- page 2: knob / select / knob / select / knob / select ----------
+        Param(b"DRV", 0, 128, active=True, formatter=_PLAIN,
+              doc="drive into filter A, 1..4x, clipped at the rail; 0 = unity"),
+        Param(b"MODE", 0, 5, active=True, formatter=_STEP,
+              labels=("LP", "BP", "HP", "NTCH", "VOWL"),
+              doc="filter A response; VOWL = formant pair morphed by FREQ, forces PAR"),
+        Param(b"DPTH", 64, 128, active=True, formatter=_PLAIN,
+              doc="modulation depth onto A's cutoff, bipolar around 64 = none"),
+        Param(b"ROUT", 0, 4, active=True, formatter=_STEP,
+              labels=("SER", "PAR", "RING", "FM"),
+              doc="SER A into B; PAR A+B; RING A*B; FM B's output modulates A's cutoff"),
+        Param(b"RATE", 64, 128, active=True, formatter=_PLAIN,
+              doc="LFO speed ~0.08..9 Hz, and the envelope release (0 slow .. 127 fast)"),
+        Param(b"SRC", 0, 3, active=True, formatter=_STEP,
+              labels=("ENV", "LFO", "BOTH"),
+              doc="what DPTH applies: the envelope follower, the LFO, or half of each"),
+    ),
+    dsp=DspSection(
+        asm="modules/filterstation/filter_station.asm",
+        priority=12,                  # after every existing module
+        bus_role=BusRole.NONE,        # an insert that also WRITES the bus
+        ybase=YBase.NEVER,
+        r7_latch_slot=0x69,           # ROTLATCH parks this block's offset here
+        gate_label=None,              # no housekeeping, so no XBUS gate
+    ),
+    # bus_client: it writes the shared accumulators, so an image with it has a
+    # bus and needs SEND as the fallback (schema.on_the_bus).
+    harness=Harness(layout_char="1", is_server=False, bus_client=True),
+)

--- a/modules/menushortcut/manifest.py
+++ b/modules/menushortcut/manifest.py
@@ -1,0 +1,129 @@
+"""MENU SHORTCUT -- MAIN MENU > CONTROL > REVERB / DELAY.
+
+The bus servers live on a track, so reaching their controls means finding
+which track hosts them and pressing [FX2] there. This adds two rows to the
+CONTROL submenu that do it for you: each selects the track HOSTING that
+server and opens its EFFECT 2 SETUP window.
+
+NOTHING ABOUT THE DATA MODEL MOVES. The parameters still live on the host
+track's FX2 page, in the Part, scene-lockable, reachable by CC exactly as
+before -- this is navigation only, which is what makes it cheap. A control
+surface of its own would need a parameter store of its own, and that is the
+swamp `docs/MAINMENU.md` section 6 declines.
+
+HOW (docs/MAINMENU.md sections 2-5, 7, all traced there):
+
+  * the CONTROL list descriptor at 0x400cbd54 holds its count at +0x00 and
+    its row array pointer at +0x18. The array cannot grow in place, so the
+    build copies the six rows into this cave, appends two, repoints the
+    pointer and bumps the count to 8. Two writes, both asserted against the
+    stock bytes first.
+  * a row is 24 bytes: label, window descriptor, action, 0, child, page id.
+    An ACTION row -- window 0, child 0, action set, id 0 -- is the shape
+    SYSTEM's USB DISK MODE and OS UPGRADE already use, so it is proven at
+    submenu level rather than inferred.
+  * the action is menu_shortcut.s: guard MIDI mode, set the page-kind
+    globals, close the menu, select the host track, open EFFECT 2 SETUP.
+
+⚠️ CONTROL, NOT THE ROOT MENU. A fifth root row is two writes as well
+(MAINMENU.md section 5) and one press shallower -- but PROJECT's and
+SYSTEM's descriptor addresses are hard-compared at 0x40064fa0..c2 for an
+alternate-list swap whose semantics are unknown, and a root leaf with no
+window descriptor is a shape stock never uses. CONTROL is the shape stock
+already runs. The row can move up once the emulator has walked this one.
+
+⚠️ UNFLASHED, and priced honestly in MAINMENU.md section 7 at ~65% for a
+first flash. The two inferences that carry the risk: that closing the menu
+from inside an action is safe (stock's own [NO] does it) and that the
+per-track FX2 id array is where tempo_cave.s reads it. The second degrades
+to "opens the current track's page" rather than crashing.
+"""
+
+import pathlib
+
+from remix.schema import CavePatch, Kind, Module
+
+# The CONTROL submenu, from docs/MAINMENU.md section 2.
+CONTROL_DESC = 0x400cbd54          # count at +0x00, rows pointer at +0x18
+CONTROL_ROWS = 0x400cc5a8
+ROW_LEN, ROW_N = 24, 6
+# menu_shortcut.s, assembled with m68k-elf-as -mcpu=5407. Position independent:
+# every address it names is an OS absolute, so it may be planted anywhere.
+# menu_shortcut.s, assembled with m68k-elf-as -mcpu=5407. Position
+# independent: every address it names is an OS absolute, so the cave may be
+# planted wherever the placer has room. Spelled out in full rather than
+# chunked -- these bytes ARE the contract, and a transcription slip in a cave
+# is a crash on the unit.
+HANDLER = bytes.fromhex(
+    "70 07 60 02 70 06 4a b9 80 00 00 12 66 4c 72 04"
+    "23 c1 46 0d 16 84 13 c1 46 c7 d8 d8 41 f9 80 00"
+    "0e cc 72 00 14 18 02 82 00 00 00 ff b4 80 67 0c"
+    "52 81 0c 81 00 00 00 08 6d ea 72 ff 2f 01 4e b9"
+    "40 06 4b c0 22 1f 4a 81 6d 0a 2f 01 4e b9 40 08"
+    "3b f8 58 8f 4e b9 40 05 99 6c 4e 75".replace(" ", ""))
+REV_ENTRY, DLY_ENTRY = 0, 4        # hrev, hdly within HANDLER
+LABELS = (b"REVERB\0", b"DELAY\0")
+
+_STOCK = pathlib.Path("out/raw/section_3_MAIN_OS.bin")
+_BASE = 0x40000400
+
+
+def _stock_rows() -> bytes:
+    """The six CONTROL rows, read from the pristine image at build time so a
+    firmware whose menu differs stops the build instead of being written
+    over."""
+    d = _STOCK.read_bytes()
+    a = CONTROL_ROWS - _BASE
+    return d[a:a + ROW_LEN * ROW_N]
+
+
+def emit(addr: int):
+    """The cave, and the two writes that hang it off CONTROL.
+
+    Layout: handler, labels, then the eight rows -- the rows last because
+    they are the only part whose CONTENT depends on `addr`.
+    """
+    blob = HANDLER
+    lab_at = {}
+    for text in LABELS:
+        lab_at[text] = addr + len(blob)
+        blob += text
+    blob += b"\0" * (-len(blob) % 4)                  # rows want alignment
+    rows_at = addr + len(blob)
+    rows = bytearray(_stock_rows())
+    for text, entry in zip(LABELS, (REV_ENTRY, DLY_ENTRY)):
+        rows += (lab_at[text].to_bytes(4, "big")      # +0x00 label
+                 + b"\0" * 4                          # +0x04 no window
+                 + (addr + entry).to_bytes(4, "big")  # +0x08 action
+                 + b"\0" * 4                          # +0x0c
+                 + b"\0" * 4                          # +0x10 no child
+                 + b"\0" * 4)                         # +0x14 id 0 -> action
+    blob += bytes(rows)
+    pokes = (
+        (CONTROL_DESC, ROW_N.to_bytes(4, "big"),
+         (ROW_N + len(LABELS)).to_bytes(4, "big")),
+        (CONTROL_DESC + 0x18, CONTROL_ROWS.to_bytes(4, "big"),
+         rows_at.to_bytes(4, "big")),
+    )
+    return blob, pokes
+
+
+MODULE = Module(
+    name="menushortcut",
+    key="MENU SHORTCUT",
+    kind=Kind.CF_PATCH,
+    doc="MAIN MENU > CONTROL > REVERB / DELAY: jump to the host track's FX2 page.",
+    cf_patches=(CavePatch(
+        label="menu shortcut cave",
+        # ⚠️ PINNED OUTSIDE THE CLONE WINDOW, at the unclaimed 2,064-byte zero
+        # run docs/MAINMENU.md section 5 names. The floating region is where
+        # descriptor clones and label formatters live, and the BamSep26 rig
+        # leaves 84 bytes there -- this cave is 300. Nothing else claims this
+        # run; the build refuses if it is not still zero.
+        cave_addr=0x400d24d0,
+        pinned=b"",                       # the content depends on the address
+        source="modules/menushortcut/menu_shortcut.s",
+        emit=emit,
+        report_note=" (CONTROL gains REVERB and DELAY rows)",
+    ),),
+)

--- a/modules/menushortcut/menu_shortcut.s
+++ b/modules/menushortcut/menu_shortcut.s
@@ -1,0 +1,54 @@
+| MAIN MENU -> the bus effects' own FX2 page  (ColdFire code cave, 3 Sep 2026)
+|
+| Two rows in the CONTROL submenu, REVERB and DELAY, whose action selects the
+| track HOSTING that server and opens its EFFECT 2 SETUP window. The path is
+| docs/MAINMENU.md section 7, traced end to end there:
+|
+|   0x80000012      non-zero = MIDI mode, where page kind 4 resolves track+8
+|   0x460d1684      current page kind (long), byte mirror at 0x46c7d8d8
+|   0x40064bc0      close MAIN MENU -- the full stock cleanup, and stock
+|                   itself calls it from handler context ([NO])
+|   0x40083bf8      select a track: clamps, writes both globals, tears down
+|                   the old track, restages the page, redraws, moves the LED
+|   0x4005996c      open EFFECT 2 SETUP (takes no arguments; toggles)
+|
+| WHICH TRACK. Not hardcoded: the handler scans the eight per-track FX2 id
+| bytes at 0x80000ecc for the id it wants (7 = ChonVerb, 6 = BongDelay) and
+| selects the one that matches. The base is 0x80000110 + track + 0xdbc, the
+| same byte modules/tempo-sync/tempo_cave.s reads through its own hook.
+| ⚠️ If that address is wrong the scan simply never matches, and the handler
+| falls through to opening the CURRENT track's page -- wrong screen, not a
+| crash. That degradation is the reason it scans rather than trusting.
+|
+| Only d0 is live on entry (the engine calls action(0)); d1, d2 and a0 are
+| scratch.
+
+        .text
+hrev:   moveq   #7,%d0                  | ChonVerb's FX2 id
+        bra.s   hcom
+hdly:   moveq   #6,%d0                  | BongDelay's FX2 id
+hcom:   tst.l   0x80000012              | MIDI mode? kind 4 would resolve
+        bne.s   hout                    | track+8 -- bail, menu stays open
+        moveq   #4,%d1
+        move.l  %d1,0x460d1684          | current page kind = FX2
+        move.b  %d1,0x46c7d8d8          | the byte mirror the key path writes
+        lea     0x80000ecc,%a0          | the eight per-track FX2 id bytes
+        moveq   #0,%d1                  | track index
+hscan:  move.b  (%a0)+,%d2
+        and.l   #0xff,%d2
+        cmp.l   %d0,%d2
+        beq.s   hfound
+        addq.l  #1,%d1
+        cmpi.l  #8,%d1
+        blt.s   hscan
+        moveq   #-1,%d1                 | not hosted anywhere: leave the
+hfound: move.l  %d1,-(%sp)              | track selection alone
+        jsr     0x40064bc0              | close the MAIN MENU first
+        move.l  (%sp)+,%d1
+        tst.l   %d1
+        blt.s   hopen
+        move.l  %d1,-(%sp)
+        jsr     0x40083bf8              | select the host track
+        addq.l  #4,%sp
+hopen:  jsr     0x4005996c              | open EFFECT 2 SETUP
+hout:   rts

--- a/modules/modstation/README.md
+++ b/modules/modstation/README.md
@@ -1,0 +1,85 @@
+# MODULATION STATION
+
+The third BamSep26 station: one modulated line, seven modes, **FX1 only**,
+replacing stock CHORUS (id 0x12). Design page:
+https://claude.ai/code/artifact/1f1bfff2-9d4e-41b6-b0a7-91a3c8989aaf
+
+| page 1 | RATE · DPTH · FDBK · MIX · →DEL · →VRB |
+|---|---|
+| page 2 | DLY · MODE (CHOR FLNG PHSR COMB TREM VIB PAN) · TONE · SHPE (TRI SIN SQR SAW) · WID · STGS (2P 4P 6P 8P) |
+
+Three sample loops, chosen once per block — the Ripple pattern, which
+`cycle_count` prices as "worst of N mode loops"; a dispatch *inside* a sample
+loop cannot be priced at all.
+
+- **LINE** (CHOR, FLNG, COMB, VIB): one interpolated tap with feedback and a
+  one-pole damping inside the loop. The modes differ only in per-block
+  coefficients — centre delay, sweep depth, feedback.
+- **PHSR**: four one-pole allpass stages swept by the LFO, tapped after 1–4
+  stages by four per-block weights, so STGS costs no branch.
+- **AMP** (TREM, PAN): the LFO on amplitude, together or opposite, which is
+  one per-block polarity word.
+
+Every mode outputs the **wet only** and MIX blends, so MIX 0 is an exact
+passthrough in all seven and 127 is vibrato or tremolo outright. The LFO runs
+**per sample** (a per-block LFO steps at 2.9 kHz, which a chorus hears as
+zipper), with two shaped copies — L and its WID-offset partner.
+
+## FX1 only, and it enforces that itself
+
+It needs a per-track line, and beside the servers the only free per-track
+buffer is the FX1 slot: every FX2 instance buffer is ChonVerb's tank on core
+0 or BongDelay's line on tracks 3–4. It reads its base from the host's bump
+allocator **at init and only there** (`docs/DSP.md` §10), and a base ≥ 0x4000
+sets a flag that sends proc down the dry path, which writes nothing to Y.
+`Claims(fx1_only=True, buffer_words=2048)` is that promise to the ledger, and
+the first three gates below are what it rests on.
+
+Two lines of 1,024 words (23 ms each) of the 3,072 an FX1 slot gives. The
+read offset is masked, not the address, so nothing depends on where the
+allocator put us.
+
+## Measured (3 Sep 2026, local)
+
+- **1,133 words** (payload A, 1,166 on B), **402 cycles/sample** (the LINE
+  loop is the worst of the four; PHSR is 354, AMP 193, dry 20).
+- `tools/verify_modstation.py`, **9 gates, all PASS**:
+  - MIX=0 is a bit-exact passthrough in all seven modes;
+  - **an FX2 instance is a bit-exact dry pass in all seven modes at any
+    setting**, and `dsp_host -guard` reports "nothing written over a loaded
+    module" — the FX1-only claim, proven;
+  - the LFO is square-law in RATE (0.5 → 3.0 cycles in 0.68 s at RATE 20 vs
+    110), measured in TREM **on a DC input**, where the output *is* the LFO;
+  - VIB reads the line: an impulse comes back **473 samples** later, which is
+    the centre delay the knob asks for;
+  - PHSR is unity magnitude (+0.01 dB against the dry);
+  - TREM modulates the amplitude, PAN drives the channels 3.3 M apart;
+  - every knob at both extremes renders.
+
+## What the gates cost to get right
+
+- **An hour was spent on a stale audition dump.** The scratch image is cached
+  against the newest mtime under `modules/`, and a stale hit does not fail —
+  it silently measures the STOCK effect whose id this module replaces. Every
+  mode read as a dry pass, the LFO looked dead, and the emulator eventually
+  died on `MACRI`, an instruction stock code uses and it does not implement.
+  The three station gates now delete and rebuild their dump first.
+- **The delay decode shifted an already-scaled product**, pinning every line
+  mode at its 8-sample floor: an 8-sample chorus, measured as an impulse
+  returning 7 samples late instead of 473.
+- **The feedback's one-pole accumulated instead of tracking** (`s += c*tap`
+  rather than `s += c*(tap − s)`), which walks the state to the rail.
+- **The allpass was not an allpass**: `y = x − c·s` instead of `y = −c·x + s`
+  measured 19.6 dB down where an allpass must be 0.0.
+- **The LFO topped out at 51 Hz** — audio rate, not an LFO.
+- Two gates measured the wrong signal before they measured the right one: an
+  envelope follower on a 438 Hz tone tracks the tone, not the sweep.
+
+## Open
+
+- Voicing: nothing has been heard. Every law here is a first guess — the
+  delay ranges per mode, the sweep depths, the phaser's range, the SHPE
+  curves.
+- SHPE's fourth position is labelled SAW but the shaper implements TRI, SIN
+  and SQR; SAW currently renders as TRI. Either the label or the shape.
+- ⚠️ UNFLASHED, and the FX1-participant bus case has never run on hardware.

--- a/modules/modstation/manifest.py
+++ b/modules/modstation/manifest.py
@@ -1,0 +1,101 @@
+"""MODULATION STATION -- one modulated line, seven modes, FX1 only.
+
+The third BamSep26 station. It REPLACES stock CHORUS (id 0x12) and covers
+what stock spreads over CHORUS, FLANGER, PHASER and COMB, plus the three the
+box never had -- tremolo, vibrato and auto-pan:
+
+    CHOR  a 10 ms line swept slowly, no feedback: the classic
+    FLNG  a 0.3 ms line swept wide, with feedback: the jet
+    PHSR  four allpass stages swept together, no line at all (STGS taps
+          the chain at 2, 4, 6 or 8 poles)
+    COMB  a short line tuned by DLY with heavy feedback: a resonator
+    TREM  the LFO on amplitude
+    VIB   the line, wet only: pitch modulation
+    PAN   the LFO on amplitude, opposite in the two channels
+
+⚠️ **FX1 ONLY, and it enforces that itself.** It needs a per-track delay line,
+and beside the servers the only free per-track buffer is the FX1 slot: every
+FX2 instance buffer is ChonVerb's tank on core 0 or BongDelay's line on
+tracks 3-4. It reads its base from the host's bump allocator at INIT (never
+in proc -- docs/DSP.md section 10), and if that base is an FX2 slot
+(>= 0x4000) it runs as a dry pass and writes NOTHING. That promise is what
+`Claims(fx1_only=True)` declares and what its render gate proves.
+
+Two lines of 1,024 words, L and R, out of the 3,072 an FX1 slot gives: 23 ms
+each, enough for chorus, flanger, vibrato and a comb down to 43 Hz. The FX1
+bases (0x1000 0x1c00 0x2800 0x3400) are all multiples of 1,024, but nothing
+here depends on that -- the read offset is masked, not the address.
+
+It is a BUS CLIENT on the other two stations' terms: ->DEL / ->VRB on page 1,
+registration gated on each knob, and it never housekeeps.
+
+DEFAULTS ARE A PASSTHROUGH (MIX 0), because a part that stored CHORUS runs
+this after the flash. ⚠️ A part's STORED bytes are stock CHORUS's -- the
+stamper (plan A6) writes ours.
+"""
+
+from remix.schema import (BusRole, Claims, DspSection, Formatter, Harness,
+                          Kind, MenuEntry, Module, Param, YBase)
+
+_PLAIN = Formatter.PLAIN
+_STEP = Formatter.STEPPED
+
+MODULE = Module(
+    name="modstation",
+    key="MODULATION STATION",
+    kind=Kind.DSP_EFFECT,
+    doc="BamSep26 station: chorus/flanger/phaser/comb/trem/vib/pan, FX1 only.",
+    menu=MenuEntry(
+        fx2_id=0x12,
+        replaces="CHORUS",
+        donor_desc=0x400d58b8,        # DARK REV: 12 active slots, selects 7/9/11
+        abbr=b"MODS",
+        fullname=b"ModStn",
+        build_tag=True,
+    ),
+    params=(
+        # ---- page 1: the performance surface, scene/CC-reachable -----------
+        Param(b"RATE", 40, active=True, formatter=_PLAIN,
+              doc="LFO speed, ~0.05 Hz to ~8 Hz on a squared taper"),
+        Param(b"DPTH", 48, active=True, formatter=_PLAIN,
+              doc="how far the LFO sweeps the line (or the amplitude, in TREM/PAN)"),
+        Param(b"FDBK", 0, active=True, formatter=_PLAIN,
+              doc="feedback around the line: the flanger's jet, the comb's ring; 0 = none"),
+        Param(b"MIX", 0, active=True, formatter=_PLAIN,
+              doc="dry/wet; 0 = exact passthrough, 64 = classic chorus, 127 = vibrato"),
+        Param(b"-DEL", 0, active=True, formatter=_PLAIN,
+              doc="send the processed signal onto the DELAY bus; 0 = not a client"),
+        Param(b"-VRB", 0, active=True, formatter=_PLAIN,
+              doc="send the processed signal onto the REVERB bus; 0 = not a client"),
+        # ---- page 2: knob / select / knob / select / knob / select ----------
+        Param(b"DLY", 30, 128, active=True, formatter=_PLAIN,
+              doc="the line's centre time, 0.2..23 ms -- in COMB it is the pitch"),
+        Param(b"MODE", 0, 7, active=True, formatter=_STEP,
+              labels=("CHOR", "FLNG", "PHSR", "COMB", "TREM", "VIB", "PAN"),
+              doc="which engine: three line modes, a phaser, and three amplitude ones"),
+        Param(b"TONE", 100, 128, active=True, formatter=_PLAIN,
+              doc="one-pole damping inside the feedback path; lower = darker each pass"),
+        Param(b"SHPE", 0, 4, active=True, formatter=_STEP,
+              labels=("TRI", "SIN", "SQR", "SAW"),
+              doc="LFO shape; SQR steps the line, which is a chorus that jumps"),
+        Param(b"WID", 64, 128, active=True, formatter=_PLAIN,
+              doc="how far the right channel's LFO lags the left, 0 = mono, 64 = quarter"),
+        Param(b"STGS", 1, 4, active=True, formatter=_STEP,
+              labels=("2P", "4P", "6P", "8P"),
+              doc="PHSR only: where the allpass chain is tapped, 2 to 8 poles"),
+    ),
+    dsp=DspSection(
+        asm="modules/modstation/mod_station.asm",
+        priority=14,                  # after the character station
+        bus_role=BusRole.NONE,        # an insert that also WRITES the bus
+        ybase=YBase.NEVER,
+        r7_latch_slot=0x69,           # ROTLATCH parks this block's offset here
+        gate_label=None,              # no housekeeping: a station never elects
+    ),
+    # The FX1-only allocator buffer: two 1,024-word lines out of the 3,072 an
+    # FX1 slot gives. `fx1_only` is the promise that an FX2 instance writes
+    # nothing -- the ledger admits it beside a server on that basis, and
+    # tools/verify_modstation.py is what proves it.
+    claims=Claims(stock_instance_buffer=True, buffer_words=2048, fx1_only=True),
+    harness=Harness(layout_char="3", is_server=False, bus_client=True),
+)

--- a/modules/modstation/manifest.py
+++ b/modules/modstation/manifest.py
@@ -35,7 +35,7 @@ stamper (plan A6) writes ours.
 """
 
 from remix.schema import (BusRole, Claims, DspSection, Formatter, Harness,
-                          Kind, MenuEntry, Module, Param, YBase)
+                          Kind, MenuEntry, ModeView, Module, Param, YBase)
 
 _PLAIN = Formatter.PLAIN
 _STEP = Formatter.STEPPED
@@ -83,6 +83,33 @@ MODULE = Module(
         Param(b"STGS", 1, 4, active=True, formatter=_STEP,
               labels=("2P", "4P", "6P", "8P"),
               doc="PHSR only: where the allpass chain is tapped, 2 to 8 poles"),
+    ),
+    # ---- what each MODE renames and re-defaults ---------------------------
+    # DLY is the line's centre time in the line modes, the comb's PITCH, and
+    # dead in the amplitude ones; FDBK is the flanger's jet and the comb's
+    # ring and nothing at all in TREM/PAN; STGS is the phaser's alone.
+    mode_slot=7,
+    mode_views=(
+        ModeView(mode=0,                        # CHOR
+                 defaults={0: 30, 1: 48, 2: 0, 3: 64, 6: 30, 10: 64}),
+        ModeView(mode=1,                        # FLNG
+                 defaults={0: 24, 1: 90, 2: 90, 3: 64, 6: 10, 10: 64}),
+        # ⚠️ ONLY SLOTS WHOSE MEANING CHANGES ARE RENAMED. Marking a knob
+        # dead with "----" in the four modes that ignore it read well and
+        # cost 56 bytes of a cave with 4 to spare -- the doc line says it
+        # instead. Renaming is for a knob that does something ELSE.
+        ModeView(mode=2,                        # PHSR
+                 names={2: b"RES"},
+                 defaults={0: 30, 1: 90, 2: 40, 3: 64, 11: 1}),
+        ModeView(mode=3,                        # COMB
+                 names={2: b"RING", 6: b"PTCH"},
+                 defaults={0: 8, 1: 20, 2: 110, 3: 64, 6: 20}),
+        ModeView(mode=4,                        # TREM
+                 defaults={0: 70, 1: 90, 2: 0, 3: 127}),
+        ModeView(mode=5,                        # VIB
+                 defaults={0: 45, 1: 40, 2: 0, 3: 127, 6: 20, 10: 64}),
+        ModeView(mode=6,                        # PAN
+                 defaults={0: 55, 1: 100, 2: 0, 3: 127}),
     ),
     dsp=DspSection(
         asm="modules/modstation/mod_station.asm",

--- a/modules/modstation/mod_station.asm
+++ b/modules/modstation/mod_station.asm
@@ -1,0 +1,958 @@
+; ---------------------------------------------------------------------------
+; MODULATION STATION -- one modulated line, seven modes, FX1 only.
+;
+; Insert contract (modules/ripple/ripple_svf.asm) plus the bus-client contract
+; the other two stations carry (modules/filterstation/): the processed mono
+; goes into both accumulators, registration is gated on each send knob, and
+; the station NEVER HOUSEKEEPS -- an FX1 instance runs before its track's FX2
+; one, so an electing station would double-flip the rotation.
+;
+; ---- FX1 ONLY, ENFORCED HERE ---------------------------------------------
+; The base comes from the host's bump allocator, read in INIT and only there
+; (docs/DSP.md section 10: X:0x213 is per-instance during init and garbage in
+; proc). FX1 slots are 0x1000 0x1c00 0x2800 0x3400; FX2 slots are 0x4000 and
+; up, and every one of those is a server's ground -- ChonVerb's tank on core
+; 0, BongDelay's line on tracks 3-4. So a base >= 0x4000 sets a flag that
+; sends proc down the DRY path, which writes NOTHING to Y. That promise is
+; what Claims(fx1_only=True) declares to the ledger, and tools/
+; verify_modstation.py is what proves it.
+;
+; Two lines of 1,024 words, L at base+0 and R at base+1024: 23 ms each, out
+; of the 3,072 an FX1 slot gives. The read offset is MASKED (& $3ff), not the
+; address, so nothing depends on where the allocator put us.
+;
+; ---- the modes -----------------------------------------------------------
+; Three sample loops, chosen once per block (the Ripple pattern, which
+; cycle_count prices as "worst of N mode loops" -- a dispatch INSIDE a sample
+; loop cannot be priced at all):
+;
+;   LINE  CHOR FLNG COMB VIB -- one modulated tap with feedback. The modes
+;         differ only in per-block coefficients: centre delay, sweep depth
+;         and feedback. VIB is the same line with the dry left out by MIX.
+;   PHSR  four one-pole allpass stages swept by the LFO, no line at all.
+;         STGS taps the chain after 1, 2, 3 or 4 stages (2, 4, 6, 8 poles)
+;         by weighting the four taps, which keeps the loop branchless.
+;   AMP   TREM and PAN: the LFO on amplitude, the same in both channels or
+;         opposite, which is one per-block polarity word.
+;
+; Every mode outputs the WET only; MIX does the blending, so MIX 0 is an
+; exact passthrough in every mode and 127 is vibrato/tremolo outright.
+;
+; ---- the LFO -------------------------------------------------------------
+; Per SAMPLE, not per block: at a 15-sample block a per-block LFO steps at
+; 2.9 kHz, which a chorus hears as zipper. Two shaped copies, L and its
+; WID-offset partner, from one phase accumulator. TRI is the basis; SIN is
+; the parabola 2t - t|t| blended in; SQR is TRI multiplied up and clamped by
+; a limiting store. All three are one code path with per-block weights.
+;
+; ---- r7 slots -------------------------------------------------------------
+;   $14 $65..$69  bus bookkeeping, SEND's layout ($69 = this block's offset)
+;   ⚠️ EVERY SLOT THE SAMPLE LOOPS TOUCH IS BELOW $40: an r7 displacement past
+;   63 assembles to the two-word long form (it cost the filter station 30
+;   words before that was found).
+;   $19 line base (per instance)     $1a dry flag: 1 = FX2 slot or MIX 0
+;   $1b write phase (PERSISTENT)     $1c LFO phase (PERSISTENT)
+;   $1d lfo L this sample            $1e lfo R this sample
+;   $1f R amplitude polarity (PAN)   $20 m (MIX)
+;   $21 centre delay, Q11.12         $22 sweep depth, Q11.12
+;   $23 feedback                     $24 tone coefficient
+;   $25 WID phase offset             $26 LFO increment per sample
+;   $27 sin blend weight             $28 square gain / 8
+;   $29 engine class                 $2a scratch (shape)
+;   $2b..$2e phaser tap weights      $2f phaser coefficient depth
+;   $30 ->DEL level                  $31 ->VRB level
+;   $32/$33 feedback tone state L/R      (PERSISTENT)
+;   $34..$37 allpass state L, 4 stages   (PERSISTENT)
+;   $38..$3b allpass state R, 4 stages   (PERSISTENT)
+;   $3c tap L  $3d tap R  $3e scratch  $3f scratch
+;
+; Every mpy is `mpy x0,y1` (the audited-signed encoding) except the send
+; taps, which are SEND's `mpy x1,y1` / `mpy x1,y0` with a non-negative level
+; second. Every Tcc reads the ONE compare above it with nothing but moves
+; between (the flag-clobber trap). No label here is a PREFIX of another --
+; dsp_asm resolves by prefix, and `ch_sat` inside `ch_satr` cost the
+; character station an afternoon.
+; ---------------------------------------------------------------------------
+
+init:
+; ROTINIT
+; ---- the allocator base, and the FX1/FX2 decision ------------------------
+; Nimbus Lite's idiom (modules/nimbuslite/nimbus_lite.asm): X:0x213 points at
+; this instance's entry in the base table. Valid HERE and nowhere else.
+        move    x:>$213,r4
+        move    #>$ffffff,m4
+        move    x:(r4),x0
+        move    x0,x:(r7+$19)           ; the line base
+; sub/tst rather than cmp: the cmp-encodes-as-max family (CLAUDE.md).
+        move    x0,a
+        move    #>$4000,x0
+        sub     x0,a                    ; base - 0x4000
+        clr     b                       ; b = 0 BEFORE the tst (the flag trap)
+        move    #>$1,x0
+        tst     a
+        tpl     x0,b                    ; base >= 0x4000: an FX2 slot
+        move    b,x:(r7+$1a)
+        tst     b
+        bne     monoclr                 ; FX2: never touch the buffer at all
+; ---- clear both lines, once, at instantiation ----------------------------
+        move    x:(r7+$19),a
+        move    a,r5
+        move    #>$ffffff,m5
+        clr     a
+        do      #2048,>moclrz
+        move    a,y:(r5)+
+moclrz:
+        nop
+monoclr:
+        clr     a
+        move    a,x:(r7+$1b)            ; write phase
+        move    a,x:(r7+$1c)            ; LFO phase
+        move    a,x:(r7+$32)            ; feedback tone states
+        move    a,x:(r7+$33)
+        move    a,x:(r7+$34)            ; allpass states, both channels
+        move    a,x:(r7+$35)
+        move    a,x:(r7+$36)
+        move    a,x:(r7+$37)
+        move    a,x:(r7+$38)
+        move    a,x:(r7+$39)
+        move    a,x:(r7+$3a)
+        move    a,x:(r7+$3b)
+        rts
+
+proc:
+; ===========================================================================
+; BUS: split-aware frame offset, verbatim from modules/send/send_client.asm
+; ===========================================================================
+        move    a,x:(r7+$14)
+        clr     a
+        move    a,x:(r7+$67)
+        move    x:(r7+$14),a
+        tst     a
+        bne     moa1
+        move    #>$1,a
+        move    a,x:(r7+$65)
+        move    n7,a
+        and     #>$f,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$66)
+        bra     mooffok
+moa1:
+        move    x:(r7+$65),a
+        and     #>$ff,a
+        move    a1,x0
+        move    x0,a
+        move    #>$1,x0
+        cmp     x0,a
+        bne     mooffok
+        clr     a
+        move    a,x:(r7+$65)
+        move    x:(r7+$66),a
+        and     #>$f,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$67)
+mooffok:
+; ---- resolve this block's write offset (per payload) -> r7+$69, r1, r2 ---
+; ROTLATCH
+        move    a,x0
+        move    #>$901,a
+        add     x0,a
+        move    x:(r7+$67),b
+        add     b,a
+        move    a,r1                    ; REVERB ACC[write] + frame offset
+        move    #>$961,a
+        add     x0,a
+        add     b,a
+        move    a,r2                    ; DELAY  ACC[write] + frame offset
+        move    #>$ffffff,m1
+        move    #>$ffffff,m2
+; ---- register, once per block, per bus, ONLY IF SENDING (r6+4 / r6+5) ----
+        move    x:(r7+$67),a
+        tst     a
+        bne     mocntz
+        move    x:(r7+$69),a
+        asr     #$4,a,a
+        move    a1,x0
+        move    x0,a
+        move    #>$9c3,x0
+        add     x0,a
+        move    a,r3
+        move    #>$ffffff,m3
+        move    #>$1,x0
+        clr     b
+        move    x:(r6+$5),a             ; ->VRB level
+        tst     a
+        tne     x0,b
+        move    y:(r3),a
+        add     b,a
+        move    a,y:(r3)
+        move    #4,n3
+        move    (r3)+n3
+        clr     b
+        move    x:(r6+$4),a             ; ->DEL level
+        tst     a
+        tne     x0,b
+        move    y:(r3),a
+        add     b,a
+        move    a,y:(r3)
+mocntz:
+        move    x:(r6+$4),x0
+        move    x0,x:(r7+$30)           ; ->DEL
+        move    x:(r6+$5),x0
+        move    x0,x:(r7+$31)           ; ->VRB
+
+; ===========================================================================
+; PER-BLOCK KNOB DECODE
+; ===========================================================================
+; MIX
+        move    x:(r6+$3),x0
+        move    x0,x:(r7+$20)
+; LFO increment: RATE^2 * $2600 + $30 per sample (~0.05 .. ~8 Hz)
+        move    x:(r6+$0),x0
+        move    x:(r6+$0),y1
+        mpy     x0,y1,a
+        move    a,x0
+; ⚠️ $600, NOT $2600: the increment is a fraction of 2^23 per SAMPLE, so
+; freq = inc * 44100 / 2^23. $2600 topped the knob out at 51 Hz -- audio
+; rate, not an LFO, and a chorus swept that fast is just noise (measured
+; 3 Sep 2026). $600 gives 0.06 Hz at the bottom and 7.9 Hz at the top.
+        move    #>$600,y1
+        mpy     x0,y1,a
+        add     #>$10,a
+        move    a,x:(r7+$26)
+; WID -> the right channel's LFO phase offset, 0 .. half a cycle
+        move    x:(r6+$e),a
+        and     #>$7f0000,a
+        move    a1,x0
+        move    x0,a
+        asr     #$1,a,a                 ; 0 .. ~0.5 of a cycle
+        move    a,x:(r7+$25)
+; SHPE (slot 9 select of r6+$d): the sin blend and the square gain
+        clr     a
+        move    a,x:(r7+$27)            ; sin weight 0
+        move    #>$100000,x0            ; square gain / 8 = 1/8, i.e. gain 1
+        move    x0,x:(r7+$28)
+        move    x:(r6+$d),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     mo_shsin
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     mo_shsqr
+        bra     mo_shdone               ; TRI, and anything unexpected
+mo_shsin:
+        move    #>$7fffff,x0            ; the parabola, all of it
+        move    x0,x:(r7+$27)
+        bra     mo_shdone
+mo_shsqr:
+        move    #>$7fffff,x0            ; gain 8, clamped by a limiting store
+        move    x0,x:(r7+$28)
+mo_shdone:
+; TONE -> the one-pole coefficient inside the feedback path
+        move    x:(r6+$d),a
+        and     #>$7f0000,a
+        move    a1,x0
+        move    x0,a
+        move    a,x0
+        move    #>$7c0000,y1
+        mpy     x0,y1,a
+        add     #>$040000,a
+        move    a,x:(r7+$24)
+; STGS (slot 11 select of r6+$e) -> the four phaser tap weights
+        clr     a
+        move    a,x:(r7+$2b)
+        move    a,x:(r7+$2c)
+        move    a,x:(r7+$2d)
+        move    a,x:(r7+$2e)
+        move    #>$7fffff,x1            ; the one that is 1.0
+        move    x:(r6+$e),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     mo_st4
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     mo_st6
+        move    #>$30000,x0
+        cmp     x0,a
+        beq     mo_st8
+        move    x1,x:(r7+$2b)           ; 2 poles: tap after stage 1
+        bra     mo_stdone
+mo_st4:
+        move    x1,x:(r7+$2c)
+        bra     mo_stdone
+mo_st6:
+        move    x1,x:(r7+$2d)
+        bra     mo_stdone
+mo_st8:
+        move    x1,x:(r7+$2e)
+mo_stdone:
+; DLY -> the centre delay in Q11.12 samples, ~0.2 .. 23 ms (8 .. 1000)
+        move    x:(r6+$c),a
+        and     #>$7f0000,a
+        move    a1,x0
+        move    x0,a
+        move    a,x0
+; ⚠️ NO SHIFT. $3e0000 IS 992*4096, so the product already lands in Q11.12:
+; mpy(DLY/128, 992*4096/2^23) leaves (992*DLY/128)*4096 in a1. The `asr #11`
+; that used to be here divided it by 2,048, which pinned every line mode at
+; its 8-sample floor -- an 8-sample chorus, measured as an impulse coming
+; back 7 samples late instead of 473 (3 Sep 2026).
+        move    #>$3e0000,y1            ; 992 samples, pre-scaled to Q11.12
+        mpy     x0,y1,a
+        add     #>$8000,a               ; + 8 samples of floor
+        move    a,x:(r7+$21)
+; DPTH -> the sweep depth in Q11.12 samples
+        move    x:(r6+$1),x0
+        move    #>$1e0000,y1            ; 480 samples, pre-scaled to Q11.12
+        mpy     x0,y1,a                 ; (no shift -- see the note above)
+        move    a,x:(r7+$22)
+; FDBK -> the feedback amount, and the phaser's sweep depth
+        move    x:(r6+$2),x0
+        move    x0,x:(r7+$23)
+        move    #>$600000,x0            ; the phaser sweeps 0.75 of its range
+        move    x0,x:(r7+$2f)
+; ---- MODE (slot 7 select of r6+$c): the engine class, and the per-mode ----
+; overrides of centre, depth and feedback. CHOR is the fall-through.
+        clr     a
+        move    a,x:(r7+$29)            ; class 0 = the LINE loop
+        move    #>$400000,x0
+        move    x0,x:(r7+$1f)           ; R polarity +1 (halved), for AMP
+        move    x:(r6+$c),a
+        and     #>$ff00,a
+        move    a1,x0
+        move    x0,a
+        asl     #$8,a,a
+        move    a,x:(r7+$2a)            ; park the mode
+        move    #>$10000,x0
+        cmp     x0,a
+        beq     mo_mflng
+        move    #>$20000,x0
+        cmp     x0,a
+        beq     mo_mphsr
+        move    #>$30000,x0
+        cmp     x0,a
+        beq     mo_mcomb
+        move    #>$40000,x0
+        cmp     x0,a
+        beq     mo_mtrem
+        move    #>$50000,x0
+        cmp     x0,a
+        beq     mo_mvib
+        move    #>$60000,x0
+        cmp     x0,a
+        beq     mo_mpan
+; CHOR: a 10 ms centre, a gentle sweep, no feedback
+        move    #>$28000,x0             ; 40 samples ~ 0.9 ms floor
+        move    x:(r7+$21),a
+        add     x0,a
+        move    a,x:(r7+$21)
+        clr     a
+        move    a,x:(r7+$23)            ; no feedback
+        bra     mo_mdone
+mo_mflng:
+        move    #>$4000,x0              ; 4 samples: the jet lives short
+        move    x0,x:(r7+$21)
+        move    x:(r7+$22),a
+        asr     #$2,a,a                 ; a quarter of the sweep
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$22)
+        bra     mo_mdone
+mo_mphsr:
+        move    #>$1,a
+        move    a,x:(r7+$29)            ; class 1 = the PHASER loop
+        bra     mo_mdone
+mo_mcomb:
+        move    x:(r7+$22),a
+        asr     #$4,a,a                 ; barely swept: it is a resonator
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$22)
+        bra     mo_mdone
+mo_mtrem:
+        move    #>$2,a
+        move    a,x:(r7+$29)            ; class 2 = the AMP loop
+        bra     mo_mdone
+mo_mvib:
+        clr     a
+        move    a,x:(r7+$23)            ; no feedback; the dry goes with MIX
+        bra     mo_mdone
+mo_mpan:
+        move    #>$2,a
+        move    a,x:(r7+$29)            ; class 2 = the AMP loop ...
+        move    #>$c00000,x0            ; ... with the right channel inverted
+        move    x0,x:(r7+$1f)           ; (-0.5, halved like every y1 gain)
+mo_mdone:
+; ---- the dry path: an FX2 slot, or MIX at zero ---------------------------
+        move    x:(r7+$1a),a            ; the FX2 flag from init
+        tst     a
+        bne     mo_dry
+        move    x:(r7+$20),a            ; MIX
+        tst     a
+        beq     mo_dry
+; ---- pick this block's engine -------------------------------------------
+        move    x:(r7+$29),a
+        move    #>$1,x0
+        cmp     x0,a
+        beq     mo_phsr
+        move    #>$2,x0
+        cmp     x0,a
+        beq     mo_amp
+
+; ===========================================================================
+; THE LINE LOOP -- CHOR, FLNG, COMB, VIB
+; ===========================================================================
+        move    #>$1,n0
+        do      n7,>molinz
+        bsr     moshap                  ; both LFOs, into $1d and $1e
+; ---- advance the write phase --------------------------------------------
+        move    x:(r7+$1b),a
+        add     #>$1,a
+        and     #>$3ff,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$1b)
+; ---- L: the modulated tap ------------------------------------------------
+        move    x:(r7+$1d),x0           ; lfo L
+        move    x:(r7+$22),y1           ; depth, Q11.12
+        mpy     x0,y1,a                 ; the sweep, Q11.12 signed
+        move    x:(r7+$21),x0           ; centre
+        add     x0,a
+        move    a,x:(r7+$3e)            ; park the total
+        asr     #$c,a,a                 ; integer samples
+        move    a1,x0
+        move    x:(r7+$1b),a            ; the write phase
+        sub     x0,a                    ; ... minus the delay
+        and     #>$3ff,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$3f)            ; park the read phase
+        move    x:(r7+$19),x0           ; the line base
+        add     x0,a
+        move    a,r5
+        move    #>$ffffff,m5
+        move    y:(r5),a                ; t0
+        move    a,x:(r7+$3c)
+        move    x:(r7+$3f),a
+        add     #>$1,a                  ; the neighbour, one sample newer
+        and     #>$3ff,a
+        move    a1,x0
+        move    x0,a
+        move    x:(r7+$19),x0
+        add     x0,a
+        move    a,r5
+        move    y:(r5),a                ; t1
+        move    x:(r7+$3c),x0
+        sub     x0,a                    ; t1 - t0
+        move    a1,x0
+        move    x:(r7+$3e),a            ; the total again, for its fraction
+        and     #>$fff,a
+        asl     #$b,a,a                 ; -> Q23
+        move    a1,y1
+        mpy     x0,y1,a                 ; frac * (t1 - t0)
+        move    x:(r7+$3c),x0
+        add     x0,a                    ; the interpolated tap
+        move    a,x:(r7+$3c)            ; wet L
+; ---- L: the feedback write ----------------------------------------------
+; the one-pole INSIDE the feedback: s += c*(tap - s). It accumulated c*tap
+; instead until 3 Sep 2026, which walks the state to the rail rather than
+; damping the loop.
+        move    x:(r7+$3c),a            ; the tap
+        move    x:(r7+$32),b            ; the state
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$24),y1           ; the coefficient
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a                     ; s'
+        move    a,x:(r7+$32)
+        move    a,x0
+        move    x:(r7+$23),y1           ; feedback
+        mpy     x0,y1,a
+        move    x:(r0),x0
+        add     x0,a                    ; input + feedback
+        move    a,x:(r7+$3e)            ; LIMITING store: the loop cannot rail
+        move    x:(r7+$1b),a
+        move    x:(r7+$19),x0
+        add     x0,a
+        move    a,r5
+        move    x:(r7+$3e),a
+        move    a,y:(r5)                ; write the line
+; ---- R: the same, on the second line ------------------------------------
+        move    x:(r7+$1e),x0           ; lfo R
+        move    x:(r7+$22),y1
+        mpy     x0,y1,a
+        move    x:(r7+$21),x0
+        add     x0,a
+        move    a,x:(r7+$3e)
+        asr     #$c,a,a
+        move    a1,x0
+        move    x:(r7+$1b),a
+        sub     x0,a
+        and     #>$3ff,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$3f)
+        move    x:(r7+$19),x0
+        add     x0,a
+        add     #>$400,a                ; the right line, 1,024 words up
+        move    a,r5
+        move    y:(r5),a
+        move    a,x:(r7+$3d)
+        move    x:(r7+$3f),a
+        add     #>$1,a
+        and     #>$3ff,a
+        move    a1,x0
+        move    x0,a
+        move    x:(r7+$19),x0
+        add     x0,a
+        add     #>$400,a
+        move    a,r5
+        move    y:(r5),a
+        move    x:(r7+$3d),x0
+        sub     x0,a
+        move    a1,x0
+        move    x:(r7+$3e),a
+        and     #>$fff,a
+        asl     #$b,a,a
+        move    a1,y1
+        mpy     x0,y1,a
+        move    x:(r7+$3d),x0
+        add     x0,a
+        move    a,x:(r7+$3d)            ; wet R
+        move    x:(r7+$3d),a
+        move    x:(r7+$33),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$24),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r7+$33)
+        move    a,x0
+        move    x:(r7+$23),y1
+        mpy     x0,y1,a
+        move    x:(r0+n0),x0
+        add     x0,a
+        move    a,x:(r7+$3e)
+        move    x:(r7+$1b),a
+        move    x:(r7+$19),x0
+        add     x0,a
+        add     #>$400,a
+        move    a,r5
+        move    x:(r7+$3e),a
+        move    a,y:(r5)
+        bsr     momixs                  ; MIX from $3c/$3d, then the sends
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+molinz:
+        nop
+        rts
+
+; ===========================================================================
+; THE PHASER LOOP -- four allpass stages, tapped by STGS
+; ===========================================================================
+mo_phsr:
+        move    #>$1,n0
+        do      n7,>mophsz
+        bsr     moshap
+; the coefficient: c = lfo * depth, so it sweeps either side of centre
+        move    x:(r7+$1d),x0
+        move    x:(r7+$2f),y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$3e)            ; c for this sample
+        move    x:(r0),a
+        move    a,x:(r7+$3c)
+        bsr     moapch                  ; the L chain, state $34..$37
+        move    x:(r7+$1e),x0           ; the right channel's own coefficient
+        move    x:(r7+$2f),y1
+        mpy     x0,y1,a
+        move    a,x:(r7+$3e)
+        move    x:(r0+n0),a
+        move    a,x:(r7+$3d)
+        bsr     moapcr                  ; the R chain, state $38..$3b
+        bsr     momixs
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+mophsz:
+        nop
+        rts
+
+; ===========================================================================
+; THE AMP LOOP -- TREM and PAN
+; ===========================================================================
+mo_amp:
+        move    #>$1,n0
+        do      n7,>moampz
+        bsr     moshap
+; gain = 1 + depth*lfo, halved like every y1 gain and doubled back after
+        move    x:(r7+$1d),x0
+        move    x:(r6+$1),y1            ; DPTH straight from the knob
+        mpy     x0,y1,a
+        asr     #$1,a,a
+        add     #>$400000,a             ; (1 + d*lfo) / 2
+        move    a,y1
+        move    x:(r0),x0
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        move    a,x:(r7+$3c)            ; wet L
+        move    x:(r7+$1e),x0           ; the right channel's LFO ...
+        move    x:(r7+$1f),y1           ; ... times its polarity (halved)
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        move    a,x0
+        move    x:(r6+$1),y1
+        mpy     x0,y1,a
+        asr     #$1,a,a
+        add     #>$400000,a
+        move    a,y1
+        move    x:(r0+n0),x0
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        move    a,x:(r7+$3d)            ; wet R
+        bsr     momixs
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+moampz:
+        nop
+        rts
+
+; ===========================================================================
+; THE DRY PATH: an FX2 slot, or MIX at zero. Frames untouched, sends only.
+; ===========================================================================
+mo_dry:
+        move    x:(r7+$31),y0
+        move    x:(r7+$30),y1
+        move    #>$1,n0
+        do      n7,>mobypz
+        move    x:(r0),a
+        move    x:(r0+n0),x0
+        add     x0,a
+        asr     #$1,a,a
+        move    a,x1
+        mpy     x1,y1,a
+        asr     #$3,a,a
+        move    y:(r2),b
+        add     b,a
+        move    a,y:(r2)+
+        mpy     x1,y0,a
+        asr     #$3,a,a
+        move    y:(r1),b
+        add     b,a
+        move    a,y:(r1)+
+        move    #>$2,n0
+        move    (r0)+n0
+        move    #>$1,n0
+mobypz:
+        nop
+        rts
+
+; ---------------------------------------------------------------------------
+; moshap -- the two LFOs for this sample, into $1d (L) and $1e (R).
+; The shaper is INLINED twice rather than called: cycle_count requires a bsr
+; callee to be straight-line, and a callee that itself calls is refused --
+; which costs the module its price, and an unpriced module cannot ship.
+; The phase advances once; the right channel reads it WID further round.
+; TRI is the basis, SIN is the parabola 2t - t|t| blended in by $27, and SQR
+; is the whole thing multiplied by 8 and clamped by a limiting store -- so
+; all three shapes are one code path with two per-block coefficients.
+; ---------------------------------------------------------------------------
+moshap:
+        move    x:(r7+$1c),a            ; the phase
+        move    x:(r7+$26),x0
+        add     x0,a
+        and     #>$7fffff,a
+        move    a1,x0
+        move    x0,a
+        move    a,x:(r7+$1c)
+        move    #>$400000,x0
+        sub     x0,a                    ; phase - 0.5
+        abs     a                       ; 0 .. 0.5
+        asl     #$2,a,a                 ; 0 .. 2, in the guard bits
+        move    #>$7fffff,x0
+        sub     x0,a                    ; the triangle, -1 .. 1
+        move    a,x:(r7+$2a)            ; LIMITING store, so |tri| <= 1
+        move    x:(r7+$2a),x1           ; tri
+        move    x1,a
+        abs     a
+        move    a,y1                    ; |tri|
+        move    x1,x0
+        mpy     x0,y1,a                 ; tri * |tri|
+        neg     a
+        move    x1,b
+        asl     #$1,b,b                 ; 2 * tri
+        add     b,a                     ; the parabola, -1 .. 1
+        move    x1,x0
+        sub     x0,a                    ; parabola - tri
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$27),y1           ; the sin blend
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     x1,a                    ; tri + w*(parabola - tri)
+        move    a,x0
+        move    x:(r7+$28),y1           ; the square gain / 8
+        mpy     x0,y1,a
+        asl     #$3,a,a
+        move    a,x:(r7+$2a)            ; LIMITING store: this IS the square
+        move    x:(r7+$2a),a
+        move    a,x:(r7+$1d)            ; lfo L
+        move    x:(r7+$1c),a
+        move    x:(r7+$25),x0           ; ... WID further round
+        add     x0,a
+        and     #>$7fffff,a
+        move    a1,x0
+        move    x0,a
+        move    #>$400000,x0
+        sub     x0,a                    ; phase - 0.5
+        abs     a                       ; 0 .. 0.5
+        asl     #$2,a,a                 ; 0 .. 2, in the guard bits
+        move    #>$7fffff,x0
+        sub     x0,a                    ; the triangle, -1 .. 1
+        move    a,x:(r7+$2a)            ; LIMITING store, so |tri| <= 1
+        move    x:(r7+$2a),x1           ; tri
+        move    x1,a
+        abs     a
+        move    a,y1                    ; |tri|
+        move    x1,x0
+        mpy     x0,y1,a                 ; tri * |tri|
+        neg     a
+        move    x1,b
+        asl     #$1,b,b                 ; 2 * tri
+        add     b,a                     ; the parabola, -1 .. 1
+        move    x1,x0
+        sub     x0,a                    ; parabola - tri
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$27),y1           ; the sin blend
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     x1,a                    ; tri + w*(parabola - tri)
+        move    a,x0
+        move    x:(r7+$28),y1           ; the square gain / 8
+        mpy     x0,y1,a
+        asl     #$3,a,a
+        move    a,x:(r7+$2a)            ; LIMITING store: this IS the square
+        move    x:(r7+$2a),a
+        move    a,x:(r7+$1e)            ; lfo R
+        rts
+
+
+; ---------------------------------------------------------------------------
+; moapch / moapcr -- the four-stage allpass chain, L and R.
+; In: $3c (or $3d) = the input, $3e = this sample's coefficient.
+; Out: the same slot holds the weighted tap. Each stage is the one-pole
+; allpass y = -c*x + s, s' = x + c*y, which is unity-magnitude at every
+; frequency -- the phase is the whole point. The four taps are weighted
+; rather than branched on, so STGS costs no branch in the loop. The stages
+; are INLINED (cycle_count refuses a bsr callee that itself calls).
+; ---------------------------------------------------------------------------
+moapch:
+        clr     b
+        move    x:(r7+$3c),a
+        move    a,x:(r7+$3f)
+        move    x:(r7+$34),x0
+        move    x:(r7+$3f),x1           ; x, the stage input
+        move    x:(r7+$3e),y1           ; c
+        mpy     x1,y1,a                 ; c * x
+        neg     a                       ; -c * x
+        move    x0,y0                   ; s
+        add     y0,a                    ; y = -c*x + s
+        move    a,x:(r7+$3f)            ; the stage output
+        move    a,x0
+        mpy     x0,y1,a                 ; c * y
+        add     x1,a                    ; s' = x + c*y
+        move    a,x:(r7+$34)
+        move    x:(r7+$3e),y1
+        move    x:(r7+$2b),y0
+        move    x:(r7+$3f),x0
+        move    y0,y1
+        mpy     x0,y1,a
+        add     a,b
+        move    x:(r7+$35),x0
+        move    x:(r7+$3f),x1           ; x, the stage input
+        move    x:(r7+$3e),y1           ; c
+        mpy     x1,y1,a                 ; c * x
+        neg     a                       ; -c * x
+        move    x0,y0                   ; s
+        add     y0,a                    ; y = -c*x + s
+        move    a,x:(r7+$3f)            ; the stage output
+        move    a,x0
+        mpy     x0,y1,a                 ; c * y
+        add     x1,a                    ; s' = x + c*y
+        move    a,x:(r7+$35)
+        move    x:(r7+$2c),y0
+        move    x:(r7+$3f),x0
+        move    y0,y1
+        mpy     x0,y1,a
+        add     a,b
+        move    x:(r7+$36),x0
+        move    x:(r7+$3f),x1           ; x, the stage input
+        move    x:(r7+$3e),y1           ; c
+        mpy     x1,y1,a                 ; c * x
+        neg     a                       ; -c * x
+        move    x0,y0                   ; s
+        add     y0,a                    ; y = -c*x + s
+        move    a,x:(r7+$3f)            ; the stage output
+        move    a,x0
+        mpy     x0,y1,a                 ; c * y
+        add     x1,a                    ; s' = x + c*y
+        move    a,x:(r7+$36)
+        move    x:(r7+$2d),y0
+        move    x:(r7+$3f),x0
+        move    y0,y1
+        mpy     x0,y1,a
+        add     a,b
+        move    x:(r7+$37),x0
+        move    x:(r7+$3f),x1           ; x, the stage input
+        move    x:(r7+$3e),y1           ; c
+        mpy     x1,y1,a                 ; c * x
+        neg     a                       ; -c * x
+        move    x0,y0                   ; s
+        add     y0,a                    ; y = -c*x + s
+        move    a,x:(r7+$3f)            ; the stage output
+        move    a,x0
+        mpy     x0,y1,a                 ; c * y
+        add     x1,a                    ; s' = x + c*y
+        move    a,x:(r7+$37)
+        move    x:(r7+$2e),y0
+        move    x:(r7+$3f),x0
+        move    y0,y1
+        mpy     x0,y1,a
+        add     a,b
+        move    b,x:(r7+$3c)
+        rts
+moapcr:
+        clr     b
+        move    x:(r7+$3d),a
+        move    a,x:(r7+$3f)
+        move    x:(r7+$38),x0
+        move    x:(r7+$3f),x1           ; x, the stage input
+        move    x:(r7+$3e),y1           ; c
+        mpy     x1,y1,a                 ; c * x
+        neg     a                       ; -c * x
+        move    x0,y0                   ; s
+        add     y0,a                    ; y = -c*x + s
+        move    a,x:(r7+$3f)            ; the stage output
+        move    a,x0
+        mpy     x0,y1,a                 ; c * y
+        add     x1,a                    ; s' = x + c*y
+        move    a,x:(r7+$38)
+        move    x:(r7+$3e),y1
+        move    x:(r7+$2b),y0
+        move    x:(r7+$3f),x0
+        move    y0,y1
+        mpy     x0,y1,a
+        add     a,b
+        move    x:(r7+$39),x0
+        move    x:(r7+$3f),x1           ; x, the stage input
+        move    x:(r7+$3e),y1           ; c
+        mpy     x1,y1,a                 ; c * x
+        neg     a                       ; -c * x
+        move    x0,y0                   ; s
+        add     y0,a                    ; y = -c*x + s
+        move    a,x:(r7+$3f)            ; the stage output
+        move    a,x0
+        mpy     x0,y1,a                 ; c * y
+        add     x1,a                    ; s' = x + c*y
+        move    a,x:(r7+$39)
+        move    x:(r7+$2c),y0
+        move    x:(r7+$3f),x0
+        move    y0,y1
+        mpy     x0,y1,a
+        add     a,b
+        move    x:(r7+$3a),x0
+        move    x:(r7+$3f),x1           ; x, the stage input
+        move    x:(r7+$3e),y1           ; c
+        mpy     x1,y1,a                 ; c * x
+        neg     a                       ; -c * x
+        move    x0,y0                   ; s
+        add     y0,a                    ; y = -c*x + s
+        move    a,x:(r7+$3f)            ; the stage output
+        move    a,x0
+        mpy     x0,y1,a                 ; c * y
+        add     x1,a                    ; s' = x + c*y
+        move    a,x:(r7+$3a)
+        move    x:(r7+$2d),y0
+        move    x:(r7+$3f),x0
+        move    y0,y1
+        mpy     x0,y1,a
+        add     a,b
+        move    x:(r7+$3b),x0
+        move    x:(r7+$3f),x1           ; x, the stage input
+        move    x:(r7+$3e),y1           ; c
+        mpy     x1,y1,a                 ; c * x
+        neg     a                       ; -c * x
+        move    x0,y0                   ; s
+        add     y0,a                    ; y = -c*x + s
+        move    a,x:(r7+$3f)            ; the stage output
+        move    a,x0
+        mpy     x0,y1,a                 ; c * y
+        add     x1,a                    ; s' = x + c*y
+        move    a,x:(r7+$3b)
+        move    x:(r7+$2e),y0
+        move    x:(r7+$3f),x0
+        move    y0,y1
+        mpy     x0,y1,a
+        add     a,b
+        move    b,x:(r7+$3d)
+        rts
+
+; ---------------------------------------------------------------------------
+; momixs -- MIX the wet in $3c/$3d against the dry still in the frame, write
+; it back, and put the PROCESSED mono onto both buses. Shared by all three
+; engines, so the mix law and the send have exactly one copy.
+; ---------------------------------------------------------------------------
+momixs:
+        move    x:(r7+$3c),a
+        move    x:(r0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1           ; m
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0)
+        move    x:(r7+$3d),a
+        move    x:(r0+n0),b
+        sub     b,a
+        asr     #$1,a,a
+        move    a,x0
+        move    x:(r7+$20),y1
+        mpy     x0,y1,a
+        asl     #$1,a,a
+        add     b,a
+        move    a,x:(r0+n0)
+        move    x:(r0),a
+        move    x:(r0+n0),x0
+        add     x0,a
+        asr     #$1,a,a
+        move    a,x1                    ; the processed mono
+        move    x:(r7+$30),y1           ; ->DEL
+        mpy     x1,y1,a
+        asr     #$3,a,a
+        move    y:(r2),b
+        add     b,a
+        move    a,y:(r2)+
+        move    x:(r7+$31),y0           ; ->VRB
+        mpy     x1,y0,a
+        asr     #$3,a,a
+        move    y:(r1),b
+        add     b,a
+        move    a,y:(r1)+
+        rts

--- a/remixes/_fs.py
+++ b/remixes/_fs.py
@@ -1,0 +1,10 @@
+"""_fs -- scratch: the FILTER STATION beside the reverb bus, for its gates.
+
+A station is a bus client, so it needs a bus to render into: the reverb
+server and SEND (the fallback). FILTER is replaced by the station, so its
+727 words are ground; every other stock effect keeps its code.
+"""
+from remix.schema import Remix
+REMIX = Remix(name="_fs", doc="scratch: FILTER STATION + ChonVerb + SEND",
+              modules=("REVERB SERVER", "SEND", "FILTER STATION"), fallback="SEND",
+              fx1=("FILTER STATION", "DJ EQ", "COMPRESSOR", "LO-FI"))

--- a/remixes/bamsep26.py
+++ b/remixes/bamsep26.py
@@ -1,0 +1,46 @@
+"""BamSep26 -- the rig: the ChonBong bus, three stations, and the stock delay.
+
+The image the set runs on. Design page:
+https://claude.ai/code/artifact/1f1bfff2-9d4e-41b6-b0a7-91a3c8989aaf
+
+    ChonVerb    the shared reverb, hosted on one of tracks 5-8
+    BongDelay   the shared delay (v5: CLEAN / pitched GRAIN / REVERSE),
+                hosted on one of tracks 1-4, with its own ->VRB
+    Send        the plain two-knob client, for a track with no station
+    DELAY       stock Echo Freeze, per track: it runs on the ColdFire and
+                costs the DSP nothing, so every track can have its own delay
+                IN PARALLEL with the shared reverb -- which the stock box
+                cannot do, because only a station's send reaches the bus
+    FilterStn   replaces FILTER  (id 0x04)
+    Character   replaces LO-FI   (id 0x1c)
+    ModStn      replaces CHORUS  (id 0x12), FX1 only
+    TEMPO SYNC  the two ColdFire caves: BongDelay's TIME reads 1/8 rather
+                than milliseconds
+
+Seven FX2 rows, which is exactly the in-place chooser list -- no scrolling.
+FX1 is NONE plus the three stations: every station takes the FX1 row of the
+stock effect it replaces, so a saved part that chose FILTER now runs the
+filter station, which is why all three default to a bit-exact passthrough.
+
+⚠️ EVERY OTHER STOCK EFFECT IS HARVESTED. Thirteen effects, 6,158 words per
+payload in one contiguous run, and an old project that still names one of
+them gets silence rather than noise (the null stub). The three the stations
+replace keep their ids and get OUR code instead.
+
+⚠️ The stations are BUS CLIENTS: ->DEL and ->VRB on page 1, scene-lockable,
+registered only when the knob is up, and none of them housekeeps. An FX1
+participant on the bus has never run on hardware -- docs/FLASHPLAN.md's
+flash 4 is where that claim is tested.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="bamsep26",
+    doc="The rig: ChonBong bus + three stations + the stock delay.",
+    modules=("REVERB SERVER", "DELAY SERVER", "SEND", "DELAY",
+             "FILTER STATION", "CHARACTER STATION", "MODULATION STATION",
+             "TEMPO SYNC"),
+    fallback="SEND",
+    fx1=("FILTER STATION", "CHARACTER STATION", "MODULATION STATION"),
+)

--- a/remixes/bamsep26.py
+++ b/remixes/bamsep26.py
@@ -16,6 +16,8 @@ https://claude.ai/code/artifact/1f1bfff2-9d4e-41b6-b0a7-91a3c8989aaf
     ModStn      replaces CHORUS  (id 0x12), FX1 only
     TEMPO SYNC  the two ColdFire caves: BongDelay's TIME reads 1/8 rather
                 than milliseconds
+    MENU SHORTCUT  MAIN MENU > CONTROL > REVERB / DELAY jumps to whichever
+                track hosts that server, and opens its FX2 page
 
 Seven FX2 rows, which is exactly the in-place chooser list -- no scrolling.
 FX1 is NONE plus the three stations: every station takes the FX1 row of the
@@ -40,7 +42,7 @@ REMIX = Remix(
     doc="The rig: ChonBong bus + three stations + the stock delay.",
     modules=("REVERB SERVER", "DELAY SERVER", "SEND", "DELAY",
              "FILTER STATION", "CHARACTER STATION", "MODULATION STATION",
-             "TEMPO SYNC"),
+             "TEMPO SYNC", "MENU SHORTCUT"),
     fallback="SEND",
     fx1=("FILTER STATION", "CHARACTER STATION", "MODULATION STATION"),
 )

--- a/remixes/stations.py
+++ b/remixes/stations.py
@@ -5,6 +5,7 @@ server and SEND (the fallback). FILTER is replaced by the station, so its
 727 words are ground; every other stock effect keeps its code.
 """
 from remix.schema import Remix
-REMIX = Remix(name="stations", doc="the stations so far (FILTER STATION) + ChonVerb + SEND",
-              modules=("REVERB SERVER", "SEND", "FILTER STATION"), fallback="SEND",
-              fx1=("FILTER STATION", "DJ EQ", "COMPRESSOR", "LO-FI"))
+REMIX = Remix(name="stations", doc="the stations so far (FILTER, CHARACTER) + ChonVerb + SEND",
+              modules=("REVERB SERVER", "SEND", "FILTER STATION", "CHARACTER STATION"),
+              fallback="SEND",
+              fx1=("FILTER STATION", "CHARACTER STATION", "DJ EQ", "COMPRESSOR"))

--- a/remixes/stations.py
+++ b/remixes/stations.py
@@ -5,7 +5,8 @@ server and SEND (the fallback). FILTER is replaced by the station, so its
 727 words are ground; every other stock effect keeps its code.
 """
 from remix.schema import Remix
-REMIX = Remix(name="stations", doc="the stations so far (FILTER, CHARACTER) + ChonVerb + SEND",
-              modules=("REVERB SERVER", "SEND", "FILTER STATION", "CHARACTER STATION"),
+REMIX = Remix(name="stations", doc="the three BamSep26 stations + ChonVerb + SEND",
+              modules=("REVERB SERVER", "SEND", "FILTER STATION", "CHARACTER STATION",
+                       "MODULATION STATION"),
               fallback="SEND",
-              fx1=("FILTER STATION", "CHARACTER STATION", "DJ EQ", "COMPRESSOR"))
+              fx1=("FILTER STATION", "CHARACTER STATION", "MODULATION STATION"))

--- a/remixes/stations.py
+++ b/remixes/stations.py
@@ -1,10 +1,10 @@
-"""_fs -- scratch: the FILTER STATION beside the reverb bus, for its gates.
+"""stations -- the BamSep26 stations beside the reverb bus, as they land.
 
 A station is a bus client, so it needs a bus to render into: the reverb
 server and SEND (the fallback). FILTER is replaced by the station, so its
 727 words are ground; every other stock effect keeps its code.
 """
 from remix.schema import Remix
-REMIX = Remix(name="_fs", doc="scratch: FILTER STATION + ChonVerb + SEND",
+REMIX = Remix(name="stations", doc="the stations so far (FILTER STATION) + ChonVerb + SEND",
               modules=("REVERB SERVER", "SEND", "FILTER STATION"), fallback="SEND",
               fx1=("FILTER STATION", "DJ EQ", "COMPRESSOR", "LO-FI"))

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -1138,21 +1138,37 @@ def main():
             # image pinned -- and with six it clears the clone block that
             # used to run straight into them.
             _c = dataclasses.replace(_c, cave_addr=(_cave_top + 0x7f) & ~0x7f)
-        assert _c.cave_addr >= _cave_top, f"{_c.label} overlaps what precedes it"
-        assert _c.cave_addr + len(_b) <= cave_limit, \
-            "past the stock zero run (or into the long chooser list)"
+        # ⚠️ A CAVE MAY LIVE OUTSIDE THE CLONE WINDOW. The region from
+        # CLONE_BASE to the chooser list is crowded -- six descriptor clones
+        # and fifteen label formatters left 84 bytes on the rig -- and
+        # docs/MAINMENU.md names two other unclaimed runs. A cave pinned into
+        # one of those is checked for being FREE (below) and for not
+        # overlapping another module's cave (the ledger), but it neither
+        # follows nor advances this region's cursor.
+        _inside = CLONE_BASE <= _c.cave_addr < cave_limit
+        if _inside:
+            assert _c.cave_addr >= _cave_top, \
+                f"{_c.label} overlaps what precedes it"
+            assert _c.cave_addr + len(_b) <= cave_limit, \
+                "past the stock zero run (or into the long chooser list)"
         if _c.hook_addr is not None:
             got = bytes(img[_c.hook_addr - BASE:
                             _c.hook_addr - BASE + len(_c.hook_stock)])
             if got != _c.hook_stock:
                 sys.exit(f"{_c.label} hook site 0x{_c.hook_addr:08x} is not "
                          f"stock ({got.hex()}) -- refusing")
+        _pokes = ()
+        if _c.emit is not None:
+            # A cave that points at itself: its bytes are a function of the
+            # address the line above just resolved (schema.CavePatch.emit).
+            _b, _pokes = _c.emit(_c.cave_addr)
         if any(img[_c.cave_addr - BASE:_c.cave_addr - BASE + len(_b)]):
             sys.exit(f"{_c.label} not free")
         # The bytes are PINNED so the build needs no m68k toolchain; when one
         # is present the source is re-assembled and compared, so a source that
         # has drifted from what we ship cannot pass unnoticed.
-        if (_c.source and not _replay and shutil.which("m68k-elf-as")
+        if (_c.source and _c.emit is None and not _replay
+                and shutil.which("m68k-elf-as")
                 and shutil.which("m68k-elf-objcopy")):
             with tempfile.TemporaryDirectory() as td:
                 o, bp = os.path.join(td, "c.o"), os.path.join(td, "c.bin")
@@ -1165,6 +1181,14 @@ def main():
                              f"pinned bytes -- re-pin them in the "
                              f"manifest deliberately")
         img[_c.cave_addr - BASE:_c.cave_addr - BASE + len(_b)] = _b
+        for _pa, _expect, _write in _pokes:
+            _got = bytes(img[_pa - BASE:_pa - BASE + len(_expect)])
+            if _got != _expect:
+                sys.exit(f"{_c.label}: 0x{_pa:08x} holds {_got.hex()}, not "
+                         f"stock {_expect.hex()} -- refusing to write over a "
+                         f"table that is not where we think it is")
+            img[_pa - BASE:_pa - BASE + len(_write)] = _write
+            print(f"    poke 0x{_pa:08x}: {_expect.hex()} -> {_write.hex()}")
         if _c.hook_addr is not None:
             img[_c.hook_addr - BASE:_c.hook_addr - BASE + 10] = \
                 b"\x4e\xb9" + _c.cave_addr.to_bytes(4, "big") + b"\x4e\x71\x4e\x71"
@@ -1179,7 +1203,8 @@ def main():
                  if _c.hook_addr is not None else "")
         print(f"  {_c.label}: {len(_b)} bytes at 0x{_c.cave_addr:08x}"
               f"{_hook}{_c.report_note}")
-        _cave_top = _c.cave_addr + len(_b)
+        if _inside:
+            _cave_top = _c.cave_addr + len(_b)
 
     # ---- PLAN §6: the mode selects print their WORDS ---------------------
     # Every stepped select drew as a bare number -- WarpFold's MODE as `1 2 3`

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -2237,12 +2237,31 @@ mkgo:""",
         if delay_src is not None:
             _texts["DELAY SERVER"] = delay_src
         # Any other selected module with DSP code loads straight from its
-        # manifest's source and gets no bus treatment, but MAY declare its own
-        # DEV repro hooks below -- the generic version of the arms the three
+        # manifest's source. A module that is a BUS CLIENT without being one
+        # of the three (a BamSep26 station: Harness.bus_client on an insert)
+        # gets the one bus treatment it needs -- its `$9xx` scratch literals
+        # relocated to the shared window under XBUS, exactly SEND's regex --
+        # and NOT the housekeeping gate, because a station never elects (its
+        # source has no XBUS_GATE marker and reads the rotation only). Its
+        # ROTINIT / ROTLATCH markers are substituted by _prep like SEND's.
+        # It MAY also declare its own DEV repro hooks below -- the generic version of the arms the three
         # core sources have at the top of main().
         for _k in ORDER:
             if _k not in _texts and _k in ASM_SRC:
-                _texts[_k] = _dev_hooks(_k, pathlib.Path(ASM_SRC[_k]).read_text())
+                _src_k = _dev_hooks(_k, pathlib.Path(ASM_SRC[_k]).read_text())
+                _mk = remix_modules().get(_k)
+                if (_x and _mk is not None and _mk.harness is not None
+                        and _mk.harness.bus_client):
+                    _n9 = len(re.findall(r"\$9[0-9a-f]{2}\b", _src_k))
+                    if not _n9:
+                        sys.exit(f"XBUS: {_k} is a bus client with no bus scratch "
+                                 f"literals to move")
+                    _src_k = re.sub(r"\$9([0-9a-f]{2})\b",
+                                    lambda m: "$%x" % (XBUS_BASE + int(m.group(1), 16)),
+                                    _src_k)
+                    print(f"  XBUS: {_k} -- {_n9} scratch refs moved to 0x{XBUS_BASE:x}, "
+                          f"a client that never housekeeps")
+                _texts[_k] = _src_k
 
         def _ybase(m, src):
             if DEV and m.dsp.dev_pin_ybase is not None:

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -99,6 +99,7 @@ from remix.schema import (DEFAULT_HARVEST, NO_FALLBACK, BusRole,  # noqa: E402
 from remix.state import fx1_hazard  # noqa: E402
 from remix import stock as stock_mod  # noqa: E402
 import label_fmt  # noqa: E402
+import mode_names  # noqa: E402
 from remix import ledger  # noqa: E402
 
 OUT = pathlib.Path("out/mainos_bus.bin")
@@ -1200,8 +1201,20 @@ def main():
         for _i, _p in enumerate(_MODS[name].params):
             if not (_p.active and _p.labels):
                 continue
-            _bytes = label_fmt.emit(_p.labels)
-            label_fmt.verify(_p.labels)
+            # A MODE select with views gets the BIGGER cave: it renames the
+            # knobs around it before printing its own word, so the panel
+            # stops calling BongDelay's grain scatter "MDEP" (tools/
+            # mode_names.py). Everything else keeps the plain label cave.
+            _mod = _MODS[name]
+            _ren = (mode_names.complete(_mod)
+                    if _i == _mod.mode_slot and _mod.mode_views else {})
+            if _ren:
+                _desc = clone_addr[name] + mode_names.NAMES_AT
+                _bytes = mode_names.emit(_p.labels, _desc, _ren)
+                mode_names.verify(_p.labels, _desc, _ren)
+            else:
+                _bytes = label_fmt.emit(_p.labels)
+                label_fmt.verify(_p.labels)
             if _lbl_top + len(_bytes) > cave_limit:
                 sys.exit(f"label formatters do not fit: {name} slot {_i} "
                          f"needs {len(_bytes)} B at 0x{_lbl_top:08x}, limit "
@@ -1211,11 +1224,12 @@ def main():
             img[_lbl_top - BASE:_lbl_top - BASE + len(_bytes)] = _bytes
             wr32(clone_addr[name] + 0x0ca + _i * 4, _lbl_top)
             _lbl.append((name, _i, _p.name.decode("latin1"), _lbl_top,
-                         len(_bytes), _p.labels))
+                         len(_bytes), _p.labels, bool(_ren)))
             _lbl_top += len(_bytes)
-    for _n, _i, _nm, _a, _sz, _labels in _lbl:
+    for _n, _i, _nm, _a, _sz, _labels, _rn in _lbl:
         print(f"  {_n:13s} slot {_i:<2} {_nm:<5} prints "
-              f"{'|'.join(_labels)}  ({_sz} B at 0x{_a:08x})")
+              f"{'|'.join(_labels)}  ({_sz} B at 0x{_a:08x})"
+              + (" + RENAMES its neighbours per mode" if _rn else ""))
     if _lbl:
         print(f"  {len(_lbl)} label formatters, "
               f"0x{max(_cave_top, cave_end):08x}..0x{_lbl_top:08x} "

--- a/tools/mode_names.py
+++ b/tools/mode_names.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""A MODE select's formatter that also RENAMES the knobs around it.
+
+A multi-mode effect reuses its knobs. BongDelay's MDEP is the tape modulation
+depth in CLEAN and the grain scatter in GRAIN; its MRAT is the modulation rate
+and the grain density. The panel printed one name for both meanings until
+this existed, and Sam said so plainly (3 Sep 2026): *"can we label the depth
+and rate to make it clear it's mod depth and mod rate not effect depth"*, and
+then *"it's only got four settings ... just feels a lil confusing"*.
+
+WHERE THE NAMES LIVE. `docs/PARAM_PAGES.md`: a descriptor carries its twelve
+parameter names as **12 x 6 bytes at E+0x4e**, NUL-padded. Our clones sit in
+the ColdFire cave region and are ordinary writable RAM, so a rename is six
+bytes copied into the clone.
+
+WHY THE MODE FORMATTER IS THE HOOK, and this is the whole trick: PLAN §6
+already gives every stepped select a cave of its own, called by the panel as
+`fmt(buf, value)` **with the value in hand** whenever the page draws that
+slot. So the rename needs no new hook site, no per-frame writer, no decode of
+which track is selected and no read of the part -- the panel hands us the
+mode, and we write the names before printing its word.
+
+⚠️ ONE DRAW LATE, BY CONSTRUCTION. If the panel draws the other slots' names
+BEFORE it formats the MODE value, a rename lands on the next redraw rather
+than this one. Turning the encoder redraws immediately, so it is invisible in
+use -- but it is inferred, not measured, and the falsifier is a panel that
+shows the old names until you touch something else.
+
+⚠️ AND IT RENAMES THE DESCRIPTOR, WHICH IS SHARED BY EVERY TRACK. Two tracks
+running the same effect in different modes have one set of names between
+them: whichever drew last wins. The panel draws one track at a time, so what
+you are looking at is right; what a photograph of another track's page would
+have shown is not.
+
+The bytes are EMITTED here rather than assembled, the same discipline as
+tools/label_fmt.py and for the same reason: the build must not need an m68k
+toolchain. `verify()` re-derives them through `m68k-elf-as -mcpu=5407`
+whenever one is on PATH, and `make check` runs it.
+"""
+from __future__ import annotations
+
+SPRINTF = 0x40013a08
+NAMES_AT = 0x4e                    # descriptor + 0x4e = 12 x 6-byte names
+NAME_LEN = 6
+CODE_LEN = 88                      # rtab starts here: the code runs to the jmp
+
+
+def _blocks(renames: dict[int, dict[int, bytes]], modes: int) -> list[bytes]:
+    """One 8-byte record per renamed slot, per mode: slot, pad, six name bytes.
+
+    EIGHT, not six: the copy is a move.l plus a move.w, and ColdFire wants
+    those aligned. The pad byte is what keeps every record on an even
+    boundary however many slots a mode renames.
+    """
+    out = []
+    for m in range(modes):
+        rec = b""
+        for slot in sorted(renames.get(m, {})):
+            nm = renames[m][slot]
+            if len(nm) > NAME_LEN - 1:
+                raise ValueError(f"mode {m} slot {slot}: {nm!r} is longer than "
+                                 f"{NAME_LEN - 1} characters")
+            rec += bytes([slot, 0]) + nm.ljust(NAME_LEN, b"\0")
+        out.append(rec + b"\xff\x00" + b"\0" * 6)      # terminator, padded
+    return out
+
+
+def emit(labels: tuple[str, ...], desc: int,
+         renames: dict[int, dict[int, bytes]]) -> bytes:
+    """The cave for a MODE select: rename the neighbours, then print the word.
+
+    labels  -- what each value prints, exactly as tools/label_fmt.py takes it
+    desc    -- the descriptor whose names are rewritten (our clone's address)
+    renames -- {mode value: {slot: 4-char name}}, already made COMPLETE by the
+               caller: every mode must restore every slot any mode renames, or
+               a name would stick after the mode that set it.
+    """
+    n = len(labels)
+    if not 1 <= n <= 128:
+        raise ValueError(f"a select needs 1..128 labels, got {n}")
+    for s in labels:
+        if "%" in s or not s.isascii():
+            raise ValueError(f"label {s!r}: the label IS the format string")
+    blocks = _blocks(renames, n)
+    # rtab and tab are both offset tables, each relative to ITS OWN address,
+    # so the cave stays position independent wherever the placer puts it.
+    rtab, rblob, off = b"", b"", 2 * n
+    for b in blocks:
+        rtab += off.to_bytes(2, "big")
+        rblob += b
+        off += len(b)
+    tab, blob, off = b"", b"", 2 * n
+    for s in labels:
+        tab += off.to_bytes(2, "big")
+        enc = s.encode("ascii") + b"\0"
+        blob += enc
+        off += len(enc)
+    # The pc-relative displacement to `tab`. ⚠️ MEASURED FROM THE
+    # INSTRUCTION'S OWN ADDRESS, not from its extension word -- checked
+    # against m68k-elf-as, which is the only reason this is right (the first
+    # attempt was 6 bytes long and would have indexed off the end of the
+    # table into the strings).
+    tab_disp = (CODE_LEN - 64) + len(rtab) + len(rblob)
+    code = bytes([
+        0x20, 0x2f, 0x00, 0x08,                       # move.l 8(sp),d0
+        0x0c, 0x80, *n.to_bytes(4, "big"),            # cmp.l  #n,d0
+        0x65, 0x02,                                   # blo.s  ok
+        0x70, 0x00,                                   # moveq  #0,d0
+        0x43, 0xfa, 0x00, 0x4a,                       # lea    rtab(pc),a1
+        0x32, 0x31, 0x0a, 0x00,                       # move.w (a1,d0.l*2),d1
+        0x02, 0x81, 0x00, 0x00, 0xff, 0xff,           # and.l  #0xffff,d1
+        0xd3, 0xc1,                                   # adda.l d1,a1
+        0x12, 0x19,                                   # move.b (a1)+,d1
+        0x0c, 0x01, 0x00, 0xff,                       # cmpi.b #0xff,d1
+        0x67, 0x1a,                                   # beq.s  rdn
+        0x52, 0x89,                                   # addq.l #1,a1
+        0x02, 0x81, 0x00, 0x00, 0x00, 0xff,           # and.l  #0xff,d1
+        0xc2, 0xfc, 0x00, 0x06,                       # mulu.w #6,d1
+        0x41, 0xf9, *desc.to_bytes(4, "big"),         # lea    desc+0x4e,a0
+        0xd1, 0xc1,                                   # adda.l d1,a0
+        0x20, 0xd9,                                   # move.l (a1)+,(a0)+
+        0x30, 0xd9,                                   # move.w (a1)+,(a0)+
+        0x60, 0xde,                                   # bra.s  rlp
+        0x41, 0xfa, *tab_disp.to_bytes(2, "big"),     # lea    tab(pc),a0
+        0x32, 0x30, 0x0a, 0x00,                       # move.w (a0,d0.l*2),d1
+        0x02, 0x81, 0x00, 0x00, 0xff, 0xff,           # and.l  #0xffff,d1
+        0xd1, 0xc1,                                   # adda.l d1,a0
+        0x2f, 0x48, 0x00, 0x08,                       # move.l a0,8(sp)
+        0x4e, 0xf9, *SPRINTF.to_bytes(4, "big"),      # jmp    sprintf
+    ])
+    out = code + rtab + rblob + tab + blob
+    return out + b"\0" * (len(out) % 2)
+
+
+def source(labels: tuple[str, ...], desc: int,
+           renames: dict[int, dict[int, bytes]]) -> str:
+    """The same cave as assembler, for verify() and for a human reading it."""
+    n = len(labels)
+    blocks = _blocks(renames, n)
+    rt = ",".join(f"r{i}-rtab" for i in range(n))
+    tb = ",".join(f"s{i}-tab" for i in range(n))
+    rb = "\n".join(
+        f"r{i}:     .byte   " + ",".join(str(b) for b in blocks[i])
+        for i in range(n))
+    ss = "\n".join(f's{i}:     .asciz  "{s}"' for i, s in enumerate(labels))
+    return (f'        .text\n'
+            f'fmt:    move.l  8(%sp),%d0\n'
+            f'        cmp.l   #{n},%d0\n'
+            f'        blo.s   ok\n'
+            f'        moveq   #0,%d0\n'
+            f'ok:     lea     rtab(%pc),%a1\n'
+            f'        move.w  (%a1,%d0.l*2),%d1\n'
+            f'        and.l   #0xffff,%d1\n'
+            f'        adda.l  %d1,%a1\n'
+            f'rlp:    move.b  (%a1)+,%d1\n'
+            f'        cmpi.b  #0xff,%d1\n'
+            f'        beq.s   rdn\n'
+            f'        addq.l  #1,%a1\n'
+            f'        and.l   #0xff,%d1\n'
+            f'        mulu.w  #{NAME_LEN},%d1\n'
+            f'        lea     0x{desc:08x},%a0\n'
+            f'        adda.l  %d1,%a0\n'
+            f'        move.l  (%a1)+,(%a0)+\n'
+            f'        move.w  (%a1)+,(%a0)+\n'
+            f'        bra.s   rlp\n'
+            f'rdn:    lea     tab(%pc),%a0\n'
+            f'        move.w  (%a0,%d0.l*2),%d1\n'
+            f'        and.l   #0xffff,%d1\n'
+            f'        adda.l  %d1,%a0\n'
+            f'        move.l  %a0,8(%sp)\n'
+            f'        jmp     0x{SPRINTF:08x}\n'
+            f'rtab:   .word   {rt}\n'
+            f'{rb}\n'
+            f'tab:    .word   {tb}\n'
+            f'{ss}\n'
+            f'        .balign 2\n')
+
+
+def verify(labels: tuple[str, ...], desc: int,
+           renames: dict[int, dict[int, bytes]]) -> None:
+    """Re-derive emit() through the real assembler. No-op without one."""
+    import os, pathlib, shutil, subprocess, tempfile
+    if not (shutil.which("m68k-elf-as") and shutil.which("m68k-elf-objcopy")):
+        return
+    with tempfile.TemporaryDirectory() as td:
+        s = os.path.join(td, "m.s")
+        pathlib.Path(s).write_text(source(labels, desc, renames))
+        o, b = os.path.join(td, "m.o"), os.path.join(td, "m.bin")
+        subprocess.run(["m68k-elf-as", "-mcpu=5407", "-o", o, s], check=True)
+        subprocess.run(["m68k-elf-objcopy", "-O", "binary", "-j", ".text",
+                        o, b], check=True)
+        want = pathlib.Path(b).read_bytes()
+        got = emit(labels, desc, renames)
+        if got[:len(want)] != want:
+            raise SystemExit(
+                f"mode_names.emit disagrees with m68k-elf-as:\n"
+                f"  emitted   {got[:len(want)].hex(' ')}\n"
+                f"  assembled {want.hex(' ')}")
+
+
+def complete(mod) -> dict[int, dict[int, bytes]]:
+    """Every mode's FULL rename set for the slots ANY of its views touches.
+
+    A sparse table would leave a name behind: land on GRAIN (MDEP -> SCAT),
+    go back to CLEAN, and the knob would still read SCAT because CLEAN never
+    said otherwise. So each mode restores the Param's own name for every slot
+    any view renames.
+    """
+    touched = sorted({sl for v in mod.mode_views for sl in v.names})
+    if not touched:
+        return {}
+    out = {}
+    n = mod.params[mod.mode_slot].count or len(mod.mode_views)
+    for m in range(n):
+        v = mod.view_for(m)
+        out[m] = {sl: (v.names.get(sl) if v else None) or mod.params[sl].name
+                  for sl in touched}
+    return out

--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -702,9 +702,25 @@ class RemixerScreen(Screen):
         rows = [("SOURCE", None)]
         if mod is None or not mod.params:
             return rows
-        return rows + [(n, sl) for n, sl in sorted(mod.knob_map().items(),
+        # ⚠️ THE NAMES FOLLOW THE MODE. A multi-mode effect reuses knobs, and
+        # a bench that prints one name for both meanings is lying half the
+        # time -- BongDelay's MDEP is the tape depth in CLEAN and the grain
+        # scatter in GRAIN. Module.knob_map_in() is the same table the
+        # ColdFire cave is emitted from, so the panel and the bench agree.
+        kmap = mod.knob_map_in(self.mode_of(mod))
+        return rows + [(n, sl) for n, sl in sorted(kmap.items(),
                                                    key=lambda kv: kv[1])
                        if mod.params[sl].active]
+
+    def mode_of(self, mod):
+        """This module's current MODE value in the bench, or None."""
+        if mod is None or mod.mode_slot is None:
+            return None
+        vals = self.app.state.knobs_for(mod)
+        for nm, sl in mod.knob_map().items():
+            if sl == mod.mode_slot:
+                return vals.get(nm, mod.params[sl].default or 0)
+        return None
 
     @staticmethod
     def dry_control(mod, vals):
@@ -1686,13 +1702,17 @@ class RemixerScreen(Screen):
                     cur_line = len(out)
                 out.append(f"[reverse]{line}[/]" if here else line)
                 continue
-            v = vals.get(name, 0)
-            hi = rig.knob_max(mod, name)
+            # ⚠️ THE DISPLAY NAME IS NOT THE STORAGE KEY. A mode view renames
+            # a slot (MDEP -> SCAT in GRAIN); storing under the display name
+            # would make the value look reset every time the mode moved.
+            canon = mod.canon_name(slot)
+            v = vals.get(canon, 0)
+            hi = rig.knob_max(mod, canon)
             if hi < 8:
                 # A SELECT reads as a word, not a level, so it gets the
                 # accent and a flat bar -- no fill to imply a range it does
                 # not have.
-                shown = f"[{WARN}]{step_label(mod, name, v):<7}[/]"
+                shown = f"[{WARN}]{step_label(mod, canon, v):<7}[/]"
                 bar = f"[{LCD}]" + "·" * 12 + "[/]"
             else:
                 shown = f"{v:>3}    "
@@ -1992,10 +2012,24 @@ class RemixerScreen(Screen):
                                         % len(files)]
             return
         vals = st.knobs_for(mod)
-        hi = rig.knob_max(mod, name)
+        slot = knobs[min(self.cur[UNIT], len(knobs) - 1)][1]
+        canon = mod.canon_name(slot)          # the store's key, not the label
+        hi = rig.knob_max(mod, canon)
         if abs(step) == 1:
-            step = self._accel(step, name, hi)
-        vals[name] = max(0, min(hi, vals.get(name, 0) + step))
+            step = self._accel(step, canon, hi)
+        vals[canon] = max(0, min(hi, vals.get(canon, 0) + step))
+        # ⚠️ A MODE CHANGE RE-DEFAULTS THE OTHER KNOBS (Sam, 3 Sep 2026: "can
+        # you adjust all of the settings to their defaults when they switch").
+        # Landing on GRAIN with the tape depth still where CLEAN left it is
+        # not a starting point, it is a puzzle. Only slots the view names are
+        # touched; everything else the operator dialled survives.
+        if mod.mode_slot is not None and slot == mod.mode_slot:
+            view = mod.view_for(vals[canon])
+            if view is not None:
+                by_slot = {sl: nm for nm, sl in mod.knob_map().items()}
+                for slot, val in view.defaults.items():
+                    if slot in by_slot:
+                        vals[by_slot[slot]] = val
 
     def move_row(self, step):
         """Reorder the loaded pane -- chooser ORDER is the panel's row order,

--- a/tools/remix/rig.py
+++ b/tools/remix/rig.py
@@ -302,13 +302,14 @@ def knob_doc(mod, name: str) -> str:
 
 def knob_labels(mod, name: str):
     """Per-value labels for a select, or None for a plain dial."""
-    return mod.params[mod.knob_map()[name]].labels
+    return mod.params[mod.knob_map_all()[name]].labels
 
 
 def knob_max(mod, name: str) -> int:
     """Highest legal value: count-1 where the manifest states a count,
-    else the stock 0..127 dial."""
-    slot = mod.knob_map()[name]
+    else the stock 0..127 dial. Accepts a MODE-view alias (SCAT for MDEP)
+    as well as the Param's own name."""
+    slot = mod.knob_map_all()[name]
     count = mod.params[slot].count
     return (count - 1) if count is not None else 127
 

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -335,6 +335,20 @@ class CavePatch:
     hook_addr: int | None = None        # where the jsr is planted
     hook_stock: bytes = b""             # bytes that MUST be there first
     registers_formatter: FormatterReg | None = None
+    # ---- a cave whose CONTENT depends on where it lands -------------------
+    # `pinned` is bytes decided before the build. A cave that contains
+    # POINTERS TO ITSELF -- a relocated menu row array, whose rows name their
+    # own labels and handlers -- cannot be: its bytes are a function of its
+    # address, and since 3 Sep 2026 addresses float. So a module may hand the
+    # build a callable instead:
+    #
+    #     emit(addr) -> (bytes, ((poke_addr, expect_stock, write), ...))
+    #
+    # The build resolves the address, calls it, plants the bytes, then asserts
+    # each poke site still holds the stock bytes before writing -- the same
+    # discipline `hook_stock` applies to a hook site, for the same reason: a
+    # table that has moved under us must stop the build, not be written over.
+    emit: object | None = None
     # Trailing prose for this cave's line in the build report, separator
     # included. The installer is generic; what a given cave actually DOES is
     # not, and the build report is the only place a human sees it.

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -56,6 +56,11 @@ STOCK_FX2_IDS = frozenset({0x04, 0x05, 0x08, 0x0c, 0x0d, 0x10, 0x11, 0x12,
                            0x13, 0x14, 0x15, 0x16, 0x18, 0x19, 0x1c})
 
 
+# Page 2 is knob/select/knob/select/knob/select, so only these three slots
+# can carry a stepped select -- and therefore a MODE.
+STEPPED_ONLY = (7, 9, 11)
+
+
 class YBase(Enum):
     """When a module's `$30000` literal is rewritten to the payload's own base.
 
@@ -435,6 +440,46 @@ class Harness:
 
 
 @dataclass(frozen=True)
+class ModeView:
+    """What ONE position of a module's MODE select renames and re-defaults.
+
+    A multi-mode effect reuses knobs: BongDelay's MDEP is the tape modulation
+    depth in CLEAN and the grain scatter in GRAIN, and a panel that prints
+    MDEP in both is telling the operator the wrong thing half the time (Sam,
+    3 Sep 2026: "it's only got four settings ... just feels a lil confusing").
+
+    `names` renames slots for this mode -- 4 characters, the field's width,
+    exactly as MenuEntry.abbr is. `defaults` is what the OTHER knobs should
+    be when the operator lands on this mode; the remixer applies them the
+    moment MODE changes, and on the unit the same table drives the cave.
+
+    Both are SPARSE: a slot absent from `names` keeps the name its Param
+    declares, and a slot absent from `defaults` keeps whatever the operator
+    had. Only name a slot whose meaning actually changes.
+    """
+
+    mode: int                                   # the select value
+    names: dict[int, bytes] = field(default_factory=dict)
+    defaults: dict[int, int] = field(default_factory=dict)
+
+    def __post_init__(self):
+        for slot, nm in self.names.items():
+            if not 0 <= slot <= 11:
+                raise ValueError(f"mode {self.mode}: slot {slot} is not 0..11")
+            if len(nm) > 4:
+                raise ValueError(
+                    f"mode {self.mode}: name {nm!r} is {len(nm)} characters; "
+                    f"the field holds FOUR plus a terminator (the 'HELL' "
+                    f"crash, CLAUDE.md)")
+        for slot, val in self.defaults.items():
+            if not 0 <= slot <= 11:
+                raise ValueError(f"mode {self.mode}: slot {slot} is not 0..11")
+            if not 0 <= val <= 127:
+                raise ValueError(f"mode {self.mode}: default {val} for slot "
+                                 f"{slot} is outside 0..127")
+
+
+@dataclass(frozen=True)
 class Module:
     """One contribution, as declared by modules/<name>/manifest.py."""
 
@@ -451,11 +496,38 @@ class Module:
     cf_patches: tuple[CavePatch, ...] = ()
     claims: Claims | None = None
     harness: Harness | None = None
+    # Which slot carries the MODE select, and what each of its positions
+    # renames and re-defaults. Empty for a single-engine module.
+    mode_slot: int | None = None
+    mode_views: tuple[ModeView, ...] = ()
 
     def __post_init__(self):
         if self.params and len(self.params) != 12:
             raise ValueError(f"{self.name}: expected 12 param slots, "
                              f"got {len(self.params)}")
+        if self.mode_views and self.mode_slot is None:
+            raise ValueError(f"{self.name}: mode_views without a mode_slot")
+        if self.mode_slot is not None:
+            if self.mode_slot not in STEPPED_ONLY:
+                raise ValueError(
+                    f"{self.name}: mode_slot {self.mode_slot} -- a select can "
+                    f"only sit on slot {', '.join(map(str, STEPPED_ONLY))}")
+            _cnt = self.params[self.mode_slot].count if self.params else None
+            _seen = set()
+            for v in self.mode_views:
+                if v.mode in _seen:
+                    raise ValueError(f"{self.name}: two views for mode {v.mode}")
+                _seen.add(v.mode)
+                if _cnt is not None and v.mode >= _cnt:
+                    raise ValueError(
+                        f"{self.name}: a view for mode {v.mode}, but the "
+                        f"select has {_cnt} positions")
+                for slot, val in v.defaults.items():
+                    _c = self.params[slot].count if self.params else None
+                    if _c is not None and val >= _c:
+                        raise ValueError(
+                            f"{self.name}: mode {v.mode} defaults slot {slot} "
+                            f"to {val}, past its {_c} positions")
         if (self.menu is not None and self.kind is not Kind.STOCK
                 and self.menu.fx2_id in STOCK_FX2_IDS
                 and not self.menu.replaces):
@@ -488,6 +560,45 @@ class Module:
                 raise ValueError(
                     f"{self.name}: slot {i} is stepped, but the companion "
                     f"byte fields are slots 7, 9 and 11")
+
+    def view_for(self, mode: int):
+        """The ModeView for a MODE value, or None. Unknown values fall back
+        to the declared names, the same way every mode decode on the DSP side
+        treats an unexpected select as its default engine."""
+        for v in self.mode_views:
+            if v.mode == mode:
+                return v
+        return None
+
+    def knob_map_in(self, mode: int | None = None) -> dict[str, int]:
+        """knob_map(), but with this MODE's renames applied. The remixer draws
+        from here and the ColdFire cave is emitted from the same table, so the
+        panel and the bench cannot drift apart."""
+        base = self.knob_map()
+        v = self.view_for(mode) if mode is not None else None
+        if v is None:
+            return base
+        by_slot = {sl: nm for nm, sl in base.items()}
+        by_slot.update({sl: nm.decode("latin1") for sl, nm in v.names.items()})
+        return {nm: sl for sl, nm in by_slot.items()}
+
+    def knob_map_all(self) -> dict[str, int]:
+        """Every name a slot answers to: its own, plus each MODE view's alias.
+        The test harness resolves `--set SCAT=40` through this, so a name the
+        panel prints is a name the bench accepts."""
+        out = dict(self.knob_map())
+        for v in self.mode_views:
+            for slot, nm in v.names.items():
+                out.setdefault(nm.decode("latin1"), slot)
+        return out
+
+    def canon_name(self, slot: int) -> str:
+        """The Param's OWN name for a slot -- what knob values are stored
+        under, whatever the current mode calls it."""
+        for nm, sl in self.knob_map().items():
+            if sl == slot:
+                return nm
+        return ""
 
     @property
     def active_params(self) -> list[int]:

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -450,9 +450,18 @@ def main():
              # the BamSep26 stations beside the reverb: FILTER is REPLACED
              # (its words are the station's ground) and the FX1 list keeps
              # only DJ EQ, COMPRESSOR and LO-FI, so ten of thirteen go
+             # the three stations take FILTER, LO-FI and CHORUS by name and
+             # nothing else is listed, so all thirteen go: one 6,158-word run.
+             # bamsep26 is the rig and has the same shape (stock DELAY is on
+             # its chooser, but it has no DSP code to give up).
+             "bamsep26": ("FILTER", "SPATIALIZER", "EQUALIZER", "PHASER",
+                          "FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
+                          "DARK REV", "COMPRESSOR", "LO-FI", "DJ EQ",
+                          "COMB FILTER"),
              "stations": ("FILTER", "SPATIALIZER", "EQUALIZER", "PHASER",
                           "FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
-                          "DARK REV", "COMB FILTER")}
+                          "DARK REV", "COMPRESSOR", "LO-FI", "DJ EQ",
+                          "COMB FILTER")}
     for _n in registry.remix_names():
         _r = registry.remix(_n)
         _hv = stock.region_of(stock.harvested(

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -446,7 +446,13 @@ def main():
              # THREE runs on purpose -- the multi-run worked example. Its
              # placement is checked for real below, not just its harvest.
              "scattered": ("SPATIALIZER", "FLANGER", "CHORUS", "PLATE REV",
-                           "SPRING REV", "DARK REV", "COMB FILTER")}
+                           "SPRING REV", "DARK REV", "COMB FILTER"),
+             # the BamSep26 stations beside the reverb: FILTER is REPLACED
+             # (its words are the station's ground) and the FX1 list keeps
+             # only DJ EQ, COMPRESSOR and LO-FI, so ten of thirteen go
+             "stations": ("FILTER", "SPATIALIZER", "EQUALIZER", "PHASER",
+                          "FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
+                          "DARK REV", "COMB FILTER")}
     for _n in registry.remix_names():
         _r = registry.remix(_n)
         _hv = stock.region_of(stock.harvested(

--- a/tools/send_probe.py
+++ b/tools/send_probe.py
@@ -761,7 +761,7 @@ def main():
             die(f"--set needs a render target -- pass --pick <letter> "
                 f"(one of {''.join(sorted(SERVER_ID))})")
         _mod = registry.by_id(SERVER_ID[_st])
-        kmap = _mod.knob_map()
+        kmap = _mod.knob_map_all()
         if _st == "R":
             base = rev
         elif _st == "D":
@@ -783,7 +783,7 @@ def main():
                 tgt_mod = registry.by_id(SERVER_ID[letter])
                 tgt_base = others.setdefault(
                     letter, list(MODULE_DEFAULTS.get(letter, [0] * 12)))
-            kmap2 = tgt_mod.knob_map()
+            kmap2 = tgt_mod.knob_map_all()
             name, _, val = spec.partition("=")
             name = name.strip().upper()
             if name not in kmap2:

--- a/tools/send_probe.py
+++ b/tools/send_probe.py
@@ -125,8 +125,8 @@ DELAY_ID = SERVER_ID.get("D")
 REV_FLAGS = {"time": "TIME", "mod": "MOD", "mix": "IN", "shmr": "SHMR",
              "rmode": "MODE", "width": "SHFT", "gate": "GATE", "rrate": "RATE"}
 DELAY_FLAGS = {"dtime": "TIME", "dfdbk": "FDBK", "dtone": "TONE",
-               "dping": "PING", "dvrbw": "-VRB", "dmix": "IN", "dwow": "DPTH",
-               "dmode": "MODE", "drate": "RATE", "dptch": "PTCH",
+               "dping": "PING", "dvrbw": "-VRB", "dmix": "PTCH", "dwow": "MDEP",
+               "dmode": "MODE", "drate": "MRAT", "dptch": "SIZE",
                "dspray": "DRV", "dfrz": "FRZE"}
 
 

--- a/tools/send_probe.py
+++ b/tools/send_probe.py
@@ -208,7 +208,7 @@ def entry_points(mem_path, fxid):
 def run(mem, dur, tail, rev_params, send_params, verbose=False, amp=0.5,
         direct=False, wave_src=None, split=0, layout='RS', delay_params=None,
         inall=False,
-        pick=None, tempo=None, insert_params=None):
+        pick=None, tempo=None, insert_params=None, feed=None):
     """-> instance 0 (the reverb) as a list of 24-bit ints, warm-up trimmed.
 
     direct=True is the CONTROL: no SEND instance at all, the tone goes into the
@@ -358,12 +358,17 @@ def run(mem, dur, tail, rev_params, send_params, verbose=False, amp=0.5,
         # every local render was blind to until 12 Aug 2026. --inall feeds
         # every live slot, so the delay's own dry is real and MIX can be
         # measured for what it does on the unit.
+        # `feed` names the letters whose tracks receive the tone (3 Sep
+        # 2026: a station sends from its OWN track, so the tone has to reach
+        # it and NOT the server, whose own dry would swamp the measurement).
         inmask = sum(1 << i for i, (_, c) in enumerate(live)
-                     if c == "S" or inall)
+                     if c == "S" or inall or (feed and c in feed))
         # The three the CLI has flags for keep their flag-driven values;
         # anything else falls back to what its own manifest declares.
         par = dict(MODULE_DEFAULTS)
         par.update({"R": rev_params, "S": send_params, "D": dpar})
+        if isinstance(insert_params, dict):     # per-letter overrides
+            par.update(insert_params)
         cmd = [str(HOST), "-mem", str(mem),
                "-init", ",".join(f"{entry(c)[0]:x}" for _, c in live),
                "-proc", ",".join(f"{entry(c)[1]:x}" for _, c in live),
@@ -664,6 +669,10 @@ def main():
     ap.add_argument("--direct", action="store_true",
                     help="CONTROL / the insert path: no SEND, tone straight "
                          "into the picked module's own track input")
+    ap.add_argument("--feed", default="", metavar="LETTERS",
+                    help="also feed the tone to these layout letters' tracks "
+                         "(a client insert sends from its own track); SENDs "
+                         "are always fed, --inall feeds everything")
     ap.add_argument("--set", action="append", default=[], metavar="NAME=VAL",
                     help="drive any knob of the RENDERED module by its "
                          "manifest name (repeatable). Resolved through the "
@@ -759,23 +768,42 @@ def main():
             base = dpar = list(dpar) if dpar is not None else list(DELAY_PARAMS)
         else:
             base = ins = list(MODULE_DEFAULTS.get(_st, [0] * 12))
+        # A `LETTER:NAME=VAL` spec drives ANOTHER live slot of a bus layout
+        # (3 Sep 2026, for the stations: a client insert's send level has to
+        # be set on the instance that sends, not on the server being
+        # measured). Per-letter lists ride `insert_params` as a dict.
+        others = {}
         for spec in a.set:
+            tgt_mod, tgt_base = _mod, base
+            if ":" in spec.split("=", 1)[0]:
+                letter, _, spec = spec.partition(":")
+                letter = letter.strip().upper()
+                if letter not in SERVER_ID:
+                    die(f"--set {letter}: is not a layout letter")
+                tgt_mod = registry.by_id(SERVER_ID[letter])
+                tgt_base = others.setdefault(
+                    letter, list(MODULE_DEFAULTS.get(letter, [0] * 12)))
+            kmap2 = tgt_mod.knob_map()
             name, _, val = spec.partition("=")
             name = name.strip().upper()
-            if name not in kmap:
-                die(f"{_mod.name} has no knob named {name!r} -- it has: "
-                    f"{' '.join(sorted(kmap))}")
-            slot = kmap[name]
+            if name not in kmap2:
+                die(f"{tgt_mod.name} has no knob named {name!r} -- it has: "
+                    f"{' '.join(sorted(kmap2))}")
+            slot = kmap2[name]
             v = int(val)
-            count = _mod.params[slot].count
+            count = tgt_mod.params[slot].count
             hi = (count - 1) if count is not None else 127
             if not 0 <= v <= hi:
-                die(f"{_mod.name} {name}={v} is out of range 0..{hi} -- a "
+                die(f"{tgt_mod.name} {name}={v} is out of range 0..{hi} -- a "
                     f"stepped select uses the value as an INDEX")
-            base[slot] = v
+            tgt_base[slot] = v
+        if others and not a.direct:
+            if ins is not None:
+                others[_st] = ins
+            ins = others
     L, R = run(mem, a.dur, a.tail, rev, snd, a.verbose, a.amp, a.direct, wsrc,
                a.split, a.layout, delay_params=dpar, pick=a.pick,
-               inall=a.inall, insert_params=ins)
+               inall=a.inall, insert_params=ins, feed=a.feed)
     # Where the tone stops, so the analysis window is the end of the TONE
     # rather than the silence after it -- see analyse().
     _tone_end = len(wsrc) if wsrc is not None else int(a.dur * SR)

--- a/tools/verify_charstation.py
+++ b/tools/verify_charstation.py
@@ -42,6 +42,16 @@ SR = 44100
 TMP = pathlib.Path("out/_chgate")
 TMP.mkdir(parents=True, exist_ok=True)
 
+# ⚠️ REBUILD THE DUMP, ALWAYS. The audition caches its scratch image against
+# the newest mtime under modules/, and a stale hit here does not fail -- it
+# silently measures the STOCK effect whose id this module replaces. That cost
+# an hour on 3 Sep 2026: every mode read as a dry pass, because the dump's
+# dispatch still pointed at stock CHORUS, and the emulator eventually died on
+# a stock instruction it does not implement.
+pathlib.Path(MEM).unlink(missing_ok=True)
+subprocess.run([sys.executable, "tools/remix/audition.py", MOD.name,
+                "out/dry/drums_110.wav"], capture_output=True)
+
 if not pathlib.Path(MEM).exists():
     sys.exit(f"no {MEM} -- build it first:\n"
              f"  python3 tools/remix/audition.py {MOD.name} out/dry/drums_110.wav")

--- a/tools/verify_charstation.py
+++ b/tools/verify_charstation.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""CHARACTER STATION render gates, with arithmetic you can predict.
+
+Renders the station straight through dsp_host (verify_hello's shape: the id
+and the slots come from the manifest, the entry points are checked against
+SEND's so an absent module cannot pass as a dry passthrough).
+
+Gates:
+  defaults    -> output bit-exact vs a full-scale bipolar ramp (the bypass)
+  MIX=0       -> bit-exact passthrough with the whole chain live
+  CRSH        -> the output is quantised: every sample a multiple of 2^k
+  SRR         -> /2 /4 /8 hold each sample exactly that many times
+  DRV/SAT     -> unity small-signal (a tiny input passes at gain 1 to 1 LSB),
+                 and every character is monotonic and bounded
+  FOLD        -> a full-scale ramp folds back: the output reverses direction
+  RING        -> at DC the output is DC * carrier, so its mean is ~0
+  COMP        -> gain reduction grows with level, and never inverts
+  TRNS        -> a step transient comes out LOUDER than steady state
+  WDTH        -> 0 = mono (L == R), 64 = untouched, 127 = doubled sides
+  every knob  -> renders without dsp_host dying
+
+The dump comes from the audition, which builds a scratch image that really
+contains this station beside SEND:
+
+    python3 tools/remix/audition.py charstation out/dry/drums_110.wav
+    python3 tools/verify_charstation.py
+"""
+import math, pathlib, struct, subprocess, sys
+
+sys.path.insert(0, "tools")
+import send_probe  # reuse its dispatch-table entry resolution
+from remix import registry
+
+MOD = registry.by_name("charstation")
+SEND = registry.by_name("send")
+K = MOD.knob_map()
+MEM = f"out/dsp/_audition_{MOD.name}_A.mem"
+HOST = "vendor/dsp56300/build/source/dsp_host/dsp_host"
+FXID = MOD.menu.fx2_id
+FRAMES, N = 15, 6000
+SR = 44100
+TMP = pathlib.Path("out/_chgate")
+TMP.mkdir(parents=True, exist_ok=True)
+
+if not pathlib.Path(MEM).exists():
+    sys.exit(f"no {MEM} -- build it first:\n"
+             f"  python3 tools/remix/audition.py {MOD.name} out/dry/drums_110.wav")
+
+init, proc = send_probe.entry_points(MEM, FXID)
+if (init, proc) == send_probe.entry_points(MEM, SEND.menu.fx2_id):
+    sys.exit(f"fx id 0x{FXID:02x} resolves to SEND's entry points -- {MOD.name} "
+             f"is NOT in this dump")
+print(f"entries from dispatch tables: init=P:0x{init:04x} proc=P:0x{proc:04x}")
+
+DEFAULTS = [(p.default or 0) for p in MOD.params]
+
+
+def params(**kw):
+    v = list(DEFAULTS)
+    for name, val in kw.items():
+        v[K[name]] = val
+    return v
+
+
+def render(samples, **kw):
+    """samples: MONO ints in Q23 -- dsp_host feeds one stream to both
+    channels (verify_hello's shape). Returns (L, R) lists."""
+    src = TMP / "ch_in.raw"
+    src.write_bytes(b"".join(struct.pack("<i", m) for m in samples))
+    out = TMP / "ch_out.raw"
+    cmd = [HOST, "-mem", MEM, "-init", f"{init:x}", "-proc", f"{proc:x}",
+           "-inst", "1", "-r7", "2", "-alloc", "1", "-inmask", "1",
+           "-frames", str(FRAMES), "-blocks", str(len(samples) // FRAMES),
+           "-in", str(src), "-out", str(out),
+           "-params", ",".join(str(x) for x in params(**kw))]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        sys.exit(f"dsp_host failed for {kw}:\n{r.stdout}\n{r.stderr}")
+    d = out.read_bytes()
+    w = struct.unpack(f"<{len(d)//4}i", d)
+    return list(w[0::2])[:len(samples)], list(w[1::2])[:len(samples)]
+
+
+def tone(hz, amp=0.4, n=N):
+    return [int(amp * 8388607 * math.sin(2 * math.pi * hz * i / SR)) for i in range(n)]
+
+
+def dc(level=0.25, n=N):
+    return [int(level * 8388607)] * n
+
+
+def rms_db(x, start=N // 2):
+    seg = x[start:]
+    return 20 * math.log10(max(1e-9, math.sqrt(sum((s / 8388607) ** 2 for s in seg) / len(seg))))
+
+
+def tail_mean(x, start=N * 3 // 4):
+    seg = x[start:]
+    return sum(seg) / len(seg)
+
+
+fails = 0
+def check(label, ok, detail=""):
+    global fails
+    print(f"  [{'PASS' if ok else 'FAIL'}] {label}{'  ' + detail if detail else ''}")
+    fails += 0 if ok else 1
+
+
+# ---- 1. defaults: bit-exact passthrough --------------------------------------
+ramp = [int(round(-8388607 + 2 * 8388607 * i / (N - 1))) for i in range(N)]
+L, R = render(ramp)
+check("defaults are a bit-exact passthrough (the bypass block)",
+      L == ramp and R == ramp,
+      "" if L == ramp else f"first diff at {next(i for i,(a,b) in enumerate(zip(L,ramp)) if a!=b)}")
+
+# ---- 2. MIX=0 with the whole chain live --------------------------------------
+L, R = render(ramp, MIX=0, DRV=127, FOLD=127, CRSH=127, COMP=127, RING=64, SRR=3)
+check("MIX=0 is a passthrough with every stage driven", L == ramp and R == ramp,
+      "" if L == ramp else f"first diff at {next(i for i,(a,b) in enumerate(zip(L,ramp)) if a!=b)}")
+
+# ---- 3. CRSH reduces the resolution -----------------------------------------
+# ⚠️ MEASURE THE WET, NOT THE OUTPUT, twice over: the saturator is a cubic
+# that fills the low bits back in, AND the mix law carries 1/128 of the live
+# dry, which is not quantised -- so every output sample is distinct however
+# hard the crush bites. The wet comes back exactly (out = dry/128 + wet*127/128)
+# and its DISTINCT LEVELS are what the crush actually sets.
+slow = [int(-8388607 + 2 * 8388607 * i / (N - 1)) for i in range(N)]
+def levels(crsh):
+    L, _ = render(slow, CRSH=crsh)
+    wet = [round((o - d / 128) * 128 / 127) for o, d in zip(L, slow)]
+    return len(set(wet[N//4:]))
+n_off, n_on = levels(1), levels(110)
+check("CRSH=110 collapses a ramp to a few levels", n_on * 8 < n_off,
+      f"{n_on} distinct wet levels against {n_off} at CRSH=0")
+
+# ---- 4. SRR holds each sample -----------------------------------------------
+# ⚠️ THE OUTPUT IS NOT HELD, THE WET IS. MIX=127 is 127/128, so the output
+# carries 1/128 of the live dry: out = dry/128 + wet*127/128. Recover the wet
+# exactly and look for its runs, rather than testing near-equality on a
+# signal that legitimately moves every sample.
+src = tone(438)
+for sel, hold in ((1, 2), (2, 4), (3, 8)):
+    L, _ = render(src, SRR=sel)
+    wet = [(o - d / 128) * 128 / 127 for o, d in zip(L, src)]
+    seg = [round(v) for v in wet[N//2:N//2 + 400]]
+    runs, cur = [], 1
+    for a, b in zip(seg, seg[1:]):
+        if abs(a - b) <= 2:
+            cur += 1
+        else:
+            runs.append(cur); cur = 1
+    typical = max(set(runs), key=runs.count) if runs else 0
+    check(f"SRR /{hold} holds the wet {hold} samples", typical == hold,
+          f"most common run {typical}")
+
+# ---- 5. saturation is unity small-signal and bounded -------------------------
+small = [int(0.001 * 8388607 * math.sin(2 * math.pi * 438 * i / SR)) for i in range(N)]
+for sat, name in ((0, "TAPE"), (1, "TUBE"), (2, "FUZZ"), (3, "BUS")):
+    L, _ = render(small, DRV=0, SAT=sat)
+    err = max(abs(a - b) for a, b in zip(L[N//2:], small[N//2:]))
+    check(f"SAT {name} is unity small-signal at DRV=0", err <= 40, f"max err {err} LSB")
+for sat, name in ((0, "TAPE"), (1, "TUBE"), (2, "FUZZ"), (3, "BUS")):
+    L, _ = render(tone(438, amp=0.9), DRV=127, SAT=sat)
+    check(f"SAT {name} stays bounded at DRV=127",
+          max(abs(v) for v in L) <= 8388607, f"peak {max(abs(v) for v in L)}")
+
+# ---- 6. FOLD folds a ramp back ----------------------------------------------
+L, _ = render(ramp, FOLD=127, DRV=0, SAT=0)
+turns = sum(1 for a, b, c in zip(L, L[1:], L[2:]) if (b - a > 0) != (c - b > 0))
+check("FOLD=127 folds a monotonic ramp (it changes direction many times)",
+      turns > 4, f"{turns} direction changes")
+
+# ---- 7. RING at DC: the output is DC * carrier, mean ~0 ----------------------
+L, _ = render(dc(), RING=64, DRV=0)
+m = abs(tail_mean(L, N // 4))
+check("RING at DC has ~zero mean (it is DC times a carrier)",
+      m < 0.05 * 0.25 * 8388607, f"mean {m:.0f} of {0.25*8388607:.0f}")
+
+# ---- 8. COMP reduces more as the level rises, and never inverts -------------
+quiet, _ = render(tone(438, amp=0.05), COMP=127, CMOD=0)
+loud, _ = render(tone(438, amp=0.9), COMP=127, CMOD=0)
+q0, _ = render(tone(438, amp=0.05), COMP=0)
+l0, _ = render(tone(438, amp=0.9), COMP=0)
+gr_q = rms_db(quiet) - rms_db(q0)
+gr_l = rms_db(loud) - rms_db(l0)
+check("COMP reduces the loud signal more than the quiet one",
+      gr_l < gr_q - 2, f"quiet {gr_q:+.1f} dB, loud {gr_l:+.1f} dB")
+unity, _ = render(tone(438, amp=0.3), COMP=0, CMOD=0)
+ref, _ = render(tone(438, amp=0.3), MIX=0)
+check("COMP=0 is unity gain (the halved-gain doubling is exact)",
+      abs(rms_db(unity) - rms_db(ref)) < 0.1,
+      f"{rms_db(unity) - rms_db(ref):+.2f} dB")
+
+# ---- 9. TRNS makes a transient louder than the steady state -----------------
+step_sig = [0] * (N // 2) + [int(0.15 * 8388607 * math.sin(2 * math.pi * 438 * i / SR)) for i in range(N // 2)]
+L, _ = render(step_sig, COMP=127, CMOD=2)
+onset = max(abs(v) for v in L[N//2:N//2 + 300])
+steady = max(abs(v) for v in L[-N//4:])
+check("TRNS boosts the onset above the steady state", onset > steady * 1.05,
+      f"onset {onset} vs steady {steady}")
+
+# ---- 10. WDTH -----------------------------------------------------------------
+# a stereo-different source: dsp_host feeds one stream to both channels, so
+# the width test rides on the RING carrier making L and R identical anyway --
+# what it can prove is that 0 collapses to mono and 64 leaves the pair alone.
+L, R = render(tone(438), WDTH=0, DRV=1)
+check("WDTH=0 is mono (L == R)", L == R, "")
+L64, R64 = render(tone(438), WDTH=64, DRV=1)
+Lref, _ = render(tone(438), DRV=1)
+check("WDTH=64 leaves the signal alone", L64 == Lref, "")
+
+# ---- 11. every knob at its extremes renders ----------------------------------
+for name in K:
+    for v in (0, 127 if MOD.params[K[name]].count in (None, 128) else MOD.params[K[name]].count - 1):
+        render(tone(438, n=600), **{name: v})
+check("every knob at both extremes renders", True)
+
+print(f"\n{fails} gate(s) failed" if fails else "\nOK")
+sys.exit(1 if fails else 0)

--- a/tools/verify_delay.py
+++ b/tools/verify_delay.py
@@ -94,10 +94,14 @@ SR = 44100
 # bit-compare (both sides got the same wrong knob) and wrong as a description
 # of what was exercised -- the same shape as the SLOT fix below, which landed
 # on 23 Aug and did not reach this line.
-BASE = [40, 60, 100, 64, 0, 90, 0, 0, 0, 0, 0, 0]
+# v5.1: slot 5 is PTCH (IN retired). 0 here so a pre-v5 REFERENCE gets
+# IN=0 and stays comparable; the GRAIN cases set PTCH explicitly.
+BASE = [40, 60, 100, 64, 0, 0, 0, 0, 0, 0, 0, 0]
 
-SLOT = {"TIME": 0, "FDBK": 1, "TONE": 2, "PING": 3, "MIX": 5,
-        "WOW": 6, "SPRAY": 9}
+SLOT = {"TIME": 0, "FDBK": 1, "TONE": 2, "PING": 3, "VRB": 4, "PTCH": 5,
+        "MDEP": 6, "MRAT": 8, "DRV": 10}
+# v5.1 (3 Sep 2026): slot 5 is PTCH (IN retired), MDEP = wow depth / GRAIN
+# scatter, MRAT = wow rate / GRAIN density, DRV = drive in every mode.
 # ⚠️ MIX (= IN since v3) moved to slot 5 in the 18 Aug 2026 IN/-VRB swap;
 # this map said 4 until 23 Aug, so the "MIX=0" case was actually pinning
 # -VRB -- harmless for its bit-compare purpose (both sides got the same
@@ -258,7 +262,6 @@ def main():
         # crossfade. At 0 the two are identical by construction, so this case
         # is what proves the change touched only the blend and nothing else
         # -- the cases above it are EXPECTED to differ across that commit.
-        ("MIX=0 (dry path untouched by the crossfade)", dp(MIX=0), 0),
     ]
     for label, params, split in CASES:
         a = render(ref_mem, params, split, source)
@@ -284,12 +287,12 @@ def main():
             # v5 numbering (3 Sep 2026): 1 = GRAIN, 2 = REVERSE; PITCH mode is
             # retired and its harmoniser lives in GRAIN's continuous pitch.
             # DINT drives the SIZE select (the PTCH slot until v5).
-            ("GRAIN unison SPRAY=0 (every grain on the same read)", 1, 1, dp(SPRAY=0)),
-            ("GRAIN unison SPRAY=127 (full scatter)", 1, 1, dp(SPRAY=127)),
-            ("GRAIN +12 on RATE, 23 ms grains", 1, 2, dp(SPRAY=60, RATE=96)),
-            ("GRAIN -12 on RATE, 186 ms grains (the distance clamp)", 1, 3,
-             dp(SPRAY=90, RATE=32)),
-            ("GRAIN sparse (DENS 0) at 93 ms", 1, 1, dp(SPRAY=64, WOW=0)),
+            ("GRAIN unison SPRAY=0 (every grain on the same read)", 1, 1, dp(MDEP=0, PTCH=64)),
+            ("GRAIN unison SPRAY=127 (full scatter)", 1, 1, dp(MDEP=127, PTCH=64)),
+            ("GRAIN +12 on PTCH, 23 ms grains", 1, 2, dp(MDEP=60, PTCH=96)),
+            ("GRAIN -12 on PTCH, 186 ms grains (the distance clamp)", 1, 3,
+             dp(MDEP=90, PTCH=32)),
+            ("GRAIN sparse (MRAT 0) at 93 ms", 1, 1, dp(MDEP=64, MRAT=0, PTCH=64)),
             ("REVERSE size 4096 (93 ms, the line's ceiling)", 2, 1, dp()),
             ("REVERSE size 512 (stutter) at TIME=127", 2, 3, dp(TIME=127)),
         ]

--- a/tools/verify_filterstation.py
+++ b/tools/verify_filterstation.py
@@ -37,6 +37,16 @@ SR = 44100
 TMP = pathlib.Path("out/_fsgate")
 TMP.mkdir(parents=True, exist_ok=True)
 
+# ⚠️ REBUILD THE DUMP, ALWAYS. The audition caches its scratch image against
+# the newest mtime under modules/, and a stale hit here does not fail -- it
+# silently measures the STOCK effect whose id this module replaces. That cost
+# an hour on 3 Sep 2026: every mode read as a dry pass, because the dump's
+# dispatch still pointed at stock CHORUS, and the emulator eventually died on
+# a stock instruction it does not implement.
+pathlib.Path(MEM).unlink(missing_ok=True)
+subprocess.run([sys.executable, "tools/remix/audition.py", MOD.name,
+                "out/dry/drums_110.wav"], capture_output=True)
+
 if not pathlib.Path(MEM).exists():
     sys.exit(f"no {MEM} -- build it first:\n"
              f"  python3 tools/remix/audition.py {MOD.name} out/dry/drums_110.wav")

--- a/tools/verify_filterstation.py
+++ b/tools/verify_filterstation.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""FILTER STATION render gates, with arithmetic you can predict.
+
+Renders the station straight through dsp_host (verify_hello's shape: the id
+and the slots come from the manifest, the entry points are checked against
+SEND's so an absent module cannot pass as a dry passthrough).
+
+Gates:
+  defaults    -> output bit-exact vs a full-scale bipolar ramp (the bypass)
+  LP slope    -> a low cutoff: 2 kHz vs 4 kHz attenuate by ~12 dB/oct (2-pole)
+  HP at DC    -> 0;   BP at DC -> 0;   NOTCH at DC -> DC (lp + hp = x)
+  base/width  -> BASE up kills DC through B (SER); WDTH down kills 8 kHz
+  RING at DC  -> A*B*2 with A = B = DC: 2*DC^2, to 1 LSB after settling
+  VOWEL       -> renders, and differs across FREQ (A vs I)
+  every knob  -> renders without dsp_host dying
+
+The dump comes from the audition, which builds a scratch image that really
+contains this station beside SEND:
+
+    python3 tools/remix/audition.py filterstation out/dry/drums_110.wav
+    python3 tools/verify_filterstation.py
+"""
+import math, pathlib, struct, subprocess, sys
+
+sys.path.insert(0, "tools")
+import send_probe  # reuse its dispatch-table entry resolution
+from remix import registry
+
+MOD = registry.by_name("filterstation")
+SEND = registry.by_name("send")
+K = MOD.knob_map()
+MEM = f"out/dsp/_audition_{MOD.name}_A.mem"
+HOST = "vendor/dsp56300/build/source/dsp_host/dsp_host"
+FXID = MOD.menu.fx2_id
+FRAMES, N = 15, 6000
+SR = 44100
+TMP = pathlib.Path("out/_fsgate")
+TMP.mkdir(parents=True, exist_ok=True)
+
+if not pathlib.Path(MEM).exists():
+    sys.exit(f"no {MEM} -- build it first:\n"
+             f"  python3 tools/remix/audition.py {MOD.name} out/dry/drums_110.wav")
+
+init, proc = send_probe.entry_points(MEM, FXID)
+if (init, proc) == send_probe.entry_points(MEM, SEND.menu.fx2_id):
+    sys.exit(f"fx id 0x{FXID:02x} resolves to SEND's entry points -- {MOD.name} "
+             f"is NOT in this dump")
+print(f"entries from dispatch tables: init=P:0x{init:04x} proc=P:0x{proc:04x}")
+
+DEFAULTS = [(p.default or 0) for p in MOD.params]
+
+
+def params(**kw):
+    v = list(DEFAULTS)
+    for name, val in kw.items():
+        v[K[name]] = val
+    return v
+
+
+def render(samples, **kw):
+    """samples: MONO ints in Q23 -- dsp_host feeds one stream to both
+    channels (verify_hello's shape). Returns (L, R) lists."""
+    src = TMP / "fs_in.raw"
+    src.write_bytes(b"".join(struct.pack("<i", m) for m in samples))
+    out = TMP / "fs_out.raw"
+    cmd = [HOST, "-mem", MEM, "-init", f"{init:x}", "-proc", f"{proc:x}",
+           "-inst", "1", "-r7", "2", "-alloc", "1", "-inmask", "1",
+           "-frames", str(FRAMES), "-blocks", str(len(samples) // FRAMES),
+           "-in", str(src), "-out", str(out),
+           "-params", ",".join(str(x) for x in params(**kw))]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        sys.exit(f"dsp_host failed for {kw}:\n{r.stdout}\n{r.stderr}")
+    d = out.read_bytes()
+    w = struct.unpack(f"<{len(d)//4}i", d)
+    return list(w[0::2])[:len(samples)], list(w[1::2])[:len(samples)]
+
+
+def tone(hz, amp=0.4, n=N):
+    return [int(amp * 8388607 * math.sin(2 * math.pi * hz * i / SR)) for i in range(n)]
+
+
+def dc(level=0.25, n=N):
+    return [int(level * 8388607)] * n
+
+
+def rms_db(x, start=N // 2):
+    seg = x[start:]
+    return 20 * math.log10(max(1e-9, math.sqrt(sum((s / 8388607) ** 2 for s in seg) / len(seg))))
+
+
+def tail_mean(x, start=N * 3 // 4):
+    seg = x[start:]
+    return sum(seg) / len(seg)
+
+
+fails = 0
+def check(label, ok, detail=""):
+    global fails
+    print(f"  [{'PASS' if ok else 'FAIL'}] {label}{'  ' + detail if detail else ''}")
+    fails += 0 if ok else 1
+
+
+# ---- 1. defaults: bit-exact passthrough --------------------------------------
+ramp = [int(round(-8388607 + 2 * 8388607 * i / (N - 1))) for i in range(N)]
+L, R = render(ramp)
+check("defaults are a bit-exact passthrough (the bypass block)",
+      L == ramp and R == ramp,
+      "" if L == ramp else f"first diff at {next(i for i,(a,b) in enumerate(zip(L,ramp)) if a!=b)}")
+
+# ---- 2. LP slope: low cutoff, 2 kHz vs 4 kHz ---------------------------------
+lo = rms_db(render(tone(2000), FREQ=30, RES=0)[0])
+hi = rms_db(render(tone(4000), FREQ=30, RES=0)[0])
+slope = lo - hi
+check("LP is a 2-pole: 2 kHz vs 4 kHz differ by ~12 dB at FREQ=30",
+      9 <= slope <= 15, f"{slope:.1f} dB/oct")
+
+# ---- 3. DC through the modes --------------------------------------------------
+d_lp = tail_mean(render(dc(), FREQ=64)[0])
+d_hp = tail_mean(render(dc(), FREQ=64, MODE=2)[0])
+d_bp = tail_mean(render(dc(), FREQ=64, MODE=1)[0])
+d_nt = tail_mean(render(dc(), FREQ=64, MODE=3)[0])
+dcv = int(0.25 * 8388607)
+check("HP at DC -> 0", abs(d_hp) < 64, f"{d_hp:.0f} LSB")
+check("BP at DC -> 0", abs(d_bp) < 64, f"{d_bp:.0f} LSB")
+check("NOTCH at DC -> DC (lp + hp = x)", abs(d_nt - dcv) < 256, f"{d_nt:.0f} vs {dcv}")
+check("LP at DC -> DC", abs(d_lp - dcv) < 256, f"{d_lp:.0f} vs {dcv}")
+
+# ---- 4. filter B: base kills DC, width kills 8 kHz (SER routing) -------------
+d_base = tail_mean(render(dc(), BASE=100)[0])
+check("BASE=100 kills DC through the pair", abs(d_base) < 64, f"{d_base:.0f} LSB")
+w_open = rms_db(render(tone(8000), WDTH=127)[0])
+w_shut = rms_db(render(tone(8000), WDTH=30)[0])
+check("WDTH=30 attenuates 8 kHz by > 20 dB vs open", w_open - w_shut > 20,
+      f"{w_open - w_shut:.1f} dB")
+
+# ---- 5. RING at DC: 2 * A * B, A = B = DC ------------------------------------
+d_ring = tail_mean(render(dc(), ROUT=2)[0])
+want = 2 * (0.25 ** 2) * 8388607
+check("RING at DC -> 2*DC^2", abs(d_ring - want) < 512, f"{d_ring:.0f} vs {want:.0f}")
+
+# ---- 6. VOWEL renders and morphs ---------------------------------------------
+va = rms_db(render(tone(1100), MODE=4, FREQ=0, RES=90)[0])     # A: F2 1090
+vi = rms_db(render(tone(1100), MODE=4, FREQ=64, RES=90)[0])    # I: F2 2290
+check("VOWEL A vs I differ at 1.1 kHz", abs(va - vi) > 3, f"A {va:.1f}  I {vi:.1f} dBFS")
+
+# ---- 7. every knob at its extremes renders -----------------------------------
+for name in K:
+    for v in (0, 127 if MOD.params[K[name]].count in (None, 128) else MOD.params[K[name]].count - 1):
+        render(tone(438, n=600), **{name: v})
+check("every knob at both extremes renders", True)
+
+print(f"\n{fails} gate(s) failed" if fails else "\nOK")
+sys.exit(1 if fails else 0)

--- a/tools/verify_menushortcut.py
+++ b/tools/verify_menushortcut.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""The MAIN MENU really gains REVERB and DELAY -- walked, not read.
+
+    python3 tools/verify_menushortcut.py [remix]      (default: bamsep26)
+
+Three checks, in rising order of what they cost to be wrong about:
+
+ 1. THE TABLE. The built image's CONTROL descriptor holds the new count and
+    points at the relocated rows, and the six stock rows came across byte for
+    byte. A static read -- but it is what the two pokes claim.
+ 2. THE WALK. Boot the image and walk the menu tree out of RAM with the
+    firmware's own table layout: the two rows must resolve with their labels,
+    with id 0 (the action path -- an id would open a menu-state screen
+    instead), and with actions pointing into the cave.
+ 3. THE GUARD. Call the REVERB action on the warm machine with MIDI mode set.
+    It must return without faulting and without touching the page-kind
+    globals: in MIDI mode page kind 4 resolves track+8, so bailing is the
+    whole point of that first `tst.l`.
+
+What this CANNOT prove is the interesting half: that closing the menu from
+inside an action and then selecting a track lands on the FX2 page. That runs
+the stock window machinery on a machine with no menu open, which is not the
+state the handler is called in. docs/MAINMENU.md section 7 prices it, and the
+flash is the test.
+"""
+import os
+import pathlib
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+BASE = 0x40000400
+IMAGE = pathlib.Path("out/mainos_bus.bin")
+STOCK = pathlib.Path("out/raw/section_3_MAIN_OS.bin")
+CONTROL_DESC, CONTROL_ROWS, ROW_LEN, STOCK_N = 0x400cbd54, 0x400cc5a8, 24, 6
+MIDI_MODE = 0x80000012
+PAGE_KIND = 0x460d1684
+WANT = ("REVERB", "DELAY")
+
+
+def main():
+    from remix import registry
+    name = sys.argv[1] if len(sys.argv) > 1 else "bamsep26"
+    if "MENU SHORTCUT" not in registry.remix(name).modules:
+        print(f"  [ -- ] {name} does not carry MENU SHORTCUT -- nothing to check")
+        return 0
+    env = {**os.environ, "REMIX": name, "XBUS": "1", "SPEC": "1"}
+    r = subprocess.run([sys.executable, "tools/build_bus.py"],
+                       capture_output=True, text=True, env=env)
+    if r.returncode != 0:
+        tail = (r.stdout + r.stderr).strip().splitlines()
+        sys.exit(f"{name}: build failed: {tail[-1] if tail else '?'}")
+    img, stock = IMAGE.read_bytes(), STOCK.read_bytes()
+    fails = 0
+
+    def check(label, ok, detail=""):
+        nonlocal fails
+        print(f"  [{'PASS' if ok else 'FAIL'}] {label}"
+              f"{'  ' + detail if detail else ''}")
+        fails += 0 if ok else 1
+
+    def u32(buf, a):
+        return int.from_bytes(buf[a - BASE:a - BASE + 4], "big")
+
+    # ---- 1. the table ----------------------------------------------------
+    count, rows = u32(img, CONTROL_DESC), u32(img, CONTROL_DESC + 0x18)
+    check("CONTROL's count is the stock six plus our two",
+          count == STOCK_N + len(WANT), f"{count}")
+    check("CONTROL's rows pointer was repointed out of the stock array",
+          rows != CONTROL_ROWS and 0x40000000 < rows < 0x40200000,
+          f"0x{rows:08x}")
+    moved = img[rows - BASE:rows - BASE + ROW_LEN * STOCK_N]
+    orig = stock[CONTROL_ROWS - BASE:CONTROL_ROWS - BASE + ROW_LEN * STOCK_N]
+    check("the six stock rows came across byte for byte", moved == orig)
+
+    # ---- 2. the walk, out of booted RAM ----------------------------------
+    import emu_bringup as emu
+    boot = emu.boot(str(IMAGE))
+    uc = boot.uc
+    control = None
+    for row in emu.read_menu_tree(uc):
+        if row["name"] == "CONTROL":
+            control = row.get("children", [])
+    if control is None:
+        check("the booted firmware still has a CONTROL menu", False)
+        print(f"\n{fails} check(s) failed")
+        return 1
+    names = [c["name"] for c in control]
+    check("the booted firmware draws our two rows at the end of CONTROL",
+          names[-len(WANT):] == list(WANT), " · ".join(names))
+    actions = {}
+    for c in control:
+        if c["name"] in WANT:
+            actions[c["name"]] = c["action"]
+            check(f"{c['name']} takes the ACTION path (id 0, not a menu state)",
+                  c["page_id"] == 0, f"id={c['page_id']}")
+            check(f"{c['name']}'s action points into the cave",
+                  0x400d2000 <= c["action"] < 0x400d8000,
+                  f"0x{c['action']:08x}")
+
+    # ---- 3. the MIDI-mode guard ------------------------------------------
+    if "REVERB" in actions:
+        before = int.from_bytes(uc.mem_read(PAGE_KIND, 4), "big")
+        uc.mem_write(MIDI_MODE, (1).to_bytes(4, "big"))
+        try:
+            emu._call(uc, actions["REVERB"], ())
+            after = int.from_bytes(uc.mem_read(PAGE_KIND, 4), "big")
+            check("in MIDI mode the action returns and changes nothing",
+                  after == before, f"page kind 0x{after:08x}")
+        except Exception as exc:                      # a fault is the answer
+            check("in MIDI mode the action returns and changes nothing",
+                  False, f"{type(exc).__name__}: {exc}")
+        finally:
+            uc.mem_write(MIDI_MODE, (0).to_bytes(4, "big"))
+
+    print(f"\n{fails} check(s) failed" if fails else "\nOK")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify_midi.py
+++ b/tools/verify_midi.py
@@ -2,13 +2,13 @@
 """Local verification of the MIDI note path (24 Aug 2026; v5 3 Sep 2026):
 note -> BongDelay GRAIN pitch (r6+$9, latched). dsp_host has no ColdFire
 cave, so the word is forced with the DNOTE= build override and the result
-compared with the RATE knob, which drives the same 2^x law.
+compared with the PTCH knob, which drives the same 2^x law.
 
   EXACT (bit-identical):
-    no note (DNOTE=0)  == RATE 64         (nothing changes)
-    note 84 (unison)   == RATE 64         (f = 0 on both paths)
+    no note (DNOTE=0)  == PTCH 64         (nothing changes)
+    note 84 (unison)   == PTCH 64         (f = 0 on both paths)
   WITHIN 40 CENTS OF NOMINAL (the grain-rate comb), 15 of the knob path (spectral peak of the wet):
-    note 96 ~ +12 (RATE 96), note 91 ~ +7, note 72 ~ -12 (RATE 32)
+    note 96 ~ +12 (PTCH 96), note 91 ~ +7, note 72 ~ -12 (PTCH 32)
 
 Slow (8 DEV builds + renders, ~1 min); not part of make check.
 """
@@ -70,23 +70,23 @@ def same(a, b):
 
 
 # v5 (3 Sep 2026): the note drives GRAIN's continuous pitch (MODE 1), the
-# same law the RATE knob uses -- so the knob path is the reference, and two
+# same law the PTCH knob uses -- so the knob path is the reference, and two
 # of the cases are BIT-IDENTICAL rather than spectral: no note ever == the
-# knob, and note 84 (the OT's unison) == RATE 64, because both feed the same
+# knob, and note 84 (the OT's unison) == PTCH 64, because both feed the same
 # 2^x arithmetic with f = 0.
-G = ("--set", "MODE=1", "--set", "DPTH=127", "--set", "DRV=0", "--set", "FDBK=0",
-     "--set", "PING=0", "--set", "TIME=127", "--set", "SIZE=1")
-knob64 = render("knob64", {}, *G, "--set", "RATE=64")
-check("DNOTE=0 == the RATE knob (no note ever: unchanged)",
-      same(knob64, render("note0", {"DNOTE": "0"}, *G, "--set", "RATE=64")))
-check("note 84 (unison) == RATE 64, bit-identical (one 2^x law, f = 0)",
-      same(knob64, render("note84", {"DNOTE": "84"}, *G, "--set", "RATE=64")))
-clean = render("clean", {}, "--set", "MODE=0", "--set", "DPTH=0", "--set", "FDBK=0",
+G = ("--set", "MODE=1", "--set", "MRAT=127", "--set", "MDEP=0", "--set", "DRV=0",
+     "--set", "FDBK=0", "--set", "PING=0", "--set", "TIME=127", "--set", "SIZE=1")
+knob64 = render("knob64", {}, *G, "--set", "PTCH=64")
+check("DNOTE=0 == the PTCH knob (no note ever: unchanged)",
+      same(knob64, render("note0", {"DNOTE": "0"}, *G, "--set", "PTCH=64")))
+check("note 84 (unison) == PTCH 64, bit-identical (one 2^x law, f = 0)",
+      same(knob64, render("note84", {"DNOTE": "84"}, *G, "--set", "PTCH=64")))
+clean = render("clean", {}, "--set", "MODE=0", "--set", "MDEP=0", "--set", "FDBK=0",
                "--set", "PING=0", "--set", "TIME=127")
 uni = peak_hz(clean, 80, 3000)
 for note, want, rate in ((96, 1200, 96), (91, 700, None), (72, -1200, 32)):
     got = 1200 * math.log2(peak_hz(render(f"note{note}", {"DNOTE": str(note)}, *G,
-                                          "--set", "RATE=64"), 80, 3000) / uni)
+                                          "--set", "PTCH=64"), 80, 3000) / uni)
     detail = f"got {got:+.1f}"
     # 40 cents of NOMINAL: the peak is read off a comb at the grain rate
     # (10.8 Hz at 93 ms), so a line's worth of error is the finder's, and
@@ -95,9 +95,9 @@ for note, want, rate in ((96, 1200, 96), (91, 700, None), (72, -1200, 32)):
     ok = abs(got - want) < 40
     if rate is not None:
         refc = 1200 * math.log2(peak_hz(render(f"rate{rate}", {}, *G, "--set",
-                                               f"RATE={rate}"), 80, 3000) / uni)
+                                               f"PTCH={rate}"), 80, 3000) / uni)
         ok = ok and abs(got - refc) < 15
-        detail += f", RATE={rate} knob path {refc:+.1f}"
+        detail += f", PTCH={rate} knob path {refc:+.1f}"
     check(f"note {note} -> {want:+5d} cents", ok, detail)
 print(f"{fails} check(s) failed" if fails else "all MIDI checks passed")
 sys.exit(1 if fails else 0)

--- a/tools/verify_modenames.py
+++ b/tools/verify_modenames.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""The MODE formatter really does rename its neighbours -- CALLED, not read.
+
+    python3 tools/verify_modenames.py [remix]      (default: bamsep26)
+
+verify_labels' method (PLAN §6), one step further. That file calls each
+select's formatter on the emulated ColdFire and compares what it PRINTED with
+the manifest, because the words are printed rather than stored. A MODE view
+also REWRITES the descriptor, so this calls the formatter with each mode value
+in turn and reads the twelve 6-byte name fields back out of the clone.
+
+What it proves, without a flash:
+  * every mode's names land in the right slots of the right descriptor;
+  * a mode that does NOT rename a slot RESTORES the Param's own name -- the
+    trap a sparse table would leave (land on GRAIN, go back to CLEAN, and the
+    knob still reads SCAT);
+  * an out-of-range mode value (a part stores a raw byte) clamps to mode 0
+    rather than indexing off the end of the table.
+
+What it cannot prove: the ORDER the panel draws in. If the names are drawn
+before the MODE value is formatted, the rename lands one redraw late. That is
+inferred, and the falsifier is on the unit.
+"""
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+BASE = 0x40000400
+BUF = 0x47f00800
+IMAGE = pathlib.Path("out/mainos_bus.bin")
+NAMES_AT = 0x4e
+NAME_LEN = 6
+
+
+def main():
+    from remix import registry
+    import mode_names
+    name = sys.argv[1] if len(sys.argv) > 1 else "bamsep26"
+    env = {**os.environ, "REMIX": name, "XBUS": "1", "SPEC": "1"}
+    r = subprocess.run([sys.executable, "tools/build_bus.py"],
+                       capture_output=True, text=True, env=env)
+    if r.returncode != 0:
+        tail = (r.stdout + r.stderr).strip().splitlines()
+        sys.exit(f"{name}: build failed: {tail[-1] if tail else '?'}")
+    # the clone addresses, from the build's own report
+    clones = {}
+    for line in r.stdout.splitlines():
+        m = re.match(r"\s+(.+?)\s+id 0x[0-9a-f]+\s+clone P=0x([0-9a-f]+)", line)
+        if m:
+            clones[m.group(1).strip()] = int(m.group(2), 16)
+    img = IMAGE.read_bytes()
+
+    def rd32(a):
+        return int.from_bytes(img[a - BASE:a - BASE + 4], "big")
+
+    import emu_bringup as emu
+    boot = emu.boot(str(IMAGE))
+    uc = boot.uc
+    mods = registry.modules()
+    remix = registry.remix(name)
+    fails = 0
+    checked = 0
+    for key in remix.modules:
+        mod = mods.get(key)
+        if mod is None or not mod.mode_views or mod.mode_slot is None:
+            continue
+        want = mode_names.complete(mod)
+        if not want:
+            continue
+        desc = clones.get(key)
+        if desc is None:
+            print(f"  [FAIL] {key}: no clone address in the build report")
+            fails += 1
+            continue
+        fmt = rd32(desc + 0x0ca + mod.mode_slot * 4)
+        labels = mod.params[mod.mode_slot].labels
+
+        def names_now():
+            out = {}
+            for slot in range(12):
+                a = desc + NAMES_AT + slot * NAME_LEN
+                raw = bytes(uc.mem_read(a, NAME_LEN))
+                out[slot] = raw.split(b"\0")[0].decode("latin1")
+            return out
+
+        for value in range(len(labels)):
+            emu._call(uc, fmt, (BUF, value))
+            got = names_now()
+            bad = [(sl, nm.decode("latin1"), got[sl])
+                   for sl, nm in want[value].items()
+                   if got[sl] != nm.decode("latin1")]
+            checked += 1
+            if bad:
+                fails += 1
+                print(f"  [FAIL] {key} mode {value} ({labels[value]}): "
+                      + ", ".join(f"slot {sl} should read {w!r}, reads {g!r}"
+                                  for sl, w, g in bad))
+            else:
+                shown = " ".join(f"{sl}:{got[sl]}" for sl in sorted(want[value]))
+                print(f"  [PASS] {key} mode {value} ({labels[value]:<5}) "
+                      f"renames {shown}")
+        # a part stores a RAW byte, so a value past the count must clamp
+        emu._call(uc, fmt, (BUF, 200))
+        got = names_now()
+        bad = [sl for sl, nm in want[0].items()
+               if got[sl] != nm.decode("latin1")]
+        checked += 1
+        if bad:
+            fails += 1
+            print(f"  [FAIL] {key}: an out-of-range mode leaves slots {bad} "
+                  f"renamed by whatever ran last")
+        else:
+            print(f"  [PASS] {key}: mode 200 clamps to mode 0's names")
+    if not checked:
+        sys.exit(f"{name}: no module in this remix declares mode_views")
+    print(f"\n{fails} of {checked} checks failed" if fails
+          else f"\nOK ({checked} checks)")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify_modstation.py
+++ b/tools/verify_modstation.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""MODULATION STATION render gates -- and the FX1-ONLY PROMISE.
+
+The station takes a per-track line from the host's bump allocator, which is
+only safe in an FX1 slot: every FX2 instance buffer is a server's ground.
+`Claims(fx1_only=True)` is the promise that an FX2 instance writes nothing,
+and the ledger admits the module beside a server on that basis -- so the
+first two gates here are what that claim rests on.
+
+Gates:
+  FX1 instance  -> MIX=0 is a bit-exact passthrough; every mode renders
+  FX2 instance  -> bit-exact DRY at any setting, in every mode
+  FX2 instance  -> dsp_host's -guard sees NO write outside the frame
+  LFO           -> the sweep rate follows RATE (measured on the wet)
+  CHOR/VIB      -> the line is really read: an impulse comes back delayed
+  PHSR          -> unity magnitude (an allpass chain changes phase, not level)
+  TREM/PAN      -> amplitude moves, and PAN moves the two channels apart
+  every knob    -> renders without dsp_host dying
+
+    python3 tools/remix/audition.py modstation out/dry/drums_110.wav
+    python3 tools/verify_modstation.py
+"""
+import math, pathlib, struct, subprocess, sys
+
+sys.path.insert(0, "tools")
+import send_probe  # reuse its dispatch-table entry resolution
+from remix import registry
+
+MOD = registry.by_name("modstation")
+SEND = registry.by_name("send")
+K = MOD.knob_map()
+MEM = f"out/dsp/_audition_{MOD.name}_A.mem"
+HOST = "vendor/dsp56300/build/source/dsp_host/dsp_host"
+FXID = MOD.menu.fx2_id
+FRAMES, N = 15, 6000
+SR = 44100
+TMP = pathlib.Path("out/_mogate")
+TMP.mkdir(parents=True, exist_ok=True)
+
+# ⚠️ REBUILD THE DUMP, ALWAYS. The audition caches its scratch image against
+# the newest mtime under modules/, and a stale hit here does not fail -- it
+# silently measures the STOCK effect whose id this module replaces. That cost
+# an hour on 3 Sep 2026: every mode read as a dry pass, because the dump's
+# dispatch still pointed at stock CHORUS, and the emulator eventually died on
+# a stock instruction it does not implement.
+pathlib.Path(MEM).unlink(missing_ok=True)
+subprocess.run([sys.executable, "tools/remix/audition.py", MOD.name,
+                "out/dry/drums_110.wav"], capture_output=True)
+
+if not pathlib.Path(MEM).exists():
+    sys.exit(f"no {MEM} -- build it first:\n"
+             f"  python3 tools/remix/audition.py {MOD.name} out/dry/drums_110.wav")
+
+init, proc = send_probe.entry_points(MEM, FXID)
+if (init, proc) == send_probe.entry_points(MEM, SEND.menu.fx2_id):
+    sys.exit(f"fx id 0x{FXID:02x} resolves to SEND's entry points -- {MOD.name} "
+             f"is NOT in this dump")
+print(f"entries from dispatch tables: init=P:0x{init:04x} proc=P:0x{proc:04x}")
+
+DEFAULTS = [(p.default or 0) for p in MOD.params]
+
+
+def params(**kw):
+    v = list(DEFAULTS)
+    for name, val in kw.items():
+        v[K[name]] = val
+    return v
+
+
+def render(samples, slot="fx1", guard=False, **kw):
+    """samples: MONO ints in Q23 -- dsp_host feeds one stream to both
+    channels (verify_hello's shape). Returns (L, R) lists."""
+    src = TMP / "mo_in.raw"
+    src.write_bytes(b"".join(struct.pack("<i", m) for m in samples))
+    out = TMP / "mo_out.raw"
+    r7, alloc = ("1", "0") if slot == "fx1" else ("2", "1")
+    cmd = [HOST, "-mem", MEM, "-init", f"{init:x}", "-proc", f"{proc:x}",
+           "-inst", "1", "-r7", r7, "-alloc", alloc, "-inmask", "1",
+           *(["-guard"] if guard else []),
+           "-frames", str(FRAMES), "-blocks", str(len(samples) // FRAMES),
+           "-in", str(src), "-out", str(out),
+           "-params", ",".join(str(x) for x in params(**kw))]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        sys.exit(f"dsp_host failed for {kw}:\n{r.stdout}\n{r.stderr}")
+    if guard:
+        render.guard_out = r.stdout + r.stderr
+    d = out.read_bytes()
+    w = struct.unpack(f"<{len(d)//4}i", d)
+    return list(w[0::2])[:len(samples)], list(w[1::2])[:len(samples)]
+
+
+def tone(hz, amp=0.4, n=N):
+    return [int(amp * 8388607 * math.sin(2 * math.pi * hz * i / SR)) for i in range(n)]
+
+
+def dc(level=0.25, n=N):
+    return [int(level * 8388607)] * n
+
+
+def rms_db(x, start=N // 2):
+    seg = x[start:]
+    return 20 * math.log10(max(1e-9, math.sqrt(sum((s / 8388607) ** 2 for s in seg) / len(seg))))
+
+
+def tail_mean(x, start=N * 3 // 4):
+    seg = x[start:]
+    return sum(seg) / len(seg)
+
+
+fails = 0
+def check(label, ok, detail=""):
+    global fails
+    print(f"  [{'PASS' if ok else 'FAIL'}] {label}{'  ' + detail if detail else ''}")
+    fails += 0 if ok else 1
+
+
+MODES = {"CHOR": 0, "FLNG": 1, "PHSR": 2, "COMB": 3, "TREM": 4, "VIB": 5, "PAN": 6}
+
+# ---- 1. FX1: MIX=0 is a bit-exact passthrough in every mode ------------------
+ramp = [int(round(-8388607 + 2 * 8388607 * i / (N - 1))) for i in range(N)]
+ok = True
+for name, m in MODES.items():
+    L, R = render(ramp, MODE=m, MIX=0)
+    if L != ramp or R != ramp:
+        ok = False
+        check(f"FX1 MIX=0 passthrough in {name}", False,
+              f"first diff at {next(i for i,(a,b) in enumerate(zip(L,ramp)) if a!=b)}")
+check("FX1: MIX=0 is a bit-exact passthrough in all seven modes", ok)
+
+# ---- 2. THE FX1-ONLY PROMISE: an FX2 instance is dry, whatever the knobs -----
+ok = True
+for name, m in MODES.items():
+    L, R = render(ramp, slot="fx2", MODE=m, MIX=127, DPTH=127, FDBK=100, RATE=90)
+    if L != ramp or R != ramp:
+        ok = False
+        check(f"FX2 instance is dry in {name}", False, "it processed the frame")
+check("FX2 instance is a bit-exact DRY PASS in all seven modes, at any setting",
+      ok)
+
+# ---- 3. ... and it writes nothing outside the frame --------------------------
+render(ramp, slot="fx2", guard=True, MODE=0, MIX=127, DPTH=127, FDBK=100)
+# dsp_host prints "guard armed: ..." on arming and "guard clean: ..." when
+# nothing was written over a loaded module; a violation prints neither.
+g = getattr(render, "guard_out", "")
+check("FX2 instance trips no write guard (it never touches the line)",
+      "guard clean" in g,
+      next((ln.strip() for ln in reversed(g.splitlines()) if "guard" in ln), ""))
+
+# ---- 4. the LFO rate follows RATE -------------------------------------------
+# ⚠️ MEASURED IN TREM ON A DC INPUT, where the output IS the LFO: an envelope
+# follower on a tone tracks the TONE, which is what two earlier versions of
+# this gate measured (446 "cycles" at every rate -- the 438 Hz carrier).
+LONG = 30000
+def lfo_cycles(rate):
+    L, _ = render([int(0.4 * 8388607)] * LONG, MODE=4, MIX=127, DPTH=127, RATE=rate)
+    seg = L[LONG//4:]
+    mid = sum(seg) / len(seg)
+    return sum(1 for a, b in zip(seg, seg[1:]) if (a < mid) != (b < mid)) / 2
+slow_n, fast_n = lfo_cycles(20), lfo_cycles(110)
+check("the LFO is square-law in RATE: the top of the knob is many times the bottom",
+      fast_n > slow_n * 4 and fast_n > 2,
+      f"RATE 20 -> {slow_n:.1f} cycles in 0.68 s, RATE 110 -> {fast_n:.1f}")
+
+# ---- 5. the line is really read: an impulse comes back delayed ---------------
+imp = [0] * N
+imp[100] = 6000000
+L, _ = render(imp, MODE=5, MIX=127, DPTH=0, DLY=60, RATE=0)   # VIB, no sweep
+late = [i for i, v in enumerate(L) if abs(v) > 100000 and i > 110]
+check("VIB reads the line: the impulse comes back later", bool(late),
+      f"first echo at sample {late[0] - 100} after the input" if late else "no echo")
+
+# ---- 6. the phaser is unity magnitude ---------------------------------------
+dryref, _ = render(tone(438), MIX=0)
+ph, _ = render(tone(438), MODE=2, MIX=127, DPTH=90, RATE=30)
+check("PHSR is unity magnitude (it moves phase, not level)",
+      abs(rms_db(ph) - rms_db(dryref)) < 3.0,
+      f"{rms_db(ph) - rms_db(dryref):+.2f} dB against the dry")
+
+# ---- 7. TREM moves the amplitude; PAN moves the channels apart --------------
+tr, _ = render(tone(438), MODE=4, MIX=127, DPTH=127, RATE=90)
+env = [abs(v) for v in tr[N//4:]]
+check("TREM modulates the amplitude", max(env) > min(env) * 3,
+      f"envelope {min(env)} .. {max(env)}")
+pl, pr = render(tone(438), MODE=6, MIX=127, DPTH=127, RATE=90)
+diff = max(abs(a - b) for a, b in zip(pl[N//4:], pr[N//4:]))
+check("PAN drives the two channels apart", diff > 400000, f"max |L-R| {diff}")
+
+# ---- 8. every knob at its extremes renders ----------------------------------
+for name in K:
+    for v in (0, 127 if MOD.params[K[name]].count in (None, 128) else MOD.params[K[name]].count - 1):
+        render(tone(438, n=600), **{name: v})
+check("every knob at both extremes renders", True)
+
+print(f"\n{fails} gate(s) failed" if fails else "\nOK")
+sys.exit(1 if fails else 0)


### PR DESCRIPTION
All three BamSep26 stations, and `remixes/bamsep26.py` — the rig. Design page: https://claude.ai/code/artifact/1f1bfff2-9d4e-41b6-b0a7-91a3c8989aaf

| station | replaces | words | cycles | gates |
|---|---|---|---|---|
| Filter | FILTER 0x04 | 983 | 339 | 11 |
| Character | LO-FI 0x1c | 833 | 405 | 22 |
| Modulation | CHORUS 0x12 | 1,133 | 402 | 9 |

**The rig**: ChonVerb + BongDelay v5 + Send + the stock Echo Freeze delay + the three stations + tempo sync. Seven FX2 rows (exactly the in-place chooser list, no scrolling), FX1 = NONE plus the three stations, every other stock effect harvested — one 6,158-word run per payload, **559 free on A, 706 on B**. All three stations are bus clients (→DEL / →VRB on page 1, knob-gated registration, none of them housekeeps).

**The modulation station is FX1-only and enforces it**: it reads its base from the bump allocator at init, and on an FX2 slot it runs a dry pass that writes nothing — because every FX2 instance buffer is a server's ground. The gates prove it both ways: bit-exact dry in all seven modes at any setting, and `dsp_host -guard` clean.

⚠️ **Cycles**: the pricer's worst case (seven character stations plus the delay on one core) is **704 over** 3,120 + the 768 FILTER credit. Sam's layout runs one or two per core; the trims are listed in each module README, and the burn-probe flash measures the real wall.

⬜ **Nothing is voiced.** Every coefficient in all three stations is a first guess; controls and tuning come next, as a pass over the finished remix.

`make check`, `verify_menu`, `verify_replaces`, `verify_labels` and the ledger selftest are green on the rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)