### PR TITLE
GRAIN cycle lever: Remix.grains rolls the reader to two per line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ verify: ## Verify the ColdFire menu edits, module ledger (+ burn probe when it f
 	  echo "  [SKIP] cf probe: no .venv, or this remix has none"
 	@$(PY) tools/verify_hidden.py $(REMIX) 2>/dev/null || \
 	  echo "  [SKIP] hidden engines: no .venv, or this remix hides nothing"
+	python3 tools/verify_grains.py $(REMIX)
 	REMIX=$(REMIX) python3 tools/verify_menu.py
 	python3 tools/verify_burn.py
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -521,6 +521,40 @@ registers an entry *inside* the cave (`cfprobe` puts its formatter at
 `+0x100` with an `.org`), so one address and one pc-relative state block
 serve the interrupt and the panel. `offset=0` is the tempo-sync shape.
 
+## THE GRAIN COUNT IS A REMIX LEVER -- `Remix.grains`
+
+BusDelay's GRAIN reader runs four grains per line, or two:
+
+```python
+REMIX = Remix(name="...", modules=(...), grains=2, fallback="SEND")
+```
+
+**Cycles, not sound.** A core cannot carry four active stations beside a
+four-grain GRAIN -- 3,294 of 3,120 usable by the pricer -- and at two grains
+it fits. Measured saving: **1,775 -> 1,305 cycles, 470**.
+
+`tools/remix/grains.py` holds the substitution, imported by BOTH the builder
+and `cycle_count.py`. That sharing is not tidiness: the first version of the
+lever was applied only in the build, so `make cycles` priced four grains for
+a two-grain image and the saving was invisible in the tool that measures it.
+
+Three edits at censused markers in the engine, and nothing else: the two
+rolled loops count 2; the grain-to-grain phase offset doubles, `G/4 -> G/2`,
+so two grains still tile the cycle; and the makeup doubles, because **four
+triangle windows at quarter offsets sum to exactly 2 while two at half
+offsets sum to exactly 1** -- the same coefficient would land 6 dB down.
+
+`tools/verify_grains.py` is the gate: the markers are where the lever expects
+them, the pricer sees the saving, and -- rendered through the real send path
+by `verify_delay` -- every NON-GRAIN case is bit-identical while every GRAIN
+case differs. Both halves matter: all-identical would mean the lever did
+nothing, a difference in CLEAN would mean it did too much.
+
+⚠️ **What is not checked is how two grains SOUND.** The arithmetic that would
+make it exactly checkable -- two half-offset triangle windows summing to 1,
+so DC in comes back flat, the identity that caught Nimbus's double-rate
+window -- needs a DC feed over the delay bus that this harness does not have.
+
 ## PLACED BUT NOT LISTED -- `Remix.hidden`
 
 A remix can carry a module with **no chooser row and no knobs on the page**:

--- a/modules/busdelay/delay_server.asm
+++ b/modules/busdelay/delay_server.asm
@@ -910,6 +910,29 @@ dwarmz:
                                         ; what verify-delay bit-compares
         move    b,x:(r7+$32)            ; GRAIN base age
         move    b,x:(r7+$5e)            ; REVERSE segment phase
+; ---- THE GRAIN COUNT IS A BUILD-TIME LEVER (4 Sep 2026) -------------------
+; Four grains per line is what this source assembles to. A remix that
+; declares `grains=2` (schema.Remix) has build_bus.py substitute three
+; things at the markers below, and nothing else changes:
+;
+;   ; GRAINCNT  the two rolled loops count 2 instead of 4
+;   ; GRAINOFF  the grain-to-grain phase offset doubles, G/4 -> G/2, so two
+;              grains still tile the cycle
+;   ; GRAINMK   the makeup doubles, because FOUR triangle windows at quarter
+;              offsets sum to exactly 2 while TWO at half offsets sum to
+;              exactly 1 -- so the same coefficient would land 6 dB down
+;
+; WHY: cycles, not sound. The delay's core cannot carry four active stations
+; beside a four-grain GRAIN (3,294 of 3,120 by the pricer); at two grains it
+; fits. The cost is half the simultaneous grain voices, which is an ear
+; decision, not a correctness one.
+;
+; ⚠️ THE HALF-OFFSET CASE HAS AN EXACT TEST and the quarter-offset one does
+; not: two triangle windows a half period apart sum to exactly 1, so DC in
+; must come back flat. That is the gate that caught Nimbus's double-rate
+; window (CLAUDE.md, the a0 trap), and it is why the two-grain build is the
+; better-checked of the two.
+;
 ; GRAIN v5's PERSISTENT latches: eight scatters, eight window multipliers
 ; and eight read advances, each re-latched at its own grain's wrap. A garbage scatter subtracts
 ; straight into a read address and a garbage multiplier is a garbage window
@@ -1512,6 +1535,7 @@ gvs0:
         move    #>$200000,x0            ; 2^(32-11)
         move    x0,x:(r7+$3f)
 gvsz:
+; GRAINOFF
 ; the read distance base: lag + G + 2, with lag = min(TIME, 12286 - mask).
 ; A grain at unity reads W - (lag + s + G + 2 - phase): at least lag + s + 2
 ; behind the write head and at most lag + s + G + 1 behind it; s tops out at
@@ -2028,6 +2052,7 @@ gmode:
         move    x0,x:(r7+$5d)           ; cursor = age (grain 0's phase)
         clr     a
         move    a,x:(r7+$1e)
+; GRAINCNT
         do      #4,>gvlz
         move    x:(r7+$5d),a            ; this grain's phase
         tst     a                       ; Z SET == its wrap
@@ -2134,6 +2159,7 @@ gvlz:
         move    x:(r7+$1e),x0
         move    x:(r7+$3d),y1           ; makeup coeff
         mpy     x0,y1,b
+; GRAINMK
         move    b,x:(r7+$24)            ; shifted OUTPUT tap L
 ; ---- READER, line R: four grains, ROLLED (v5) ----------------------------
 ; Records of THREE words at r7+$4c: s (latched scatter), w (window
@@ -2151,6 +2177,7 @@ gvlz:
         move    x0,x:(r7+$5d)           ; cursor = age (grain 0's phase)
         clr     a
         move    a,x:(r7+$1f)
+; GRAINCNT
         do      #4,>gvrz
         move    x:(r7+$5d),a            ; this grain's phase
         tst     a                       ; Z SET == its wrap
@@ -2254,6 +2281,7 @@ gvrz:
         move    x:(r7+$1f),x0
         move    x:(r7+$3d),y1
         mpy     x0,y1,b
+; GRAINMK
         move    b,x:(r7+$25)            ; shifted OUTPUT tap R
         bra     pdone
 ; MODEFORK_MID -- alternative 2: REVERSE

--- a/remixes/bamsep27.py
+++ b/remixes/bamsep27.py
@@ -29,9 +29,7 @@ fresh or unassigned track still dispatches to real code, and it is hidden
 too: its knobs default to 0, so such a track is inert and looks like every
 other empty FX2.
 
-Still to come: GRAIN drops to two grains (the cycle lever the delay core
-needs once the stations are actually turned up), and the two menu screens
-that edit the engines.
+Still to come: the two menu screens that edit the engines.
 """
 
 from remix.schema import Remix
@@ -44,6 +42,7 @@ REMIX = Remix(
              "TEMPO SYNC", "MENU SHORTCUT"),
     hidden=("REVERB SERVER", "DELAY SERVER", "SEND",
             "SPECTRUM", "CHARACTER", "MODULATION"),
+    grains=2,          # the cycle lever: four stations beside the delay
     fallback="SEND",
     fx1=("SPECTRUM", "CHARACTER", "MODULATION"),
 )

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -2410,6 +2410,23 @@ mkgo:""",
                 return _sub(src)
             return src
 
+        # ---- GRAINS: BusDelay's GRAIN reader, four per line or two -------
+        # A CYCLE LEVER (schema.Remix.grains). The substitution itself lives
+        # in tools/remix/grains.py, imported by the PRICER too -- they
+        # disagreed the first time this was written, and an image rolled to
+        # two grains that `make cycles` still prices at four hides the exact
+        # saving the lever exists for.
+        if REMIX.grains != 4 and "DELAY SERVER" in _texts:
+            from remix import grains as _grains
+            try:
+                _texts["DELAY SERVER"] = _grains.roll(_texts["DELAY SERVER"],
+                                                      REMIX.grains)
+            except ValueError as _e:
+                sys.exit(f"grains={REMIX.grains}: {_e} -- the GRAIN reader "
+                         f"moved under the lever")
+            print(f"  GRAINS: BusDelay's GRAIN reader rolled to "
+                  f"{REMIX.grains} per line (offset G/2, makeup doubled)")
+
         # ---- HOSTGUARD: a HIDDEN engine runs on its host slot only --------
         # A hidden engine (schema.Remix.hidden) is hosted by the project's
         # stamp, not by the chooser. Dispatch is per id and shared by every

--- a/tools/cycle_count.py
+++ b/tools/cycle_count.py
@@ -27,6 +27,7 @@ as a floor. It is exact for the code and optimistic about the bus.
 
 Usage:  python3 tools/cycle_count.py [--verify] [--json]
 """
+import os
 import json
 import pathlib
 import re
@@ -228,6 +229,15 @@ def prep(name):
         return src
     src = _ASM[name].read_text()
     if name == "delay_server":
+        # THE GRAIN LEVER, priced as built. schema.Remix.grains rolls the
+        # reader to two grains per line for the cycles; pricing the source
+        # instead reports the four-grain figure for a two-grain image, which
+        # is the saving invisible in the tool that measures it.
+        _g = registry.remix(os.environ.get("REMIX")
+                            or registry.DEFAULT_REMIX).grains
+        if _g != 4:
+            from remix import grains as _grains
+            src = _grains.roll(src, _g)
         # build_bus.py rewrites this per payload; the value cannot change the
         # word count, but assert the shape it relies on so a drift is loud.
         if src.count("$30000") != 1:

--- a/tools/remix/grains.py
+++ b/tools/remix/grains.py
@@ -1,0 +1,44 @@
+"""BusDelay's GRAIN reader: four grains per line, or two.
+
+ONE COPY OF THE SUBSTITUTION, imported by both the builder and the pricer.
+They disagreed the first time this lever was written -- the image was rolled
+to two grains and `make cycles` still priced four, so the saving the lever
+exists for was invisible in the tool that measures it.
+
+Three edits and nothing else (the markers live in the engine source):
+
+  ; GRAINCNT   the two rolled loops count 2 instead of 4
+  ; GRAINOFF   the grain-to-grain phase offset doubles, G/4 -> G/2, so two
+              grains still tile the cycle
+  ; GRAINMK    the makeup doubles: FOUR triangle windows at quarter offsets
+              sum to exactly 2, TWO at half offsets sum to exactly 1
+
+The doubling is `asl #$1`, the engine's own arithmetic form -- it keeps the
+extension byte consistent with A1, which a logical shift would not
+(CLAUDE.md's A2-staleness trap, paid on the next store).
+"""
+
+MARKERS = (("; GRAINCNT\n", 2), ("; GRAINOFF\n", 1), ("; GRAINMK\n", 2))
+
+
+def census(src):
+    """[(marker, found, expected)] for every marker whose count is wrong."""
+    return [(m, src.count(m), n) for m, n in MARKERS if src.count(m) != n]
+
+
+def roll(src, grains):
+    """The delay source with its GRAIN reader rolled to `grains` per line."""
+    if grains == 4:
+        return src
+    bad = census(src)
+    if bad:
+        raise ValueError("; ".join(f"{m.strip()}: {f} markers, expected {n}"
+                                   for m, f, n in bad))
+    src = src.replace("; GRAINCNT\n        do      #4,", "        do      #2,")
+    src = src.replace("; GRAINOFF\n", """        move    x:(r7+$39),a
+        asl     #$1,a,a                 ; grain-to-grain offset G/4 -> G/2
+        move    a1,x0
+        move    x0,x:(r7+$39)
+""", 1)
+    return src.replace("; GRAINMK\n", """        asl     #$1,b,b                 ; two windows sum to 1, not 2
+""")

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -806,9 +806,30 @@ class Remix:
     # runs this code. A module that must run on one track only has to detect
     # that itself, the way modules/modulation does with its allocator slot.
     hidden: tuple[str, ...] = ()
+    # GRAINS PER LINE in BusDelay's GRAIN mode: 4 (the source's own) or 2.
+    #
+    # A CYCLE LEVER, not a voicing choice. The delay's core cannot carry four
+    # active stations beside a four-grain GRAIN -- 3,294 of 3,120 usable by
+    # the pricer -- and at two grains it fits with room. The cost is half the
+    # simultaneous grain voices.
+    #
+    # build_bus.py substitutes at three markers in the engine: the two rolled
+    # loops count 2, the grain-to-grain phase offset doubles (G/4 -> G/2, so
+    # two grains still tile the cycle), and the makeup doubles, because four
+    # triangle windows at quarter offsets sum to exactly 2 while two at half
+    # offsets sum to exactly 1.
+    #
+    # ⚠️ The two-grain build is the BETTER-CHECKED one: two triangle windows
+    # a half period apart sum to exactly 1, so DC in must come back flat --
+    # the gate that caught Nimbus's double-rate window. Four at quarter
+    # offsets have no such exact identity.
+    grains: int = 4
     fx1: tuple[str, ...] = ()
 
     def __post_init__(self):
+        if self.grains not in (2, 4):
+            raise ValueError(f"grains={self.grains}: BusDelay's GRAIN reader "
+                             f"is built for 4 or 2 per line, nothing else")
         if self.fallback != NO_FALLBACK and self.fallback not in self.modules:
             raise ValueError(
                 f"remix {self.name!r}: fallback {self.fallback!r} is not in "

--- a/tools/verify_grains.py
+++ b/tools/verify_grains.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""The GRAIN cycle lever changes GRAIN and nothing else.
+
+    python3 tools/verify_grains.py [remix]      (default: bamsep27)
+
+`schema.Remix.grains = 2` rolls BusDelay's reader from four grains per line
+to two, for the cycles: the delay's core cannot carry four active stations
+beside a four-grain GRAIN. Three things have to hold.
+
+ 1. THE SUBSTITUTION IS THE ONE THE BUILD USES. Both the builder and the
+    pricer import tools/remix/grains.py, and the markers are censused, so a
+    reader that moved stops the build instead of quietly assembling four
+    grains under a two-grain report.
+ 2. THE PRICER SEES IT. The rolled engine must price CHEAPER than the source
+    -- the whole point of the lever is a number, and the first version of it
+    was invisible to `make cycles`, which is the tool that measures the thing
+    it exists for.
+ 3. IT TOUCHES GRAIN AND NOTHING ELSE, rendered through the real send path.
+    `tools/verify_delay.py` renders both engines into the delay hatch and
+    compares: every non-GRAIN case must be BIT-IDENTICAL, and the GRAIN cases
+    must DIFFER. Both halves matter -- all-identical would mean the lever did
+    nothing, and a difference in CLEAN would mean it did too much.
+
+What this does NOT check is how two grains SOUND. That is an ear pass, and
+the arithmetic that makes it checkable at all -- two triangle windows a half
+period apart sum to exactly 1, so DC in comes back flat -- needs a DC feed
+over the delay bus that this harness does not have yet.
+"""
+import os
+import pathlib
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+SRC = pathlib.Path("modules/busdelay/delay_server.asm")
+
+
+def main():
+    from remix import grains, registry
+    name = sys.argv[1] if len(sys.argv) > 1 else "bamsep27"
+    remix = registry.remix(name)
+    if remix.grains == 4:
+        print(f"  [ -- ] {name} runs four grains -- no lever to check")
+        return 0
+    fails = 0
+
+    def check(label, ok, detail=""):
+        nonlocal fails
+        print(f"  [{'PASS' if ok else 'FAIL'}] {label}"
+              f"{'  ' + detail if detail else ''}")
+        fails += 0 if ok else 1
+
+    src = SRC.read_text()
+    bad = grains.census(src)
+    check("the engine carries exactly the markers the lever substitutes",
+          not bad, "; ".join(f"{m.strip()} {f}/{n}" for m, f, n in bad))
+    if bad:
+        print(f"\n{fails} check(s) failed")
+        return 1
+    rolled = grains.roll(src, remix.grains)
+    check("rolling changes the source", rolled != src)
+    check("the rolled loops count the declared grains",
+          rolled.count(f"do      #{remix.grains},") >= 2,
+          f"{rolled.count(f'do      #{remix.grains},')} rolled loops")
+
+    # ---- the pricer -------------------------------------------------------
+    def price(env):
+        r = subprocess.run([sys.executable, "tools/cycle_count.py"],
+                           capture_output=True, text=True,
+                           env={**os.environ, **env})
+        for line in r.stdout.splitlines():
+            if line.startswith("delay_server"):
+                return int(line.split()[1])
+        return None
+
+    four = price({"REMIX": "bus"})
+    two = price({"REMIX": name})
+    if four and two:
+        check("the pricer sees the lever: the rolled engine is cheaper",
+              two < four, f"{four} -> {two} cycles, saving {four - two}")
+
+    # ---- rendered: GRAIN differs, everything else is bit-identical --------
+    tmp = pathlib.Path("out/_grains")
+    tmp.mkdir(parents=True, exist_ok=True)
+    cand = tmp / "delay_rolled.asm"
+    cand.write_text(rolled)
+    # ⚠️ REMIX MUST NOT LEAK INTO THE DELAY GATE. verify_delay builds its own
+    # DELAY HATCH -- every server real, no SPEC -- and a remix that HIDES the
+    # delay compiles the host guard into both engines, so the hatch it built
+    # under an inherited REMIX rendered a guarded engine at a non-host slot
+    # and produced no comparable cases at all (0/0, under `make verify` only,
+    # because standalone the variable was unset). Pin it to the plain remix.
+    r = subprocess.run([sys.executable, "tools/verify_delay.py", str(cand)],
+                       capture_output=True, text=True,
+                       env={**os.environ, "REMIX": "bus"})
+    lines = [l for l in r.stdout.splitlines() if "[PASS]" in l or "[FAIL]" in l]
+    if not lines:
+        check("verify_delay ran", False, (r.stdout + r.stderr).strip()[-200:])
+    else:
+        ident = [l for l in lines if "bit-identical:" in l]
+        grain = [l for l in ident if "GRAIN" in l]
+        other = [l for l in ident if "GRAIN" not in l]
+        check("every NON-GRAIN case is bit-identical",
+              other and all("[PASS]" in l for l in other),
+              f"{sum('[PASS]' in l for l in other)}/{len(other)}")
+        check("every GRAIN case DIFFERS -- the lever did something",
+              grain and all("[FAIL]" in l for l in grain),
+              f"{sum('[FAIL]' in l for l in grain)}/{len(grain)}")
+        sens = [l for l in lines if "sensitive" in l or "mode is LIVE" in l]
+        check("the comparison could have seen a difference anywhere",
+              sens and all("[PASS]" in l for l in sens),
+              f"{sum('[PASS]' in l for l in sens)}/{len(sens)} controls")
+
+    print(f"\n{fails} check(s) failed" if fails else "\nOK")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify_hidden.py
+++ b/tools/verify_hidden.py
@@ -222,6 +222,15 @@ def main():
     mem_a = pathlib.Path("out/dsp/mem_dev_A.mem")
     scratch = pathlib.Path("out/_hidden")
     scratch.mkdir(parents=True, exist_ok=True)
+    # ⚠️ BUILD THE DUMP HERE, ALWAYS. These gates run in sequence under
+    # `make verify` and several of them rebuild the same .mem files -- the
+    # delay's bit-identity gate writes the hatch dump with no guard at all,
+    # so a render against whatever was left on disk reported a guarded engine
+    # as wet. Same lesson as the station gates' audition cache (3 Sep 2026):
+    # a stale dump does not fail, it measures the wrong image.
+    subprocess.run([sys.executable, "tools/build_bus.py"],
+                   capture_output=True, text=True,
+                   env={**os.environ, "REMIX": name, "DEV": "1", "XBUS": "1"})
     if pathlib.Path(HOST).exists() and mem_a.exists():
         FRAMES, N = 15, 6000
         src = scratch / "in.raw"


### PR DESCRIPTION
Design pass 2, step 4: the cycle lever the delay core needs once the stations are actually turned up.

`Remix.grains = 2` rolls BusDelay's GRAIN reader from four grains per line to two. **Measured saving: 1,775 to 1,305 cycles, 470.** The delay core in the rig's layout goes from 3,294 of 3,120 usable to comfortably inside it.

Three edits at censused markers and nothing else: the two rolled loops count 2; the grain-to-grain phase offset doubles so two grains still tile the cycle; and the makeup doubles, because four triangle windows at quarter offsets sum to exactly 2 while two at half offsets sum to exactly 1.

- **The substitution is shared** between the builder and the pricer (tools/remix/grains.py). The first version applied it only in the build, so make cycles priced four grains for a two-grain image and the saving was invisible in the tool that measures it.
- **tools/verify_grains.py** is the gate. Rendered through the real send path: every non-GRAIN case bit-identical (9 of 9), every GRAIN case differs (5 of 5), and 8 of 8 sensitivity controls pass. All-identical would mean the lever did nothing; a difference in CLEAN would mean it did too much.
- Two ordering defects fell out of running the gates together, both stale-artifact shaped: the hidden gate now builds its own dump, and the delay gate is pinned to the plain remix so a guarded engine is not rendered at a non-host slot.

Not checked: how two grains sound. The exact test, DC in coming back flat, needs a DC feed over the delay bus this harness does not have.

Gates: make check; make verify on bamsep27, bus, bamsep26, mutables; refhash 26 of 26 bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
