### PR TITLE
SELECT PROBE: put the byte first, and give the page a refresh knob

### DIFF
--- a/modules/hello/manifest.py
+++ b/modules/hello/manifest.py
@@ -45,7 +45,17 @@ MODULE = Module(
         # ---- page 1 -------------------------------------------------------
         Param(b"GAIN", 127, 128, active=True, formatter=Formatter.PLAIN,
               doc="linear level, out = in x GAIN/128; 127 exact pass, 0 silence"),
-        Param(), Param(), Param(), Param(), Param(),
+        # ⚠️ A DELIBERATE DO-NOTHING KNOB. The engine reads slot 0 and nothing
+        # else, so this changes no audio -- it exists so a probe registered on
+        # GAIN can be REFRESHED without moving GAIN. A formatter only runs
+        # when the page redraws, and on the unit the only way to force a
+        # redraw was to wiggle the very knob whose value selects what the
+        # probe shows (modules/selprobe): the refresh gesture perturbed the
+        # measurement. Turning this one redraws the page and leaves GAIN
+        # alone.
+        Param(b"RDRW", 0, active=True, formatter=Formatter.PLAIN,
+              doc="does nothing to the audio; turn it to force a redraw"),
+        Param(), Param(), Param(), Param(),
         # ---- page 2: none in v1 (taper select will land on slot 7) --------
         Param(), Param(), Param(), Param(), Param(), Param(),
     ),

--- a/modules/selprobe/README.md
+++ b/modules/selprobe/README.md
@@ -31,10 +31,22 @@ project, and **writes nothing**.
    | **24–29** | **4 — FX2** |
    | 30+ | pinned to page 4, slot 5 |
 
-   The number printed is `page * 4096 + slot * 256 + the byte`, so the row
-   being read is always visible beside the value. `-` means no project.
-4. On the **same track**, open page 2 of its FX2 effect and turn a select.
-5. Go back to HELLO WORLD's GAIN and read it again.
+   The number printed is **`byte * 256 + page * 16 + slot`** — the byte
+   LEADS. Printed the other way round, a MODE step moved a five-digit
+   number by one and was unreadable on the unit. A MODE step is now a jump
+   of 256. The row is still in the last two digits. `-` means no project.
+
+4. ⚠️ **Refresh with `RDRW`, HELLO WORLD's second knob — never with GAIN.**
+   A formatter runs only when the page redraws, and GAIN's value is what
+   selects the row, so wiggling GAIN to force a redraw MOVES WHAT YOU ARE
+   LOOKING AT. On the first hardware attempt that made the reading
+   unusable: "it did not move" could not be told from "I could not see it
+   move". `RDRW` changes no audio and exists only to redraw the page.
+5. **On the SAME track** — the probe reads whichever track you are viewing —
+   open FX1 page 2 and turn a select. On Spectrum those are MODE (slot 1),
+   ROUT (slot 3) and SRC (slot 5); the even slots are knobs and live in a
+   different array, so they will read 0 here whatever you do.
+6. Come back, turn `RDRW` to refresh, and read GAIN again.
 
 ## What the answer means
 

--- a/modules/selprobe/manifest.py
+++ b/modules/selprobe/manifest.py
@@ -17,10 +17,19 @@ HOW TO READ IT. The readout is HELLO WORLD's GAIN, and GAIN's own value
 picks BOTH the page and the slot -- `slot = value mod 6`, `page = value div
 6` -- so one knob reads the whole parameter space: 0-5 is page 0, 6-11 page
 1, 12-17 page 2, **18-23 page 3 (FX1)**, **24-29 page 4 (FX2)**, and
-anything above 29 pins to page 4 slot 5. The number printed is
-`page * 4096 + slot * 256 + value`, so the row being read is always visible
-beside the byte and a mis-set knob cannot be mistaken for a wrong formula.
-`-` means no project.
+anything above 29 pins to page 4 slot 5. The number printed is **`byte * 256 + page * 16 + slot`** -- the BYTE
+LEADS, because printed the other way round a MODE step moved the number by
+one in five digits (12544 to 12545) and was unreadable on the unit. A MODE
+step is now a jump of 256. The row is still in the last two digits, so a
+knob that slipped is still distinguishable from a byte that changed. `-`
+means no project.
+
+⚠️ **REFRESH WITH HELLO WORLD'S SECOND KNOB, `RDRW`, NOT WITH GAIN.** A
+formatter runs only when the page redraws, and GAIN's value is what selects
+the row -- so wiggling GAIN to force a redraw MOVES WHAT YOU ARE LOOKING AT.
+That made the first hardware attempt unreadable: "it did not move" could not
+be told from "I could not see it move". `RDRW` changes no audio and exists
+purely to redraw the page with GAIN untouched.
 
 ⚠️ THE FIRST BUILD READ FX2 ONLY, and shipped in an image that HIDES every
 effect with an FX2 page-2 select -- so there was nothing on the unit to turn
@@ -44,7 +53,7 @@ PROBE_BYTES = bytes.fromhex(
     "b2836c02260172064c4130032803220376064c031000242f0018761db6826c02"
     "24039481263946c82456676670001039100b14cf223c000018b24c010000d680"
     "70001039100b14cc721e4c010000d68006830008f04a200472064c010000d680"
-    "d6822043720012102004e988d082e188d0814cd7001c4fef00102f004879400b"
+    "d6822043720012102001e988d084e988d0824cd7001c4fef00102f004879400b"
     "465d2f2f000c4eb940013a084fef000c4e754cd7001c4fef0010487a00102f2f"
     "00084eb940013a08508f4e752d000000"
 )
@@ -62,9 +71,8 @@ MODULE = Module(
             pinned=PROBE_BYTES,
             source="modules/selprobe/selprobe.s",
             registers_formatter=FormatterReg(module="HELLO WORLD", slot=0),
-            report_note=" (HELLO WORLD GAIN prints page*4096 + slot*256 + "
-                        "the select byte at DB+0x8f04a + track*30 + "
-                        "page*6 + slot)",
+            report_note=" (HELLO WORLD GAIN picks page+slot and prints "
+                        "byte*256 + page*16 + slot; RDRW refreshes)",
         ),
     ),
 )

--- a/modules/selprobe/selprobe.s
+++ b/modules/selprobe/selprobe.s
@@ -102,13 +102,22 @@ fmt:    lea     -16(%sp),%sp
         moveq   #0,%d1
         move.b  (%a0),%d1               | the byte the formula addresses
 
-| print as page*4096 + slot*256 + value, so the row being read is always
-| visible beside the byte and a mis-set knob cannot look like a wrong formula
-        move.l  %d4,%d0
+| ---- THE BYTE COMES FIRST -------------------------------------------------
+| Printed page*4096 + slot*256 + byte, a MODE step moved the number by ONE in
+| five digits -- 12544 to 12545 -- which on the unit was unreadable, and the
+| operator could not tell "it did not move" from "I could not see it move".
+| The byte is what the measurement is ABOUT, so it leads:
+|
+|     byte*256 + page*16 + slot
+|
+| A MODE step is now a jump of 256: 49, 305, 561, 817, 1073 for MODE 0..4 on
+| page 3 slot 1. The row is still visible in the last two digits, so a
+| knob that slipped is still distinguishable from a byte that changed.
+        move.l  %d1,%d0
+        lsl.l   #4,%d0
+        add.l   %d4,%d0
         lsl.l   #4,%d0
         add.l   %d2,%d0
-        lsl.l   #8,%d0
-        add.l   %d1,%d0
         movem.l (%sp),%d2-%d4
         lea     16(%sp),%sp
         move.l  %d0,-(%sp)


### PR DESCRIPTION
Two flaws the first hardware attempt exposed, both mine.

**The change was invisible.** Printed page-first, a MODE step moved a five-digit number by one. The byte now leads, so a MODE step is a jump of 256, with the row still readable in the last two digits.

**The refresh gesture perturbed the measurement.** A formatter runs only on redraw, and GAIN's value selects the row, so wiggling GAIN to refresh moved what was being looked at: "it did not move" could not be told from "I could not see it move". HELLO WORLD gains a second knob, RDRW, that the engine never reads and which exists only to redraw the page.

Verified against planted bytes through the firmware's own formatter path: the arithmetic is exact.

The README now also records that the probe reads whichever track is being viewed, and that only the odd page-2 slots are selects. Both cost a reading attempt today.

make check green, verify green on selprobe and hello, refhash 26 of 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
