### PR TITLE
Hide SEND and the stations from FX2: an empty chooser, sends stay on the stations

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -542,6 +542,17 @@ That is how an effect stops being a per-track choice and becomes part of the
 instrument -- the bus engines are hosted by the project's stamp, and their
 controls belong on a main-menu screen (`docs/MAINMENU.md` section 6).
 
+⚠️ **A hidden module that is also on the FX1 chooser KEEPS its names.** One
+descriptor serves both menus, so blanking it would empty its FX1 page too.
+The rule is automatic: `hidden` minus `fx1` is what gets blanked, which is
+how the stations come off the FX2 chooser and still draw when chosen on FX1.
+
+⚠️ **The fallback may be hidden.** It has no row to park a cursor on, so the
+cursor goes to 0; its descriptor is still cloned and its id still resolves to
+it, which is the half that matters -- an unassigned track has to dispatch to
+real code. Hide every module and the FX2 chooser is a bare terminator with a
+zero-row viewport; the window still opens and draws (emulator, 4 Sep 2026).
+
 ⚠️ **It belongs to the REMIX, not the module**, and the bit-identity gate is
 what said so: declared on the module, hiding the engines emptied the plain
 `bus` image's chooser too, three rows to one. A remix hides an engine only

--- a/remixes/bamsep27.py
+++ b/remixes/bamsep27.py
@@ -1,28 +1,37 @@
-"""BamSep27 -- the rig with the engines off the chooser (design pass 2).
+"""BamSep27 -- the rig with an empty FX2 chooser (design pass 2).
 
-The second design pass, built one step at a time. What is different from
-`bamsep26` today:
+Every track is the same shape: a STATION on FX1, carrying that track's two
+bus sends, and NOTHING on FX2. What differs from `bamsep26`:
 
-  * BusVerb and BusDelay are HIDDEN -- placed, dispatched and cloned, but on
-    no chooser row and drawn with no knobs. A track hosts an engine because
-    the project says so, not because somebody turned the chooser, and the
-    engines' controls belong on the two main-menu screens (docs/MAINMENU.md
-    section 6, not built yet).
+  * NOTHING IS ON THE FX2 CHOOSER -- zero rows. The two engines, the SEND
+    client and the three stations are all placed, dispatched and cloned, and
+    none of them is listed. A track hosts an engine because the project says
+    so; a station is chosen on FX1; and an FX2 slot is simply empty.
+  * The engines and SEND are drawn BLANK: their twelve names are cleared, so
+    the host's FX2 page shows nothing at all. The stations keep their names,
+    because one descriptor serves both menus and blanking them would empty
+    their FX1 page too.
+  * Each engine also gets the HOST GUARD: it runs on the bank's first FX2
+    state block and passes dry on every other, so an old part naming its id
+    on another track cannot start a second instance writing the host's tank.
   * The stock DELAY row is gone. Flash 4 (4 Sep 2026) wedged the unit every
     time a part LOADED with it selected -- a squeal that survived a project
     change and needed a power cycle, where re-selecting the same effect on
     the panel did not. Unexplained, and not worth explaining: the rig does
     not want it.
 
-Still to come before this remix is the rig: the sends move off the stations
-and onto the engines' otherwise blank pages, GRAIN drops to two grains (the
-cycle lever the delay core needs once the stations are actually turned up),
-and the two menu screens.
+⚠️ THE SENDS STAY ON THE STATIONS. Design pass 2 first moved them to FX2,
+and the arithmetic refused: both engines already use all twelve parameter
+slots, and putting their controls on a menu screen frees none of them --
+the screen edits those same twelve. Sends on the stations are uniform
+anyway, since every track has one. SEND is kept only as the FALLBACK, so a
+fresh or unassigned track still dispatches to real code, and it is hidden
+too: its knobs default to 0, so such a track is inert and looks like every
+other empty FX2.
 
-⚠️ An id dispatches the same code on every track, so hiding an engine does
-not stop an old part naming it on some other track. What stops that is the
-engine reading its own allocator slot and passing dry off its host, the
-idiom modules/modulation already uses. Not built yet either.
+Still to come: GRAIN drops to two grains (the cycle lever the delay core
+needs once the stations are actually turned up), and the two menu screens
+that edit the engines.
 """
 
 from remix.schema import Remix
@@ -33,7 +42,8 @@ REMIX = Remix(
     modules=("REVERB SERVER", "DELAY SERVER", "SEND",
              "SPECTRUM", "CHARACTER", "MODULATION",
              "TEMPO SYNC", "MENU SHORTCUT"),
-    hidden=("REVERB SERVER", "DELAY SERVER"),
+    hidden=("REVERB SERVER", "DELAY SERVER", "SEND",
+            "SPECTRUM", "CHARACTER", "MODULATION"),
     fallback="SEND",
     fx1=("SPECTRUM", "CHARACTER", "MODULATION"),
 )

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -442,7 +442,12 @@ FULLNAME = {m.key: m.menu.fullname + (BUILD_TAG if m.menu.build_tag else b"")
 # leave the donor's), so its track page draws no knobs. Counts, defaults and
 # enable bits are untouched, which is what keeps the parameter writer and the
 # frame builder working for the menu screen that edits it.
-RENAMES = {m.key: ([(i, b"") for i in range(12)] if m.key in HIDDEN else
+# ⚠️ NOT EVERY HIDDEN MODULE GETS BLANK NAMES. One descriptor serves BOTH
+# menus, so blanking a module that is also on the FX1 chooser would empty its
+# FX1 page too. A hidden module on FX1 loses its FX2 row and keeps its names;
+# only a hidden module that is nowhere on FX1 is drawn empty.
+BLANKED = [k for k in HIDDEN if k not in REMIX.fx1]
+RENAMES = {m.key: ([(i, b"") for i in range(12)] if m.key in BLANKED else
                    [(i, p.name) for i, p in enumerate(m.params)
                     if p.name is not None]) for m in _CLONED}
 # Explicit per-knob defaults -- NOT the donor's, which are sized for a
@@ -1120,7 +1125,13 @@ def main():
         if rd32(r) != FX2_LIST:
             sys.exit(f"list ref at 0x{r:08x} not stock FX2_LIST -- refusing")
         wr32(r, list_addr)
-    fb_pos = 0 if NO_FB else ORDER.index(REMIX.fallback)
+    # The fallback's cursor position. A HIDDEN fallback has no row of its
+    # own, so there is no position to point at: park the cursor at 0. A
+    # fresh track then dispatches to the fallback's code and its chooser
+    # opens on row 0, which in a remix that hides its fallback is whatever
+    # row 0 is -- or nothing, if the chooser is empty by design.
+    fb_pos = (0 if (NO_FB or REMIX.fallback in HIDDEN)
+              else ORDER.index(REMIX.fallback))
     # The cursor position of every listed effect, past the NONE row if one
     # was restored -- ID2POS is an index into `real`, not into ORDER.
     for pos, name in enumerate(ORDER):
@@ -1375,9 +1386,9 @@ def main():
                              f"3,072-word FX1 allocation")
                 _fx1_desc.append(_m.menu.donor_desc + 0x38)
                 continue
-            if _n not in ORDER:
-                sys.exit(f"fx1={_n!r}: it has no FX2 chooser row, so there "
-                         f"is no descriptor clone for FX1 to point at")
+            if _n not in CARRIED:
+                sys.exit(f"fx1={_n!r}: this remix does not carry it, so "
+                         f"there is no descriptor clone for FX1 to point at")
             # A REPLACEMENT is listed by its own key. The composed list is
             # rebuilt from scratch in the cave, so the stock row its id
             # inherited (the in-place repoint above edits the STOCK list,
@@ -1529,9 +1540,14 @@ def main():
           f"  chooser list = {len(real)} entries at 0x{list_addr:08x} (the "
           f"long list cave), {_none}, viewport {rows} rows -- it scrolls")
     if HIDDEN:
-        print(f"  placed but NOT LISTED: {', '.join(HIDDEN)} -- code, id and "
-              f"clone present, no chooser row, twelve names blanked so the "
-              f"track page draws nothing")
+        _b = [k for k in HIDDEN if k in BLANKED]
+        _n = [k for k in HIDDEN if k not in BLANKED]
+        print(f"  placed but NOT LISTED on FX2: {', '.join(HIDDEN)} -- code, "
+              f"id and clone present, no chooser row"
+              + (f"; names blanked (page draws nothing): {', '.join(_b)}" if _b
+                 else "")
+              + (f"; names KEPT (on the FX1 chooser): {', '.join(_n)}" if _n
+                 else ""))
     if STOCK_ROWS:
         print(f"  stock rows kept: {', '.join(STOCK_ROWS)} -- descriptors, "
               f"code and dispatch untouched on both cores")
@@ -2409,12 +2425,15 @@ mkgo:""",
         # bank's SECOND slot, so a guard compiled in unconditionally would
         # render every voicing pass and every verify_roll comparison DRY.
         # It goes in only for a remix that asks, and `hidden` is the ask.
+        # A module OPTS IN by carrying the marker. Hiding alone must not
+        # gate anything: SEND is hidden in a remix whose FX2 pages are all
+        # blank, and it still has to run on every track -- a fresh track IS
+        # a send, and it does the bus housekeeping.
         for _k in HIDDEN:
-            if _k not in _texts:
+            if _k not in _texts or "; HOSTGUARD\n" not in _texts[_k]:
                 continue
             if _texts[_k].count("; HOSTGUARD\n") != 1:
-                sys.exit(f"{_k} is hidden, but its source has no single "
-                         f"; HOSTGUARD marker to gate on")
+                sys.exit(f"{_k}: more than one ; HOSTGUARD marker")
             _texts[_k] = _texts[_k].replace("; HOSTGUARD\n", """
         move    r7,a
         move    #>$6200,x0

--- a/tools/render_reverb.py
+++ b/tools/render_reverb.py
@@ -333,6 +333,23 @@ REVERB_ID = 0x07                 # NEW_IDS["REVERB SERVER"] in build_bus.py
 INIT_TAB, PROC_TAB = 0x215, 0x235    # X memory, the dispatcher's two tables
 
 
+def _guarded(mem):
+    """Does the SELECTED REMIX compile the HOSTGUARD into the reverb?
+
+    Read from the remix rather than from the dump: a .mem carries no marker
+    that survives assembly cleanly, and every other tool here already keys
+    off REMIX. A remix that hides the reverb guards it (build_bus.py), and a
+    guarded engine only runs on the bank's FIRST FX2 slot.
+    """
+    try:
+        sys.path.insert(0, str(ROOT / "tools"))
+        from remix import registry
+        r = registry.remix(os.environ.get("REMIX") or registry.DEFAULT_REMIX)
+        return "REVERB SERVER" in r.hidden
+    except Exception:
+        return False
+
+
 def entry_points(mem_path):
     """Read the reverb's init/proc addresses out of the dump being rendered.
 
@@ -397,8 +414,17 @@ def run(mem, src, values, tail_s, verbose, entry=None):
             f.write(struct.pack("<i", max(-8388608, min(8388607, int(v * 8388607)))))
 
     init, proc = entry or entry_points(mem)
+    # ⚠️ THE STATE BLOCK IS NOT FREE TO CHOOSE ANY MORE. A remix that HIDES
+    # the reverb compiles in build_bus.py's HOSTGUARD, which runs the engine
+    # on the bank's FIRST FX2 slot (r7 = 0x6200, `-r7 2`) and passes dry on
+    # every other -- so the historical `-r7 4`, the SECOND slot, renders
+    # silence and every comparison built on it goes blind. verify_burn caught
+    # exactly that on the first guarded remix: it reported its own harness
+    # insensitive rather than reporting a result, which is the gate working.
+    # RVR7 overrides; the default follows the image on disk.
+    r7 = os.environ.get("RVR7") or ("2" if _guarded(mem) else "4")
     cmd = [str(HOST), "-mem", str(mem), "-init", f"{init:x}", "-proc", f"{proc:x}",
-           "-inst", "1", "-r7", "4", "-alloc", "3", "-blocks", str(blocks),
+           "-inst", "1", "-r7", r7, "-alloc", "3", "-blocks", str(blocks),
            "-in", str(tmp), "-out", str(out),
            "-params", ",".join(str(v) for v in values)]
     r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)

--- a/tools/verify_hidden.py
+++ b/tools/verify_hidden.py
@@ -89,21 +89,50 @@ def main():
               [clones[o] for o in clones if o != key], f"0x{P:08x}")
         names = [bytes(img[P - BASE + P_PARAM_NAMES + 6 * i:][:6]).split(b"\0")[0]
                  for i in range(12)]
-        check(f"{key}: all twelve parameter names are blank",
-              not any(names), " ".join(n.decode("latin1") or "-" for n in names))
+        # ⚠️ A HIDDEN MODULE THAT IS ALSO ON FX1 KEEPS ITS NAMES. One
+        # descriptor serves both menus, so blanking it would empty its FX1
+        # page too -- the stations are hidden from the FX2 chooser and still
+        # have to draw when they are selected on FX1.
+        if key in remix.fx1:
+            want = [(p.name or b"") for p in mods[key].params]
+            check(f"{key}: on FX1, so its names are KEPT, not blanked",
+                  names == want,
+                  " ".join(n.decode("latin1") or "-" for n in names[:6]))
+        else:
+            check(f"{key}: all twelve parameter names are blank",
+                  not any(names),
+                  " ".join(n.decode("latin1") or "-" for n in names))
+        # ⚠️ OVER THE ACTIVE SLOTS ONLY. A module need not use all twelve --
+        # SEND has two knobs -- and an inactive slot keeps whatever byte the
+        # cloned DONOR had there, which is not a defect and not the
+        # manifest's. Checking all twelve reported SEND as broken.
+        act = [i for i, p in enumerate(mods[key].params) if p.active]
         defaults = list(img[P - BASE + P_DEFAULTS:][:12])
         want = [(p.default or 0) & 0x7f for p in mods[key].params]
-        check(f"{key}: its defaults are the manifest's, untouched by hiding",
-              defaults == want, f"{defaults[:6]}...")
+        check(f"{key}: its {len(act)} active defaults are the manifest's",
+              all(defaults[i] == want[i] for i in act),
+              " ".join(f"{defaults[i]}" for i in act[:6]))
         lo, hi = u32(P + P_PENABLE_LO), u32(P + P_PENABLE_HI)
-        check(f"{key}: its enable bits are set, so the DSP still receives",
-              (lo & 0x11111111) == 0x11111111 and (hi & 0x11111111) != 0,
-              f"lo={lo:08x} hi={hi:08x}")
+        bits = ((hi & 0xffffffff) << 32) | (lo & 0xffffffff)
+        on = [i for i in range(12) if (bits >> (4 * i)) & 1]
+        check(f"{key}: exactly its active slots are enabled, so the DSP "
+              f"still receives", on == act,
+              f"enabled {on} vs active {act}")
         check(f"{key}: its cursor entry is the fallback's, not stock's",
               u32(ID2POS + mods[key].menu.fx2_id * 4) == fb_pos, f"{fb_pos}")
 
     # the chooser list is exactly the listed modules
-    for cand in (NEW_LIST, LONG_LIST):
+    # ⚠️ AN EMPTY CHOOSER IS A VALID OUTCOME, and the loop below cannot find
+    # a list that has no rows: with every module hidden the list is a bare
+    # terminator. Check that shape directly rather than reporting "not found".
+    listed_p = [clones[k] for k in listed]
+    if not listed_p:
+        check("the chooser list is empty: a bare terminator, no rows",
+              u32(NEW_LIST) == 0, f"first word 0x{u32(NEW_LIST):08x}")
+        for key in hidden:
+            check(f"{key} is not in the chooser list", True)
+        cand = None
+    for cand in ((NEW_LIST, LONG_LIST) if listed_p else ()):
         row = [u32(cand + 4 * i) for i in range(16)]
         if row[0] in clones.values():
             entries = []
@@ -111,7 +140,6 @@ def main():
                 if v == 0:
                     break
                 entries.append(v)
-            listed_p = [clones[k] for k in listed]
             check("the chooser lists exactly the modules that are not hidden",
                   entries == listed_p,
                   f"{len(entries)} rows at 0x{cand:08x}, expected {len(listed_p)}")
@@ -120,7 +148,8 @@ def main():
                       clones[key] not in entries)
             break
     else:
-        check("found the chooser list in the image", False)
+        if listed_p:
+            check("found the chooser list in the image", False)
 
     # ---- 2 and 3. the booted machine -------------------------------------
     import emu_bringup as emu
@@ -137,7 +166,8 @@ def main():
     # BusVerb's slot 11, so comparing the engine's names against the raw
     # capture reports a knob that is not the engine's. Subtract a baseline
     # render -- the same track with an id that draws nothing of its own.
-    key = hidden[0]
+    blanked = [k for k in hidden if k not in remix.fx1]
+    key = blanked[0] if blanked else hidden[0]
     hid_id = mods[key].menu.fx2_id
     base_texts = set(texts(emu.render_fx2(boot, track=4, effect_id=0x02)))
     drew_hidden = set(texts(emu.render_fx2(boot, track=4, effect_id=hid_id)))
@@ -145,8 +175,11 @@ def main():
     check(f"{key}'s page draws none of its knob names",
           not (hid_names & (drew_hidden - base_texts)),
           " ".join(sorted(hid_names & (drew_hidden - base_texts))) or "none drawn")
-    ctl = listed[0] if listed else None
-    if ctl and not mods[ctl].is_stock:
+    # the control: a module whose names ARE drawn -- a listed one, or a
+    # hidden one kept for FX1
+    ctl = next((k for k in listed if not mods[k].is_stock),
+               next((k for k in hidden if k in remix.fx1), None))
+    if ctl:
         drew_listed = set(texts(emu.render_fx2(boot, track=4,
                                                effect_id=mods[ctl].menu.fx2_id)))
         ctl_names = {p.name.decode("latin1") for p in mods[ctl].params if p.name}
@@ -225,7 +258,7 @@ def main():
             w = struct.unpack(f"<{len(d)//4}i", d)
             return list(w[0::2])[:N]
 
-        for key in hidden:
+        for key in [k for k in hidden if k in ("REVERB SERVER", "DELAY SERVER")]:
             # ⚠️ AT ITS DEFAULTS AN ENGINE IS ALREADY A DRY PASS -- both
             # engines are RETURNS whose IN defaults to 0 (v5, 23 Aug 2026),
             # so a control render has to open the input, or "the guard went

--- a/tools/verify_menu.py
+++ b/tools/verify_menu.py
@@ -197,8 +197,14 @@ def main():
     # script assumed a module every time and died with a KeyError on `warped`
     # and every other no-bus remix -- a traceback, not a failed check, so
     # `REMIX=warped make verify` reported nothing at all. Found 3 Sep 2026.
+    # A HIDDEN fallback is not in EXPECT (it has no chooser row), and its
+    # cursor parks at 0 because there is no row to point at. Its descriptor
+    # is still cloned and its id still resolves to it, which is the half
+    # that matters -- an unassigned track has to dispatch to real code.
     if FALLBACK == _NO_FALLBACK:
         fb_p, fb_pos = FX1_NONE, 0
+    elif FALLBACK in REMIX.hidden:
+        fb_p, fb_pos = rd32(img, FX2_IDS + _MODS[FALLBACK].menu.fx2_id * 4), 0
     else:
         fb_p, fb_pos = rd32(img, FX2_IDS + EXPECT[FALLBACK][0] * 4), \
             EXPECT[FALLBACK][1]


### PR DESCRIPTION
Design pass 2, step 3.

**The send move is off.** Both engines already use all twelve parameter slots, and a menu screen frees none of them: it edits those same twelve. Sends stay on the stations, which is uniform since every track has one. And a SEND on FX2 beside a sending station is a second tap that registers twice and halves everyone's share through the auto-gain, so FX2 carries nothing at all.

- SEND hidden, kept only as the fallback (blank page, knobs 0, inert). A hidden fallback parks its cursor at 0.
- Stations hidden from FX2 but **keep their names**: one descriptor serves both menus, so blanking would empty their FX1 page. The rule is automatic, hidden minus fx1.
- HOSTGUARD is now opt-in by marker, because SEND must run on every track (it does the bus housekeeping).
- The reverb render picks its state block from the remix. A guarded engine runs on the bank's first slot only, so the historical second-slot render was silent. The burn gate caught this by declaring its own harness blind rather than reporting a result.
- **Empty chooser checked in the emulator**: zero rows, a bare terminator, the window opens and draws; the host and an unassigned track draw nothing; a station chosen on FX1 draws its full page.

Gates: make check; make verify on bamsep27, bamsep26, bus, warped, mutables; verify_hidden 40 checks; refhash 26 of 26 bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
