### PR TITLE
CF PROBE: a ColdFire headroom probe around the per-frame delay routine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,8 @@ verify: ## Verify the ColdFire menu edits, module ledger (+ burn probe when it f
 	  echo "  [SKIP] per-mode knob names: no .venv, or this remix has none"
 	@$(PY) tools/verify_menushortcut.py $(REMIX) 2>/dev/null || \
 	  echo "  [SKIP] menu shortcut: no .venv, or this remix has none"
+	@$(PY) tools/verify_cfprobe.py $(REMIX) 2>/dev/null || \
+	  echo "  [SKIP] cf probe: no .venv, or this remix has none"
 	REMIX=$(REMIX) python3 tools/verify_menu.py
 	python3 tools/verify_burn.py
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -789,6 +789,47 @@ official installer does, and it is simpler. This is the same image with our
 chooser edits reverted, which is only interesting if some ColdFire cave is
 worth keeping.
 
+### 8. ColdFire machines — the headroom probe first, then Braids / the Pickup donor
+
+Asked 3 Sep 2026: is there room for more machines, and could something
+like Mutable's **Braids** come in? On the DSP the rig has **334 / 474
+words** free and only two FX2 ids, so a Braids subset (the table-free
+analogue models, ~1,000–1,500 words, hand-written) needs a lever first —
+the core-1 OMR flip or a dropped station. The wavetable families have
+nowhere to live on the DSP at all.
+
+**The ColdFire is the more interesting host, and it does not need the
+DSP.** The stock Echo Freeze already does per-sample EMAC work in 16-sample
+frames inside the audio interrupt (`docs/EXTERNAL.md` §1), so a cave in
+that routine can render into a track's ring. In its favour: Braids is
+integer C++ for a 72 MHz Cortex-M3 with no FPU and could be **compiled**
+(`m68k-elf-gcc`, not installed; the binutils are) rather than rewritten;
+the ColdFire owns the sequencer, so a trig and a note per track are native;
+and the local ColdFire emulator runs the EMAC exactly. Two unknowns block
+it, and both are cheap:
+
+- **ColdFire headroom is unmeasured.** ✅ **BUILT 4 Sep 2026:
+  `modules/cfprobe`** — a cave around the frame routine's only call site
+  (`0x40004b12`, IPL 5) reading DMA timer 3, a fader-driven burn inside the
+  measurement, and a readout on HELLO WORLD's GAIN. Emulator-proven
+  (`tools/verify_cfprobe.py`, 22 checks); the numbers are
+  `docs/FLASHPLAN.md` flash 5's to find. The interrupt level matters: the
+  routine runs ABOVE the RTOS time slice and the level-4 MIDI framer, so
+  UI or card streaming should give before audio; if audio gives first, the
+  audio DMA sits at or below level 5 and every added cycle is paid by audio.
+- **A code home.** The known free flash is 1 KB at `0x400c4702` and the
+  2 KB zero run; a Braids build is far larger. Unpriced.
+
+**The Pickup machine as a donor** (Sam, 4 Sep 2026: "a rich donor for new
+things"). What is known: its recorder arm length comes off the FIN/FOUT
+ladder ÷ tempo24 at `0x40005ff0` (`EXTERNAL.md` §6c), the arm site is
+`0x400060c4`, and it records into CPU-side SDRAM like the delay's rings.
+Unknown, and the next reading job: where its playback loop lives, whether
+it runs in the same per-frame routine as the delay, and what its per-track
+record looks like — because a machine that already owns a recorder ring, a
+trig path and a pitch/rate parameter page is most of what a ColdFire
+synth voice needs. Read it after the probe's numbers are in.
+
 ## The flash backlog
 
 **What is on the unit is tag 77 / R58, 24 August 2026** — 134 commits ago.
@@ -802,7 +843,8 @@ hosts going quiet only while a return is live. `docs/BUS.md` "The returns";
 `tools/verify_returns.py` is its gate, and `make verify-bus` came back 19/19
 across the edit — with no return in the rig nothing changed, to the bit.
 
-**`docs/FLASHPLAN.md` is the schedule** — three images, ordered so the
+**`docs/FLASHPLAN.md` is the schedule** — three images plus the rig, and
+since 4 Sep 2026 a fifth, the ColdFire headroom probe (§8), ordered so the
 cheapest and safest goes first, each shaped to stack independent claims whose
 failures stay distinguishable, and each with what would falsify it. The
 platform work needs no flash at all: refhash proves a default selection is

--- a/docs/FLASHPLAN.md
+++ b/docs/FLASHPLAN.md
@@ -295,6 +295,30 @@ which.
 
 ---
 
+## Flash 5 — the ColdFire headroom probe (cfprobe)
+
+**The image:** `REMIX=cfprobe make image` — the rig plus HELLO WORLD and
+CF PROBE. **The question:** how much of each audio frame a ColdFire-side
+machine could take (PLAN §8: a Braids port, a Pickup-machine descendant).
+`modules/cfprobe/README.md` is the full procedure; `tools/verify_cfprobe.py`
+(22 checks, emulator-driven) is the gate.
+
+Independent of flash 4's claims and cheap to stack on the same day, but a
+SEPARATE image: the burn is the crossfader and the readout is a diagnostic
+knob, so it is not something to leave on the unit.
+
+| | claim | how to see it | falsified by |
+|---|---|---|---|
+| i | the hook runs once per 16-sample frame at a 132 MHz bus clock | HELLO WORLD's GAIN at 0–31 prints ≈ `47891` | a clean multiple (the interrupt runs per DMA block: still a measurement, bigger frame); any other value (the clock inference is wrong; the ratios still hold); `-` after ten seconds (the hook is not running per frame at all) |
+| ii | the delay routine's cost at rest | GAIN 64–95 prints `r<pct>`; GAIN 96–127 prints the same `t<pct>` at fader 0 | `t` ≠ `r` at fader 0 — the probe is wrong, stop |
+| iii | the routine has no expensive occasional path | GAIN 32–63 `x` ≈ `r` at rest; move a stock DELAY's TIME and watch `x` | `x` ≫ `r` |
+| iv | **the starvation point and what starves first** | full set playing, sample streaming, MIDI clock in, UI scrolling; fader up 8 steps at a time, record `t`/`x` and the first symptom | (this is the measurement) — UI lag, streaming stutter, MIDI drift, audio crackle, hang, in rising order of what it would mean |
+
+Write down `t` at the first symptom and `r` at rest: the difference is the
+frame fraction a ColdFire machine may take. Core cycles ≈ 2× the ticks 🟡.
+
+---
+
 ## Before every flash
 
 From `docs/FLASHING.md` and the card workflow this project already uses:
@@ -331,7 +355,8 @@ gets written down, which this project has been burned by more than once.
 
 ## What is deliberately not in this plan
 
-- **The main-menu shortcut** (PLAN §5) — not built, so nothing to flash.
+- ~~The main-menu shortcut — not built~~ Built 3 Sep 2026 and in the rig:
+  flash 4's claim ix.
 - **An FX1 chooser SHORTER than the viewport.** `fieldtest` lists ten, above
   the seven-row window, so the shrink path is exercised but not the extreme.
   A three-row FX1 list is the interesting case for the viewport literal and

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -508,6 +508,19 @@ bytes, plant a `jsr` to the cave, and have the cave replay what it displaced
 before doing its own work. The installer is generic — contributing a cave
 needs no change to the build.
 
+**The hook span is `len(hook_stock)`** (4 Sep 2026): the six-byte `jsr`
+followed by nops to the end of the displaced instructions, so `hook_stock`
+must be whole instructions, at least six bytes and even. Both tempo-sync
+hooks are ten; `modules/cfprobe` is the first eight-byte one (a `jsr` and a
+move-to-SR). A pc-relative instruction in `hook_stock` is fine to *replace*
+— the cave does the work itself — but cannot be *replayed* at the cave's
+address, so `TEMPOCAVE=replay` refuses such a cave rather than mis-jump.
+
+**A cave can be both a hook target and a formatter**: `FormatterReg(offset=…)`
+registers an entry *inside* the cave (`cfprobe` puts its formatter at
+`+0x100` with an `.org`), so one address and one pc-relative state block
+serve the interrupt and the panel. `offset=0` is the tempo-sync shape.
+
 **Caves float unless pinned** (3 Sep 2026). A remix with more than three
 descriptor clones used to run the clone block straight into the tempo cave
 pinned at `0x400d7000` — three clones end exactly there, so the shipping

--- a/modules/cfprobe/README.md
+++ b/modules/cfprobe/README.md
@@ -1,0 +1,124 @@
+# CF PROBE — measuring the ColdFire's headroom
+
+The question: **how much of each audio frame can the ColdFire give to a new
+machine** — a Braids port, a Pickup-machine descendant — before the rest of
+the firmware starves? Nothing local can answer it. The emulator runs the
+EMAC exactly and at no fixed rate, so "it keeps up in Unicorn" is worthless
+(same lesson as the DSP burn sweep). This module is the one flash that
+answers it, and it answers two numbers:
+
+- **what the per-frame delay routine already costs**, as a fraction of the
+  frame, and
+- **where the rest of the system gives out** when that routine is made
+  heavier, and what gives out first.
+
+## What is in the image
+
+One cave, floated behind the descriptor clones, with two entry points:
+
+| | |
+|---|---|
+| `+0x000` | hooked from `0x40004b12`, the frame routine's only call site, inside the audio interrupt at IPL 5. The cave calls `0x400031a0` itself, reads DMA timer 3 before and after, runs the burn, replays the displaced `move.w #0x2700,%sr`, returns |
+| `+0x100` | a display formatter registered on **HELLO WORLD's GAIN** (`FormatterReg(offset=0x100)`) |
+
+Per frame: `t0 ; routine ; t1 ; burn ; t2`, giving `routine = t1−t0`,
+`total = t2−t0`, `period = t0 − last t0`. Frames whose period is implausible
+(first frame, a counter reset, a stall) are discarded. Sums run over
+1,024-frame windows (~0.37 s) and are published at the end of each, so a
+reading is never stale by more than a window and no sum overflows.
+
+The clock is DMA timer 3 at the internal bus clock, free-running 32-bit
+(`DTMR3 = 0x000b`, `DTRR3` never written). ✅ Read from the disassembly
+(`0x400209c0`); DMA timer 2's one-second reference of 132,000,000 ticks
+(`0x40040438`) makes the bus clock **132 MHz** 🟡 inferred — and one
+16-sample frame **47,891 ticks**. The PERIOD readout is the check.
+
+The burn is the **crossfader**: `iterations = fader × 128`, a six-instruction
+loop, inside the measurement, so the readout reports the burn's true cost.
+Fader 0 is a pure measurement. ⚠️ The fader also crossfades scenes: sweep on
+a project without scene locks, or expect the sound to change with it.
+
+## The readout — HELLO WORLD's GAIN, by band
+
+| GAIN | prints | meaning |
+|---|---|---|
+| 96–127 | `t62` | mean **total** busy (routine + burn), % of the period |
+| 64–95 | `r25` | mean **routine** busy, burn excluded |
+| 32–63 | `x83` | the **worst single frame** in the window, total, % |
+| 0–31 | `47891` | mean period in ticks |
+| any | `-` | no window published yet |
+
+The panel redraws a label when the knob moves, so **nudge GAIN to refresh**.
+GAIN is also HELLO WORLD's gain: bands below 96 attenuate that track (at
+64 it is −6 dB). A probe image is not a performance image.
+
+## Procedure
+
+```bash
+REMIX=cfprobe make image          # the rig + HELLO WORLD + CF PROBE
+.venv/bin/python3 tools/verify_cfprobe.py   # 22 checks, emulator-driven
+```
+
+Flash per `docs/FLASHING.md`. Load the rig project (`ot_project.py rigproj`)
+or a real set. Put **HELLO WORLD** on any track's FX2 and leave GAIN at 127.
+
+**1. At rest, fader 0.** Read all four bands and write them down.
+
+- PERIOD ≈ **47,891** confirms per-frame at 132 MHz. A clean multiple
+  (95,782; 766,256) means the interrupt runs per that many frames — still
+  a valid measurement, but the frame is bigger than assumed. Anything else
+  falsifies the bus-clock inference; the ratios below stay right.
+- `t` = `r` at fader 0 (no burn). If not, the probe is wrong, stop.
+- `r` is **the routine's cost today**. `x` is its worst frame; if `x` is far
+  above `r`, the routine has an occasional expensive path (DMA reprogramming
+  on a time change is the obvious one — move a delay TIME and watch `x`).
+- `-` after ten seconds means every frame is being discarded: the hook is
+  not running per frame at all. That is a finding, not a fault; the stubbed
+  emulator run proves the code, the period guard is 1,048,576 ticks.
+
+**2. The sweep.** Play the full set: eight tracks, stock DELAYs on, a sample
+streaming from the card, MIDI clock in, and scroll the UI while it runs.
+Raise the fader **8 steps at a time**. At each step nudge GAIN and record
+`t`, `x`, and the first symptom, in this order of likelihood:
+
+| symptom | what it says |
+|---|---|
+| the UI lags or stops redrawing | the RTOS time slice is starved — the probe runs above it |
+| a streaming sample stutters or stops | card streaming starved — the field failure that matters |
+| MIDI clock drifts, notes late | the level-4 MIDI framer is starved (it sits below IPL 5) |
+| audio crackle or dropout | audio DMA is at or below level 5 — every added cycle is paid by audio directly. The most important finding if it comes first |
+| a hang | the wall was a cliff; note the fader, power-cycle |
+
+**3. The number.** Headroom for a ColdFire machine, per frame:
+
+```
+headroom = t(first symptom) − r(rest)      in % of the period
+ticks    = headroom × period               bus-clock ticks per frame
+```
+
+Core cycles are ~2× the ticks 🟡 (MCF5445x core clock = 2× internal bus
+clock — inferred from the family's clock tree, unmeasured). Braids' heavy
+models render a 24-sample block in ~60% of a 72 MHz Cortex-M3's time; that
+is the comparison to price against.
+
+## What would falsify what
+
+| claim | falsified by |
+|---|---|
+| the hook runs once per 16-sample frame | PERIOD not ≈ 47,891 |
+| the bus clock is 132 MHz | PERIOD ≈ 47,891 × k for no integer k |
+| the routine is cheap and steady | `r` above ~30, or `x` ≫ `r` at rest |
+| the RTOS gives before audio | audio crackle before UI lag |
+| the counter is never zeroed under us | can't be seen directly; a window with an absurd PERIOD is one that ate a reset |
+
+## What is deliberately not here
+
+- **No per-task attribution.** The probe measures the one routine and what
+  the whole system tolerates above it. Which task starves is read off the
+  symptom, not a counter.
+- **No idle-loop counter.** Instrumenting the scheduler's idle path would
+  give whole-CPU headroom, but the hook site would be in the RTOS core and
+  the failure mode of getting it wrong is a dead unit. The burn sweep gets
+  the same number from the other side.
+- **TEMPOCAVE=replay** does not apply: the displaced jsr is pc-relative and
+  the build refuses to replay it.

--- a/modules/cfprobe/cfprobe.s
+++ b/modules/cfprobe/cfprobe.s
@@ -1,0 +1,182 @@
+| CF PROBE -- ColdFire headroom probe: how much of the audio frame is spent
+| in the per-frame delay routine, and how much more it can carry (4 Sep 2026)
+|
+| ONE CAVE, TWO ENTRY POINTS.
+|   +0x000  probe   hooked from 0x40004b12, the frame routine's ONLY call
+|                   site (a pc-relative jsr inside the audio interrupt, run
+|                   at IPL 5 between `move.w #0x2500,%sr` and
+|                   `move.w #0x2700,%sr`). The hook displaces the jsr AND the
+|                   following move-to-SR (8 bytes); the cave calls the
+|                   routine itself, times it, burns, then replays the SR
+|                   write and returns to 0x40004b1a.
+|   +0x100  fmt     a display formatter, registered on HELLO WORLD's GAIN
+|                   (schema.FormatterReg offset=0x100). Same signature as
+|                   every stock formatter: fmt(char *buf, int value).
+|
+| THE CLOCK is DMA timer 3, DTCN3 at 0xfc07c00c: the firmware programs
+| DTMR3 = 0x000b at 0x400209c0 (bus clock, prescale 1, restart mode) and
+| never writes DTRR3, whose reset value is 0xffffffff -- so it is a free
+| running 32-bit counter at the internal bus clock, wrapping every 2^32
+| ticks. Deltas are taken modulo 2^32. The firmware DOES zero DTCN3 itself
+| on some event (`clr.l 0xfc07c00c` at 0x400559a8), and the guard below
+| discards any frame whose period is implausible. DMA timer 2's reference
+| of 132,000,000 ticks per second (0x40040438) says the bus clock is
+| 132 MHz, which makes one 16-sample frame at 44.1 kHz 47,891 ticks -- the
+| readout's PERIOD band is the check on that inference. Nothing in the
+| arithmetic depends on it: every busy figure is a RATIO to the measured
+| period.
+|
+| PER FRAME:
+|     t0 = DTCN3 ; jsr 0x400031a0 ; t1 = DTCN3 ; burn ; t2 = DTCN3
+|     routine = t1 - t0        total = t2 - t0        period = t0 - last_t0
+|   discarded (not accumulated) when period > LIMIT (1,048,576 ticks, ~22
+|   frames) or total > period: the first frame after boot, a counter reset
+|   under us, a stalled frame. If EVERY frame is discarded the readout stays
+|   "-", which is itself a finding: the hook is not running per frame.
+|   Accumulated over a WINDOW of 1,024 frames (~0.37 s) then published to
+|   a second block the formatter reads, so no sum can overflow 32 bits and
+|   a reading is never half a window old.
+|
+| THE BURN is the crossfader: iterations = fader * 128, fader read from
+| 0x460d16c8 (0..127; the panel and MIDI CC 48 both write it), six
+| single-cycle-class instructions per iteration, so fader 127 is on the
+| order of two frames of busy time. It is INSIDE the measurement (t2), so
+| the readout reports the burn's true cost in ticks and the sweep is
+| self-measuring: turn the fader up until something starves, read the
+| percentage where it did. Fader 0 = no burn = a pure measurement.
+|
+| THE READOUT is HELLO WORLD's GAIN knob, banded by its value:
+|     96..127  "t<pct>"   mean TOTAL busy (routine + burn) as % of the period
+|     64..95   "r<pct>"   mean ROUTINE busy, burn excluded
+|     32..63   "x<pct>"   worst single frame's total busy in the window
+|      0..31   "<ticks>"  mean period in ticks (47891 expected at 132 MHz)
+|   "-" until the first window has been published. The panel redraws a
+|   label on a knob change, so nudge GAIN to refresh. (GAIN is also the
+|   insert's gain: the bands below 96 attenuate that track. A probe image
+|   is not a performance image.)
+|
+| Registers: the probe uses d0/d1/a0 (dead across the call it wraps: the
+| routine clobbers them without reading them) and saves d2/d3. The formatter
+| clobbers d0/d1/a0/a1 like every stock formatter and saves d2.
+| Position-independent apart from the OS absolutes (pc-relative state).
+
+        .text
+
+| ---- +0x000: the hook target ------------------------------------------
+probe:  move.l  %d2,-(%sp)
+        move.l  %d3,-(%sp)
+        move.l  0xfc07c00c,%d2          | t0
+        jsr     0x400031a0              | the per-frame delay routine
+        move.l  0xfc07c00c,%d3          | t1
+        move.l  0x460d16c8,%d0          | crossfader 0..127
+        and.l   #0x7f,%d0
+        lsl.l   #7,%d0                  | iterations = fader * 128
+        beq.s   noburn
+burn:   addq.l  #1,%d1
+        addq.l  #1,%d1
+        addq.l  #1,%d1
+        addq.l  #1,%d1
+        subq.l  #1,%d0
+        bne.s   burn
+noburn: move.l  0xfc07c00c,%d1          | t2
+        lea     st(%pc),%a0
+        sub.l   %d2,%d3                 | routine = t1 - t0
+        sub.l   %d2,%d1                 | total   = t2 - t0
+        move.l  %d2,%d0
+        sub.l   (%a0),%d0               | period  = t0 - last_t0
+        move.l  %d2,(%a0)               | last_t0 = t0
+        cmp.l   #0x100000,%d0           | LIMIT: ~22 frames (7.9 ms) -- room
+        bhi.s   done                    | for the interrupt to turn out to run
+                                        | per 256-sample DMA block rather than
+                                        | per frame; unsigned, so a reset
+                                        | (negative) fails it too. Sums stay
+                                        | under 2^32 at 1,024 x LIMIT.
+        cmp.l   %d0,%d1
+        bhi.s   done                    | total > period: not a real frame
+        add.l   %d3,4(%a0)              | sum_routine
+        add.l   %d1,8(%a0)              | sum_total
+        add.l   %d0,12(%a0)             | sum_period
+        cmp.l   16(%a0),%d1
+        bls.s   1f
+        move.l  %d1,16(%a0)             | max_total
+1:      addq.l  #1,20(%a0)              | n
+        move.l  20(%a0),%d0
+        cmp.l   #1024,%d0               | WINDOW
+        bne.s   done
+        move.l  4(%a0),24(%a0)          | publish the window ...
+        move.l  8(%a0),28(%a0)
+        move.l  12(%a0),32(%a0)
+        move.l  16(%a0),36(%a0)
+        move.l  20(%a0),40(%a0)
+        clr.l   4(%a0)                  | ... and start the next
+        clr.l   8(%a0)
+        clr.l   12(%a0)
+        clr.l   16(%a0)
+        clr.l   20(%a0)
+        addq.l  #1,44(%a0)              | windows published
+done:   move.l  (%sp)+,%d3
+        move.l  (%sp)+,%d2
+        move.w  #0x2700,%sr             | displaced from 0x40004b16
+        rts
+
+| ---- +0x100: the formatter ------------------------------------------
+        .org    0x100, 0
+fmt:    move.l  %d2,-(%sp)              | buf 8(sp), value 12(sp)
+        move.l  12(%sp),%d0
+        lea     st(%pc),%a0
+        move.l  40(%a0),%d2             | pub_n
+        beq.s   none
+        lsr.l   #5,%d0                  | band 0..3
+        bne.s   band1
+        move.l  32(%a0),%d1             | band 0: mean period = pub_period / pub_n
+        divu.l  %d2,%d1
+        lea     s_d(%pc),%a1
+        bra.s   out
+band1:  subq.l  #1,%d0
+        bne.s   band2
+        move.l  32(%a0),%d2             | band 1: max_total * 100 / mean period
+        divu.l  40(%a0),%d2
+        beq.s   none
+        move.l  36(%a0),%d1
+        moveq   #100,%d0
+        mulu.l  %d0,%d1
+        divu.l  %d2,%d1
+        lea     s_x(%pc),%a1
+        bra.s   out
+band2:  move.l  32(%a0),%d2             | bands 2, 3: sum * 100 / sum_period,
+        move.l  #100,%d1                | as sum / (sum_period / 100) so the
+        divu.l  %d1,%d2                 | product cannot overflow
+        beq.s   none
+        subq.l  #1,%d0
+        bne.s   band3
+        move.l  24(%a0),%d1             | band 2: routine
+        lea     s_r(%pc),%a1
+        bra.s   div
+band3:  move.l  28(%a0),%d1             | band 3: total
+        lea     s_t(%pc),%a1
+div:    divu.l  %d2,%d1
+out:    move.l  (%sp)+,%d2              | buf back at 4(sp)
+        move.l  %d1,-(%sp)              | value
+        move.l  %a1,-(%sp)              | format
+        move.l  12(%sp),-(%sp)          | buf
+        jsr     0x40013a08              | sprintf(buf, format, value)
+        lea     12(%sp),%sp
+        rts
+none:   move.l  (%sp)+,%d2
+        pea     s_none(%pc)
+        move.l  8(%sp),-(%sp)           | buf
+        jsr     0x40013a08              | sprintf(buf, "-")
+        addq.l  #8,%sp
+        rts
+
+s_t:    .asciz  "t%d"
+s_r:    .asciz  "r%d"
+s_x:    .asciz  "x%d"
+s_d:    .asciz  "%d"
+s_none: .asciz  "-"
+        .balign 4
+st:     .long   0                       | +0  last_t0
+        .long   0, 0, 0, 0, 0           | +4  sum_routine, sum_total,
+                                        |     sum_period, max_total, n
+        .long   0, 0, 0, 0, 0           | +24 published copies of the five
+        .long   0                       | +44 windows published

--- a/modules/cfprobe/manifest.py
+++ b/modules/cfprobe/manifest.py
@@ -1,0 +1,95 @@
+"""CF PROBE -- ColdFire headroom probe: a timing cave around the per-frame
+delay routine, a fader-driven burn inside it, and a readout on HELLO WORLD.
+
+THE QUESTION IT ANSWERS. A ColdFire-side machine (a Braids port, a Pickup
+donor) would live in the audio interrupt's per-frame routine, where the
+stock Echo Freeze delay already does per-sample EMAC work
+(docs/EXTERNAL.md section 1). Nothing in the project measures how much of
+each 16-sample frame that routine already takes, or how much more the rest
+of the firmware -- sequencer, UI, card streaming, MIDI -- can lose to it
+before it starves. The emulator cannot answer either: Unicorn runs the EMAC
+exactly and at no fixed rate. This module is the flash that answers both.
+
+WHAT IT DOES, per frame (modules/cfprobe/cfprobe.s carries the detail):
+    t0 = DTCN3 ; jsr 0x400031a0 ; t1 = DTCN3 ; burn ; t2 = DTCN3
+accumulated over 1,024-frame windows, and drawn on HELLO WORLD's GAIN by
+band: 96..127 mean total busy %, 64..95 mean routine busy %, 32..63 worst
+frame %, 0..31 mean period in bus-clock ticks (47,891 expected at 132 MHz).
+The burn is the crossfader, iterations = fader * 128, inside the
+measurement, so the sweep reads its own cost. Fader 0 is a pure measurement.
+
+THE HOOK is the frame routine's ONLY call site, 0x40004b12 inside the audio
+interrupt at IPL 5: `jsr %pc@(0x400031a0)` and the `move.w #0x2700,%sr`
+after it, eight bytes, the first hook in the project that is not ten. The
+cave makes the call itself and replays the SR write last, so the burn runs
+at the routine's own interrupt level -- exactly where added code would.
+
+THE CLOCK is DMA timer 3, free running at the bus clock (DTMR3 = 0x000b,
+DTRR3 never written). The firmware zeroes DTCN3 itself on some event; the
+cave discards any frame whose period is implausible.
+
+WHAT IT CANNOT TELL YOU. Which task starves first, and at what reading.
+That is the point of the sweep: raise the fader on a full project until
+something audibly or visibly gives, then read GAIN 127's band. It runs at
+IPL 5, above the RTOS time slice and the level-4 MIDI framer, so expect the
+UI or card streaming to give before audio does; if audio gives first, the
+audio DMA sits below level 5 and every added cycle is paid by audio.
+
+TEMPOCAVE=replay does not apply to this cave (the displaced jsr is
+pc-relative) and the build refuses it. NOTEMPO=1 installs nothing, as for
+every cave.
+"""
+
+from remix.schema import CavePatch, FormatterReg, Kind, Module
+
+# 0x40004b12: `jsr %pc@(0x400031a0)` then `move.w #0x2700,%sr`. Both are
+# displaced; the cave performs both. Execution resumes at 0x40004b1a,
+# `move.l 0x46104d3e,%d0`, which reloads d0 -- nothing the cave clobbers is
+# live there (docs/EXTERNAL.md section 1 for the routine, the disassembly
+# at 0x40004b00 for the site).
+PROBE_HOOK = 0x40004b12
+PROBE_HOOK_STOCK = bytes.fromhex("4ebae68c" "46fc2700")
+
+# The formatter's entry inside the cave: `.org 0x100` in cfprobe.s.
+FMT_OFFSET = 0x100
+
+PROBE_CAVE_BYTES = bytes.fromhex(
+    "2f022f032439fc07c00c4eb9400031a02639fc07c00c2039460d16c802800000"
+    "007fef88670c5281528152815281538066f42239fc07c00c41fa016e96829282"
+    "2002909020820c80001000006260b280625cd7a80004d3a80008d1a8000cb2a8"
+    "001063042141001052a80014202800140c800000040066362168000400182168"
+    "0008001c2168000c002021680010002421680014002842a8000442a8000842a8"
+    "000c42a8001042a8001452a8002c261f241f46fc27004e750000000000000000"
+    "0000000000000000000000000000000000000000000000000000000000000000"
+    "0000000000000000000000000000000000000000000000000000000000000000"
+    "2f02202f000c41fa00a0242800286772ea88660e222800204c42100143fa0084"
+    "604a53806620242800204c682002002867502228002470644c0010004c421001"
+    "43fa005c60262428002072644c41200267305380660a2228001843fa003e6008"
+    "2228001c43fa00304c421001241f2f012f092f2f000c4eb940013a084fef000c"
+    "4e75241f487a001f2f2f00084eb940013a08508f4e7574256400722564007825"
+    "64002564002d0000000000000000000000000000000000000000000000000000"
+    "000000000000000000000000000000000000000000000000"
+)
+assert len(PROBE_CAVE_BYTES) > FMT_OFFSET
+
+MODULE = Module(
+    name="cfprobe",
+    key="CF PROBE",
+    kind=Kind.CF_PATCH,
+    doc="ColdFire headroom probe: times the per-frame delay routine, burns "
+        "on the fader, reads out on HELLO WORLD's GAIN.",
+    cf_patches=(
+        CavePatch(
+            label="cf probe cave",
+            cave_addr=None,          # floats: pc-relative state, OS absolutes
+            pinned=PROBE_CAVE_BYTES,
+            source="modules/cfprobe/cfprobe.s",
+            hook_addr=PROBE_HOOK,
+            hook_stock=PROBE_HOOK_STOCK,
+            registers_formatter=FormatterReg(module="HELLO WORLD", slot=0,
+                                             offset=FMT_OFFSET),
+            report_note=" (times 0x400031a0 per frame; burn = fader*128; "
+                        "readout on HELLO WORLD GAIN: t/r/x %, period ticks)",
+        ),
+    ),
+)

--- a/remixes/cfprobe.py
+++ b/remixes/cfprobe.py
@@ -1,0 +1,29 @@
+"""CFPROBE -- the rig plus the ColdFire headroom probe and its readout.
+
+BamSep26 as it will be flashed, with two additions: HELLO WORLD, whose GAIN
+knob is the probe's display, and CF PROBE, the cave that times the audio
+interrupt's per-frame delay routine and burns on the crossfader. The point
+of building it on the rig rather than on `hello` is the load: the sweep
+must run against the ColdFire work a real set produces, and the DSP
+selection is the one the set will use.
+
+Eight FX2 rows, one past the in-place chooser list, so the panel scrolls.
+Select HELLO WORLD on any track to read the probe; the DSP side of HELLO
+WORLD is a gain, so keep that track's GAIN at 96..127 (the total-busy band,
+and within 2 dB of unity) unless you are reading another band.
+
+A diagnostic image, not a performance one. docs/FLASHPLAN.md prices the
+flash and modules/cfprobe/README.md is the procedure.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="cfprobe",
+    doc="The rig plus the ColdFire headroom probe, read out on HELLO WORLD.",
+    modules=("REVERB SERVER", "DELAY SERVER", "SEND", "DELAY",
+             "FILTER STATION", "CHARACTER STATION", "MODULATION STATION",
+             "TEMPO SYNC", "MENU SHORTCUT", "HELLO WORLD", "CF PROBE"),
+    fallback="SEND",
+    fx1=("FILTER STATION", "CHARACTER STATION", "MODULATION STATION"),
+)

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -1134,6 +1134,14 @@ def main():
     for _c in _caves:
         _b = _c.pinned
         if _replay and _c.hook_addr is not None:
+            # Replaying displaced bytes at the cave's address only works for
+            # position-independent stock. cfprobe displaces a pc-relative
+            # jsr, which replayed from the cave would land in hyperspace
+            # inside the audio interrupt -- refuse rather than build that.
+            if _c.hook_stock[:2] in (b"\x4e\xba", b"\x4e\xbb") \
+                    or _c.hook_stock[:1] == b"\x61":
+                sys.exit(f"{_c.label}: TEMPOCAVE=replay cannot replay "
+                         f"pc-relative stock ({_c.hook_stock.hex()})")
             _b = _c.hook_stock + bytes.fromhex("4e75")
             print(f"  {_c.label}: REPLAY-ONLY diagnostic (TEMPOCAVE=replay)")
         _plan.append((_c, _b))
@@ -1208,14 +1216,24 @@ def main():
             img[_pa - BASE:_pa - BASE + len(_write)] = _write
             print(f"    poke 0x{_pa:08x}: {_expect.hex()} -> {_write.hex()}")
         if _c.hook_addr is not None:
-            img[_c.hook_addr - BASE:_c.hook_addr - BASE + 10] = \
-                b"\x4e\xb9" + _c.cave_addr.to_bytes(4, "big") + b"\x4e\x71\x4e\x71"
+            # The jsr is six bytes; the rest of the displaced span is nops.
+            # hook_stock is whole instructions, so its length is the span:
+            # ten for both tempo-sync caves, eight for cfprobe (a jsr plus
+            # a move-to-SR). Anything shorter than the jsr, or odd, is a
+            # manifest error.
+            _n = len(_c.hook_stock)
+            assert _n >= 6 and _n % 2 == 0, \
+                f"{_c.label}: hook_stock must be >= 6 even bytes, got {_n}"
+            img[_c.hook_addr - BASE:_c.hook_addr - BASE + _n] = \
+                b"\x4e\xb9" + _c.cave_addr.to_bytes(4, "big") \
+                + b"\x4e\x71" * ((_n - 6) // 2)
         # A formatter registration names the module it draws for, so a remix
         # that omits that module skips the write instead of pointing into a
         # descriptor which was never cloned.
         _reg = _c.registers_formatter
         if _reg is not None and _reg.module in clone_addr:
-            wr32(clone_addr[_reg.module] + 0x0ca + _reg.slot * 4, _c.cave_addr)
+            wr32(clone_addr[_reg.module] + 0x0ca + _reg.slot * 4,
+                 _c.cave_addr + _reg.offset)
             wr32(clone_addr[_reg.module] + 0x0fa + _reg.slot * 4, 0)
         _hook = (f", hook at 0x{_c.hook_addr:08x}"
                  if _c.hook_addr is not None else "")

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -296,6 +296,13 @@ class FormatterReg:
 
     module: str        # target module KEY, e.g. "DELAY SERVER"
     slot: int          # which of its twelve parameters this formatter draws
+    # Byte offset of the formatter's entry INSIDE the cave. 0 (the default)
+    # is a cave that is nothing but a formatter, the tempo-sync shape. A
+    # cave that is also a HOOK target keeps its hook entry at +0 (the
+    # installer's jsr lands there) and puts the formatter further in --
+    # modules/cfprobe puts it at +0x100 with an `.org`, so one cave, one
+    # address and one pc-relative state block serve both callers.
+    offset: int = 0
 
 
 @dataclass(frozen=True)

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -458,6 +458,12 @@ def main():
                           "FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
                           "DARK REV", "COMPRESSOR", "LO-FI", "DJ EQ",
                           "COMB FILTER"),
+             # cfprobe is the rig plus HELLO WORLD and the ColdFire probe
+             # cave: the same harvest, 27 more words placed.
+             "cfprobe": ("FILTER", "SPATIALIZER", "EQUALIZER", "PHASER",
+                         "FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
+                         "DARK REV", "COMPRESSOR", "LO-FI", "DJ EQ",
+                         "COMB FILTER"),
              "stations": ("FILTER", "SPATIALIZER", "EQUALIZER", "PHASER",
                           "FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
                           "DARK REV", "COMPRESSOR", "LO-FI", "DJ EQ",

--- a/tools/verify_cfprobe.py
+++ b/tools/verify_cfprobe.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""The ColdFire headroom probe does its arithmetic -- driven, not read.
+
+    python3 tools/verify_cfprobe.py [remix]      (default: cfprobe)
+
+ 1. THE IMAGE. The hook at 0x40004b12 is `jsr cave ; nop` with the addq
+    before it and the move.l after it untouched; the cave's bytes are the
+    pinned ones; HELLO WORLD's slot-0 formatter points at cave+0x100 and its
+    widget word is zero.
+ 2. THE PROBE, on the booted machine. The frame routine is stubbed to `rts`
+    (its real body is DMA descriptor arithmetic against peripherals the
+    emulator reads as all-ones) and DMA timer 3's counter is scripted, so
+    every delta is known. The probe is called as the audio interrupt would
+    call it: the first frame is discarded (no last_t0), 1,024 good frames
+    publish a window with the expected sums and max, a counter reset is
+    discarded, the burn loop runs fader*128 times, and the second window's
+    max is the one spiked frame.
+ 3. THE READOUT. The formatter is called with a buffer and one value per
+    band, before any window ("-") and after the second, and the strings are
+    what the arithmetic in cfprobe.s predicts.
+
+What this CANNOT prove: any number of ticks. Unicorn has no cycle model, so
+the routine's real cost and the starvation point are the flash's to find.
+modules/cfprobe/README.md is the procedure.
+"""
+import os
+import pathlib
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+BASE = 0x40000400
+IMAGE = pathlib.Path("out/mainos_bus.bin")
+HOOK = 0x40004b12
+FRAME_ROUTINE = 0x400031a0
+DTCN3 = 0xfc07c00c
+FADER = 0x460d16c8
+SPRINTF_BUF = 0x47f10000
+PERIOD, ROUTINE, WINDOW, LIMIT = 47891, 12000, 1024, 0x100000
+ST = {"last": 0, "sum_r": 4, "sum_t": 8, "sum_p": 12, "max": 16, "n": 20,
+      "pub_r": 24, "pub_t": 28, "pub_p": 32, "pub_max": 36, "pub_n": 40,
+      "windows": 44}
+
+
+def main():
+    from remix import registry
+    name = sys.argv[1] if len(sys.argv) > 1 else "cfprobe"
+    remix = registry.remix(name)
+    if "CF PROBE" not in remix.modules:
+        print(f"  [ -- ] {name} does not carry CF PROBE -- nothing to check")
+        return 0
+    mod = registry.modules()["CF PROBE"]
+    cave = mod.cf_patches[0]
+    pinned, fmt_off = cave.pinned, cave.registers_formatter.offset
+    env = {**os.environ, "REMIX": name, "XBUS": "1", "SPEC": "1"}
+    r = subprocess.run([sys.executable, "tools/build_bus.py"],
+                       capture_output=True, text=True, env=env)
+    if r.returncode != 0:
+        tail = (r.stdout + r.stderr).strip().splitlines()
+        sys.exit(f"{name}: build failed: {tail[-1] if tail else '?'}")
+    img = IMAGE.read_bytes()
+    fails = 0
+
+    def check(label, ok, detail=""):
+        nonlocal fails
+        print(f"  [{'PASS' if ok else 'FAIL'}] {label}"
+              f"{'  ' + detail if detail else ''}")
+        fails += 0 if ok else 1
+
+    def u32(buf, a):
+        return int.from_bytes(buf[a - BASE:a - BASE + 4], "big")
+
+    # ---- 1. the image ----------------------------------------------------
+    at = img.find(pinned)
+    check("the cave's pinned bytes are in the image exactly once",
+          at >= 0 and img.find(pinned, at + 1) < 0)
+    if at < 0:
+        print(f"\n{fails} check(s) failed")
+        return 1
+    cave_addr = BASE + at
+    site = img[HOOK - 6 - BASE:HOOK + 8 + 6 - BASE]
+    want = (bytes.fromhex("46fc2500") + b"\x4e\xb9"
+            + cave_addr.to_bytes(4, "big") + b"\x4e\x71"
+            + bytes.fromhex("203946104d3e"))
+    check("hook site: SR write, jsr cave, nop, then the stock move.l",
+          site[2:] == want and site[:2] == bytes.fromhex("4d3e"),
+          f"cave 0x{cave_addr:08x}")
+    fmt_ptr = (cave_addr + fmt_off).to_bytes(4, "big")
+    hits = [i for i in range(0, len(img) - 4, 2) if img[i:i + 4] == fmt_ptr]
+    hello = BASE + hits[0] - 0x0ca if len(hits) == 1 else None
+    check("HELLO WORLD slot 0's formatter is cave+0x%x, once" % fmt_off,
+          hello is not None, f"descriptor 0x{hello:08x}" if hello else
+          f"{len(hits)} hits")
+    if hello:
+        check("its widget word (B) is zero: a plain dial that prints A",
+              u32(img, hello + 0x0fa) == 0)
+    check("the formatter entry is the expected prologue (move.l d2,-(sp))",
+          pinned[fmt_off:fmt_off + 2] == b"\x2f\x02")
+
+    # ---- 2. the probe, driven --------------------------------------------
+    import emu_bringup as emu
+    from unicorn import UC_HOOK_CODE
+    boot = emu.boot(str(IMAGE))
+    uc = boot.uc
+    uc.mem_write(FRAME_ROUTINE, b"\x4e\x75")          # rts: stub the routine
+    try:
+        uc.ctl_flush_tb()
+    except Exception:
+        pass
+    script = {"t": 0x10000000, "reads": []}
+
+    def dtcn_read(u, off, size, data):
+        # Each read hands out the scripted counter and advances it by the
+        # next scripted step: t0, then +routine, then +burn.
+        v = script["t"]
+        script["reads"].append(v)
+        step = script["steps"].pop(0) if script.get("steps") else 0
+        script["t"] = (v + step) & 0xffffffff
+        return v
+
+    uc.mem_unmap(0xfc07c000, 0x1000)
+    uc.mmio_map(0xfc07c000, 0x1000, dtcn_read, None, None, None)
+    check("DMA timer 3's page is now the scripted counter", True)
+    calls = {"routine": 0, "burn": 0}
+    uc.hook_add(UC_HOOK_CODE, lambda u, a, s, d: calls.__setitem__(
+        "routine", calls["routine"] + 1), begin=FRAME_ROUTINE, end=FRAME_ROUTINE)
+    burn_subq = cave_addr + pinned.find(bytes.fromhex("5380" "66f4"))
+    uc.hook_add(UC_HOOK_CODE, lambda u, a, s, d: calls.__setitem__(
+        "burn", calls["burn"] + 1), begin=burn_subq, end=burn_subq)
+    st = cave_addr + pinned.rfind(b"-\x00") + 2
+    st = (st + 3) & ~3
+
+    def state(k):
+        return int.from_bytes(uc.mem_read(st + ST[k], 4), "big")
+
+    def frame(routine=ROUTINE, burn=0, gap=PERIOD, fader=0):
+        # gap: this frame's t0 minus the last frame's t0.
+        uc.mem_write(FADER, fader.to_bytes(4, "big"))
+        t0 = (script["t0"] + gap) & 0xffffffff if "t0" in script else script["t"]
+        script["t"], script["t0"] = t0, t0
+        script["steps"] = [routine, burn, 0]
+        emu._call(uc, cave_addr, ())
+
+    frame()                                            # no last_t0 yet
+    check("the first frame is discarded (no previous t0)",
+          state("n") == 0 and state("last") == 0x10000000,
+          f"n={state('n')} last=0x{state('last'):08x}")
+    check("the frame routine was called once", calls["routine"] == 1)
+    for _ in range(WINDOW):
+        frame()
+    check(f"{WINDOW} good frames publish a window",
+          state("windows") == 1 and state("pub_n") == WINDOW
+          and state("n") == 0 and state("sum_t") == 0,
+          f"windows={state('windows')} pub_n={state('pub_n')}")
+    check("published sums are frames x routine, frames x period, max = routine",
+          state("pub_r") == WINDOW * ROUTINE and state("pub_t") == WINDOW * ROUTINE
+          and state("pub_p") == WINDOW * PERIOD and state("pub_max") == ROUTINE)
+    frame(gap=-5_000_000)                              # the counter was zeroed
+    check("a counter reset under the probe is discarded",
+          state("n") == 0, f"n={state('n')}")
+    frame(gap=LIMIT + 1)                               # a stalled frame
+    check("a period past the limit is discarded", state("n") == 0)
+    frame(routine=PERIOD + 1)                          # busy longer than the period
+    check("a frame busier than its period is discarded", state("n") == 0)
+    before = calls["burn"]
+    frame(burn=18000, fader=64)
+    check("fader 64 burns 64 x 128 iterations", calls["burn"] - before == 64 * 128,
+          f"{calls['burn'] - before}")
+    check("the burn counts in total but not in routine",
+          state("sum_t") == ROUTINE + 18000 and state("sum_r") == ROUTINE)
+    for _ in range(WINDOW - 2):
+        frame(burn=18000, fader=0)                     # scripted burn, no loop
+    frame(burn=28000)                                  # the spike
+    check("the second window's max is the spiked frame",
+          state("windows") == 2 and state("pub_max") == ROUTINE + 28000,
+          f"windows={state('windows')} max={state('pub_max')}")
+
+    # ---- 3. the readout --------------------------------------------------
+    def fmt(value):
+        uc.mem_write(SPRINTF_BUF, b"\0" * 16)
+        emu._call(uc, cave_addr + fmt_off, (SPRINTF_BUF, value))
+        raw = bytes(uc.mem_read(SPRINTF_BUF, 16))
+        return raw[:raw.find(b"\0")].decode("ascii", "replace")
+
+    pub_t = (WINDOW - 1) * (ROUTINE + 18000) + ROUTINE + 28000
+    pub_p = WINDOW * PERIOD
+    want = {127: f"t{pub_t // (pub_p // 100)}", 96: f"t{pub_t // (pub_p // 100)}",
+            95: f"r{WINDOW * ROUTINE // (pub_p // 100)}",
+            63: f"x{(ROUTINE + 28000) * 100 // PERIOD}", 0: f"{PERIOD}"}
+    for v, s in want.items():
+        got = fmt(v)
+        check(f"GAIN {v:3d} draws {s!r}", got == s, f"got {got!r}")
+    # A machine with no window yet draws "-": zero the published block.
+    uc.mem_write(st + ST["pub_n"], b"\0\0\0\0")
+    check("before the first window every band draws '-'",
+          all(fmt(v) == "-" for v in (0, 40, 70, 127)))
+
+    print(f"\n{fails} check(s) failed" if fails else "\nOK")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify_menu.py
+++ b/tools/verify_menu.py
@@ -124,20 +124,16 @@ CAVE_LO, CAVE_HI = 0x400d6b20, 0x400d7c3c
 # window is full -- the character station's BUS-mode renames tipped the rig
 # over. build_bus.py's OVERFLOW_RUN / OVERFLOW_RUN_END.
 OVF_LO, OVF_HI = 0x400d24d0, 0x400d2ce0
-# TIME's sticky-snap formatter is the tempo-sync cave that registers itself
-# as DELAY SERVER slot 0. Its address FLOATS since 3 Sep 2026 (it sits
-# behind the descriptor clones, however many there are), so it is
-# recognised by its pinned bytes in the image rather than by a constant.
-def _time_fmt_cave():
-    _ts = _MODS.get("TEMPO SYNC")
-    if _ts is None:
-        return None
-    for _c in _ts.cf_patches:
-        _r = _c.registers_formatter
-        if _r is not None and _r.module == "DELAY SERVER" and _r.slot == 0:
-            return _c
-    return None
-TIME_FMT_CAVE = _time_fmt_cave()
+# A cave may register itself as some module's per-slot label formatter:
+# the tempo-sync cave draws DELAY SERVER's TIME as `1/8`, and the cfprobe
+# cave draws its readout on HELLO WORLD's GAIN from an entry 0x100 inside
+# itself (schema.FormatterReg.offset). Cave addresses FLOAT since 3 Sep
+# 2026, so a registration is recognised by the cave's pinned bytes in the
+# image at the entry minus its offset, not by a constant.
+REG_FMT = {(_c.registers_formatter.module, _c.registers_formatter.slot):
+           (_c.pinned, _c.registers_formatter.offset)
+           for _k in REMIX.modules for _c in _MODS[_k].cf_patches
+           if _c.registers_formatter is not None}
 
 
 def main():
@@ -320,16 +316,20 @@ def main():
                       f"the tick widget and 0x12a=0, with A either stock's "
                       f"enumerated formatter or a label cave "
                       f"(got 0x{f1:08x}/0x{f2:08x}/0x{f3:08x})")
-            elif (name == "DELAY SERVER" and i == 0 and TIME_FMT_CAVE is not None
-                  and CAVE_LO <= f1 < CAVE_HI
-                  and img[f1 - BASE:f1 - BASE + len(TIME_FMT_CAVE.pinned)]
-                  == TIME_FMT_CAVE.pinned):
-                # TIME's sticky-snap label formatter (modules/tempo-sync/time_fmt.s, 24 Aug
-                # 2026): a knob with A = our cave and B = 0 -- stock DELAY
-                # TIME's own shape (A = 0x4003c718, B = 0).
+            elif ((name, i) in REG_FMT
+                  and (CAVE_LO <= f1 < CAVE_HI or OVF_LO <= f1 < OVF_HI)
+                  and img[f1 - REG_FMT[(name, i)][1] - BASE:
+                          f1 - REG_FMT[(name, i)][1] - BASE
+                          + len(REG_FMT[(name, i)][0])]
+                  == REG_FMT[(name, i)][0]):
+                # A registered label formatter (time_fmt.s, 24 Aug 2026;
+                # cfprobe.s, 4 Sep 2026): a knob with A = our cave's entry
+                # and B = 0 -- stock DELAY TIME's own shape (A = 0x4003c718,
+                # B = 0). Without the cave (NOTEMPO=1) the slot falls through
+                # to the plain-knob rule below, as before.
                 check(f2 == 0,
-                      f"{name}: p0 TIME carries the label formatter, so B is 0 "
-                      f"(got 0x{f2:08x})")
+                      f"{name}: p{i} carries a registered label formatter at "
+                      f"0x{f1:08x}, so B is 0 (got 0x{f2:08x})")
             else:
                 check(f1 == 0 and f2 == 0,
                       f"{name}: p{i} count {cnt} is a KNOB, so both formatters "


### PR DESCRIPTION
## Summary
- **modules/cfprobe** — a 472-byte ColdFire cave hooked at `0x40004b12`, the frame routine's only call site inside the audio interrupt (IPL 5). It times `0x400031a0` with DMA timer 3, burns `fader × 128` iterations inside the measurement, and publishes 1,024-frame windows. A formatter at `+0x100` draws the readout on HELLO WORLD's GAIN: mean total %, mean routine %, worst frame %, period ticks.
- **remixes/cfprobe** — the rig plus HELLO WORLD and the probe; a diagnostic image.
- **Build:** the hook span follows `len(hook_stock)` (first 8-byte hook); `TEMPOCAVE=replay` refuses a pc-relative hook; `FormatterReg.offset` registers an entry inside a cave. **refhash: 26/26 bit-identical.**
- **verify_menu** recognises any registered formatter by its cave bytes (was: tempo-sync by name).
- **tools/verify_cfprobe.py** — 22 emulator-driven checks (stubbed routine, scripted timer, discards, burn count, every readout string). In `make verify`.
- **Docs:** README with the hardware procedure and falsifiers, FLASHPLAN flash 5, PLAN §8 (ColdFire machines: Braids, the Pickup donor), MODULES.md.

## Test plan
- [x] `make check` green on the default remix
- [x] `REMIX=cfprobe make verify` green, `make verify` green
- [x] `scripts/refhash.sh check` — ALL 26 CASES BIT-IDENTICAL
- [x] `tools/verify_cfprobe.py cfprobe` — 22/22
- [ ] Flash 5 on hardware: PERIOD ≈ 47891, `t` = `r` at fader 0, then the sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)