### PR TITLE
HOSTGUARD: a hidden engine runs on its host slot and is dry elsewhere

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -552,6 +552,27 @@ every track and both menus, so a saved part naming that id ANYWHERE runs the
 code. A module that must run on one track only has to detect that itself,
 the way `modules/modulation` does with its allocator slot.
 
+**A hidden engine also gets a HOST GUARD.** Hiding takes an engine off the
+panel; it does not make its id private, because dispatch is per id and shared
+by every track. So `build_bus.py` substitutes a gate at each engine's
+`; HOSTGUARD` marker for the remixes that hide it: the engine runs on the
+bank's FIRST FX2 state block (`r7 == 0x6200` — `docs/DSP.md`, "The
+allocator's instance model") and passes dry on every other, which is exactly
+the condition its position-0 housekeeping election already uses, so the two
+can never disagree. An old part naming the id on another track then gets a
+bit-exact dry pass instead of a second instance writing the host's tank.
+
+⚠️ **Substituted, never compiled in unconditionally**, and the local harness
+is why: `render_reverb.py` runs the reverb at `-r7 4`, the bank's SECOND
+slot, so a guard in the shipped source would render every voicing pass and
+every `verify_roll` comparison dry.
+
+⚠️ **Two traps bit while placing that marker**, both caught by refhash and
+both of the family CLAUDE.md names. The comment first contained the phrase
+the payload-gate census greps for, which reported the untouched `bus` image's
+payload A as gated out; and it sat inside the burn probe's cut anchor,
+which made `make burn` refuse. A comment is build input here.
+
 `tools/verify_hidden.py` is the gate: the clone and its id, blank names,
 manifest defaults and enable bits intact, absent from the chooser list, a
 cursor entry pointing at the fallback, a page that draws none of its names

--- a/modules/busdelay/delay_server.asm
+++ b/modules/busdelay/delay_server.asm
@@ -411,6 +411,25 @@ proc:
 ; re-derives from r7 state per call, so the two sub-calls of a split block
 ; are sample-continuous by construction.
         move    a,x:(r7+$14)            ; call flag: $010000 = the a=1 call
+; build_bus.py substitutes a host-slot gate at the marker below, for a
+; remix that HIDES this engine (schema.Remix.hidden). A hidden engine is hosted by
+; the project's stamp rather than by the chooser, so it should run on its
+; host track and nowhere else: dispatch is per id and shared by every track,
+; so an old part naming this id on another track would otherwise get a
+; SECOND instance sharing this one's hardcoded Y base. The gate is r7 ==
+; 0x6200, the bank's first FX2 state block (measured, docs/DSP.md "The
+; allocator's instance model"), which is the same condition the position-0
+; housekeeping election below already uses -- so a guarded instance is never
+; a housekeeper that has gone dry, nor a wet engine that skips the
+; election. (Worded around the phrase build_bus.py censuses for: it
+; greps the SOURCE for the payload-gate marker, comments included, so
+; writing that phrase here reported the plain `bus` image's payload A
+; as gated out -- caught by refhash, and the same family as the
+; base-literal census CLAUDE.md warns about, which refused the build
+; when this very comment first tried to name it.)
+; Inert in a normal build: it is a comment, and local renders (which run at
+; -r7 4, the bank's SECOND slot) are unaffected unless a remix asks for it.
+; HOSTGUARD
 
 ; ---- BUS.md: split-aware frame offset + position-0 election --------------
 ; Verbatim from modules/send/send_client.asm / modules/busverb/reverb_server.asm (BUS.md Known

--- a/modules/busverb/reverb_server.asm
+++ b/modules/busverb/reverb_server.asm
@@ -275,6 +275,25 @@ proc:
         move    a,x:(r7+$14)            ; call flag: $010000 = the a=1 call
                                         ; (the dispatcher's #$1 is left-
                                         ; aligned), 0 = the split sub-call
+; build_bus.py substitutes a host-slot gate at the marker below, for a
+; remix that HIDES this engine (schema.Remix.hidden). A hidden engine is hosted by
+; the project's stamp rather than by the chooser, so it should run on its
+; host track and nowhere else: dispatch is per id and shared by every track,
+; so an old part naming this id on another track would otherwise get a
+; SECOND instance sharing this one's hardcoded Y base. The gate is r7 ==
+; 0x6200, the bank's first FX2 state block (measured, docs/DSP.md "The
+; allocator's instance model"), which is the same condition the position-0
+; housekeeping election below already uses -- so a guarded instance is never
+; a housekeeper that has gone dry, nor a wet engine that skips the
+; election. (Worded around the phrase build_bus.py censuses for: it
+; greps the SOURCE for the payload-gate marker, comments included, so
+; writing that phrase here reported the plain `bus` image's payload A
+; as gated out -- caught by refhash, and the same family as the
+; base-literal census CLAUDE.md warns about, which refused the build
+; when this very comment first tried to name it.)
+; Inert in a normal build: it is a comment, and local renders (which run at
+; -r7 4, the bank's SECOND slot) are unaffected unless a remix asks for it.
+; HOSTGUARD
 ; MARKER_ENTRY
 
 ; ---- BUS.md: split-aware frame offset within the shared bus buffers, and

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -2394,6 +2394,38 @@ mkgo:""",
                 return _sub(src)
             return src
 
+        # ---- HOSTGUARD: a HIDDEN engine runs on its host slot only --------
+        # A hidden engine (schema.Remix.hidden) is hosted by the project's
+        # stamp, not by the chooser. Dispatch is per id and shared by every
+        # track, so an old part naming that id on another track would get a
+        # SECOND instance sharing this one's hardcoded Y base -- two reverbs
+        # writing one tank. The gate is r7 == 0x6200, the bank's first FX2
+        # state block (docs/DSP.md "The allocator's instance model"), which
+        # is exactly the condition the engines' position-0 housekeeping
+        # election already uses, so the two can never disagree.
+        #
+        # ⚠️ SUBSTITUTED, NOT SHIPPED IN THE SOURCE, and the local render
+        # harness is why: render_reverb.py runs the reverb at -r7 4, the
+        # bank's SECOND slot, so a guard compiled in unconditionally would
+        # render every voicing pass and every verify_roll comparison DRY.
+        # It goes in only for a remix that asks, and `hidden` is the ask.
+        for _k in HIDDEN:
+            if _k not in _texts:
+                continue
+            if _texts[_k].count("; HOSTGUARD\n") != 1:
+                sys.exit(f"{_k} is hidden, but its source has no single "
+                         f"; HOSTGUARD marker to gate on")
+            _texts[_k] = _texts[_k].replace("; HOSTGUARD\n", """
+        move    r7,a
+        move    #>$6200,x0
+        cmp     x0,a
+        bne     hostquit                ; not the host slot: exact dry pass
+""", 1) + """
+hostquit:
+        rts
+"""
+            print(f"  HOSTGUARD: {_k} runs on r7=0x6200 only, dry elsewhere")
+
         plan = tuple(
             (m.key, _prep(_ybase(m, _texts[m.key]), m.key, m.dsp.r7_latch_slot))
             for m in sorted((remix_modules()[k] for k in CARRIED

--- a/tools/verify_hidden.py
+++ b/tools/verify_hidden.py
@@ -22,6 +22,11 @@ once for that to be true, and three of them are invisible in the build report.
  4. THE CODE. The engine's DSP entry points are its own, not the fallback's
     -- the guard `send_probe` grew when a missing effect silently rendered as
     a SEND.
+ 5. THE HOST GUARD, rendered through dsp_host. A hidden engine runs on the
+    bank's first FX2 state block and passes dry on every other, so an old
+    part naming its id on another track cannot get a second instance sharing
+    its hardcoded Y base. Both halves are rendered, because "it went dry" and
+    "it never ran at all" look the same from one render.
 
 What this CANNOT prove is the panel itself: that a real [FX2] press on the
 host draws an empty page rather than a stale one. That is the flash's.
@@ -165,12 +170,93 @@ def main():
 
     # ---- 4. the code -----------------------------------------------------
     import send_probe
-    mem = "out/dsp/payload_A.mem"
+    mem = "out/dsp/mem_dev_A.mem"
     if pathlib.Path(mem).exists():
         ent = send_probe.entry_points(mem, hid_id)
         fb = send_probe.entry_points(mem, fb_id)
         check(f"{key}'s DSP entry points are its own, not {remix.fallback}'s",
               ent != fb, f"init=P:0x{ent[0]:04x} vs 0x{fb[0]:04x}")
+
+    # ---- 5. THE HOST GUARD, rendered ------------------------------------
+    # A hidden engine gets build_bus.py's HOSTGUARD: it runs on the bank's
+    # first FX2 state block (r7 = 0x6200, dsp_host's `-r7 2`) and passes dry
+    # on every other. Both halves are rendered here, because "it went dry"
+    # and "it never ran" look identical from one render.
+    import struct
+    HOST = "vendor/dsp56300/build/source/dsp_host/dsp_host"
+    # The DEV hatch's dump: build_bus.py writes it with DEV=1 XBUS=1, and it
+    # is what send_probe and every render gate here already use.
+    mem_a = pathlib.Path("out/dsp/mem_dev_A.mem")
+    scratch = pathlib.Path("out/_hidden")
+    scratch.mkdir(parents=True, exist_ok=True)
+    if pathlib.Path(HOST).exists() and mem_a.exists():
+        FRAMES, N = 15, 6000
+        src = scratch / "in.raw"
+        import math
+        samples = [int(0.4 * 8388607 * math.sin(2 * math.pi * 220 * i / 44100))
+                   for i in range(N)]
+        src.write_bytes(b"".join(struct.pack("<i", v) for v in samples))
+
+        def render(key, r7, **over):
+            # The DELAY HATCH dump (DEV=1 XBUS=1, no SPEC): every server is
+            # real in payload A, which is the only dump that can render the
+            # delay at all -- a SPEC dump aliases its id to SEND and would
+            # render a plausible dry pass for the wrong reason (12 Aug 2026).
+            mem = "out/dsp/mem_dev_A.mem"
+            if not pathlib.Path(mem).exists():
+                return None
+            init, proc = send_probe.entry_points(mem, mods[key].menu.fx2_id)
+            out = scratch / f"out_{r7}.raw"
+            vals = [(p.default or 0) & 0x7f for p in mods[key].params]
+            kmap = {(p.name or b"").decode("latin1"): i
+                    for i, p in enumerate(mods[key].params)}
+            for n, v in over.items():
+                vals[kmap[n]] = v
+            params = ",".join(str(v) for v in vals)
+            r = subprocess.run(
+                [HOST, "-mem", mem, "-init", f"{init:x}", "-proc", f"{proc:x}",
+                 "-inst", "1", "-r7", str(r7), "-alloc", "1", "-inmask", "1",
+                 "-frames", str(FRAMES), "-blocks", str(N // FRAMES),
+                 "-in", str(src), "-out", str(out), "-params", params],
+                capture_output=True, text=True)
+            if r.returncode != 0:
+                return None
+            d = out.read_bytes()
+            w = struct.unpack(f"<{len(d)//4}i", d)
+            return list(w[0::2])[:N]
+
+        for key in hidden:
+            # ⚠️ AT ITS DEFAULTS AN ENGINE IS ALREADY A DRY PASS -- both
+            # engines are RETURNS whose IN defaults to 0 (v5, 23 Aug 2026),
+            # so a control render has to open the input, or "the guard went
+            # dry" and "the engine is dry anyway" are the same picture.
+            wet = {"IN": 127} if "IN" in [ (p.name or b"").decode("latin1")
+                                           for p in mods[key].params ] else {}
+            host = render(key, 2, **wet)
+            away = render(key, 4, **wet)
+            if host is None or away is None:
+                check(f"{key}: rendered at both slots", False, "dsp_host failed")
+                continue
+            check(f"{key} at r7=0x6400 is a BIT-EXACT dry pass",
+                  away == samples,
+                  f"{sum(1 for a, b in zip(away, samples) if a != b)} sample(s) differ")
+            if host == samples and not wet:
+                # ⚠️ THE INSTRUMENT IS BLIND HERE, and saying so is the point.
+                # BusDelay's own IN was retired in v5: its only input is the
+                # DELAY bus, and this harness feeds no bus, so its host render
+                # is silent whether the guard fired or not. A pass here would
+                # be worthless and a fail would be wrong. The dry half above
+                # still means something -- it is bit-exact, which a running
+                # engine with no input also is -- so what this line reports is
+                # the gap, not a verdict.
+                print(f"  [SKIP] {key} at r7=0x6200 really runs -- it has no "
+                      f"own-track input (bus only), so this harness cannot "
+                      f"tell a guarded instance from an unfed one")
+            else:
+                check(f"{key} at r7=0x6200 (its host) really runs",
+                      host != samples,
+                      f"{sum(1 for a, b in zip(host, samples) if a != b)} "
+                      f"sample(s) differ")
 
     print(f"\n{fails} check(s) failed" if fails else "\nOK")
     return 1 if fails else 0


### PR DESCRIPTION
Design pass 2, step 2.

- A remix that hides an engine gets a gate substituted at its `; HOSTGUARD` marker: it runs on the bank's first FX2 state block (`r7 == 0x6200`) and passes dry on every other. Same condition the position-0 housekeeping election already uses, so the two cannot disagree.
- **Substituted, not shipped in the source**: `render_reverb.py` runs at `-r7 4`, so an unconditional guard would render every voicing pass dry. Seven words, only for a remix that asks. refhash 26/26 bit-identical.
- Two traps bit while placing the marker, both caught by refhash: the comment carried the phrase the payload-gate census greps for, and it sat inside the burn probe's cut anchor.
- `verify_hidden` renders both halves. For BusDelay the harness is blind and says so rather than passing — v5 retired its own IN, so its only input is the bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)