### PR TITLE
Remix.hidden: an engine placed, dispatched and drawn with no knobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,8 @@ verify: ## Verify the ColdFire menu edits, module ledger (+ burn probe when it f
 	  echo "  [SKIP] menu shortcut: no .venv, or this remix has none"
 	@$(PY) tools/verify_cfprobe.py $(REMIX) 2>/dev/null || \
 	  echo "  [SKIP] cf probe: no .venv, or this remix has none"
+	@$(PY) tools/verify_hidden.py $(REMIX) 2>/dev/null || \
+	  echo "  [SKIP] hidden engines: no .venv, or this remix hides nothing"
 	REMIX=$(REMIX) python3 tools/verify_menu.py
 	python3 tools/verify_burn.py
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -521,6 +521,45 @@ registers an entry *inside* the cave (`cfprobe` puts its formatter at
 `+0x100` with an `.org`), so one address and one pc-relative state block
 serve the interrupt and the panel. `offset=0` is the tempo-sync shape.
 
+## PLACED BUT NOT LISTED -- `Remix.hidden`
+
+A remix can carry a module with **no chooser row and no knobs on the page**:
+
+```python
+REMIX = Remix(name="...", modules=(..., "REVERB SERVER"),
+              hidden=("REVERB SERVER",), fallback="SEND")
+```
+
+The module's code is placed, its id dispatches to it and its descriptor is
+cloned as usual. What changes is that it takes no row, and its twelve
+parameter NAMES are written blank -- which is what empties the page. The
+counts, defaults and enable bits are untouched, so the firmware's own
+parameter writer still clamps and commits every slot and the frame builder
+still carries it to the DSP. Both halves measured in the emulator, 4 Sep
+2026: the page drew nothing, and a write landed in the Part.
+
+That is how an effect stops being a per-track choice and becomes part of the
+instrument -- the bus engines are hosted by the project's stamp, and their
+controls belong on a main-menu screen (`docs/MAINMENU.md` section 6).
+
+⚠️ **It belongs to the REMIX, not the module**, and the bit-identity gate is
+what said so: declared on the module, hiding the engines emptied the plain
+`bus` image's chooser too, three rows to one. A remix hides an engine only
+when it also carries the screen that edits it.
+
+⚠️ **It does not make the id private.** Dispatch is per id and shared by
+every track and both menus, so a saved part naming that id ANYWHERE runs the
+code. A module that must run on one track only has to detect that itself,
+the way `modules/modulation` does with its allocator slot.
+
+`tools/verify_hidden.py` is the gate: the clone and its id, blank names,
+manifest defaults and enable bits intact, absent from the chooser list, a
+cursor entry pointing at the fallback, a page that draws none of its names
+(against a baseline render, because the playback page's own knobs are
+captured too and one of them is called RATE), a control render that DOES
+draw a listed module's names, the writer still landing a value, and DSP
+entry points that are the module's own rather than the fallback's.
+
 **Caves float unless pinned** (3 Sep 2026). A remix with more than three
 descriptor clones used to run the clone block straight into the tempo cave
 pinned at `0x400d7000` — three clones end exactly there, so the shipping

--- a/remixes/bamsep27.py
+++ b/remixes/bamsep27.py
@@ -1,0 +1,39 @@
+"""BamSep27 -- the rig with the engines off the chooser (design pass 2).
+
+The second design pass, built one step at a time. What is different from
+`bamsep26` today:
+
+  * BusVerb and BusDelay are HIDDEN -- placed, dispatched and cloned, but on
+    no chooser row and drawn with no knobs. A track hosts an engine because
+    the project says so, not because somebody turned the chooser, and the
+    engines' controls belong on the two main-menu screens (docs/MAINMENU.md
+    section 6, not built yet).
+  * The stock DELAY row is gone. Flash 4 (4 Sep 2026) wedged the unit every
+    time a part LOADED with it selected -- a squeal that survived a project
+    change and needed a power cycle, where re-selecting the same effect on
+    the panel did not. Unexplained, and not worth explaining: the rig does
+    not want it.
+
+Still to come before this remix is the rig: the sends move off the stations
+and onto the engines' otherwise blank pages, GRAIN drops to two grains (the
+cycle lever the delay core needs once the stations are actually turned up),
+and the two menu screens.
+
+⚠️ An id dispatches the same code on every track, so hiding an engine does
+not stop an old part naming it on some other track. What stops that is the
+engine reading its own allocator slot and passing dry off its host, the
+idiom modules/modulation already uses. Not built yet either.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="bamsep27",
+    doc="Design pass 2: the rig with the engines hidden and no stock delay.",
+    modules=("REVERB SERVER", "DELAY SERVER", "SEND",
+             "SPECTRUM", "CHARACTER", "MODULATION",
+             "TEMPO SYNC", "MENU SHORTCUT"),
+    hidden=("REVERB SERVER", "DELAY SERVER"),
+    fallback="SEND",
+    fx1=("SPECTRUM", "CHARACTER", "MODULATION"),
+)

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -190,6 +190,13 @@ REMIX = remix_registry.remix(os.environ.get("REMIX")
                              or remix_registry.DEFAULT_REMIX)
 ORDER = [k for k in REMIX.modules
          if remix_modules()[k].menu is not None]
+# A HIDDEN module (schema.Remix.hidden) is placed, dispatched and cloned but
+# takes no chooser row: it reaches a track through the project's stored id,
+# never through the panel. ORDER is what the chooser lists; CARRIED is what
+# gets a clone, code and a dispatch entry.
+CARRIED = ORDER
+HIDDEN = [k for k in CARRIED if k in REMIX.hidden]
+ORDER = [k for k in CARRIED if k not in HIDDEN]
 # THE FIRMWARE'S OWN NONE AS THE FALLBACK, for a remix with no bus (see
 # schema.NO_FALLBACK, which is also what refuses it beside a bus
 # participant). Unimplemented ids -- and id 0, a fresh part's -- then resolve
@@ -415,7 +422,7 @@ BUILD_TAG = b"79"
 # bare synonyms for "no effect". 0x06 is the exact id tools/build_dspprobe.py
 # proved runs custom DSP code on real hardware. schema.py enforces the range.
 _MODS = remix_modules()
-_SEL = [_MODS[k] for k in ORDER]
+_SEL = [_MODS[k] for k in CARRIED]
 # A STOCK row (tools/remix/stock.py) gets no clone, no code and no words:
 # its descriptor and dispatch are where stock put them. The build writes
 # its list row and cursor position and nothing else, so everything derived
@@ -431,8 +438,13 @@ FULLNAME = {m.key: m.menu.fullname + (BUILD_TAG if m.menu.build_tag else b"")
             for m in _CLONED}
 # A name of None means "leave the donor's", which is a different thing from
 # b"" (blank the slot). Both are in use: SEND blanks ten of FILTER's names.
-RENAMES = {m.key: [(i, p.name) for i, p in enumerate(m.params)
-                   if p.name is not None] for m in _CLONED}
+# A HIDDEN module's twelve names are blanked (b"" -- not None, which would
+# leave the donor's), so its track page draws no knobs. Counts, defaults and
+# enable bits are untouched, which is what keeps the parameter writer and the
+# frame builder working for the menu screen that edits it.
+RENAMES = {m.key: ([(i, b"") for i in range(12)] if m.key in HIDDEN else
+                   [(i, p.name) for i, p in enumerate(m.params)
+                    if p.name is not None]) for m in _CLONED}
 # Explicit per-knob defaults -- NOT the donor's, which are sized for a
 # different algorithm on that slot. DARK REV's MIX default is 0 (a freshly
 # selected reverb would be silent) and SPRING's TONE-slot default is 0 (our
@@ -713,7 +725,7 @@ ASM_SRC = {k: v for k, v in {**_DEF_ASM,
                              else "dsp/page2_probe.asm" if os.environ.get("PROBE") == "1"
                              else "dsp/tempoprobe.asm" if os.environ.get("TPROBE") == "1"
                              else os.environ.get("RVSRC") or _DEF_ASM.get("REVERB SERVER")),
-           "SEND": _DEF_ASM.get("SEND")}.items() if k in ORDER}
+           "SEND": _DEF_ASM.get("SEND")}.items() if k in CARRIED}
 
 # per payload: donor P addresses for CODE space, the proven null stub, the
 # X:0x215/X:0x235 module address, and DELAY SERVER's payload-specific Y base
@@ -1108,10 +1120,16 @@ def main():
         if rd32(r) != FX2_LIST:
             sys.exit(f"list ref at 0x{r:08x} not stock FX2_LIST -- refusing")
         wr32(r, list_addr)
+    fb_pos = 0 if NO_FB else ORDER.index(REMIX.fallback)
     # The cursor position of every listed effect, past the NONE row if one
     # was restored -- ID2POS is an index into `real`, not into ORDER.
     for pos, name in enumerate(ORDER):
         wr32(ID2POS + NEW_IDS[name] * 4, pos + (1 if NO_FB else 0))
+    # A HIDDEN module has no row, so it has no cursor position of its own.
+    # Point it at the fallback's, so opening the chooser on the track that
+    # hosts it lands somewhere real instead of on whatever stock left there.
+    for name in HIDDEN:
+        wr32(ID2POS + NEW_IDS[name] * 4, fb_pos)
     # ==== 1b. ColdFire caves, from whichever modules carry them =============
     # A cave is how a module changes the firmware's BEHAVIOUR rather than
     # adding an effect: assert the hook site still holds the stock bytes,
@@ -1345,7 +1363,7 @@ def main():
             if _m is None:
                 sys.exit(f"fx1={_n!r}: no such effect")
             if _m.is_stock:
-                _rep = [k for k in ORDER if _MODS[k].menu is not None
+                _rep = [k for k in CARRIED if _MODS[k].menu is not None
                         and _MODS[k].menu.replaces == _n]
                 if _rep:
                     sys.exit(f"fx1={_n!r}: {_rep[0]} replaces it in this "
@@ -1464,7 +1482,6 @@ def main():
     # alias id 0 to SEND: its descriptor, its cursor position, and (below) its
     # DSP dispatch. Every unassigned track is then a SEND automatically.
     fb_desc = FX1_NONE if NO_FB else clone_addr[REMIX.fallback]
-    fb_pos = 0 if NO_FB else ORDER.index(REMIX.fallback)
     wr32(FX2_IDS + NONE_ID * 4, fb_desc)
     wr32(ID2POS + NONE_ID * 4, fb_pos)
     # A module this remix leaves out still owns an id, and a saved project can
@@ -1511,6 +1528,10 @@ def main():
           f"{len(real)} rows (no padding)" if len(real) <= CHOOSER_ROWS else
           f"  chooser list = {len(real)} entries at 0x{list_addr:08x} (the "
           f"long list cave), {_none}, viewport {rows} rows -- it scrolls")
+    if HIDDEN:
+        print(f"  placed but NOT LISTED: {', '.join(HIDDEN)} -- code, id and "
+              f"clone present, no chooser row, twelve names blanked so the "
+              f"track page draws nothing")
     if STOCK_ROWS:
         print(f"  stock rows kept: {', '.join(STOCK_ROWS)} -- descriptors, "
               f"code and dispatch untouched on both cores")
@@ -2349,7 +2370,7 @@ mkgo:""",
         # ROTINIT / ROTLATCH markers are substituted by _prep like SEND's.
         # It MAY also declare its own DEV repro hooks below -- the generic version of the arms the three
         # core sources have at the top of main().
-        for _k in ORDER:
+        for _k in CARRIED:
             if _k not in _texts and _k in ASM_SRC:
                 _src_k = _dev_hooks(_k, pathlib.Path(ASM_SRC[_k]).read_text())
                 _mk = remix_modules().get(_k)
@@ -2375,7 +2396,7 @@ mkgo:""",
 
         plan = tuple(
             (m.key, _prep(_ybase(m, _texts[m.key]), m.key, m.dsp.r7_latch_slot))
-            for m in sorted((remix_modules()[k] for k in ORDER
+            for m in sorted((remix_modules()[k] for k in CARRIED
                              if k in _texts), key=lambda m: m.dsp.priority))
         if _x:
             _g = [n for n, t in plan if "never housekeeps" in t]

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -782,6 +782,30 @@ class Remix:
     # What is left is exactly the INSERT class: WarpFold, Ripple, Rungs,
     # Streamz, BodeShift, Hello World -- and SEND, which is buffer-free
     # (untested there, but nothing measured argues against it).
+    # PLACED BUT NOT LISTED. Each key here is carried by the image -- code,
+    # id, descriptor clone -- and takes NO CHOOSER ROW, with its twelve
+    # parameter names blanked so the track page it lands on draws no knobs.
+    #
+    # This is how an effect stops being a per-track choice and becomes part
+    # of the instrument: the two bus engines are hosted by the project stamp,
+    # not by turning a chooser, and their controls live on a main-menu screen
+    # instead of a track page (docs/MAINMENU.md section 6). Blanking the
+    # NAMES is what empties the page: the parameter COUNTS and enable bits
+    # stay, so the stock parameter writer still clamps and commits every slot
+    # and the frame builder still carries it to the DSP -- measured in the
+    # emulator, 4 Sep 2026, both halves (the page drew nothing; the writer
+    # landed a value in the Part).
+    #
+    # ⚠️ IT BELONGS TO THE REMIX, NOT THE MODULE, and the bit-identity gate
+    # is what said so: declared on the module, hiding the engines emptied
+    # the plain `bus` image's chooser too, from three rows to one. A remix
+    # hides an engine only when it also carries the screen that edits it.
+    #
+    # ⚠️ IT DOES NOT MAKE THE ID PRIVATE. Dispatch is per id and shared by
+    # every track and both menus, so a saved part that names this id ANYWHERE
+    # runs this code. A module that must run on one track only has to detect
+    # that itself, the way modules/modulation does with its allocator slot.
+    hidden: tuple[str, ...] = ()
     fx1: tuple[str, ...] = ()
 
     def __post_init__(self):

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -460,6 +460,13 @@ def main():
                           "COMB FILTER"),
              # cfprobe is the rig plus HELLO WORLD and the ColdFire probe
              # cave: the same harvest, 27 more words placed.
+             # bamsep27 is design pass 2: the same three stations, so the
+             # same harvest, minus the stock DELAY row (which has no DSP
+             # code to give up anyway).
+             "bamsep27": ("FILTER", "SPATIALIZER", "EQUALIZER", "PHASER",
+                          "FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
+                          "DARK REV", "COMPRESSOR", "LO-FI", "DJ EQ",
+                          "COMB FILTER"),
              "cfprobe": ("FILTER", "SPATIALIZER", "EQUALIZER", "PHASER",
                          "FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
                          "DARK REV", "COMPRESSOR", "LO-FI", "DJ EQ",

--- a/tools/verify_hidden.py
+++ b/tools/verify_hidden.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""A HIDDEN engine is placed, dispatched, off the chooser and draws nothing.
+
+    python3 tools/verify_hidden.py [remix]      (default: bamsep27)
+
+`Remix.hidden` takes an effect off the panel without taking it out of the
+image: the project's stored id still reaches it, and a main-menu screen edits
+it through the firmware's own parameter writer. Four things have to hold at
+once for that to be true, and three of them are invisible in the build report.
+
+ 1. THE IMAGE. The engine's clone exists and its id points at it; its twelve
+    parameter NAMES are blank while its counts, defaults and enable bits are
+    the manifest's; it is absent from the chooser list, which is exactly the
+    listed modules and no more; and its cursor entry is the fallback's rather
+    than stock's leftover.
+ 2. THE PAGE, on the booted machine. Rendering the host track's FX2 page
+    draws no knob names at all -- and the same render with a LISTED module
+    assigned draws its names, so the check can fail.
+ 3. THE WRITER, on the booted machine. The stock parameter writer still lands
+    a value in the Part for a hidden engine's slot: blanking names must not
+    cost the menu screen its edit path.
+ 4. THE CODE. The engine's DSP entry points are its own, not the fallback's
+    -- the guard `send_probe` grew when a missing effect silently rendered as
+    a SEND.
+
+What this CANNOT prove is the panel itself: that a real [FX2] press on the
+host draws an empty page rather than a stale one. That is the flash's.
+"""
+import os
+import pathlib
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+BASE = 0x40000400
+IMAGE = pathlib.Path("out/mainos_bus.bin")
+P_PARAM_NAMES, P_DEFAULTS = 0x16, 0x5e
+P_PENABLE_LO, P_PENABLE_HI = 0x18e, 0x18a
+FX2_IDS, ID2POS = 0x400d5fdc, 0x400d6150   # build_bus.py's own
+NEW_LIST, LONG_LIST = 0x400d6b00, 0x400d7bbc
+WRITER = 0x40054cd8
+
+
+def main():
+    from remix import registry
+    name = sys.argv[1] if len(sys.argv) > 1 else "bamsep27"
+    remix = registry.remix(name)
+    mods = registry.modules()
+    hidden = [k for k in remix.modules
+              if mods[k].menu is not None and k in remix.hidden]
+    listed = [k for k in remix.modules
+              if mods[k].menu is not None and k not in remix.hidden]
+    if not hidden:
+        print(f"  [ -- ] {name} hides nothing -- nothing to check")
+        return 0
+    env = {**os.environ, "REMIX": name, "XBUS": "1", "SPEC": "1"}
+    r = subprocess.run([sys.executable, "tools/build_bus.py"],
+                       capture_output=True, text=True, env=env)
+    if r.returncode != 0:
+        tail = (r.stdout + r.stderr).strip().splitlines()
+        sys.exit(f"{name}: build failed: {tail[-1] if tail else '?'}")
+    img = IMAGE.read_bytes()
+    fails = 0
+
+    def check(label, ok, detail=""):
+        nonlocal fails
+        print(f"  [{'PASS' if ok else 'FAIL'}] {label}"
+              f"{'  ' + detail if detail else ''}")
+        fails += 0 if ok else 1
+
+    def u32(a):
+        return int.from_bytes(img[a - BASE:a - BASE + 4], "big")
+
+    # ---- 1. the image ----------------------------------------------------
+    fb_id = mods[remix.fallback].menu.fx2_id
+    fb_pos = u32(ID2POS + fb_id * 4)
+    clones = {}
+    for key in hidden + listed:
+        clones[key] = u32(FX2_IDS + mods[key].menu.fx2_id * 4)
+    for key in hidden:
+        P = clones[key]
+        check(f"{key}: its id resolves to a clone of its own",
+              0x400d6b20 <= P < 0x400d7c3c and P not in
+              [clones[o] for o in clones if o != key], f"0x{P:08x}")
+        names = [bytes(img[P - BASE + P_PARAM_NAMES + 6 * i:][:6]).split(b"\0")[0]
+                 for i in range(12)]
+        check(f"{key}: all twelve parameter names are blank",
+              not any(names), " ".join(n.decode("latin1") or "-" for n in names))
+        defaults = list(img[P - BASE + P_DEFAULTS:][:12])
+        want = [(p.default or 0) & 0x7f for p in mods[key].params]
+        check(f"{key}: its defaults are the manifest's, untouched by hiding",
+              defaults == want, f"{defaults[:6]}...")
+        lo, hi = u32(P + P_PENABLE_LO), u32(P + P_PENABLE_HI)
+        check(f"{key}: its enable bits are set, so the DSP still receives",
+              (lo & 0x11111111) == 0x11111111 and (hi & 0x11111111) != 0,
+              f"lo={lo:08x} hi={hi:08x}")
+        check(f"{key}: its cursor entry is the fallback's, not stock's",
+              u32(ID2POS + mods[key].menu.fx2_id * 4) == fb_pos, f"{fb_pos}")
+
+    # the chooser list is exactly the listed modules
+    for cand in (NEW_LIST, LONG_LIST):
+        row = [u32(cand + 4 * i) for i in range(16)]
+        if row[0] in clones.values():
+            entries = []
+            for v in row:
+                if v == 0:
+                    break
+                entries.append(v)
+            listed_p = [clones[k] for k in listed]
+            check("the chooser lists exactly the modules that are not hidden",
+                  entries == listed_p,
+                  f"{len(entries)} rows at 0x{cand:08x}, expected {len(listed_p)}")
+            for key in hidden:
+                check(f"{key} is not in the chooser list",
+                      clones[key] not in entries)
+            break
+    else:
+        check("found the chooser list in the image", False)
+
+    # ---- 2 and 3. the booted machine -------------------------------------
+    import emu_bringup as emu
+    from unicorn import UcError
+    boot = emu.boot(str(IMAGE))
+    uc = boot.uc
+    uc.mem_map(0x100a0000, 0x10000)
+
+    def texts(draws):
+        return [t for _, _, t in draws if t.strip()]
+
+    # ⚠️ THE CAPTURE INCLUDES THE PLAYBACK PAGE, whose own knobs (LEV PTCH
+    # STRT LEN RATE RTRG RTIM) are redrawn with the FX2 page. RATE is also
+    # BusVerb's slot 11, so comparing the engine's names against the raw
+    # capture reports a knob that is not the engine's. Subtract a baseline
+    # render -- the same track with an id that draws nothing of its own.
+    key = hidden[0]
+    hid_id = mods[key].menu.fx2_id
+    base_texts = set(texts(emu.render_fx2(boot, track=4, effect_id=0x02)))
+    drew_hidden = set(texts(emu.render_fx2(boot, track=4, effect_id=hid_id)))
+    hid_names = {p.name.decode("latin1") for p in mods[key].params if p.name}
+    check(f"{key}'s page draws none of its knob names",
+          not (hid_names & (drew_hidden - base_texts)),
+          " ".join(sorted(hid_names & (drew_hidden - base_texts))) or "none drawn")
+    ctl = listed[0] if listed else None
+    if ctl and not mods[ctl].is_stock:
+        drew_listed = set(texts(emu.render_fx2(boot, track=4,
+                                               effect_id=mods[ctl].menu.fx2_id)))
+        ctl_names = {p.name.decode("latin1") for p in mods[ctl].params if p.name}
+        check(f"the same render DOES draw {ctl}'s names, so the check can fail",
+              bool(ctl_names & (drew_listed - base_texts)),
+              " ".join(sorted(ctl_names & (drew_listed - base_texts))[:4]))
+
+    emu.assign_fx2(boot, track=4, effect_id=hid_id)
+    part = emu.FAKE_PART
+    lo_a, hi_a = part + 0x8e000, part + 0x92000
+    before = bytes(uc.mem_read(lo_a, hi_a - lo_a))
+    try:
+        emu._call(uc, WRITER, (4, 0, 99))
+    except UcError:
+        pass
+    after = bytes(uc.mem_read(lo_a, hi_a - lo_a))
+    moved = [i for i in range(len(before)) if before[i] != after[i]]
+    check(f"the stock writer still lands a value for {key} slot 0",
+          any(after[i] == 99 for i in moved),
+          f"{len(moved)} byte(s) changed")
+
+    # ---- 4. the code -----------------------------------------------------
+    import send_probe
+    mem = "out/dsp/payload_A.mem"
+    if pathlib.Path(mem).exists():
+        ent = send_probe.entry_points(mem, hid_id)
+        fb = send_probe.entry_points(mem, fb_id)
+        check(f"{key}'s DSP entry points are its own, not {remix.fallback}'s",
+              ent != fb, f"init=P:0x{ent[0]:04x} vs 0x{fb[0]:04x}")
+
+    print(f"\n{fails} check(s) failed" if fails else "\nOK")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify_menu.py
+++ b/tools/verify_menu.py
@@ -67,7 +67,13 @@ FX1_ROWCOUNT_AT = 0x40059be6            # FX1's viewport literal
 # module made a per-remix hand copy impossible (29 Aug 2026).
 REMIX = _reg.remix(os.environ.get("REMIX") or _reg.DEFAULT_REMIX)
 _MODS = _reg.modules()
-_ORDER = [k for k in REMIX.modules if _MODS[k].menu is not None]
+# A HIDDEN module (schema.Remix.hidden) is carried but takes no chooser row,
+# so it is not in the order the list, the positions or the row count are
+# checked against. Its own gate is tools/verify_hidden.py, which checks the
+# things this file would otherwise have to invert: no row, blank names, and
+# the writer still reaching it.
+_ORDER = [k for k in REMIX.modules
+          if _MODS[k].menu is not None and k not in REMIX.hidden]
 EXPECT = {k: (_MODS[k].menu.fx2_id, i) for i, k in enumerate(_ORDER)}
 # WITH NO FALLBACK the firmware's own NONE goes back at row 0, as a stock
 # unit has it, so the list is one longer than the modules and every position


### PR DESCRIPTION
Design pass 2, step 1 of the build.

- `Remix.hidden` carries a module with no chooser row and blank parameter names, so its track page draws nothing. Counts and enable bits stay, so the stock parameter writer and the frame builder still work — the path a main-menu screen will edit through.
- Both halves measured in the emulator before building: the page drew nothing; a write landed in the Part.
- **refhash caught a design error**: on `MenuEntry` the flag emptied the plain `bus` chooser too. Moved to `Remix`; 26 cases bit-identical.
- `remixes/bamsep27.py` is design pass 2 so far: engines hidden, no stock DELAY row (flash 4 wedged on it at load).
- `tools/verify_hidden.py`, 16 emulator-driven checks, in `make verify`.

Still to come: the per-track host guard, the send move, GRAIN at two grains, the two screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)