### PR TITLE
analyze.sh: avoid bash4-only mapfile for stock macOS bash 3.2

### DIFF
--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -11,7 +11,14 @@ EXTRACTED=downloads/extracted
 OUT=out
 mkdir -p "$OUT"
 
-mapfile -t ARTIFACTS < <(find "$EXTRACTED" -type f \( -iname '*.bin' -o -iname '*.syx' \) 2>/dev/null)
+# `mapfile` is a bash 4+ builtin. macOS ships /bin/bash 3.2 (frozen there for
+# GPLv3 reasons), where it doesn't exist -- so this line broke for anyone on
+# stock macOS despite the project assuming "macOS + Homebrew" throughout. The
+# while/read form below is bash-3.2-safe and needs nothing extra installed.
+ARTIFACTS=()
+while IFS= read -r f; do
+  ARTIFACTS+=("$f")
+done < <(find "$EXTRACTED" -type f \( -iname '*.bin' -o -iname '*.syx' \) 2>/dev/null)
 if [ "${#ARTIFACTS[@]}" -eq 0 ]; then
   echo "[analyze] no .bin/.syx under $EXTRACTED — run scripts/fetch-os.sh first." >&2
   exit 1


### PR DESCRIPTION
\`scripts/analyze.sh\` used \`mapfile\`, a bash 4+ builtin. macOS ships
/bin/bash 3.2.57 (frozen there for GPLv3 reasons), so \`make recon\` fails
immediately on a stock Mac with:

    scripts/analyze.sh: line 14: mapfile: command not found

despite the README assuming "macOS + Homebrew" throughout, and
\`scripts/setup.sh\` never installing/upgrading bash itself.

Replaced with a while/read loop building the same array - bash 3.2-safe,
no new dependency. Verified locally: \`make recon\` now runs clean through
entropy/binwalk/strings/eft and produces \`out/raw/section_3_MAIN_OS.bin\`
as before.