### PR TITLE
SELECT PROBE, fourth build: designed around how the panel actually behaves

### DIFF
--- a/modules/hello/manifest.py
+++ b/modules/hello/manifest.py
@@ -45,17 +45,7 @@ MODULE = Module(
         # ---- page 1 -------------------------------------------------------
         Param(b"GAIN", 127, 128, active=True, formatter=Formatter.PLAIN,
               doc="linear level, out = in x GAIN/128; 127 exact pass, 0 silence"),
-        # ⚠️ A DELIBERATE DO-NOTHING KNOB. The engine reads slot 0 and nothing
-        # else, so this changes no audio -- it exists so a probe registered on
-        # GAIN can be REFRESHED without moving GAIN. A formatter only runs
-        # when the page redraws, and on the unit the only way to force a
-        # redraw was to wiggle the very knob whose value selects what the
-        # probe shows (modules/selprobe): the refresh gesture perturbed the
-        # measurement. Turning this one redraws the page and leaves GAIN
-        # alone.
-        Param(b"RDRW", 0, active=True, formatter=Formatter.PLAIN,
-              doc="does nothing to the audio; turn it to force a redraw"),
-        Param(), Param(), Param(), Param(),
+        Param(), Param(), Param(), Param(), Param(),
         # ---- page 2: none in v1 (taper select will land on slot 7) --------
         Param(), Param(), Param(), Param(), Param(), Param(),
     ),

--- a/modules/selprobe/README.md
+++ b/modules/selprobe/README.md
@@ -6,95 +6,72 @@
 DB + part*6322 + 0x8f04a + track*30 + page*6 + slot
 ```
 
-and drove the firmware's own two-phase editor into writing that array. But
-every local attempt to confirm the **track, page and slot terms** landed the
-write at offset zero, because the emulator boots with no CF card and the
-project database is empty. Three reads hit that same wall.
+The **track term is confirmed** (4 Sep 2026, build 80: T3 and T4 read
+different bytes at the same slot). The page and slot terms are what this
+build tests. It writes nothing — it prints the byte the formula addresses.
 
-This probe settles it from the other side, on a real unit with a real
-project, and **writes nothing**.
+## What the panel does, and why three builds failed
 
-## The measurement
+- **A knob's value is shown only while that knob turns.** A readout on GAIN
+  is visible only while GAIN moves — and GAIN is also what chooses the row.
+  So the bands are ten values wide: wiggle GAIN, read, stay in the band.
+- **Turning another knob redraws only its own label.** A "refresh" knob
+  cannot refresh anything. Build 82's RDRW is gone.
+- **The byte must dominate the number.** Build 81 put it in the last digit;
+  a MODE step moved a five-digit number by one.
+- **The remix hides every FX2 effect with a page-2 select**, so the turnable
+  selects are on FX1. This build reads both pages.
 
-1. Build and flash `REMIX=selprobe make image`. Load a project.
-2. Put **HELLO WORLD** on any track's FX2 and open that page.
-3. **GAIN is the readout.** Its value picks BOTH the page and the slot —
-   `slot = value mod 6`, `page = value div 6` — so one knob reads the whole
-   parameter space:
+## Reading it
 
-   | GAIN | page |
-   |---|---|
-   | 0–5 | 0 |
-   | 6–11 | 1 |
-   | 12–17 | 2 |
-   | **18–23** | **3 — FX1** |
-   | **24–29** | **4 — FX2** |
-   | 30+ | pinned to page 4, slot 5 |
+Registered on HELLO WORLD's GAIN. Number = `byte*100 + page*10 + slot`.
 
-   The number printed is **`byte * 256 + page * 16 + slot`** — the byte
-   LEADS. Printed the other way round, a MODE step moved a five-digit
-   number by one and was unreadable on the unit. A MODE step is now a jump
-   of 256. The row is still in the last two digits. `-` means no project.
+| GAIN | page | slot |
+|---|---|---|
+| 0–9 | FX1 (3) | 0 |
+| 10–19 | FX1 | 1 — **Spectrum's MODE** |
+| 20–29 | FX1 | 2 |
+| 30–39 | FX1 | 3 — ROUT |
+| 40–49 | FX1 | 4 |
+| 50–59 | FX1 | 5 — SRC |
+| 60–69 | FX2 (4) | 0 |
+| … | … | ten per slot |
+| 110–119 | FX2 | 5 |
 
-4. ⚠️ **Refresh with `RDRW`, HELLO WORLD's second knob — never with GAIN.**
-   A formatter runs only when the page redraws, and GAIN's value is what
-   selects the row, so wiggling GAIN to force a redraw MOVES WHAT YOU ARE
-   LOOKING AT. On the first hardware attempt that made the reading
-   unusable: "it did not move" could not be told from "I could not see it
-   move". `RDRW` changes no audio and exists only to redraw the page.
-5. **On the SAME track** — the probe reads whichever track you are viewing —
-   open FX1 page 2 and turn a select. On Spectrum those are MODE (slot 1),
-   ROUT (slot 3) and SRC (slot 5); the even slots are knobs and live in a
-   different array, so they will read 0 here whatever you do.
-6. Come back, turn `RDRW` to refresh, and read GAIN again.
+Only the **odd slots are selects**; even slots are knobs in another array
+and read 0 whatever you do.
 
-## What the answer means
+## The measurement, exactly
 
-| what you see | what it says |
+1. Flash `OCTATRACK_OCTABAM83.bin`. Power-cycle. Load a project.
+2. Pick a track with Spectrum on FX1 — T3. Put **HELLO WORLD on T3's FX2**.
+3. Turn GAIN to about **15** and wiggle it between 12 and 18. While it moves
+   the display shows a number. It should be **one of 31, 131, 231, 331,
+   431** — FX1 MODE's row, and the number says which position MODE is in.
+   Write it down.
+4. On **T3's FX1** page 2, turn **MODE** up one step.
+5. Back on T3's FX2, wiggle GAIN between 12 and 18 again and read.
+
+| you see | it means |
 |---|---|
-| the low byte follows the select you turned | ✅ the formula is right, and a screen can address a select directly |
-| it never changes | the track or page term is wrong — the byte we address is not the one the panel writes |
-| it changes when you turn a select on a DIFFERENT track | the `track*30` term is wrong, and by how many tracks the offset is out |
-| it changes for the wrong slot | the `page*6 + slot` term is wrong; the slot shown says which byte moved |
+| the number went **up by 100** | ✅ the formula is right, end to end |
+| the same number | the page or slot term is wrong |
+| a number not in the list | GAIN left the band; wiggle nearer 15 |
+| `-` | no project loaded |
 
-Page is fixed at 4, which §9c measured as FX2 from the page-1 writer's own
-arithmetic. If nothing on FX2 moves the number, try the same turn on FX1 to
-tell "wrong page" from "wrong array".
+The probe reads the track you are viewing. A select turned on any other
+track cannot move it.
 
 ## Why it only reads
 
-A formatter runs inside a redraw, and the firmware's select editor **ends in
-redraw calls**. A probe that invoked the editor would re-enter the drawing
-code from inside it. This one calls nothing and stores nothing but the
-caller's sprintf buffer.
+A formatter runs inside a redraw, and the firmware's select editor ends in
+redraw calls; a probe that invoked it would re-enter the drawing code. This
+one stores nothing but the caller's sprintf buffer.
 
-⚠️ Mutually exclusive with `modules/cfprobe`: both register on HELLO WORLD's
-GAIN. `remixes/selprobe.py` carries this one alone.
-
-## What the unit has already said (4 Sep 2026, build 80)
-
-The first build read FX2's page only, and shipped in an image that hides
-every effect having an FX2 page-2 select — so there was nothing to turn.
-It still returned a result, from two tracks read at the same slot:
-
-| track | printed | slot | byte |
-|---|---|---|---|
-| T3 | 1281 | 5 | 1 |
-| T4 | 1344 | 5 | 64 |
-
-✅ **Different tracks give different bytes, so the `track*30` term is
-LIVE.** Had the track offset been ignored — which is exactly what happened
-in the emulator, where every write landed at offset zero — both tracks would
-have read the same byte. That was the single most doubtful term in the
-formula, and it is now the one with evidence behind it.
-
-Still unconfirmed: the `page*6 + slot` terms, which is what the page-walking
-build above is for.
+⚠️ Mutually exclusive with `modules/cfprobe`: both take HELLO WORLD's GAIN.
 
 ## Verified locally
 
-Rendered through the booted firmware's own formatter path: with no project
-it prints `-`, and with a Part mapped it prints `0`, `256` and `1280` for
-GAIN 0, 30 and 127 — slots 0, 1 and 5 of a zeroed array. That proves the
-cave runs, decodes the knob and reads the address it computes. What it
-cannot prove locally is the only thing it exists for: which byte that is.
+Through the booted firmware's own formatter path with planted bytes: FX1
+slot 1 holding 2 prints **231**, holding 0 prints **31**; FX2 slot 1 holding
+2 prints **241**. `-` with no project.

--- a/modules/selprobe/manifest.py
+++ b/modules/selprobe/manifest.py
@@ -13,29 +13,21 @@ PRINTS the byte the formula addresses. Turn a page-2 select on the panel:
 if this number follows it, the formula is right; if it does not, the value
 shown says how far off it is.
 
-HOW TO READ IT. The readout is HELLO WORLD's GAIN, and GAIN's own value
-picks BOTH the page and the slot -- `slot = value mod 6`, `page = value div
-6` -- so one knob reads the whole parameter space: 0-5 is page 0, 6-11 page
-1, 12-17 page 2, **18-23 page 3 (FX1)**, **24-29 page 4 (FX2)**, and
-anything above 29 pins to page 4 slot 5. The number printed is **`byte * 256 + page * 16 + slot`** -- the BYTE
-LEADS, because printed the other way round a MODE step moved the number by
-one in five digits (12544 to 12545) and was unreadable on the unit. A MODE
-step is now a jump of 256. The row is still in the last two digits, so a
-knob that slipped is still distinguishable from a byte that changed. `-`
-means no project.
+HOW TO READ IT -- fourth build, designed around how the panel behaves. A
+knob's value is shown ONLY WHILE IT TURNS, so the readout is visible only
+while GAIN moves; GAIN is also what picks the row, so the row bands are TEN
+values wide and a wiggle stays inside one. GAIN 0-59 reads FX1 (page 3),
+60-119 reads FX2 (page 4), ten values per slot. The number is
+`byte*100 + page*10 + slot`: hundreds = the byte, tens = page, units = slot.
+FX1's MODE (page 3, slot 1) therefore reads 31, 131, 231, 331 or 431 for
+its five positions. `-` means no project.
 
-⚠️ **REFRESH WITH HELLO WORLD'S SECOND KNOB, `RDRW`, NOT WITH GAIN.** A
-formatter runs only when the page redraws, and GAIN's value is what selects
-the row -- so wiggling GAIN to force a redraw MOVES WHAT YOU ARE LOOKING AT.
-That made the first hardware attempt unreadable: "it did not move" could not
-be told from "I could not see it move". `RDRW` changes no audio and exists
-purely to redraw the page with GAIN untouched.
-
-⚠️ THE FIRST BUILD READ FX2 ONLY, and shipped in an image that HIDES every
-effect with an FX2 page-2 select -- so there was nothing on the unit to turn
-and nothing the probe could ever see move. The stations on FX1 do have
-selects (Spectrum's MODE, ROUT and SRC), which is why the page is now part
-of what the knob chooses rather than an assumption baked into the cave.
+Three flashes went into learning that: build 80 read a page nothing in the
+image could turn; build 81 put the byte in the last digit and needed GAIN
+wiggled to refresh, which moved the row; build 82 added a "refresh" knob
+that could not refresh anything, because a turning knob redraws only its
+own label. This one reads while GAIN wiggles inside a wide band, on BOTH
+FX pages, with the byte leading.
 
 ⚠️ MUTUALLY EXCLUSIVE WITH `modules/cfprobe`: both register on HELLO
 WORLD's GAIN. `remixes/selprobe.py` carries this one alone.
@@ -49,13 +41,12 @@ nothing and stores nothing but the caller's sprintf buffer.
 from remix.schema import CavePatch, FormatterReg, Kind, Module
 
 PROBE_BYTES = bytes.fromhex(
-    "4feffff048d7001c202f0018721db2806c02200172064c410000262f0018721d"
-    "b2836c02260172064c4130032803220376064c031000242f0018761db6826c02"
-    "24039481263946c82456676670001039100b14cf223c000018b24c010000d680"
-    "70001039100b14cc721e4c010000d68006830008f04a200472064c010000d680"
-    "d6822043720012102001e988d084e988d0824cd7001c4fef00102f004879400b"
-    "465d2f2f000c4eb940013a084fef000c4e754cd7001c4fef0010487a00102f2f"
-    "00084eb940013a08508f4e752d000000"
+    "4feffff048d7001c202f00187277b2806c0220017803723bb2806c0804800000"
+    "003c7804720a4c4100002400263946c82456677070001039100b14cf223c0000"
+    "18b24c010000d68070001039100b14cc721e4c010000d68006830008f04a2004"
+    "72064c010000d680d68220437200121070644c0010002004760a4c030000d280"
+    "d28220014cd7001c4fef00102f004879400b465d2f2f000c4eb940013a084fef"
+    "000c4e754cd7001c4fef0010487a00102f2f00084eb940013a08508f4e752d00"
 )
 
 MODULE = Module(
@@ -71,8 +62,8 @@ MODULE = Module(
             pinned=PROBE_BYTES,
             source="modules/selprobe/selprobe.s",
             registers_formatter=FormatterReg(module="HELLO WORLD", slot=0),
-            report_note=" (HELLO WORLD GAIN picks page+slot and prints "
-                        "byte*256 + page*16 + slot; RDRW refreshes)",
+            report_note=" (HELLO WORLD GAIN: 0-59 FX1, 60-119 FX2, ten per "
+                        "slot; prints byte*100 + page*10 + slot)",
         ),
     ),
 )

--- a/modules/selprobe/selprobe.s
+++ b/modules/selprobe/selprobe.s
@@ -1,87 +1,52 @@
-| SELECT-ARRAY READOUT -- a display formatter, not a writer (4 Sep 2026)
+| SELECT-ARRAY READOUT, fourth build -- designed around the PANEL (4 Sep 2026)
 |
-| THE QUESTION IT SETTLES. docs/MAINMENU.md 9c-ii decoded where a page-2
-| SELECT's value lives:
+| Three flashes taught what a probe on this panel has to respect:
 |
-|     DB + part*6322 + 0x8f04a + track*30 + page*6 + slot
+|   * A knob's VALUE is shown only while that knob is TURNING. So the readout
+|     is visible only while GAIN moves, and GAIN is also what chooses the
+|     row. Therefore the row bands must be WIDE enough that a wiggle stays
+|     inside one: ten values per band. Wiggle GAIN, read the number, stay in
+|     the band.
+|   * Turning a NEIGHBOURING knob redraws only that knob's label. A "refresh
+|     knob" does nothing. Removed.
+|   * The image that carries this hides every FX2 effect with a page-2
+|     select, so the turnable selects are on FX1 (Spectrum's MODE/ROUT/SRC).
+|     The probe covers BOTH FX1 and FX2 so the page term is tested too.
+|   * The byte being measured must DOMINATE the number: hundreds and up.
 |
-| and drove the firmware's own two-phase editor into writing that array --
-| but on a machine with NO PROJECT LOADED the write landed at offset zero,
-| so the track/page/slot terms are decoded but UNCONFIRMED. Every local
-| attempt to confirm them hit the same wall: the emulator boots with no CF
-| card, so the project DB and everything hanging off it are empty.
+| GAIN picks the row:
+|     0..59    FX1 (page 3)    slot = GAIN / 10
+|     60..119  FX2 (page 4)    slot = (GAIN - 60) / 10
+|     120+     pinned to FX2 slot 5
 |
-| This settles it from the other side and needs no writer at all. It PRINTS
-| the byte that formula addresses, on a real unit with a real project. Turn
-| a page-2 select on the panel: if the number here follows it, the formula
-| is right; if it does not, the formula is wrong and the printed value says
-| how far off.
+| The number shown is   byte*100 + page*10 + slot
+|     e.g. FX1 MODE (page 3, slot 1) reads 31, 131, 231, 331, 431 for MODE
+|     positions 1..5. Hundreds = the byte. Tens = page. Units = slot.
 |
-| WHERE IT DRAWS. Registered as HELLO WORLD's GAIN formatter, the same
-| readout slot modules/cfprobe uses -- so the two are MUTUALLY EXCLUSIVE in
-| one image, and remixes/selprobe.py carries this one alone.
-|
-| WHAT THE KNOB CHOOSES. GAIN's own value picks what is shown, so one knob
-| reads the whole block:
-|
-|     0..20    slot 0        the first page-2 select of the current track
-|     21..41   slot 1
-|     42..62   slot 2
-|     63..83   slot 3
-|     84..104  slot 4
-|     105..127 slot 5
-|
-| PAGE is fixed at 4 (FX2), the page docs/MAINMENU.md 9c measured as the FX2
-| one from the page-1 writer's own arithmetic.
-|
-| ⚠️ READ-ONLY BY CONSTRUCTION. It calls nothing and stores nothing; the
-| only thing it writes is the caller's sprintf buffer. A formatter runs
-| inside a redraw, and the firmware's own select editor ENDS in redraw
-| calls, so a formatter that invoked it would re-enter the drawing code --
-| which is why this probe reads rather than writes.
-|
-| Clobbers d0/d1/a0/a1 like every stock formatter; saves the rest.
+| Reads    DB + part*6322 + 0x8f04a + track*30 + page*6 + slot
+| for the CURRENT track (0x100b14cc) and part (0x100b14cf). It writes
+| nothing but the caller's sprintf buffer. Registered on HELLO WORLD's GAIN.
 
         .text
 fmt:    lea     -16(%sp),%sp
-        movem.l %d2-%d4,(%sp)           | 12 bytes: buf 20(sp), value 24(sp)
-| ---- GAIN encodes PAGE and SLOT, not slot alone -------------------------
-| The first build read FX2's page only, and the image it shipped in hides
-| every effect that HAS an FX2 page-2 select -- so there was nothing on the
-| unit to turn and nothing the probe could ever see move. One knob now reads
-| the whole space instead of assuming a page:
-|
-|     slot = value mod 6,  page = value div 6,  clamped to page 4
-|
-| so GAIN 0..5 is page 0, 6..11 page 1, 12..17 page 2, 18..23 page 3 (FX1),
-| 24..29 page 4 (FX2), and anything above 29 pins to page 4 slot 5.
+        movem.l %d2-%d4,(%sp)           | buf 20(sp), value 24(sp)
         move.l  24(%sp),%d0             | GAIN 0..127
-        moveq   #29,%d1
+        moveq   #119,%d1
         cmp.l   %d0,%d1
         bge.s   1f
-        move.l  %d1,%d0                 | above 29: pin to page 4, slot 5
-1:      moveq   #6,%d1
-        divu.l  %d1,%d0                 | d0 = page, remainder in the pair
-        move.l  24(%sp),%d3
-        moveq   #29,%d1
-        cmp.l   %d3,%d1
+        move.l  %d1,%d0                 | pin 120+ to 119
+1:      moveq   #3,%d4                  | page 3 = FX1
+        moveq   #59,%d1
+        cmp.l   %d0,%d1
         bge.s   2f
-        move.l  %d1,%d3
-2:      moveq   #6,%d1
-        divu.l  %d1,%d3
-        move.l  %d3,%d4                 | d4 = page (again, for the address)
-        move.l  %d3,%d1
-        moveq   #6,%d3
-        mulu.l  %d3,%d1
-        move.l  24(%sp),%d2
-        moveq   #29,%d3
-        cmp.l   %d2,%d3
-        bge.s   3f
-        move.l  %d3,%d2
-3:      sub.l   %d1,%d2                 | d2 = slot = value - page*6
+        sub.l   #60,%d0                 | 60..119 -> FX2
+        moveq   #4,%d4
+2:      moveq   #10,%d1
+        divu.l  %d1,%d0                 | slot = band / 10, 0..5
+        move.l  %d0,%d2                 | d2 = slot
 
-        move.l  0x46c82456,%d3          | the project DB base
-        beq.s   none                    | no project: nothing to read
+        move.l  0x46c82456,%d3          | project DB base
+        beq.s   none
         moveq   #0,%d0
         move.b  0x100b14cf,%d0          | current part
         move.l  #6322,%d1
@@ -89,9 +54,9 @@ fmt:    lea     -16(%sp),%sp
         add.l   %d0,%d3
         moveq   #0,%d0
         move.b  0x100b14cc,%d0          | current track
-        move.l  #30,%d1
-        mulu.l  %d1,%d0                 | track*30
-        add.l   %d0,%d3
+        moveq   #30,%d1
+        mulu.l  %d1,%d0
+        add.l   %d0,%d3                 | + track*30
         add.l   #0x8f04a,%d3            | the select array
         move.l  %d4,%d0
         moveq   #6,%d1
@@ -100,24 +65,16 @@ fmt:    lea     -16(%sp),%sp
         add.l   %d2,%d3                 | + slot
         move.l  %d3,%a0
         moveq   #0,%d1
-        move.b  (%a0),%d1               | the byte the formula addresses
+        move.b  (%a0),%d1               | the byte
 
-| ---- THE BYTE COMES FIRST -------------------------------------------------
-| Printed page*4096 + slot*256 + byte, a MODE step moved the number by ONE in
-| five digits -- 12544 to 12545 -- which on the unit was unreadable, and the
-| operator could not tell "it did not move" from "I could not see it move".
-| The byte is what the measurement is ABOUT, so it leads:
-|
-|     byte*256 + page*16 + slot
-|
-| A MODE step is now a jump of 256: 49, 305, 561, 817, 1073 for MODE 0..4 on
-| page 3 slot 1. The row is still visible in the last two digits, so a
-| knob that slipped is still distinguishable from a byte that changed.
+        move.l  #100,%d0
+        mulu.l  %d0,%d1                 | byte*100
+        move.l  %d4,%d0
+        moveq   #10,%d3
+        mulu.l  %d3,%d0                 | page*10
+        add.l   %d0,%d1
+        add.l   %d2,%d1                 | + slot
         move.l  %d1,%d0
-        lsl.l   #4,%d0
-        add.l   %d4,%d0
-        lsl.l   #4,%d0
-        add.l   %d2,%d0
         movem.l (%sp),%d2-%d4
         lea     16(%sp),%sp
         move.l  %d0,-(%sp)


### PR DESCRIPTION
Three flashes taught what a probe on this panel has to respect; this build respects all of it.

- A knob's value shows only while it turns, and GAIN is also the row selector, so the bands are ten values wide: wiggle GAIN, read, stay in the band.
- A neighbouring knob redraws only its own label, so build 82's refresh knob is removed.
- The image hides every FX2 effect with a page-2 select, so the turnable selects are on FX1; the probe covers both pages so the page term is tested too.
- The byte leads: FX1 MODE reads 31, 131, 231, 331 or 431, a step being a jump of 100.

Verified through the firmware's own formatter path with planted bytes; exact. The README is the whole procedure with every expected number written down before the flash.

make check green, verify green on selprobe and hello, refhash 26 of 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
