### PR TITLE
The build tag follows BUILD, so the file and the panel cannot disagree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ DSP_ASM := vendor/dsp56300/build/source/dsp_host/dsp_asm
 # Stamped into the OS version field (max 10 chars) so the unit tells you which
 # build it is running. Bump BUILD every time you flash: a unit whose version
 # string you cannot map back to a commit is a unit you are guessing about.
-BUILD   ?= 79
+BUILD   ?= 79          # the image's version AND the build tag the panel
+                       # shows in every effect name (tools/build_bus.py)
 VERSION ?= OCTABAM$(BUILD)
 
 # Which modules the image carries. `make modules` lists what is available;
@@ -46,7 +47,7 @@ recon: ## Unpack + static recon -> out/raw/section_3_MAIN_OS.bin
 
 .PHONY: bus
 bus: ## THE build: one server per core, cross-core bus -> out/mainos_bus.bin
-	REMIX=$(REMIX) XBUS=1 SPEC=1 python3 tools/build_bus.py
+	REMIX=$(REMIX) BUILD=$(BUILD) XBUS=1 SPEC=1 python3 tools/build_bus.py
 
 .PHONY: bus-plain
 bus-plain: ## Build without specialization (both servers on both cores)

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -409,7 +409,16 @@ NO_FB = REMIX.fallback == NO_FALLBACK
 # the Character station returning both wets on the master (RVRB/DLY in
 # SAT=BUS), hosts quiet only while a return is live; label formatters
 # overflow into the second zero run. Flash 4, docs/FLASHPLAN.md.
-BUILD_TAG = b"79"
+# ⚠️ IT FOLLOWS THE MAKEFILE'S `BUILD` (4 Sep 2026). It was a literal here
+# and the Makefile's BUILD chose the FILENAME, so `BUILD=80 make image` wrote
+# OCTATRACK_OCTABAM80.bin whose panel said `BusVerb79` -- the file and the
+# unit disagreeing about which image it is, which is the exact ambiguity
+# this tag exists to prevent. The default stays 79, so an unset BUILD builds
+# what it always did; refhash's 26 cases are bit-identical across the change.
+BUILD_TAG = os.environ.get("BUILD", "79").encode()
+if not (BUILD_TAG.isdigit() and 1 <= len(BUILD_TAG) <= 2):
+    sys.exit(f"BUILD={BUILD_TAG.decode()!r}: the tag is appended to a 13-byte "
+             f"name field, so it must be one or two digits")
 
 # ---- the module tables, derived from modules/*/manifest.py ------------------
 # One statement per fact, living in the module that owns it. These dicts keep


### PR DESCRIPTION
The tag was a literal while the Makefile's BUILD chose the filename, so a BUILD=80 image had a panel saying 79. Hit today building the select probe beside the rig: two images, both tagged 79, which is the ambiguity the tag exists to prevent.

The tag now reads BUILD, defaulting to 79 so an unset build is unchanged, and the bus target passes BUILD through. One or two digits, checked, since the tag is appended to a 13-byte name field.

refhash 26 of 26 bit-identical; make check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)