### PR TITLE
Rename the station modules: SPECTRUM, CHARACTER, MODULATION

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -678,7 +678,7 @@ is the slice of that road worth having.
 ### 6b. Per-mode knob NAMES — DONE 3 Sep 2026, emulator-proven
 
 **A MODE select now renames the knobs around it.** BusDelay's MDEP/MRAT read
-SCAT/DENS in GRAIN, and the modulation station's FDBK/DLY read RES and
+SCAT/DENS in GRAIN, and the Modulation station's FDBK/DLY read RES and
 RING/PTCH in PHSR and COMB. `ModeView` in the manifest is the single
 declaration; the remixer's UNIT pane follows it, `send_probe --set` accepts
 the aliases, and `tools/mode_names.py` emits a MODE formatter that rewrites
@@ -842,7 +842,7 @@ stepped-select labels, stock effects listable beside ours, the insert card,
 a module on FX1, a donor region beyond the three reverbs, the BamSep26 rig
 (three stations, BusDelay v5) — and, since 3 Sep 2026, **the returns**:
 the engines' wet published stereo and four deep, returned at the master by
-the character station in BUS mode (RVRB/DLY on the CRSH/RING knobs), the
+the Character station in BUS mode (RVRB/DLY on the CRSH/RING knobs), the
 hosts going quiet only while a return is live. `docs/BUS.md` "The returns";
 `tools/verify_returns.py` is its gate, and `make verify-bus` came back 19/19
 across the edit — with no return in the rig nothing changed, to the bit.

--- a/docs/BUS.md
+++ b/docs/BUS.md
@@ -911,7 +911,7 @@ ACC-write addressing needed for the dry sends already existed.
 
 **Built and emulator-verified, 3 Sep 2026 (`tools/verify_returns.py`, 18
 gates); not flashed.** The two engines' wet leaves the bus and enters the mix
-at the MASTER, through a character station in BUS mode — so the host tracks
+at the MASTER, through a Character station in BUS mode — so the host tracks
 (the delay's on 1–4, the reverb's on 5–8) play their own material dry, like
 every other track, and the reverb and delay each arrive once, at one level,
 under one knob. Design page:
@@ -928,7 +928,7 @@ accumulators' race, the accumulators' fix. Stereo because the return is what
 the master hears; a mono M would have thrown the reverb's width and the
 delay's ping-pong away.
 
-**What reads it.** `modules/charstation/` with `SAT = BUS`. On a master
+**What reads it.** `modules/character/` with `SAT = BUS`. On a master
 chain CRSH and RING are knobs nobody turns, so BUS repurposes them as the
 **RVRB** and **DLY** return levels (a `ModeView` renames them on the panel and
 in the remixer, and the crush and ring stages go neutral). Each sample, AFTER

--- a/docs/FLASHPLAN.md
+++ b/docs/FLASHPLAN.md
@@ -45,7 +45,7 @@ flashes 2 and 3 are for.
 | A module on FX1 | FX1's chooser relocated into the cave, its three `lea` refs repointed, its own id **and cursor** tables written | ColdFire emulator only |
 | A donor region beyond the reverbs | any stock effect's words can be taken; every one is self-contained | `dsp_reach` over both payloads — **static** |
 | Hello World (Bryan T) | builds and runs | flashed on **his** unit, not Sam's |
-| **The returns** (3 Sep 2026) | the engines' wet arrives once, at the master, through the character station in BUS mode (RVRB/DLY); the hosts go quiet ONLY while a return is live, and print as before otherwise | `tools/verify_returns.py` 18/18 and `make verify-bus` 19/19 — single-core: the delay's wet and its RETD stamp both cross cores on the unit, which no local test can see; and `0x360d3-5` next door was dead on hardware for R36 |
+| **The returns** (3 Sep 2026) | the engines' wet arrives once, at the master, through the Character station in BUS mode (RVRB/DLY); the hosts go quiet ONLY while a return is live, and print as before otherwise | `tools/verify_returns.py` 18/18 and `make verify-bus` 19/19 — single-core: the delay's wet and its RETD stamp both cross cores on the unit, which no local test can see; and `0x360d3-5` next door was dead on hardware for R36 |
 
 ---
 
@@ -280,8 +280,8 @@ each one's failure has a different shape from the next.
 | | claim | how to see it | falsified by |
 |---|---|---|---|
 | i | six descriptor clones + floated caves; label formatters and the FX1 list in the SECOND zero run | every station's page draws all twelve names; MODE/SAT/CMOD print words; BusDelay TIME prints `1/8`; FX1 chooser = NONE + three stations | garbage names, a select printing a number, a chooser with junk rows |
-| ii | FX1 default = filter station, dry at defaults | a part that chose FILTER runs the station and sounds unchanged | any tone change on a track at station defaults |
-| iii | the modulation station is dry on FX2 and modulates on FX1 | T5's FX1 modstation audible in CHOR; the same module chosen on T3's FX2 is a dry pass | **test on T7/T8 first** — a wrong FX1 detection on tracks 5–6 writes into BusVerb's tank |
+| ii | FX1 default = Spectrum station, dry at defaults | a part that chose FILTER runs the station and sounds unchanged | any tone change on a track at station defaults |
+| iii | the Modulation station is dry on FX2 and modulates on FX1 | T5's FX1 modulation audible in CHOR; the same module chosen on T3's FX2 is a dry pass | **test on T7/T8 first** — a wrong FX1 detection on tracks 5–6 writes into BusVerb's tank |
 | iv | harvested ids from an old project = silence, not noise | load the untouched set: tracks that named PLATE/SPRING/COMB etc. are silent | noise, a hang |
 | v | **an FX1 station sending on T5** — a bus participant on FX1 has never run on hardware | T5's →VRB reaches the reverb; sweep tracks × modes and listen for the rotation-class artefacts (stutter, a block-rate buzz) | stutter that follows dispatch position |
 | vi | stock DELAY on FX2 beside a sending station on FX1 | T2: delay repeats in the mix, the reverb of the DRY signal on the bus, not of the repeats | silence on FX2, or the repeats reaching the reverb |

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -276,7 +276,7 @@ keeps its name and says so in its `doc`.
 
 ## A STATION: an insert that is also a bus client
 
-The BamSep26 stations (`modules/filterstation/` is the first) are per-track
+The BamSep26 stations (`modules/spectrum/` is the first) are per-track
 inserts that also SEND: page-1 →DEL / →VRB knobs, the processed mono added
 into both accumulators. What that takes, beyond the insert contract:
 
@@ -763,7 +763,7 @@ same effect on both slots of one track is two independent instances that
 happen to run in series.
 
 **A `replaces` module is listed on FX1 by its own key** (since 3 Sep 2026):
-`fx1=("FILTER STATION", ...)`, never the stock key it replaces — the build
+`fx1=("SPECTRUM", ...)`, never the stock key it replaces — the build
 refuses `fx1=("FILTER",)` beside a module that replaces FILTER, because
 that row would draw the stock name over our code. A composed list is
 rebuilt from scratch in the cave, so the stock row the replacement inherited

--- a/modules/busdelay/delay_server.asm
+++ b/modules/busdelay/delay_server.asm
@@ -630,7 +630,7 @@ bus_mine:
         add     b,a
         move    a,x:(r7+$63)            ; this call's DELAY ACC read address
 ; ---- this call's DELAY WET write address: STEREO, FOUR DEEP (3 Sep 2026) --
-; Read now, by a character station in BUS mode -- the return on the master
+; Read now, by a Character station in BUS mode -- the return on the master
 ; (docs/BUS.md "The returns"), which is on the OTHER core -- so it takes the
 ; accumulators' four-buffer rotation and carries L and R (32 words a buffer,
 ; interleaved: the ping-pong image is the point of the delay). The base is

--- a/modules/busverb/reverb_server.asm
+++ b/modules/busverb/reverb_server.asm
@@ -481,7 +481,7 @@ bus_mine:
         add     b,a
         move    a,x:(r7+$63)            ; this call's ACC read address
 ; ---- this call's REVERB WET write address: STEREO, FOUR DEEP (3 Sep 2026) --
-; The wet is READ now -- by a character station in BUS mode, the return on
+; The wet is READ now -- by a Character station in BUS mode, the return on
 ; the master (docs/BUS.md "The returns") -- so it carries the same cross-core
 ; race the accumulators do and takes the same four-buffer rotation, and it
 ; carries L and R (32 words a buffer, interleaved) because the return is what

--- a/modules/character/README.md
+++ b/modules/character/README.md
@@ -1,4 +1,4 @@
-# CHARACTER STATION
+# CHARACTER
 
 The second BamSep26 station: everything that dirties or tightens a track, in
 one insert, **replacing stock LO-FI** (id 0x1c) on both menus and in every
@@ -29,7 +29,7 @@ rather than a fader for the dirt.
   compressor's threshold to 1.0 and the other modes set the boost flag to 0.
 - **WDTH** is mid/side: 64 untouched, 0 mono, 127 double sides. With BUS +
   GLUE + WDTH this is the master chain on T8's FX1.
-- **→DEL / →VRB** make it a bus client on the filter station's terms:
+- **→DEL / →VRB** make it a bus client on the Spectrum station's terms:
   knob-gated registration, and it never housekeeps.
 - **SAT = BUS is also the RETURN** (3 Sep 2026, `docs/BUS.md` "The
   returns"). On a master chain CRSH and RING are knobs nobody turns, so BUS
@@ -54,7 +54,7 @@ and nothing else changes — that is the whole sidechain-ducking path.
   the 3,120 + 768 FILTER credit. Sam's layout runs one or two. Trims if it
   must come down: drop RING (~12), a single `chsatur` call by rolling the two
   channels (~13), the TUBE asymmetry (~10 per channel).
-- `tools/verify_charstation.py`, **22 gates, all PASS**: defaults bit-exact;
+- `tools/verify_character.py`, **22 gates, all PASS**: defaults bit-exact;
   MIX=0 bit-exact with every stage driven; CRSH=110 collapses a ramp to 144
   wet levels against 4,500; SRR holds the wet exactly 2/4/8 samples; all four
   SAT characters unity small-signal at DRV=0 and bounded at DRV=127; FOLD

--- a/modules/character/character.asm
+++ b/modules/character/character.asm
@@ -1,13 +1,13 @@
 ; ---------------------------------------------------------------------------
-; CHARACTER STATION -- crush, fold, ring, saturate, compress, width, sends.
+; CHARACTER -- crush, fold, ring, saturate, compress, width, sends.
 ;
 ; Insert contract (modules/ripple/ripple_svf.asm): frames in place at
 ; x:(r0)/x:(r0+n0), knobs from r6, state in this instance's r7 block. PLUS
 ; the bus-client contract from modules/send/send_client.asm, exactly as
-; modules/filterstation/ carries it: the PROCESSED mono goes into both
+; modules/spectrum/ carries it: the PROCESSED mono goes into both
 ; accumulators, registration is gated on each send knob, and the station
 ; NEVER HOUSEKEEPS (an FX1 instance runs before its track's FX2 one, so an
-; electing station would double-flip the rotation -- see filterstation's
+; electing station would double-flip the rotation -- see spectrum's
 ; header for the full argument).
 ;
 ; ---- the chain, fixed order ----------------------------------------------
@@ -48,7 +48,7 @@
 ;   $30 ->DEL level     $31 ->VRB level
 ;   $3e RVRB return level  $3f DLY return level   (BUS mode only, else 0)
 ;   per sample / persistent (ALL BELOW $40 -- an r7 displacement past 63
-;   assembles to the two-word long form, which cost the filter station 30
+;   assembles to the two-word long form, which cost the Spectrum station 30
 ;   words before it was found):
 ;   $19 held L (PERSISTENT)      $1a held R (PERSISTENT)
 ;   $1b srr counter (PERSISTENT) $1c carrier phase (PERSISTENT)

--- a/modules/character/manifest.py
+++ b/modules/character/manifest.py
@@ -1,4 +1,4 @@
-"""CHARACTER STATION -- everything that dirties or tightens, and a bus sender.
+"""CHARACTER -- everything that dirties or tightens, and a bus sender.
 
 The second BamSep26 station. A per-track INSERT that REPLACES stock LO-FI
 (id 0x1c, both menus, and every saved part that chose LO-FI):
@@ -53,8 +53,8 @@ _PLAIN = Formatter.PLAIN
 _STEP = Formatter.STEPPED
 
 MODULE = Module(
-    name="charstation",
-    key="CHARACTER STATION",
+    name="character",
+    key="CHARACTER",
     kind=Kind.DSP_EFFECT,
     doc="BamSep26 station: crush, fold/ring, saturation, compressor, width, sends.",
     menu=MenuEntry(
@@ -105,8 +105,8 @@ MODULE = Module(
                  defaults={2: 127, 8: 127}),
     ),
     dsp=DspSection(
-        asm="modules/charstation/char_station.asm",
-        priority=13,                  # after the filter station
+        asm="modules/character/character.asm",
+        priority=13,                  # after the Spectrum station
         bus_role=BusRole.NONE,        # an insert that also WRITES the bus
         ybase=YBase.NEVER,
         r7_latch_slot=0x69,           # ROTLATCH parks this block's offset here

--- a/modules/modulation/README.md
+++ b/modules/modulation/README.md
@@ -1,4 +1,4 @@
-# MODULATION STATION
+# MODULATION
 
 The third BamSep26 station: one modulated line, seven modes, **FX1 only**,
 replacing stock CHORUS (id 0x12). Design page:
@@ -43,7 +43,7 @@ allocator put us.
 
 - **1,133 words** (payload A, 1,166 on B), **402 cycles/sample** (the LINE
   loop is the worst of the four; PHSR is 354, AMP 193, dry 20).
-- `tools/verify_modstation.py`, **9 gates, all PASS**:
+- `tools/verify_modulation.py`, **9 gates, all PASS**:
   - MIX=0 is a bit-exact passthrough in all seven modes;
   - **an FX2 instance is a bit-exact dry pass in all seven modes at any
     setting**, and `dsp_host -guard` reports "nothing written over a loaded

--- a/modules/modulation/manifest.py
+++ b/modules/modulation/manifest.py
@@ -1,4 +1,4 @@
-"""MODULATION STATION -- one modulated line, seven modes, FX1 only.
+"""MODULATION -- one modulated line, seven modes, FX1 only.
 
 The third BamSep26 station. It REPLACES stock CHORUS (id 0x12) and covers
 what stock spreads over CHORUS, FLANGER, PHASER and COMB, plus the three the
@@ -41,8 +41,8 @@ _PLAIN = Formatter.PLAIN
 _STEP = Formatter.STEPPED
 
 MODULE = Module(
-    name="modstation",
-    key="MODULATION STATION",
+    name="modulation",
+    key="MODULATION",
     kind=Kind.DSP_EFFECT,
     doc="BamSep26 station: chorus/flanger/phaser/comb/trem/vib/pan, FX1 only.",
     menu=MenuEntry(
@@ -112,8 +112,8 @@ MODULE = Module(
                  defaults={0: 55, 1: 100, 2: 0, 3: 127}),
     ),
     dsp=DspSection(
-        asm="modules/modstation/mod_station.asm",
-        priority=14,                  # after the character station
+        asm="modules/modulation/modulation.asm",
+        priority=14,                  # after the Character station
         bus_role=BusRole.NONE,        # an insert that also WRITES the bus
         ybase=YBase.NEVER,
         r7_latch_slot=0x69,           # ROTLATCH parks this block's offset here
@@ -122,7 +122,7 @@ MODULE = Module(
     # The FX1-only allocator buffer: two 1,024-word lines out of the 3,072 an
     # FX1 slot gives. `fx1_only` is the promise that an FX2 instance writes
     # nothing -- the ledger admits it beside a server on that basis, and
-    # tools/verify_modstation.py is what proves it.
+    # tools/verify_modulation.py is what proves it.
     claims=Claims(stock_instance_buffer=True, buffer_words=2048, fx1_only=True),
     harness=Harness(layout_char="3", is_server=False, bus_client=True),
 )

--- a/modules/modulation/modulation.asm
+++ b/modules/modulation/modulation.asm
@@ -1,8 +1,8 @@
 ; ---------------------------------------------------------------------------
-; MODULATION STATION -- one modulated line, seven modes, FX1 only.
+; MODULATION -- one modulated line, seven modes, FX1 only.
 ;
 ; Insert contract (modules/ripple/ripple_svf.asm) plus the bus-client contract
-; the other two stations carry (modules/filterstation/): the processed mono
+; the other two stations carry (modules/spectrum/): the processed mono
 ; goes into both accumulators, registration is gated on each send knob, and
 ; the station NEVER HOUSEKEEPS -- an FX1 instance runs before its track's FX2
 ; one, so an electing station would double-flip the rotation.
@@ -15,7 +15,7 @@
 ; 0, BusDelay's line on tracks 3-4. So a base >= 0x4000 sets a flag that
 ; sends proc down the DRY path, which writes NOTHING to Y. That promise is
 ; what Claims(fx1_only=True) declares to the ledger, and tools/
-; verify_modstation.py is what proves it.
+; verify_modulation.py is what proves it.
 ;
 ; Two lines of 1,024 words, L at base+0 and R at base+1024: 23 ms each, out
 ; of the 3,072 an FX1 slot gives. The read offset is MASKED (& $3ff), not the
@@ -50,7 +50,7 @@
 ; ---- r7 slots -------------------------------------------------------------
 ;   $14 $65..$69  bus bookkeeping, SEND's layout ($69 = this block's offset)
 ;   ⚠️ EVERY SLOT THE SAMPLE LOOPS TOUCH IS BELOW $40: an r7 displacement past
-;   63 assembles to the two-word long form (it cost the filter station 30
+;   63 assembles to the two-word long form (it cost the Spectrum station 30
 ;   words before that was found).
 ;   $19 line base (per instance)     $1a dry flag: 1 = FX2 slot or MIX 0
 ;   $1b write phase (PERSISTENT)     $1c LFO phase (PERSISTENT)
@@ -74,7 +74,7 @@
 ; second. Every Tcc reads the ONE compare above it with nothing but moves
 ; between (the flag-clobber trap). No label here is a PREFIX of another --
 ; dsp_asm resolves by prefix, and `ch_sat` inside `ch_satr` cost the
-; character station an afternoon.
+; Character station an afternoon.
 ; ---------------------------------------------------------------------------
 
 init:

--- a/modules/spectrum/README.md
+++ b/modules/spectrum/README.md
@@ -1,4 +1,4 @@
-# FILTER STATION
+# SPECTRUM
 
 The first BamSep26 station: two filters, four routings, one modulation and
 two bus sends in one insert, **replacing stock FILTER** (id 0x04) on both
@@ -41,7 +41,7 @@ on FILTER's stored values sent at 64 through a closed, resonant filter).
   sends. Stock FILTER is 192 for one filter. Seven of these on one core is
   at the cliff by the pricer; four on FX1 plus three SENDs beside the reverb
   is 1,384 + 1,356 + 60.
-- `tools/verify_filterstation.py` (needs the audition dump): defaults
+- `tools/verify_spectrum.py` (needs the audition dump): defaults
   bit-exact on a full-scale ramp; LP 12.9 dB/oct between 2 and 4 kHz at
   FREQ 30; HP and BP at DC → 0 (−2 / −1 LSB); NOTCH and LP at DC → DC (5
   LSB low); BASE 100 kills DC through the pair (4 LSB); WDTH 30 takes 55 dB

--- a/modules/spectrum/manifest.py
+++ b/modules/spectrum/manifest.py
@@ -1,4 +1,4 @@
-"""FILTER STATION -- two filters in one insert, and a bus sender.
+"""SPECTRUM -- two filters in one insert, and a bus sender.
 
 The first BamSep26 station. A per-track INSERT that REPLACES stock FILTER
 (id 0x04, both menus, and every saved part that chose FILTER), built the way
@@ -38,8 +38,8 @@ _PLAIN = Formatter.PLAIN
 _STEP = Formatter.STEPPED
 
 MODULE = Module(
-    name="filterstation",
-    key="FILTER STATION",
+    name="spectrum",
+    key="SPECTRUM",
     kind=Kind.DSP_EFFECT,
     doc="BamSep26 station: dual filter (SVF + base/width), LFO/env, SER/PAR/RING/FM, sends.",
     menu=MenuEntry(
@@ -82,7 +82,7 @@ MODULE = Module(
               doc="what DPTH applies: the envelope follower, the LFO, or half of each"),
     ),
     dsp=DspSection(
-        asm="modules/filterstation/filter_station.asm",
+        asm="modules/spectrum/spectrum.asm",
         priority=12,                  # after every existing module
         bus_role=BusRole.NONE,        # an insert that also WRITES the bus
         ybase=YBase.NEVER,

--- a/modules/spectrum/spectrum.asm
+++ b/modules/spectrum/spectrum.asm
@@ -1,5 +1,5 @@
 ; ---------------------------------------------------------------------------
-; FILTER STATION -- two filters, four routings, one modulation, two sends.
+; SPECTRUM -- two filters, four routings, one modulation, two sends.
 ;
 ; Insert contract (modules/ripple/ripple_svf.asm): frames in place at
 ; x:(r0)/x:(r0+n0), knobs from r6, state in this instance's r7 block. PLUS

--- a/remixes/bamsep26.py
+++ b/remixes/bamsep26.py
@@ -11,7 +11,7 @@ https://claude.ai/code/artifact/1f1bfff2-9d4e-41b6-b0a7-91a3c8989aaf
                 costs the DSP nothing, so every track can have its own delay
                 IN PARALLEL with the shared reverb -- which the stock box
                 cannot do, because only a station's send reaches the bus
-    Spectrum    the filter station, on FILTER's old id 0x04
+    Spectrum    the Spectrum station, on FILTER's old id 0x04
     Character   replaces LO-FI   (id 0x1c)
     Modulation  on CHORUS's old id 0x12, FX1 only
     TEMPO SYNC  the two ColdFire caves: BusDelay's TIME reads 1/8 rather
@@ -22,7 +22,7 @@ https://claude.ai/code/artifact/1f1bfff2-9d4e-41b6-b0a7-91a3c8989aaf
 Seven FX2 rows, which is exactly the in-place chooser list -- no scrolling.
 FX1 is NONE plus the three stations: every station takes the FX1 row of the
 stock effect it replaces, so a saved part that chose FILTER now runs the
-filter station, which is why all three default to a bit-exact passthrough.
+Spectrum station, which is why all three default to a bit-exact passthrough.
 
 ⚠️ EVERY OTHER STOCK EFFECT IS HARVESTED. Thirteen effects, 6,158 words per
 payload in one contiguous run, and an old project that still names one of
@@ -41,8 +41,8 @@ REMIX = Remix(
     name="bamsep26",
     doc="The rig: bus (BusVerb + BusDelay) + three stations + the stock delay.",
     modules=("REVERB SERVER", "DELAY SERVER", "SEND", "DELAY",
-             "FILTER STATION", "CHARACTER STATION", "MODULATION STATION",
+             "SPECTRUM", "CHARACTER", "MODULATION",
              "TEMPO SYNC", "MENU SHORTCUT"),
     fallback="SEND",
-    fx1=("FILTER STATION", "CHARACTER STATION", "MODULATION STATION"),
+    fx1=("SPECTRUM", "CHARACTER", "MODULATION"),
 )

--- a/remixes/cfprobe.py
+++ b/remixes/cfprobe.py
@@ -22,8 +22,8 @@ REMIX = Remix(
     name="cfprobe",
     doc="The rig plus the ColdFire headroom probe, read out on HELLO WORLD.",
     modules=("REVERB SERVER", "DELAY SERVER", "SEND", "DELAY",
-             "FILTER STATION", "CHARACTER STATION", "MODULATION STATION",
+             "SPECTRUM", "CHARACTER", "MODULATION",
              "TEMPO SYNC", "MENU SHORTCUT", "HELLO WORLD", "CF PROBE"),
     fallback="SEND",
-    fx1=("FILTER STATION", "CHARACTER STATION", "MODULATION STATION"),
+    fx1=("SPECTRUM", "CHARACTER", "MODULATION"),
 )

--- a/remixes/stations.py
+++ b/remixes/stations.py
@@ -6,7 +6,7 @@ server and SEND (the fallback). FILTER is replaced by the station, so its
 """
 from remix.schema import Remix
 REMIX = Remix(name="stations", doc="the three BamSep26 stations + BusVerb + SEND",
-              modules=("REVERB SERVER", "SEND", "FILTER STATION", "CHARACTER STATION",
-                       "MODULATION STATION"),
+              modules=("REVERB SERVER", "SEND", "SPECTRUM", "CHARACTER",
+                       "MODULATION"),
               fallback="SEND",
-              fx1=("FILTER STATION", "CHARACTER STATION", "MODULATION STATION"))
+              fx1=("SPECTRUM", "CHARACTER", "MODULATION"))

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -399,7 +399,7 @@ NO_FB = REMIX.fallback == NO_FALLBACK
 # this tag -- the knob working for the first time; the makeup holds level.
 # 79 == OCTABAM79 == the BamSep26 rig + THE RETURNS (3 Sep 2026): three
 # stations (FILTER/LO-FI/CHORUS replaced, all bus senders), BusDelay v5,
-# the character station returning both wets on the master (RVRB/DLY in
+# the Character station returning both wets on the master (RVRB/DLY in
 # SAT=BUS), hosts quiet only while a return is live; label formatters
 # overflow into the second zero run. Flash 4, docs/FLASHPLAN.md.
 BUILD_TAG = b"79"

--- a/tools/cycle_count.py
+++ b/tools/cycle_count.py
@@ -164,7 +164,7 @@ def bank_worst(rows, mods, fx1=(), stock_fx1_keys=()):
         pass
     # ON FX1 = listed there by name, OR a replacement (MenuEntry.replaces)
     # inheriting the stock row when the remix leaves stock's FX1 list
-    # alone: FILTER STATION on FILTER's id is on FX1 whether or not
+    # alone: SPECTRUM on FILTER's id is on FX1 whether or not
     # anyone typed it, so it is priced x4 like anything else there.
     fx1_mods = [m for m in mods if m["stem"] in cyc
                 and (m["key"] in fx1

--- a/tools/ot_project.py
+++ b/tools/ot_project.py
@@ -382,19 +382,19 @@ def make_test_project(src, dest, remix_name):
 # One part = the whole rig on its eight tracks, as designed (the BamSep26
 # page and docs/BUS.md "The returns"): stations on FX1 everywhere, the two
 # engines in T1's and T5's FX2, the stock delay where a track wants one, and
-# T8's character station in SAT=BUS with both returns up. Every part of every
+# T8's Character station in SAT=BUS with both returns up. Every part of every
 # bank gets the same layout, so any pattern is the rig. Knob bytes are the
 # manifest defaults with the few deliberate exceptions listed per track.
 RIG = (
     # track, FX1 (key, {knob: val}),                FX2 (key, {knob: val})
-    (1, ("CHARACTER STATION", {"-VRB": 30}),        ("DELAY SERVER", {})),
-    (2, ("FILTER STATION", {"-VRB": 40, "-DEL": 30}), ("DELAY", {})),
-    (3, ("FILTER STATION", {"-VRB": 30}),           ("CHARACTER STATION", {})),
-    (4, ("FILTER STATION", {"-DEL": 40}),           ("DELAY", {})),
-    (5, ("MODULATION STATION", {"-VRB": 40}),       ("REVERB SERVER", {})),
-    (6, ("FILTER STATION", {"-VRB": 50}),           ("DELAY", {})),
-    (7, ("CHARACTER STATION", {"-VRB": 40, "-DEL": 20}), ("DELAY", {})),
-    (8, ("CHARACTER STATION", {"SAT": 3, "CRSH": 127, "RING": 127,
+    (1, ("CHARACTER", {"-VRB": 30}),        ("DELAY SERVER", {})),
+    (2, ("SPECTRUM", {"-VRB": 40, "-DEL": 30}), ("DELAY", {})),
+    (3, ("SPECTRUM", {"-VRB": 30}),           ("CHARACTER", {})),
+    (4, ("SPECTRUM", {"-DEL": 40}),           ("DELAY", {})),
+    (5, ("MODULATION", {"-VRB": 40}),       ("REVERB SERVER", {})),
+    (6, ("SPECTRUM", {"-VRB": 50}),           ("DELAY", {})),
+    (7, ("CHARACTER", {"-VRB": 40, "-DEL": 20}), ("DELAY", {})),
+    (8, ("CHARACTER", {"SAT": 3, "CRSH": 127, "RING": 127,
                                "CMOD": 1, "COMP": 40}), (None, {})),
 )
 

--- a/tools/send_probe.py
+++ b/tools/send_probe.py
@@ -681,7 +681,7 @@ def main():
                          "per-effect flag; an unknown name dies instead of "
                          "driving the wrong slot.")
     ap.add_argument("--return", dest="ret", action="store_true",
-                    help="append a CHARACTER STATION in SAT=BUS with both "
+                    help="append a CHARACTER in SAT=BUS with both "
                          "return levels at 127 to the layout and measure "
                          "ITS output: the engines' wet as the master hears "
                          "it, two blocks late (docs/BUS.md 'The returns'). "
@@ -690,9 +690,9 @@ def main():
     a = ap.parse_args()
     if a.ret:
         _rl = next((m.harness.layout_char for m in registry.modules().values()
-                    if m.name == "charstation" and m.harness is not None), None)
+                    if m.name == "character" and m.harness is not None), None)
         if _rl is None:
-            die("--return needs the character station in the registry")
+            die("--return needs the Character station in the registry")
         if _rl in a.layout.upper():
             die(f"--return: the layout already has a {_rl!r}; set its knobs "
                 f"with --set {_rl}:SAT=3 etc. instead")

--- a/tools/verify_character.py
+++ b/tools/verify_character.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""CHARACTER STATION render gates, with arithmetic you can predict.
+"""CHARACTER render gates, with arithmetic you can predict.
 
 Renders the station straight through dsp_host (verify_hello's shape: the id
 and the slots come from the manifest, the entry points are checked against
@@ -22,8 +22,8 @@ Gates:
 The dump comes from the audition, which builds a scratch image that really
 contains this station beside SEND:
 
-    python3 tools/remix/audition.py charstation out/dry/drums_110.wav
-    python3 tools/verify_charstation.py
+    python3 tools/remix/audition.py character out/dry/drums_110.wav
+    python3 tools/verify_character.py
 """
 import math, pathlib, struct, subprocess, sys
 
@@ -31,7 +31,7 @@ sys.path.insert(0, "tools")
 import send_probe  # reuse its dispatch-table entry resolution
 from remix import registry
 
-MOD = registry.by_name("charstation")
+MOD = registry.by_name("character")
 SEND = registry.by_name("send")
 K = MOD.knob_map()
 MEM = f"out/dsp/_audition_{MOD.name}_A.mem"

--- a/tools/verify_menu.py
+++ b/tools/verify_menu.py
@@ -121,7 +121,7 @@ STEPPED_FMT = (0x4003c718, 0x40047254)
 CAVE_LO, CAVE_HI = 0x400d6b20, 0x400d7c3c
 # ... and, since 3 Sep 2026, the second zero run docs/MAINMENU.md section 5
 # names: label formatters (and the FX1 list) overflow into it when the clone
-# window is full -- the character station's BUS-mode renames tipped the rig
+# window is full -- the Character station's BUS-mode renames tipped the rig
 # over. build_bus.py's OVERFLOW_RUN / OVERFLOW_RUN_END.
 OVF_LO, OVF_HI = 0x400d24d0, 0x400d2ce0
 # A cave may register itself as some module's per-slot label formatter:

--- a/tools/verify_modulation.py
+++ b/tools/verify_modulation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""MODULATION STATION render gates -- and the FX1-ONLY PROMISE.
+"""MODULATION render gates -- and the FX1-ONLY PROMISE.
 
 The station takes a per-track line from the host's bump allocator, which is
 only safe in an FX1 slot: every FX2 instance buffer is a server's ground.
@@ -17,8 +17,8 @@ Gates:
   TREM/PAN      -> amplitude moves, and PAN moves the two channels apart
   every knob    -> renders without dsp_host dying
 
-    python3 tools/remix/audition.py modstation out/dry/drums_110.wav
-    python3 tools/verify_modstation.py
+    python3 tools/remix/audition.py modulation out/dry/drums_110.wav
+    python3 tools/verify_modulation.py
 """
 import math, pathlib, struct, subprocess, sys
 
@@ -26,7 +26,7 @@ sys.path.insert(0, "tools")
 import send_probe  # reuse its dispatch-table entry resolution
 from remix import registry
 
-MOD = registry.by_name("modstation")
+MOD = registry.by_name("modulation")
 SEND = registry.by_name("send")
 K = MOD.knob_map()
 MEM = f"out/dsp/_audition_{MOD.name}_A.mem"

--- a/tools/verify_nimbus.py
+++ b/tools/verify_nimbus.py
@@ -13,7 +13,7 @@ sample. The DC gate cannot see rate, which is why it passed.
             sum to exactly 1 (the a0 2x trap's gate, kept)
 
 The dump comes from the audition (rebuilt every run -- a stale one silently
-measures the stock effect whose id this module holds, see verify_charstation).
+measures the stock effect whose id this module holds, see verify_character).
 """
 import math, pathlib, struct, subprocess, sys
 

--- a/tools/verify_returns.py
+++ b/tools/verify_returns.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """THE RETURNS: the engines' wet, published to the bus and returned at the
-master by a character station in BUS mode (docs/BUS.md "The returns").
+master by a Character station in BUS mode (docs/BUS.md "The returns").
 
 Renders through send_probe.run() against the DEV dump (all three servers
 real), so a layout can hold the reverb, the delay and the station at once.
@@ -41,7 +41,7 @@ import send_probe
 from remix import registry
 
 MEM = pathlib.Path("out/dsp/mem_dev_A.mem")
-# ⚠️ REBUILD THE DUMP, ALWAYS (verify_charstation's rule). mem_dev_A.mem is
+# ⚠️ REBUILD THE DUMP, ALWAYS (verify_character's rule). mem_dev_A.mem is
 # whatever the last DEV build left -- verify-bus rebuilds it from the DEFAULT
 # remix, which has no station, and then id 0x1c dispatches to STOCK LO-FI:
 # the host keeps printing, the "return" is LO-FI processing silence, and
@@ -55,7 +55,7 @@ if _r.returncode != 0:
     sys.exit("the DEV build failed:\n" + _r.stdout[-2000:] + _r.stderr[-2000:])
 if not MEM.exists():
     sys.exit("the DEV build wrote no out/dsp/mem_dev_A.mem")
-CH = registry.by_name("charstation")
+CH = registry.by_name("character")
 L2 = CH.harness.layout_char
 K = CH.knob_map_all()
 for c in ("R", "D", "S", L2):
@@ -65,7 +65,7 @@ for c in ("R", "D", "S", L2):
 # renders a plausible dry passthrough (CLAUDE.md).
 if send_probe.entry_points(str(MEM), send_probe.SERVER_ID[L2]) == \
         send_probe.entry_points(str(MEM), send_probe.SERVER_ID["S"]):
-    sys.exit("the character station is not in this dump (its entry is SEND's)")
+    sys.exit("the Character station is not in this dump (its entry is SEND's)")
 
 FRAMES = send_probe.FRAMES
 REV = list(send_probe.REV_PARAMS)          # IN = 0: a pure return

--- a/tools/verify_spectrum.py
+++ b/tools/verify_spectrum.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""FILTER STATION render gates, with arithmetic you can predict.
+"""SPECTRUM render gates, with arithmetic you can predict.
 
 Renders the station straight through dsp_host (verify_hello's shape: the id
 and the slots come from the manifest, the entry points are checked against
@@ -17,8 +17,8 @@ Gates:
 The dump comes from the audition, which builds a scratch image that really
 contains this station beside SEND:
 
-    python3 tools/remix/audition.py filterstation out/dry/drums_110.wav
-    python3 tools/verify_filterstation.py
+    python3 tools/remix/audition.py spectrum out/dry/drums_110.wav
+    python3 tools/verify_spectrum.py
 """
 import math, pathlib, struct, subprocess, sys
 
@@ -26,7 +26,7 @@ sys.path.insert(0, "tools")
 import send_probe  # reuse its dispatch-table entry resolution
 from remix import registry
 
-MOD = registry.by_name("filterstation")
+MOD = registry.by_name("spectrum")
 SEND = registry.by_name("send")
 K = MOD.knob_map()
 MEM = f"out/dsp/_audition_{MOD.name}_A.mem"


### PR DESCRIPTION
Follows the panel names from #70, all the way down: directories, engine sources, verifier filenames, module keys, docs.

- `modules/spectrum`, `modules/character`, `modules/modulation`; `spectrum.asm`, `character.asm`, `modulation.asm`; `tools/verify_spectrum.py` and siblings.
- Keys `SPECTRUM` / `CHARACTER` / `MODULATION` — one name per station everywhere, no suffix.
- refhash 26 cases: every artifact hashed identical; the only difference is the module names in the build report line, which is the rename itself. Baseline re-saved.
- Gates: spectrum 11/11, character 22/22, modulation 10/10; `make check` and `REMIX=bamsep26 make verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)