### PR TITLE
remixer: rebuild after stock FX1 chooser changes

### DIFF
--- a/tools/remix/app.py
+++ b/tools/remix/app.py
@@ -2241,10 +2241,11 @@ class RemixerScreen(Screen):
         mod = self.selected_module()
         if mod is None:
             return
+        before = tuple(st.fx1)
         st.msg = st.toggle_fx1(mod.key, disp(mod))
-        if mod.key in st.sel:
+        if tuple(st.fx1) != before:
             st.loaded_name = ""
-            self.schedule_sync()         # it changes the image
+            self.schedule_sync()         # chooser change changes the image/harvest
         self.rerender()
 
     def action_fix(self):


### PR DESCRIPTION
Fix stale Workbench build state after toggling stock FX1 effects.

Stock FX1 effects live in `st.fx1`, not normally in `st.sel`, so
`action_fx1()` could change the derived harvest without scheduling a rebuild.
This left `st.regions` / `app.boot` describing the previous donor layout.

Schedule a sync whenever the FX1 chooser actually changes.

Reproduced by removing/restoring DJ EQ in a dynamic-donor layout. After the
fix the Workbench rebuilds immediately and reports the actual placement result.

Tested on current main:
- `make verify` passes
- `make check`: ALL CHECKS PASSED