### PR TITLE
SELECT PROBE: one knob walks every page, and the track term is confirmed live

### DIFF
--- a/modules/selprobe/README.md
+++ b/modules/selprobe/README.md
@@ -18,11 +18,21 @@ project, and **writes nothing**.
 
 1. Build and flash `REMIX=selprobe make image`. Load a project.
 2. Put **HELLO WORLD** on any track's FX2 and open that page.
-3. **GAIN is the readout.** Its own value picks which of the six page-2
-   slots is shown — 0–20 is slot 0, then 21 per slot up to slot 5 — and the
-   number printed is `slot * 256 + the byte`, so the slot is always visible
-   beside the value and a mis-set knob cannot be mistaken for a wrong
-   formula. `-` means no project is loaded.
+3. **GAIN is the readout.** Its value picks BOTH the page and the slot —
+   `slot = value mod 6`, `page = value div 6` — so one knob reads the whole
+   parameter space:
+
+   | GAIN | page |
+   |---|---|
+   | 0–5 | 0 |
+   | 6–11 | 1 |
+   | 12–17 | 2 |
+   | **18–23** | **3 — FX1** |
+   | **24–29** | **4 — FX2** |
+   | 30+ | pinned to page 4, slot 5 |
+
+   The number printed is `page * 4096 + slot * 256 + the byte`, so the row
+   being read is always visible beside the value. `-` means no project.
 4. On the **same track**, open page 2 of its FX2 effect and turn a select.
 5. Go back to HELLO WORLD's GAIN and read it again.
 
@@ -48,6 +58,26 @@ caller's sprintf buffer.
 
 ⚠️ Mutually exclusive with `modules/cfprobe`: both register on HELLO WORLD's
 GAIN. `remixes/selprobe.py` carries this one alone.
+
+## What the unit has already said (4 Sep 2026, build 80)
+
+The first build read FX2's page only, and shipped in an image that hides
+every effect having an FX2 page-2 select — so there was nothing to turn.
+It still returned a result, from two tracks read at the same slot:
+
+| track | printed | slot | byte |
+|---|---|---|---|
+| T3 | 1281 | 5 | 1 |
+| T4 | 1344 | 5 | 64 |
+
+✅ **Different tracks give different bytes, so the `track*30` term is
+LIVE.** Had the track offset been ignored — which is exactly what happened
+in the emulator, where every write landed at offset zero — both tracks would
+have read the same byte. That was the single most doubtful term in the
+formula, and it is now the one with evidence behind it.
+
+Still unconfirmed: the `page*6 + slot` terms, which is what the page-walking
+build above is for.
 
 ## Verified locally
 

--- a/modules/selprobe/manifest.py
+++ b/modules/selprobe/manifest.py
@@ -14,10 +14,19 @@ if this number follows it, the formula is right; if it does not, the value
 shown says how far off it is.
 
 HOW TO READ IT. The readout is HELLO WORLD's GAIN, and GAIN's own value
-picks which of the six page-2 slots is shown, so one knob reads the whole
-block: 0-20 is slot 0, then 21 per slot up to slot 5. The number printed is
-`slot * 256 + value`, so the slot is always visible beside the byte and a
-mis-set knob cannot be mistaken for a wrong formula. `-` means no project.
+picks BOTH the page and the slot -- `slot = value mod 6`, `page = value div
+6` -- so one knob reads the whole parameter space: 0-5 is page 0, 6-11 page
+1, 12-17 page 2, **18-23 page 3 (FX1)**, **24-29 page 4 (FX2)**, and
+anything above 29 pins to page 4 slot 5. The number printed is
+`page * 4096 + slot * 256 + value`, so the row being read is always visible
+beside the byte and a mis-set knob cannot be mistaken for a wrong formula.
+`-` means no project.
+
+⚠️ THE FIRST BUILD READ FX2 ONLY, and shipped in an image that HIDES every
+effect with an FX2 page-2 select -- so there was nothing on the unit to turn
+and nothing the probe could ever see move. The stations on FX1 do have
+selects (Spectrum's MODE, ROUT and SRC), which is why the page is now part
+of what the knob chooses rather than an assumption baked into the cave.
 
 ⚠️ MUTUALLY EXCLUSIVE WITH `modules/cfprobe`: both register on HELLO
 WORLD's GAIN. `remixes/selprobe.py` carries this one alone.
@@ -31,11 +40,13 @@ nothing and stores nothing but the caller's sprintf buffer.
 from remix.schema import CavePatch, FormatterReg, Kind, Module
 
 PROBE_BYTES = bytes.fromhex(
-    "4feffff048d7001c202f001872154c4100007205b2806c0220012400263946c8"
-    "2456675e70001039100b14cf223c000018b24c010000d68070001039100b14cc"
-    "721e4c010000d68006830008f04a068300000018d6822043720012102002e188"
-    "d0814cd7001c4fef00102f004879400b465d2f2f000c4eb940013a084fef000c"
-    "4e754cd7001c4fef0010487a00102f2f00084eb940013a08508f4e752d000000"
+    "4feffff048d7001c202f0018721db2806c02200172064c410000262f0018721d"
+    "b2836c02260172064c4130032803220376064c031000242f0018761db6826c02"
+    "24039481263946c82456676670001039100b14cf223c000018b24c010000d680"
+    "70001039100b14cc721e4c010000d68006830008f04a200472064c010000d680"
+    "d6822043720012102004e988d082e188d0814cd7001c4fef00102f004879400b"
+    "465d2f2f000c4eb940013a084fef000c4e754cd7001c4fef0010487a00102f2f"
+    "00084eb940013a08508f4e752d000000"
 )
 
 MODULE = Module(
@@ -51,8 +62,9 @@ MODULE = Module(
             pinned=PROBE_BYTES,
             source="modules/selprobe/selprobe.s",
             registers_formatter=FormatterReg(module="HELLO WORLD", slot=0),
-            report_note=" (HELLO WORLD GAIN prints slot*256 + the select "
-                        "byte at DB+0x8f04a + track*30 + 24 + slot)",
+            report_note=" (HELLO WORLD GAIN prints page*4096 + slot*256 + "
+                        "the select byte at DB+0x8f04a + track*30 + "
+                        "page*6 + slot)",
         ),
     ),
 )

--- a/modules/selprobe/selprobe.s
+++ b/modules/selprobe/selprobe.s
@@ -45,14 +45,40 @@
         .text
 fmt:    lea     -16(%sp),%sp
         movem.l %d2-%d4,(%sp)           | 12 bytes: buf 20(sp), value 24(sp)
+| ---- GAIN encodes PAGE and SLOT, not slot alone -------------------------
+| The first build read FX2's page only, and the image it shipped in hides
+| every effect that HAS an FX2 page-2 select -- so there was nothing on the
+| unit to turn and nothing the probe could ever see move. One knob now reads
+| the whole space instead of assuming a page:
+|
+|     slot = value mod 6,  page = value div 6,  clamped to page 4
+|
+| so GAIN 0..5 is page 0, 6..11 page 1, 12..17 page 2, 18..23 page 3 (FX1),
+| 24..29 page 4 (FX2), and anything above 29 pins to page 4 slot 5.
         move.l  24(%sp),%d0             | GAIN 0..127
-        move.l  #21,%d1
-        divu.l  %d1,%d0                 | slot = value / 21
-        moveq   #5,%d1
+        moveq   #29,%d1
         cmp.l   %d0,%d1
         bge.s   1f
-        move.l  %d1,%d0                 | the top band is 105..127
-1:      move.l  %d0,%d2                 | d2 = slot 0..5
+        move.l  %d1,%d0                 | above 29: pin to page 4, slot 5
+1:      moveq   #6,%d1
+        divu.l  %d1,%d0                 | d0 = page, remainder in the pair
+        move.l  24(%sp),%d3
+        moveq   #29,%d1
+        cmp.l   %d3,%d1
+        bge.s   2f
+        move.l  %d1,%d3
+2:      moveq   #6,%d1
+        divu.l  %d1,%d3
+        move.l  %d3,%d4                 | d4 = page (again, for the address)
+        move.l  %d3,%d1
+        moveq   #6,%d3
+        mulu.l  %d3,%d1
+        move.l  24(%sp),%d2
+        moveq   #29,%d3
+        cmp.l   %d2,%d3
+        bge.s   3f
+        move.l  %d3,%d2
+3:      sub.l   %d1,%d2                 | d2 = slot = value - page*6
 
         move.l  0x46c82456,%d3          | the project DB base
         beq.s   none                    | no project: nothing to read
@@ -67,15 +93,22 @@ fmt:    lea     -16(%sp),%sp
         mulu.l  %d1,%d0                 | track*30
         add.l   %d0,%d3
         add.l   #0x8f04a,%d3            | the select array
-        add.l   #24,%d3                 | page 4 -> +4*6
+        move.l  %d4,%d0
+        moveq   #6,%d1
+        mulu.l  %d1,%d0
+        add.l   %d0,%d3                 | + page*6
         add.l   %d2,%d3                 | + slot
         move.l  %d3,%a0
         moveq   #0,%d1
         move.b  (%a0),%d1               | the byte the formula addresses
 
-        move.l  %d2,%d0
+| print as page*4096 + slot*256 + value, so the row being read is always
+| visible beside the byte and a mis-set knob cannot look like a wrong formula
+        move.l  %d4,%d0
+        lsl.l   #4,%d0
+        add.l   %d2,%d0
         lsl.l   #8,%d0
-        add.l   %d1,%d0                 | print as slot*256 + value
+        add.l   %d1,%d0
         movem.l (%sp),%d2-%d4
         lea     16(%sp),%sp
         move.l  %d0,-(%sp)


### PR DESCRIPTION
The first probe build read FX2's page only, and shipped in an image that hides every effect having an FX2 page-2 select, so there was nothing on the unit to turn. My error in building the image. The page is now part of what the knob chooses: slot = value mod 6, page = value div 6, so GAIN 18-23 reads FX1 and 24-29 reads FX2, printed as page, slot and byte together.

**The first build still returned a result.** Two tracks read at the same slot: T3 printed 1281 (byte 1), T4 printed 1344 (byte 64). Different tracks give different bytes, so the track term is live. Had it been ignored, as it was in the emulator where every write landed at offset zero, both would have read the same. That was the most doubtful term in the formula.

The page and slot terms are what this build is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
