### PR TITLE
Recorder ingest (Bryan T sessions 2–5) + emulator M4 card, M5 frames/ticks, route A scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,17 @@ emu-setup: ## Provision the remixer deps (unicorn + textual) into .venv via uv
 	uv sync --extra emu
 	@echo "remixer ready — 'make remix' (docs/EMU.md for the emulator view)"
 
+# The card: build a FAT16 image from a project directory, boot, mount it with
+# the firmware's own storage stack and load the project (docs/EMU.md M4).
+#   make emu-card PROJECT=~/octa/backups/<snapshot>/<project> [SET=OCTABAM NAME=RIG]
+PROJECT ?=
+SET ?= OCTABAM
+NAME ?=
+.PHONY: emu-card
+emu-card: ## Boot with an emulated CF card holding PROJECT and load it
+	@test -n "$(PROJECT)" || { echo "usage: make emu-card PROJECT=<project dir> [SET=..] [NAME=..]"; exit 1; }
+	$(PY) tools/emu_card.py --project "$(PROJECT)" --set "$(SET)" $(if $(NAME),--name "$(NAME)",)
+
 # -------------------------------------------------------------------- misc --
 
 .PHONY: disasm

--- a/PLAN.md
+++ b/PLAN.md
@@ -672,7 +672,7 @@ far needs A; `docs/EMU.md` keeps it on the table.
 **Next emulator milestone, parked 4 Sep 2026: a LOADED PROJECT (card
 emulation).** The emulator boots with no project, so `PART` is null and every
 panel path that keys off the project — the select committer, part save and
-load, stamp defaults, the untraced recorder write path — cannot be driven to
+load, stamp defaults, the recorder write path — cannot be driven to
 the right address; that gap is what turned the select-array question into
 four hardware probe flashes (80–83) with no signal. The firmware does its own
 FAT parsing, so the emulator only has to answer ATA sector reads from an

--- a/PLAN.md
+++ b/PLAN.md
@@ -669,8 +669,11 @@ something needs task-interleaving behaviour, route **A** (emulate the RTOS:
 dispatch the trap via VBR `[0x400b9668]`, drive a timer tick). Nothing built so
 far needs A; `docs/EMU.md` keeps it on the table.
 
-**Next emulator milestone, parked 4 Sep 2026: a LOADED PROJECT (card
-emulation).** The emulator boots with no project, so `PART` is null and every
+**Emulator milestone 4, BUILT 5 Sep 2026: a LOADED PROJECT (card
+emulation) — `tools/emu_card.py`, `make emu-card PROJECT=<dir>`, `docs/EMU.md`
+M4.** The trigger below arrived with the recorder work; the paragraph is kept
+as the design record. The async-completion risk turned out to be one hook on
+the RTOS event wait. The emulator booted with no project, so `PART` was null and every
 panel path that keys off the project — the select committer, part save and
 load, stamp defaults, the recorder write path — cannot be driven to
 the right address; that gap is what turned the select-array question into

--- a/PLAN.md
+++ b/PLAN.md
@@ -666,8 +666,11 @@ Remaining toward full fidelity: item-level menu descent and live dial *values*
 (same detour shape — drive the real key handler `FUN_40064e64`, capture the
 XOR-highlight `FUN_40012254`, and assign the effect to the track) and, only if
 something needs task-interleaving behaviour, route **A** (emulate the RTOS:
-dispatch the trap via VBR `[0x400b9668]`, drive a timer tick). Nothing built so
-far needs A; `docs/EMU.md` keeps it on the table.
+dispatch the trap via VBR `[0x400b9668]`, drive a timer tick). **Scoped 6 Sep
+2026 — `docs/RTOS_FORK.md`**: kernel decoded, feasibility spike passed, five
+milestones (M6a–e) with the fidelity gate that M5's one-trig test must land
+identically under the real scheduler. The recorder-arm path (M5 "path B") is
+the first consumer; Sam chose it as the next emulator lift.
 
 **Emulator milestone 4, BUILT 5 Sep 2026: a LOADED PROJECT (card
 emulation) — `tools/emu_card.py`, `make emu-card PROJECT=<dir>`, `docs/EMU.md`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,8 +89,10 @@ It is a custom microkernel with all the classic components:
   that is waiting and forces a reschedule with `0xFC04_C010 |= 0x800` (ColdFire interrupt controller).
 
 **Scheduler / context switch core** ✓ (`FUN_4000056e`, reached by `TRAP #0` and by the timer):
-1. Saves ALL of the current task's registers (D0–D7, A0–A6, SR) into its TCB `_DAT_800068fc`
-   at offsets `0x0c`–`0x48` (hence the TCB layout: saved context at `0x0c`+, SP at `0x38`).
+1. Saves ALL of the current task's registers (D0–D7, A0–A7) into its TCB `_DAT_800068fc`
+   at offsets `0x0c`–`0x4b` (`moveml d0-sp`; **SP at `0x48`** — corrected 6 Sep 2026 from
+   "`0x38`", read byte-exact at `0x40000560`/`0x4000062c`; SR is not in the block, it
+   travels in the exception frame the `rte` pops). Full layout in `docs/RTOS_FORK.md` §2.
 2. Takes the highest-priority ready task (head of the queue at `_DAT_800068d8`).
 3. Clears the reschedule bit (`0xFC04_C010 &= ~0x800`) and **re-arms the ColdFire PIT timer
    `0xFC08_0000` (reload `0xb3f`)** = the time-slice quantum → **time-preemptive** scheduler.

--- a/docs/DSP.md
+++ b/docs/DSP.md
@@ -816,7 +816,18 @@ The two remaining tempo readers outside the sequencer are UI: `0x40031d70`
 A third non-UI reader turned up 2 Sep 2026: `0x4006e3b2` converts the
 recorder's RLEN to samples, `(raw+1) × 63504000 / (4·tempo24)`
 (`EXTERNAL.md` §6). It feeds the CPU-side recorder, not a frame record, so
-the conclusion below is unchanged.
+the conclusion below is unchanged. (5 Sep 2026: the converter that actually
+reaches the recorder's `arm()` is `0x40006dfc`, which *rounds*; `0x4006e3b2`'s
+consumer is open — `EXTERNAL.md` §6, Sessions 2–4.)
+
+**tempo24 is an integer count of 1/24 BPM** (measured 5 Sep 2026):
+`0x4009c5f4` splits it `÷24` / `mod 24` for display; `0x4009c5b8` returns
+the pattern's own word (`blob + pattern×0x8ed8 + 0x8e58`) when
+`[0x80000024]` is set, else `0x80000020`; the writer at `0x4004bc54` scales
+it by `[0x46c7d328]/1000` with a truncating `divs` (nominal 1000, clamp
+≤1100 — the tempo nudge, inferred from shape) before the 720..7200 clamp.
+A displayed `x.y` BPM is therefore not exactly representable unless
+`y ∈ {0, 5}`; the UI's rounding rule is not read.
 
 **Conclusion of the static pass (inferred, one flash from measured):** the
 ColdFire computes every tempo-derived rate itself and ships rates, not BPM.

--- a/docs/DSP.md
+++ b/docs/DSP.md
@@ -820,14 +820,16 @@ the conclusion below is unchanged. (5 Sep 2026: the converter that actually
 reaches the recorder's `arm()` is `0x40006dfc`, which *rounds*; `0x4006e3b2`'s
 consumer is open — `EXTERNAL.md` §6, Sessions 2–4.)
 
-**tempo24 is an integer count of 1/24 BPM** (measured 5 Sep 2026):
-`0x4009c5f4` splits it `÷24` / `mod 24` for display; `0x4009c5b8` returns
+**tempo24 is an integer count of 1/24 BPM, and the UI grid is ten uneven
+24ths per BPM** (measured 5 Sep 2026): the setter `0x4009c7c4(bpm, tenths)`
+computes `24·bpm + (23·tenths + 4)/9` (truncating), so tenths `0..9` become
+`0 3 5 8 10 13 15 18 20 23` — a displayed `.5` is +0.5417 BPM. `0x4009c5f4`
+displays it back (`÷24`, `mod 24`, `(9·f + 11)/23`); `0x4009c5b8` returns
 the pattern's own word (`blob + pattern×0x8ed8 + 0x8e58`) when
 `[0x80000024]` is set, else `0x80000020`; the writer at `0x4004bc54` scales
 it by `[0x46c7d328]/1000` with a truncating `divs` (nominal 1000, clamp
 ≤1100 — the tempo nudge, inferred from shape) before the 720..7200 clamp.
-A displayed `x.y` BPM is therefore not exactly representable unless
-`y ∈ {0, 5}`; the UI's rounding rule is not read.
+`EXTERNAL.md` §6 has the recorder consequences.
 
 **Conclusion of the static pass (inferred, one flash from measured):** the
 ColdFire computes every tempo-derived rate itself and ships rates, not BPM.

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -213,10 +213,131 @@ the string hook — the audio side (`render_reverb`, the `v` audition view) is
 where knob values are heard. Editing a value in the page + reading it back as
 text is the remaining nicety.
 
+## Milestone 4 — the card, and a project loaded from it ✅ (5 Sep 2026)
+
+`tools/emu_card.py`. The trigger PLAN.md §5 set for this — "the SECOND
+project-dependent path" — arrived with the recorder work (the write path can
+only be armed from a part on a loaded project), and the parts work had been
+waiting on it since the probe flashes of 4 Sep. Run:
+
+```sh
+.venv/bin/python3 tools/emu_card.py --project <dir> --set OCTABAM --name RIG
+make emu-card PROJECT=<dir>            # same, defaults
+```
+
+builds `out/emu_card.img`, boots the raw image, attaches the card, runs the
+firmware's own storage bring-up and loads `/OCTABAM/RIG` through the engine
+task. Everything below is measured in the emulator against the canonical
+image unless marked.
+
+**The card is a FAT16 image the firmware mounts itself.** A pure-Python
+builder (`build_image`) writes MBR + one partition + BPB + FATs + a
+directory tree with VFAT long names. The firmware's mount is picky in
+exactly the ways the code says (`0x400168e8`: `0x55AA`, partition type 4 /
+6 / 0x0e or a bare FAT32 BPB; `0x40017ad4`: 512-byte sectors, ≤ 16384
+sectors per FAT), and macOS mounts the same image and reads the files back
+byte-identical, which is the independent check on the builder.
+
+**The ATA model is small because the driver is.** Task-file registers in
+the FlexBus window `0x90000000` (`ARCHITECTURE.md` §5), IDENTIFY answering
+"PIO only" so the variant detection at `0x40015e28` never touches the
+on-chip DMA channel, READ/WRITE SECTORS, and the handful of no-data
+commands the driver issues (SET FEATURES, STANDBY, CFA). The ATA host
+status byte `0xfc0a4039` must read with bit 3 clear (the code moves it into
+CCR and tests N), which the all-ones default violates — `EXTRA_OVERRIDES`
+in `emu_bringup.boot` exists for that.
+
+**The RTOS boundary was one hook, not a scheduler.** The PIO handlers
+(`0x40014b94` READ, `0x40014c48` WRITE, `0x400159bc` IDENTIFY) only program
+the registers; the data phase is the ATA interrupt handler at `0x40015304`,
+which streams 256 words per sector and signals the RTOS event the queue
+primitive `0x4001568c` blocks on (`0x40000818`). We never take the
+interrupt. A hook on `0x40000818` performs the transfer the handler would
+have — same bookkeeping words (`0x46c8c592` count, `0x46c8c594` buffer,
+`0x46c8c593` command, `0x460bac18` IDENTIFY buffer, `0x460bae18` lock) —
+and returns as if the event had fired; a second hook at the primitive's
+no-wait return (`0x40015786`) completes asynchronous commands the same way.
+Timer waits (the delay helper `0x40020c7c`) pass instantly. Every other wait
+is logged, so a silently satisfied wait for something that never happened
+is visible in the record.
+
+**Cold init is the main task's own list.** After the ATA subsystem init
+(`0x400160f8`: interrupt vector 0xb6, the two 64/32-entry command queues,
+16 event objects) the main init task (`0x4001fc00`) runs eight subsystem
+inits before parking; `card_init` runs the same list, plus the engine-side
+queue creator `0x40040b14` (queues `0x460d17ce/ee/ae`, 1024-entry rings)
+which the list does not reach. Then card detect/mount `0x40061648(1)`
+returns 0 with `0x460d1cb8 = 1`: IDENTIFY, SET FEATURES, LBA 0 (MBR), the
+BPB and the first 256 FAT sectors, in that order.
+
+**Loading a project is engine command 4, run by the real engine task.**
+The UI's `0x40023c7c(name)` posts a slot (opcode 4, the name, three
+callbacks) to `0x460d17ce`; the engine task (`0x4008445c`, Bryan T's
+46-opcode dispatcher, `EXTERNAL.md` §6) does the work. Its handlers address
+locals through the task's frame pointer, so they only run inside the task:
+`engine_start` runs it from its entry to the first receive call, and
+`engine_run_once` resumes at that call with a message queued and stops when
+the loop comes back round to it, keeping the task's registers between calls.
+Opcode 4 reads `project.work`, `markers.work`, the eight arrangements and
+**all sixteen bank files**, probes every sample slot (the firmware's own
+log on the card records each missing sample, which is how the load was
+first proven real), and sets the project database pointer
+(`0x46c82456 = 0x400e21e0`, the bank-blob base Bryan's doc predicts). The
+RIG project loads in ~35 s: 30,955 sectors read, 300 written (the log).
+RELOAD BANK, opcode 20 (`0x40022778(mask)`, message "RELOADING BANK"), is
+the same loader for a **bitmask** of banks — bank A is mask 1, not index 0.
+
+**The proof.** Part 1 of bank A in RAM (`PART + 0x8ed80/+0x8ed88 + track`)
+reads FX1 `[28,4,4,4,18,4,28,28]` and FX2 `[6,8,27,8,7,9,8,0]`; the same
+bytes in `bank01.work` on disk (`ot_project.py`'s `0x8eed6 + 9/+0x11`) are
+identical, and `render_fx2(r, track, effect_id=None)` draws the bank's own
+part name, `Pt:1 VERSE`. (The knob rows draw blank against the RAW image,
+which has no descriptors for the octabam effect ids; use the built image.)
+
+**The set name is an absolute path.** The firmware's default is
+`"/PRESETS"` (`0x400b46ef`) and its log names bank files
+`/PRESETS/<project>/bank01.work`. Named `"OCTABAM"` without the slash, the
+project itself loaded (relative to the root) and every bank was then
+"missing. Initializing to empty bank" — the loader had changed into the
+project directory. `set_names` prefixes the slash. On Sam's card the set
+folder IS `PRESETS`, holding `OCTABAM_RIG`, `ChongBongolo 26`, and the rest.
+
+**Three things Unicorn's CFV4E core cannot do, now shimmed in `_run_until`:**
+
+- `bitrev`, `byterev`, `ff1` (ColdFire ISA_C) raise the illegal-instruction
+  exception. 437 sites in the image — 219 `byterev`, most of them in the
+  FAT code swapping little-endian fields, and the RTOS event-bit allocator
+  is `bitrev`+`ff1`. objdump cannot decode them either (`.short 0x02c0`).
+- A misaligned `movem.l` may raise an address error (the firmware's memset
+  clears 16 bytes at a time and was seen with an odd destination). A shim
+  emulates the long form, modes (An), (An)+, −(An), (d16,An) — but it has
+  **not fired** in any successful run (the stop that prompted it was the
+  budget, below), so it is an untested guard, marked as such.
+- Long detours: a project load runs for hundreds of millions of
+  instructions, so the old 20M-instruction call budget silently cut the
+  loader short with no trap. `_run_until` now runs to its stop address in
+  bursts and tells a poll (PC pinned, no writes) from slow progress. (The
+  reads themselves are quick: ~2,000 sectors in 23 s.)
+
+**Two traps for whoever extends this.**
+
+- The first project load "succeeded" with default effect ids in every part:
+  it had stopped at the instruction budget, not at the end. A cold detour
+  that returns quietly is not evidence it finished — `_run_until` now runs
+  to its stop address and raises `DetourTrap` / `DetourStall` otherwise.
+- The WRITE SECTORS handler streams the first sector through the data
+  register itself and decrements the count byte before returning, so at
+  completion the count byte is SECTORS REMAINING and reads 0 for a
+  one-sector write. Treating 0 as 256 (the READ convention) turned the
+  log-file appends into 256-sector writes and wiped the card image; the
+  next load then found an empty root. The model commits per sector as data
+  arrives and only writes the remainder at completion.
+
 ## The RTOS fork — still open, still not forced
 
-Milestone 2 took route **B** (detour) and it carries the remixer: a menu- or
-cave-patch is visible and walkable without a flash. Route **A** (emulate the
+Milestones 2 and 4 took route **B** (detour) and it carries the remixer and
+the card: a menu- or cave-patch is visible and walkable without a flash, and
+a project loads through the firmware's own storage stack. Route **A** (emulate the
 RTOS — dispatch `trap #0` via VBR `[0x400b9668]`, drive a timer tick, run the
 real scheduler) remains the later fidelity upgrade, the only one that could
 show behaviour emerging from real task interleaving. Nothing built so far

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -333,6 +333,77 @@ folder IS `PRESETS`, holding `OCTABAM_RIG`, `ChongBongolo 26`, and the rest.
   next load then found an empty root. The model commits per sector as data
   arrives and only writes the remainder at completion.
 
+## Milestone 5 — frames and ticks, cold (IN PROGRESS, 6 Sep 2026)
+
+`tools/emu_frames.py`. The aim is Bryan T's session-5 ask (`EXTERNAL.md`
+§6): with a project loaded and the sequencer running, log the per-track
+trigger word the per-frame dispatcher reads (`0x4000d32e`), whose low
+nibble is a trig's sample offset within the 16-sample frame, and see whether
+it walks from pass to pass. What runs, all measured in the emulator:
+
+**The frame builder is an interrupt handler.** `0x4000aad0` (installed on
+vector 0x41 at `0x4001fbf8`): `lea sp@(-252) / moveml d0-fp`, re-entry
+guard `0x46104d4e`, ping index read from the DSP host port `0x2000001c`
+(must be 0 or 1 or it `halt`s at `0x4000ab40`), a poll of `0x20000004`
+until bit 7 clears, ..., the per-track dispatcher `0x4000d2a0`, the packer,
+`rte` at `0x4000d9ae`. `run_frame` pushes a ColdFire exception frame with
+the detour sentinel as return PC and runs to the `rte`, which Unicorn
+reports as exception 256 rather than executing. 12,000 frames run clean.
+
+**The sequencer tick is a forced interrupt, not a timer.** `0x400a1e10`
+(saves all registers, acks INTC `0xfc048010`, sends MIDI clock `0xF8`) is
+raised by the frame handler itself: a countdown `0x46107570`, decremented
+by `tempo24 << 4` per frame, expires and the frame handler ORs bit 0 into
+`0xfc048010` (`0x4000ae00`; a re-sync variant at `0x4000aea0`). The tick
+handler runs four times per MIDI clock (96 PPQN): its tail reloads
+`0x46107568 := 2,646,000` (one 16th step / 6, in units where one sample is
+`tempo24`) and only every fourth call advances the tick clock `0x4610757c`
+and re-syncs the frame clock `0x46104cf4` to it. `emu_frames` hooks both
+force sites and runs the tick after the frame that raised it; interrupt
+priority (whether the tick pre-empts the frame handler mid-way on hardware)
+is the one thing not modelled.
+
+**The trig-time loop — the producer of the nibble Bryan could not trace.**
+`0x4000aef6`: for each of 31 entries in the event table `0x80001904`,
+`dt = event − now` (`now = 0x46104cf0 = 0x46104cf4 + tempo24 << 4`),
+`smi` flags the past, `msacl dt × Q` with `Q = −2³¹/tempo24` (MACSR 0x20,
+fractional, truncating) gives the offset in samples, `+16`, `spl`-clamped
+to ≥ 0, stored as a byte in `0x800017d6[]` (flags to `0x80001798[]`). The
+dispatcher's word is assembled at `0x4000c98c`: `byte | 0x0210 |
+(0x46c7faa4[track] & 0xF000)` — only for a track whose immediate-action
+slot `0x46c7e9fa[track]` (written by the QREC scheduler `0x40005178` when
+a step trig fires) is non-zero. So the nibble is the truncated fractional
+sample position of the event, and a walk is arithmetically expected
+whenever the pattern period in samples is not an integer.
+
+**Transport.** `0x4009b964(arg)` with the sequencer stopped runs the start
+case: state `0x800065b8 := 1`, phase increment `0x46107570 := tempo24 << 4`,
+a post to the UI queue `0x460d1664`. The project's MIDI byte `0x80000028`
+bit 0 is CLOCK RECEIVE; Sam's projects have it set (the Rytm is master), and
+with it set the engine waits for an external clock that never comes —
+`--internal-clock` clears it.
+
+**Two more things Unicorn's core lacks, shimmed in `_run_until`:** the EMAC
+**MAC-with-parallel-load** forms (`msacl Ry,Rx,<ea>,Rw,ACC`, used by the
+trig-time loop, the packer and the delay routine) — the shim does the load
+and address update in Python and executes the plain form natively from a
+trampoline so the accumulator state stays in the core; address-register
+operands and the inverted acc bit of the load form are handled per
+binutils' reading of this image. And Unicorn's `until` address is not
+honoured when the instruction there raises: the trampoline parks on a
+`nop` instead.
+
+**Where it stands.** With the RIG or ChongBongolo 26 project loaded, the
+transport started on the internal clock and 12,000 frames run: ticks fire
+at the right rate, the tick and frame clocks track, the step engine
+(`0x400a1f68`) is entered every fourth tick and the event table advances —
+but **no step trig ever fires**: the QREC scheduler is never called and the
+per-track running states `0x80006500[t]` stay 0 (the transport's start
+case only promotes them from state 2; the pattern records in RAM are dense
+and valid). The per-track loop at `0x400a28f0` is the next thing to read.
+`--kick` forces `0x80006514`, which turned out to be a pattern-change
+countdown, not the step clock (one write, at `0x400a223c`, then nothing).
+
 ## The RTOS fork — still open, still not forced
 
 Milestones 2 and 4 took route **B** (detour) and it carries the remixer and

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -436,15 +436,21 @@ ordinary trig landing in RAM) but does not answer Bryan's literal question.
 needs no new instrumentation — just `--bpm 128` and a pattern length of 4
 vs 32 steps.
 
-## The RTOS fork — still open, still not forced
+## The RTOS fork — scoped 6 Sep 2026, not started
 
 Milestones 2 and 4 took route **B** (detour) and it carries the remixer and
 the card: a menu- or cave-patch is visible and walkable without a flash, and
-a project loads through the firmware's own storage stack. Route **A** (emulate the
-RTOS — dispatch `trap #0` via VBR `[0x400b9668]`, drive a timer tick, run the
-real scheduler) remains the later fidelity upgrade, the only one that could
-show behaviour emerging from real task interleaving. Nothing built so far
-needs it.
+a project loads through the firmware's own storage stack. Route **A** —
+run the firmware's own scheduler — is the fidelity upgrade that shows
+behaviour emerging from real task interleaving, and M5's recorder-arm path
+("path B" above) is the first thing that needs it. **`docs/RTOS_FORK.md`
+is the scope**: the kernel decoded byte-exact (a ~0x200-byte scheduler,
+eight tasks, one entry shared by `trap #0` and a 5 ms PIT tick, VBR =
+`0x40000000`), a passing feasibility spike (Unicorn raises intno 256 at
+`rte` and dispatches nothing itself, so the exception mechanism is ours to
+run — and it works), the design (time in samples, events delivered at burst
+boundaries), five milestones tagged judgment/mechanical, and the fidelity
+gate: M5's one-trig test must land identically under route A.
 
 ## Reproduce
 

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -393,16 +393,48 @@ binutils' reading of this image. And Unicorn's `until` address is not
 honoured when the instruction there raises: the trampoline parks on a
 `nop` instead.
 
-**Where it stands.** With the RIG or ChongBongolo 26 project loaded, the
-transport started on the internal clock and 12,000 frames run: ticks fire
-at the right rate, the tick and frame clocks track, the step engine
-(`0x400a1f68`) is entered every fourth tick and the event table advances —
-but **no step trig ever fires**: the QREC scheduler is never called and the
-per-track running states `0x80006500[t]` stay 0 (the transport's start
-case only promotes them from state 2; the pattern records in RAM are dense
-and valid). The per-track loop at `0x400a28f0` is the next thing to read.
-`--kick` forces `0x80006514`, which turned out to be a pattern-change
-countdown, not the step clock (one write, at `0x400a223c`, then nothing).
+**Retracted: "no step trig ever fires."** That was true only for a
+project whose per-track running states start at 0 (the transport's start
+case promotes a track from state 2, and the RIG/ChongBongolo projects never
+reach state 2 cold). With a card **freshly saved on the unit** carrying one
+trig (track 1, step 1, `out/_testproj`, 6 Sep) and `--poke-trig` setting a
+second step directly in the loaded pattern record, the whole path now runs
+end to end: `--start` (transport `0x4009b964(0)` then `0x4009b5c8(t)` for
+every track) promotes all eight tracks to state 1 (`0x80006500` reads
+`01` × 8), the step handler `0x4009d1e8` is called at every boundary for
+every track, and on the boundary carrying the set mask bit it takes the
+trig path (`0x4009d422`) and schedules an absolute fire time into the event
+table `0x80001904[track]`.
+
+**Where the trig actually lands is not `0x4000d32e` / `0x46104d26`.** That
+was Bryan's anchor and the header comment's original claim; both are real
+code, but in this run neither ever carries the fired trig. The live path is
+a *different* per-frame gate at `0x4000b800` (called once per track from
+the frame handler, before the `0x4000d2a0` dispatcher): it tests the
+scheduled time against the frame clock, and — when due and the track isn't
+muted for that event — copies the trig-time loop's clamped sample-offset
+byte (`0x800017d6[track]`) into `0x46104d15[track]` and ORs in flag bits
+above it (`0x4000b9bc`/`0x4000b9f2`; bit 4 = hold, confirmed here: byte
+`0xa6` OR `0x10` → `0xb6`). `0x46104d26` (`FW_TRIG_WORDS`) stayed all-zero
+through the whole 400-frame run that produced this trig; its only writer
+found so far (`0x4000d378`) writes zero every frame regardless of whether
+anything is due.
+
+**Open, and this is the actual gap against Bryan's ask**: `RLEN` (the value
+he asked to vary, 4 vs 32) is a **recorder** parameter — its converter
+(`0x4006e3b2`) reads a per-track byte at `0x80000cf4`, which only means
+anything for a track with a recorder machine armed. The test project used
+here has an ordinary trig on an unconfigured track (`machine types part 1`
+all zero) — that is almost certainly why `0x46104d26` never lit up: the
+array may genuinely be recorder-specific, reached only along the arm/RLEN
+path this project never exercises. Confirming that needs a project with a
+track's machine set to a recorder and RSRC armed, which has not been built
+yet — this run establishes the mechanics (frames, ticks, transport, an
+ordinary trig landing in RAM) but does not answer Bryan's literal question.
+`tools/emu_frames.py` now logs both arrays every run (`FW_LIVE_NIBBLE` and
+`FW_TRIG_WORDS`) so the next attempt, once a recorder-armed project exists,
+needs no new instrumentation — just `--bpm 128` and a pattern length of 4
+vs 32 steps.
 
 ## The RTOS fork — still open, still not forced
 

--- a/docs/EXTERNAL.md
+++ b/docs/EXTERNAL.md
@@ -338,6 +338,7 @@ discipline, same hash-verified image. **Scope is the recorder's control
 path only** — parameters, storage, triggering, and the engine's arm/open
 machinery. The audio write path (where samples land in RAM) and the buffer
 addresses are explicitly *not* traced; §9 of his document lists them open.
+**Sessions 2–4 (received 5 Sep 2026, ingested below) close both.**
 
 His motivation is the community's "clickless recorder" technique, which
 works at some Tempo/RLEN combinations and not others — so the tempo-dependent
@@ -492,7 +493,7 @@ base and `@(1)` displacement) indexed by part. Annotated there, not rewritten.
 ### What it changes for us
 
 Nothing we build — the recorder is CPU-side machinery around a write path
-that is still unlocated. What it hands us is a **mapped publish path for a
+that Sessions 2–4 (below) then located. What it hands us is a **mapped publish path for a
 setup page** (`0x80000c94` → `0x80000cf4` per frame) and the recorder's
 length arithmetic in known units, which is where any "clickless loop" patch
 would go. Neither is on the plan.
@@ -516,6 +517,206 @@ Findings flow back as notes, by agreement. Worth sending, all measured here:
    one-shot/hold/stop/retrig) — our labels for his open bit semantics.
 6. `0x460d17ce`'s consumer also handles RELOAD BANK (types `0x14`, `6`).
 
+### Sessions 2–4 (received 5 Sep 2026): the pool, the write path, the loop point
+
+Same file, extended in place — his §12, §13 and §14, with §9's open list
+amended. Scope moves from the control path to everything Session 1 left
+open: **where the buffers are, how samples get in, and what happens at the
+loop point.** His motivating question — is there a crossfade at the wrap —
+is answered: **no, it is a hard cut.** Sessions 2 and 3 are largely a record
+of leads that failed, and his §14.9 retracts three of §13's own conclusions
+in a table; the results are in §14. He rebuilt the image twice from CF-card
+update files with a Python port of the aPLib depacker and got our hash both
+times, and confirmed `m68k:547x` and `m68k:cfv4e` are the same decoder.
+
+#### ✅ Re-verified here, 5 Sep 2026
+
+Same method as above: canonical image, `scripts/disasm.sh emac`, plus a
+byte sweep for his literals and negative results.
+
+| his claim | what we read |
+|---|---|
+| pool cold init `0x40096f7a`: cursor `0x8000691c := 0`, count `14602 → 0x80006920`, block array `0x46c2e9c0`, index table `0x46c2e580`, fill `1..14602` | byte-identical |
+| block address `= blk×6144 + 0x40A955E0` as `lsll #13` − `lsll #11` at `0x400963b4` | exact |
+| recorder row `(track+2) × 14602` at `0x40095aa4` and in the segment builder `0x40006fc4` | both exact |
+| segment emission `0x40007298`: `muluw #6144`, `mulsl` bytes-per-frame, `addil #0x40A955E0`, ptr / signed count at `a1@` / `a1@(4)` | exact |
+| lazy allocation `0x40007196–e2`: `tstw` the row entry, `tstb 0x80000052` (`DYNAMIC_RECORDERS`), pop the free list, clear both halves | exact |
+| pack loop `0x40007854`: `movel / moveb / movel / movew` — 6 B per 24-bit stereo frame | exact |
+| position advance `0x400072ba–be`; loop point `clrl %fp@(24)` at `0x4000703c`; ping-pong flip `0x40007032–36`; wrap test `cmpl %fp@(24),%d4 / bhis` at `0x40007004` | exact |
+| 16-sample limit extension `0x40006e2a–4c`: `addil #15 / cmpl %sp@(64) / blts / addil #16` | exact |
+| the converter that feeds `arm()`, `0x40006dfc–10`: `#31752000 / mulsl / macl / movclrl / addql #1 / asrl #1` | exact — it **rounds** half-up |
+| "exactly one `andil #-16` in the image, at `0x40003646` in the delay" | our sweep: exactly one, that address |
+| settings keys `RECORD_24BIT`, `DYNAMIC_RECORDERS`, `RESERVED_RECORDER_COUNT/LENGTH`; metadata keys `BPMx24`, `LOOP_BARSx100`, `TSMODE`, `LOOPMODE` | all present, `0x400b7d49–0x400b7d80` and `0x400b79fc–0x400b7a26` |
+| `0x40A955E0` as a literal | 23 sites, including his boot memcpy `0x4000045e/4c8`, the emission `0x400072a8`, `0x400963c6` |
+| per-frame dispatcher `0x4000d2a0–86`: 8 tracks × { `0x400068e4(track, page e4, 0, nibble)`; if `word & 0xd0`: `0x40005ff0(track, word)`; `0x400068e4(track, page e0, nibble, 16)` } | exact; note the two halves use the two page-flip globals `0x800000e4` and `0x800000e0` |
+
+#### 🟡 Adopted (we read the same bytes; the interpretation is his)
+
+- **Recorder buffers are not rings.** Each is a chain of 6144-byte blocks
+  drawn lazily from one shared pool of 14,602 blocks at `0x40A955E0`
+  (85.56 MiB — the Flex RAM figure). Ten rows of block numbers live at
+  `0x46c2e9c0`: rows 0–1 are the double-buffered free/sample map, rows 2–9
+  are recorder tracks 0–7. Blocks are popped from the free list as the
+  write position reaches them, which is why MAX consumes all RAM.
+- **The write path is a read-modify-write** in the per-track engine-service
+  function `0x400068e4`, called twice per frame per track: unpack the
+  existing content (`0x400072f2`) → EMAC mix of four sources with per-sample
+  gain ramps (`0x40007680`, output `0x800062cc`) → pack back to the same
+  segments (`0x40007826`). Overdub is the native operation.
+- **The loop point is a hard cut, taken inside the frame.** The segment
+  builder emits up to four segments per 16-sample call (a frame may straddle
+  a block boundary *and* the loop point), tests the position against the
+  boundary and resets it to zero mid-frame. No blend, no tail read-back,
+  anywhere on the path. **The 16-sample frame does not quantise a LOOP
+  length.**
+- `length = round(steps × 15876000 / tempo24)` samples, half-up, at the
+  converter that feeds `arm()`. That is a **different converter** from the
+  truncating `0x4006e3b2` we verified on 2 Sep; that one compares its result
+  against 64 and does not reach `arm()`, so its role is now open.
+- **The 16-sample limit extension** (`0x40006e2a`): when fewer than 16
+  samples remain to the recording *limit*, the limit becomes
+  `position + 16`. It extends, never truncates, and it is the recording END,
+  not the loop wrap; whether it applies once or per wrap is his open item.
+- Settings schema (`DYNAMIC_RECORDERS`, `RECORD_24BIT`, the reserve pair —
+  `RESERVED_RECORDER_LENGTH × 44100` is the seconds→samples path), the
+  saved-metadata field map at state `+272..+296`, and DMA channels 1 and 6
+  as input-capture staging (`0x80003390` page-flipped, `0x80005e60` fixed)
+  — his inference from count and shape, not confirmed by an INAB/INCD
+  reference.
+
+#### ❌ What it retracts of ours
+
+| where | we said | it is |
+|---|---|---|
+| this section, 2 Sep | write path and buffer addresses unlocated; buffers possibly neighbouring the delay rings at `0x4F502C10` | pool at `0x40A955E0`, block-chained, unrelated to the delay's contiguous rings |
+| `PLAN.md` §5 | "the untraced recorder write path" among the project-dependent paths the emulator cannot drive | traced; still project-dependent (it needs a part with a recorder armed), so the emulator point stands |
+
+#### ❌ One correction for him
+
+His §13.2 reads the interrupt handler at `0x40004860–0x40004bd0` — the
+round-robin state machine on DMA channel 0 writing to a `0x2000_00xx`
+interface — as **control-surface polling, "ruled out"**. It is the
+**ColdFire→DSP audio frame transfer** we documented in `DSP.md` §6c: the
+7-step machine at `0x46104d3e`, TCD `0xFC045000`, the DSP host port at
+`0x2000001c`, 336-word per-track records per ping. Measured from our side
+for months — every module in this repo receives its parameters through it.
+The "no recorder-table reference" observation is correct and expected: what
+crosses that port is the mixed frame, not a buffer.
+
+#### Our own measured additions, 5 Sep 2026
+
+**tempo24 is an integer count of 1/24 BPM, and the displayed tempo is not
+always representable.** `0x4009c5f4` splits the tempo word into `÷24` and
+`mod 24` for display; the source routine `0x4009c5b8` returns the pattern's
+own word (`blob + pattern×0x8ed8 + 0x8e58`) when `[0x80000024]` (per-pattern
+tempo) is set, else the global `0x80000020`. The writer at `0x4004bc54`
+scales it by `[0x46c7d328] / 1000` with a **truncating** `divs` before the
+720..7200 clamp (nominal 1000, clamped ≤1100, stepped by 20 and set to 1010
+in the same function — the tempo nudge 🟡 inferred from the shape). Two
+consequences for his §14.8:
+
+1. A displayed `x.y` BPM with `y ∉ {0, 5}` is one of two adjacent tempo24
+   values, and the UI conversion site is not read. He assumed
+   `round(BPM×24)`. Under the other choice his 298.2/2 row becomes 4,437
+   samples (error 0.116, rounded *up*) and 286.2/2 becomes 4,623 (0.18):
+   the **divisibility condition is unaffected** (`BPM×24` is integral iff
+   the tenths digit is 0 or 5), but the "error magnitude ranks severity"
+   fit loses two of its four non-zero points. Test at `.0`/`.5` tempos, or
+   read the word back.
+2. **His clickless count does not reproduce.** Over BPM 30.0–300.0 by 0.1 ×
+   RLEN 2–64 (170,163 combinations, matching his denominator) exact
+   divisibility gives 4,560 under `round`, 5,804 under truncation, 5,909 as
+   an exact rational; he reports 5,279. The `MOD 16` subset under `round`
+   is 1,357 (he: 2,017). The headline — the mod-16 sheet is a strict subset
+   discarding roughly three quarters of the usable settings — survives; the
+   figures need his grid definition.
+
+Under external MIDI clock (Sam's rig: the Rytm is master) tempo24 is
+whatever the clock-follower computes; nothing then divides, and the
+technique cannot be relied on at all. 🟡 inferred — the follower's write is
+not read.
+
+#### The 16-sample question — an answer to his confusion, all inferred
+
+He was confident the 16-sample frame dictated the bad sound-on-sound
+behaviour, found the one place 16 appears, and his session then falsified
+it as the click mechanism. Both halves are right, and they are about
+**two different 16s**:
+
+- **The 16 he expected — length quantised to frames, hence "hard
+  truncation" — is not there.** The wrap is sample-accurate (segment
+  builder, above), and his own clean rows prove it: 88,200, 22,050 and
+  4,410 are integer lengths that are **not** multiples of 16 (≡ 8, 2, 10
+  mod 16) and all loop cleanly. That alone kills "16 dictates SOS" and
+  shows why the community `MOD 16` rule works: it is sufficient only because
+  it implies an integer length. The 16 he found is an end-of-recording
+  *extension*; on a LOOP=ON buffer it may never run.
+- **Where 16 plausibly still bites: the relative frame phase of two
+  processes over one buffer.** In an SOS patch the recorder's
+  read-modify-write and the flex playback read both walk the same block
+  chain in 16-sample frames. Within a frame their order is fixed. If the
+  two heads are offset by `d` samples, the reader sees either all
+  this-pass content or all last-pass content — consistent, no seam — unless
+  `d` falls in a **15-sample band next to zero** (which side depends on the
+  fixed order), where every frame returns a mixture: a new/old
+  discontinuity **once per frame, at 2,756 Hz**, with the amplitude of the
+  newest layer. That is a buzz, not a tick, and it needs no crossfade to
+  explain. With exact divisibility `d` never moves. With per-pass error `ε`
+  it walks at `ε` per pass, enters the band after about `0.5/ε` passes and
+  leaves after about `16/ε` — so the model predicts the clicking **starts
+  within a few passes, lasts `16/ε` passes** (≈33 loops at ε = 0.48, about
+  10 s at 199/4 and 3 s at 298.2/2; ≈48 loops at 251/16, about 46 s) **and
+  then stops** until `d` has walked the whole buffer, thousands of passes
+  later. It also predicts a **direction dependence**: only drift toward the
+  band clicks, so roughly half the non-divisible settings should go clean
+  for good after a short latency shift. His four clicking rows do not split
+  cleanly by rounding direction under either tempo24 rule, which counts
+  against the simplest form of this; a second reader (the recorder's own
+  RMW read is one) would put a band on both sides.
+- **The simpler alternative** is the per-pass seam itself: a flex retrig or
+  a wrap on a buffer whose length differs from the sequencer period by less
+  than a sample gives one dropped or repeated sample per pass — a small
+  tick, indefinitely, every pass. It cannot produce "clicks horribly", but
+  it may be what the `.0/.5`-tempo rows that still click are hearing.
+
+**What discriminates them, on his unit, no firmware needed:**
+
+1. Does the clicking **stop** after `~16/ε` passes (frame phase), or
+   continue for as long as it runs (seam)?
+2. Record, **stop** the recorder, then play the buffer looped. No live
+   writer → no frame-phase seam. If it still clicks, it is the seam.
+3. Run the set at `.0`/`.5` tempos only, so tempo24 is unambiguous, and log
+   the rounding **direction** with the outcome.
+4. State the patch exactly: **what is trigged per pass** — a REC trig, a
+   PLAY trig, both, or neither (one arm, both free-running)? The drift
+   argument needs one side re-triggered by the sequencer and the other
+   free-running at `L`; with both free-running the offset is constant and
+   the mechanism is something else again. His document never says, and the
+   answer changes which of the above can even apply. Note his own §12.2:
+   the arm-time position `+300` **survives a re-arm** (re-bounded, not
+   zeroed) — if the live position inherits that, a REC trig per pass does
+   not re-synchronise the recorder either.
+
+Finally, the sub-frame trig nibble he names as prime suspect
+(`0x46104d26`, low nibble = sample offset within the frame) is the *same*
+rounding seen from the sequencer side — a trig at fractional position `kP`
+lands on an integer sample, so consecutive passes land one sample apart —
+not an independent mechanism. It is what makes the sequencer sample-accurate
+inside the 16-sample frame, and so it is the second reason the frame size
+does not appear in his data.
+
+#### Notes back to Bryan (5 Sep)
+
+1. DMA channel 0 / `0x40004860` is the ColdFire→DSP frame transfer, not
+   control-surface polling (`DSP.md` §6c).
+2. tempo24 is an integer; `x.y` BPM is ambiguous unless `y ∈ {0, 5}`;
+   the nudge scales it with a truncating divide (`0x4004bc54`).
+3. The 5,279 / 2,017 counts do not reproduce under `round` (4,560 / 1,357)
+   or truncation (5,804); which grid?
+4. The frame-phase-band hypothesis and the four discriminating tests above.
+5. `0x4006e3b2` (truncating RLEN converter) is now the one whose consumer is
+   open, since `0x40006dfc` is the one that reaches `arm()`.
+
 ## Open threads worth knowing about
 
 Bryan flags these as still open:
@@ -532,13 +733,21 @@ Bryan flags these as still open:
 - The marker-list writer that BEAT snapping reads, and with it what TSNS
   actually parameterizes (inferred to select snap candidates).
 
-From the recorder session (2 Sep), still open on both sides:
+From the recorder sessions (2 and 5 Sep), still open on both sides:
 
-- **The audio write path and the recorder buffer addresses** — nothing in
-  the session touched the code that moves samples into the buffers. His
-  expectation is a frame-rate DMA sibling of `0x400031a0`; the state-record
-  length fields (`+300/304/308`) and the pointer at control `+20` are the
-  likely route.
+- ~~**The audio write path and the recorder buffer addresses**~~ ✅ **CLOSED
+  by his Session 4, 5 Sep 2026**: pool `0x40A955E0`, 6144-byte block chains,
+  read-modify-write in `0x400068e4`, hard cut at the loop point (§6 above).
+  Not a DMA sibling of the delay after all — the CPU packs the samples.
+- **Why a sub-sample per-pass rounding error becomes an audible splice** —
+  his §14.8 fit is empirically strong and mechanically empty; the
+  frame-phase-band hypothesis and four hardware tests above are our offer.
+- Whether the 16-sample limit extension (`0x40006e2a`) runs once at record
+  end or at every wrap; which caller passes `%fp@(32) = 0`.
+- The consumer of the truncating RLEN converter `0x4006e3b2`, now that
+  `0x40006dfc` is the one that reaches `arm()`.
+- How the UI turns a displayed `x.y` BPM into the integer tempo24 (round or
+  truncate), and what the MIDI-clock follower writes.
 - The TRIG=ONE / SRC3=MAIN default fixup that the descriptor does not carry.
 - SRC3 routing, the AB/CD gain application point, FIN/FOUT fade generation,
   QPL playback machinery (state `+297`), the ONE2 two-phase behaviour, and

--- a/docs/EXTERNAL.md
+++ b/docs/EXTERNAL.md
@@ -410,7 +410,13 @@ trailing `(x+1) >> 1` rounds to nearest. ⚠️ One inference remains inside
 that: the EMAC `macl` must be running in *fractional* mode (product `>> 31`)
 for the result to land on the display series. It is the only mode that
 does, and it is the same left-shift-by-one alignment our own DSP trap about
-reading `a0` is made of — but nobody has read `MACSR`. **Why a pickup
+reading `a0` is made of — but nobody has read `MACSR`. ✅ **Closed 6 Sep
+2026 (Bryan's session-5 note, re-verified here): `MACSR = 0x20`** — set by
+`moveq #32 / movel %d0,%macsr` at `0x4000cf60` in the frame builder and
+re-set immediately (`movel #32,%macsr`) at `0x4000d3ae`: fractional, signed,
+no saturation, and the round/truncate bit CLEAR, so the extraction
+*truncates*. objdump mis-syncs the first site (it prints an `andil`), which
+is why it went unfound. **Why a pickup
 machine's arm length comes from the FOUT slot is open**; his display-order =
 raw-order check covered TRIG/RLEN/INAB/INCD, not slot 7.
 
@@ -651,27 +657,38 @@ per frame; a read frame is a seam if the pass id changes between two
 consecutive buffer positions other than the wrap itself. Results over his
 table:
 
-| setting | L | ε = P − L | write-first | read-first |
-|---|---|---|---|---|
-| 199/4 | 13,296 | +0.482 | clean | seams passes 2–32 (9.3 s), then clean |
-| 298.2/2 | 4,436 | +0.496 | clean | seams 2–31 (3.0 s), then clean |
-| 286.2/2 | 4,623 | −0.493 | seams 2–31 (3.1 s), then clean | clean |
-| 251/16 | 42,167 | +0.331 | clean | seams 2–46 (43 s), then clean |
-| 198/16 | 53,455 | −0.455 | seams 2–34 (40 s), then clean | clean |
-| 229/16 | 46,218 | +0.341 | clean | seams 2–45 (46 s), then clean |
-| 120/16, 120/4, 300/2 | — | 0 | clean | clean |
-| 199/4, both free-running (flex loops at L, never retriggered) | | | clean | clean |
+| setting | L | ε = P − L | write-first | read-first | hardware |
+|---|---|---|---|---|---|
+| 199/4 | 13,296 | +0.482 | clean | seams passes 2–32 (9.3 s), then clean | clicks |
+| 298.2/2 | 4,436 | +0.496 | clean | seams 2–31 (3.0 s), then clean | clicks |
+| 286.2/2 | 4,623 | −0.493 | seams 2–31 (3.1 s), then clean | clean | clicks |
+| 251/16 | 42,167 | +0.331 | clean | seams 2–46 (43 s), then clean | clicks |
+| 198/16 | 53,454 | +0.545 | clean | seams 1–28 (34 s), then clean | not recorded |
+| 229/16 | 46,218 | +0.341 | clean | seams 2–45 (46 s), then clean | not recorded |
+| 261.3/2 | 5,062 | +0.500 | clean | seams 2–30 (3.3 s), then clean | clicks |
+| 128/16 | 82,687 | +0.500 | clean | seams 1–31 (58 s), then clean | clicks (predicted, then observed) |
+| 128/4 | 20,672 | −0.125 | seams 5–123 (56 s), then clean | clean | his proposed test |
+| 120/16, 120/4, 300/2, 128/32 | — | 0 | clean | clean | clean |
+| 199/4, both free-running (flex loops at L, never retriggered) | | | clean | clean | |
+
+(Lengths are the firmware's own arithmetic — see the 6 Sep correction
+below; the first version of this table used round-half-up and had 198/16 as
+53,455, rounded up. `ε` here is `P − L`; Bryan's sign is the reverse.)
 
 While in the band **every** frame of the pass is a seam frame — a 2,756 Hz
 buzz, not a tick. The zero-error rows are clean under both orders, as
 observed. The direction rule is strict: rounded-down lengths seam only when
 the flex read precedes the recorder write within a frame, rounded-up
-lengths only under the opposite order. Three of his four clicking rows are
-rounded-down; **286.2/2 is rounded-up**, so a single fixed order predicts
-it clean and his log says it clicks. Either the model needs a second reader
-(the recorder's own read-modify-write read is one) or that row is the one
-to repeat first. The model is arithmetic, not the firmware; it says what
-the hypothesis predicts, so the hardware test has numbers to hit or miss.
+lengths only under the opposite order. With the corrected lengths **every
+clicking row he has measured is rounded-down except 286.2/2**, and all of
+them seam under the read-first order; 286.2/2 alone would need the other.
+So the direction question now rests on two rows: 286.2/2, and his own
+proposed 128/4 (rounded-up, ε = −0.125), which the read-first model
+predicts clean. If 128/4 clicks, a single fixed order is dead and the model
+needs a second reader (the recorder's own read-modify-write read is one) or
+a second error source (trig placement, which he now argues is independent
+of length). The model is arithmetic, not the firmware; it says what the
+hypothesis predicts, so the hardware test has numbers to hit or miss.
 
 #### The 16-sample question — an answer to his confusion, all inferred
 
@@ -733,9 +750,10 @@ it as the click mechanism. Both halves are right, and they are about
    the arm-time position `+300` **survives a re-arm** (re-bounded, not
    zeroed) — if the live position inherits that, a REC trig per pass does
    not re-synchronise the recorder either.
-5. Repeat **286.2/2** first, and add **198/16** (rounded-up, ε = −0.455):
-   if both click, the single-order model is dead; if 198/16 is clean and
-   286.2/2 was a different patch, it lives.
+5. Repeat **286.2/2** first, and add **128/4** (rounded-up, ε = −0.125):
+   if both click, the single-order model is dead. (This test first named
+   198/16 as the rounded-up row; that value was his transcription slip,
+   corrected 6 Sep — 198/16 is rounded-down like the rest.)
 
 Finally, the sub-frame trig nibble he names as prime suspect
 (`0x46104d26`, low nibble = sample offset within the frame) is the *same*
@@ -744,6 +762,59 @@ lands on an integer sample, so consecutive passes land one sample apart —
 not an independent mechanism. It is what makes the sequencer sample-accurate
 inside the 16-sample frame, and so it is the second reason the frame size
 does not appear in his data.
+
+#### Session-5 note (received 6 Sep 2026): the MAC truncates, and one row of his was wrong
+
+`note-for-bam-session5.md`, plus the four sessions consolidated as
+`RECORDER.md` (new header, §14.8a, the §14.8 row corrected inline). Same
+image, every instruction machine-checked against objdump.
+
+**✅ Re-verified here.** `MACSR = 0x20` at `0x4000cf60` (`moveq #32` into
+`movel %d0,%macsr`; objdump mis-syncs it) and `0x4000d3ae` (`movel
+#32,%macsr`). The length arithmetic, final form:
+
+```
+tempo24 = 24·bpm + (23·tenths + 4)/9
+Q       = trunc(2³¹ / tempo24)                      0x4000cab8, biased low
+L       = ( ((steps × 31,752,000) × Q >> 31) + 1 ) >> 1     0x40006dfc..e10
+```
+
+Run over his rows here it reproduces all thirteen (including the FOUT
+cross-check: 1 step at 120 BPM → 5,512, not 5,513). It disagrees with
+round-half-up on **20,205** of the 170,163 grid cells by our count — he
+reports 41,860, which we take as a different definition of the comparison
+rather than an error, and have not resolved. Never on an exact cell: the
+5,279 / 2,017 clean sets are identical under both, so the practical result
+stands.
+
+**❌ His 198/16 row was his own transcription slip**, not our disagreement:
+correct value 53,454, rounded *down*, `ε = +0.545` in our sign (his is
+`L − P`). Our simulation table and test 5 above are corrected accordingly,
+and `tools/recorder_framephase.py` now uses the firmware's arithmetic.
+
+**What he retracts of his own:** §13.2 (DMA ch0 as control-surface
+scanning — he found it in our `DSP.md` §6c) and §13.9's hardware-modulo-DMA
+hypothesis (no ring, nothing to wrap). He lists our storage addresses (ATA
+ISR `0x40015304`, queue primitive `0x4001568c`, event wait `0x40000818`,
+queue creator `0x40040b14`, RELOAD BANK = opcode 20 bitmask, LOAD PROJECT
+via `0x40023c7c`, set name `0x100f8480`) as **reported by us, unverified by
+him** — the right status; they are measured in the emulator, not on hardware.
+
+**New hardware rows:** 261.3/2 and 128/16 click on the first repeat (the
+second predicted before testing). He reads them with 286.2/2 as "both
+directions click"; in the corrected arithmetic they are all rounded-down
+except 286.2/2, so the direction evidence is that one row (table above).
+
+**His ask, restated, is our next emulator milestone:** log the per-track
+trigger word across frames with a recorder armed — the slot is
+`%sp@(144)` at dispatcher entry (`0x4000d32a`), low nibble = sample offset
+within the frame, bits `0xD0` gate the arm-caller, written back at
+`0x4000d378` — for **128 BPM / RLEN 4** (ε ≠ 0) against **128 / RLEN 32**
+(ε = 0). If the nibble walks in the first and holds in the second, the
+click's other error source is found. Static reading cannot show an
+accumulator advancing during a wait; a frame-by-frame trace can. With a
+project now loading in the emulator (`EMU.md` M4) the remaining pieces are
+the frame builder run per frame and the transport started.
 
 #### Notes back to Bryan (5 Sep)
 
@@ -757,6 +828,12 @@ does not appear in his data.
    and the five discriminating tests above; 286.2/2 and 198/16 first.
 5. `0x4006e3b2` (truncating RLEN converter) is now the one whose consumer is
    open, since `0x40006dfc` is the one that reaches `arm()`.
+
+**6 Sep:** MACSR and both writers re-verified; his thirteen rows reproduce
+under the final formula; our 20,205 vs his 41,860 is unresolved and flagged
+as definitional; 198/16 corrected in our table; 128/4 replaces 198/16 as
+the rounded-up test alongside 286.2/2; the trigger-word log is the next
+emulator milestone.
 
 ## Open threads worth knowing about
 

--- a/docs/EXTERNAL.md
+++ b/docs/EXTERNAL.md
@@ -605,36 +605,73 @@ crosses that port is the mixed frame, not a buffer.
 
 #### Our own measured additions, 5 Sep 2026
 
-**tempo24 is an integer count of 1/24 BPM, and the displayed tempo is not
-always representable.** `0x4009c5f4` splits the tempo word into `÷24` and
-`mod 24` for display; the source routine `0x4009c5b8` returns the pattern's
-own word (`blob + pattern×0x8ed8 + 0x8e58`) when `[0x80000024]` (per-pattern
-tempo) is set, else the global `0x80000020`. The writer at `0x4004bc54`
-scales it by `[0x46c7d328] / 1000` with a **truncating** `divs` before the
-720..7200 clamp (nominal 1000, clamped ≤1100, stepped by 20 and set to 1010
-in the same function — the tempo nudge 🟡 inferred from the shape). Two
-consequences for his §14.8:
+**How the tempo is stored, and the UI conversion his sweep needed.**
+tempo24 is an integer count of 1/24 BPM. The UI setter
+`0x4009c7c4(bpm, tenths)` computes
 
-1. A displayed `x.y` BPM with `y ∉ {0, 5}` is one of two adjacent tempo24
-   values, and the UI conversion site is not read. He assumed
-   `round(BPM×24)`. Under the other choice his 298.2/2 row becomes 4,437
-   samples (error 0.116, rounded *up*) and 286.2/2 becomes 4,623 (0.18):
-   the **divisibility condition is unaffected** (`BPM×24` is integral iff
-   the tenths digit is 0 or 5), but the "error magnitude ranks severity"
-   fit loses two of its four non-zero points. Test at `.0`/`.5` tempos, or
-   read the word back.
-2. **His clickless count does not reproduce.** Over BPM 30.0–300.0 by 0.1 ×
-   RLEN 2–64 (170,163 combinations, matching his denominator) exact
-   divisibility gives 4,560 under `round`, 5,804 under truncation, 5,909 as
-   an exact rational; he reports 5,279. The `MOD 16` subset under `round`
-   is 1,357 (he: 2,017). The headline — the mod-16 sheet is a strict subset
-   discarding roughly three quarters of the usable settings — survives; the
-   figures need his grid definition.
+```
+tempo24 = 24·bpm + (23·tenths + 4) / 9        (truncating divs; clamp 30.0..300.0)
+tenths 0..9  →  frac24  0 3 5 8 10 13 15 18 20 23
+```
 
-Under external MIDI clock (Sam's rig: the Rytm is master) tempo24 is
-whatever the clock-follower computes; nothing then divides, and the
-technique cannot be relied on at all. 🟡 inferred — the follower's write is
-not read.
+— not `round(2.4·tenths)` (`0 2 5 7 10 12 14 17 19 22`), which agrees only
+at `.0`, `.2` and `.4`. So a displayed tempo is one exact tempo24, but its
+BPM is not what the screen says: `.5` is +0.5417 BPM, `.9` is +0.9583. The
+display helper `0x4009c5f4` inverts it (`÷24`, `mod 24`, `(9·f + 11)/23`).
+The source routine `0x4009c5b8` returns the pattern's own word
+(`blob + pattern×0x8ed8 + 0x8e58`) when `[0x80000024]` (per-pattern tempo)
+is set, else the global `0x80000020`; all seven callers of the raw setter
+`0x4009c708` pass stored words (state `+276` snapshots, pattern records, the
+`0xb40` = 120 BPM default). The nudge writer at `0x4004bc54` scales by
+`[0x46c7d328]/1000`, truncating (nominal 1000, clamp ≤1100 — the tempo nudge
+🟡 inferred from shape). Under external MIDI clock (Sam's rig: the Rytm is
+master) the follower's word need not sit on this grid at all, so nothing
+divides — 🟡 its writer is not read.
+
+**His counts reproduce exactly under that mapping**: 5,279
+exactly-divisible settings and 2,017 with length ≡ 0 mod 16, over 2,701
+tempos × 63 RLEN values. Of the 5,279, 3,000 are at `.0`; `.5` and `.9`
+contribute 17 each. His two fractional rows are both `.2`, where the rules
+agree, so his table stands as printed. ❌ *Retracted the same day:* the
+first draft of this section said the counts did not reproduce (4,560 /
+1,357); that used `round(BPM×24)`, wrong for seven of the ten tenths.
+
+**The 16-sample limit extension runs at arm time, not per wrap** (measured
+by location): `0x40006e2a` sits inside the arm-calling converter, between
+the length computation and its `jsr arm` at `0x40006edc`, operating on the
+per-track record that call passes to `arm()`; the segment builder's wrap
+path (`0x4000703c`) is inline arithmetic and does not reach it. A LOOP=ON
+buffer armed once sees it once. That closes his §14.7 open item and removes
+the last way 16 could have quantised a loop.
+
+**The frame-phase model, simulated** — `tools/recorder_framephase.py`.
+Pass-id stamping, no audio: the recorder free-runs at `L` in 16-sample
+frames, the flex read is retriggered at `round(k·P)`, both in a fixed order
+per frame; a read frame is a seam if the pass id changes between two
+consecutive buffer positions other than the wrap itself. Results over his
+table:
+
+| setting | L | ε = P − L | write-first | read-first |
+|---|---|---|---|---|
+| 199/4 | 13,296 | +0.482 | clean | seams passes 2–32 (9.3 s), then clean |
+| 298.2/2 | 4,436 | +0.496 | clean | seams 2–31 (3.0 s), then clean |
+| 286.2/2 | 4,623 | −0.493 | seams 2–31 (3.1 s), then clean | clean |
+| 251/16 | 42,167 | +0.331 | clean | seams 2–46 (43 s), then clean |
+| 198/16 | 53,455 | −0.455 | seams 2–34 (40 s), then clean | clean |
+| 229/16 | 46,218 | +0.341 | clean | seams 2–45 (46 s), then clean |
+| 120/16, 120/4, 300/2 | — | 0 | clean | clean |
+| 199/4, both free-running (flex loops at L, never retriggered) | | | clean | clean |
+
+While in the band **every** frame of the pass is a seam frame — a 2,756 Hz
+buzz, not a tick. The zero-error rows are clean under both orders, as
+observed. The direction rule is strict: rounded-down lengths seam only when
+the flex read precedes the recorder write within a frame, rounded-up
+lengths only under the opposite order. Three of his four clicking rows are
+rounded-down; **286.2/2 is rounded-up**, so a single fixed order predicts
+it clean and his log says it clicks. Either the model needs a second reader
+(the recorder's own read-modify-write read is one) or that row is the one
+to repeat first. The model is arithmetic, not the firmware; it says what
+the hypothesis predicts, so the hardware test has numbers to hit or miss.
 
 #### The 16-sample question — an answer to his confusion, all inferred
 
@@ -669,10 +706,10 @@ it as the click mechanism. Both halves are right, and they are about
   then stops** until `d` has walked the whole buffer, thousands of passes
   later. It also predicts a **direction dependence**: only drift toward the
   band clicks, so roughly half the non-divisible settings should go clean
-  for good after a short latency shift. His four clicking rows do not split
-  cleanly by rounding direction under either tempo24 rule, which counts
-  against the simplest form of this; a second reader (the recorder's own
-  RMW read is one) would put a band on both sides.
+  for good after a short latency shift. Simulated above: three of his four
+  clicking rows fit one frame order, 286.2/2 fits the other; a second
+  reader (the recorder's own RMW read is one) would put a band on both
+  sides.
 - **The simpler alternative** is the per-pass seam itself: a flex retrig or
   a wrap on a buffer whose length differs from the sequencer period by less
   than a sample gives one dropped or repeated sample per pass — a small
@@ -696,6 +733,9 @@ it as the click mechanism. Both halves are right, and they are about
    the arm-time position `+300` **survives a re-arm** (re-bounded, not
    zeroed) — if the live position inherits that, a REC trig per pass does
    not re-synchronise the recorder either.
+5. Repeat **286.2/2** first, and add **198/16** (rounded-up, ε = −0.455):
+   if both click, the single-order model is dead; if 198/16 is clean and
+   286.2/2 was a different patch, it lives.
 
 Finally, the sub-frame trig nibble he names as prime suspect
 (`0x46104d26`, low nibble = sample offset within the frame) is the *same*
@@ -709,11 +749,12 @@ does not appear in his data.
 
 1. DMA channel 0 / `0x40004860` is the ColdFire→DSP frame transfer, not
    control-surface polling (`DSP.md` §6c).
-2. tempo24 is an integer; `x.y` BPM is ambiguous unless `y ∈ {0, 5}`;
-   the nudge scales it with a truncating divide (`0x4004bc54`).
-3. The 5,279 / 2,017 counts do not reproduce under `round` (4,560 / 1,357)
-   or truncation (5,804); which grid?
-4. The frame-phase-band hypothesis and the four discriminating tests above.
+2. The UI tempo conversion is `tempo24 = 24·bpm + (23·tenths + 4)/9`
+   (`0x4009c7c4`, truncating); his 5,279 / 2,017 reproduce exactly under
+   it. `.5` is not half a BPM.
+3. The 16-sample limit extension is arm-time (by location), closing §14.7.
+4. The frame-phase-band model, its simulation (`tools/recorder_framephase.py`)
+   and the five discriminating tests above; 286.2/2 and 198/16 first.
 5. `0x4006e3b2` (truncating RLEN converter) is now the one whose consumer is
    open, since `0x40006dfc` is the one that reaches `arm()`.
 
@@ -742,12 +783,12 @@ From the recorder sessions (2 and 5 Sep), still open on both sides:
 - **Why a sub-sample per-pass rounding error becomes an audible splice** —
   his §14.8 fit is empirically strong and mechanically empty; the
   frame-phase-band hypothesis and four hardware tests above are our offer.
-- Whether the 16-sample limit extension (`0x40006e2a`) runs once at record
-  end or at every wrap; which caller passes `%fp@(32) = 0`.
+- Which arm caller passes `%fp@(32) = 0` (the 16-sample extension itself is
+  settled: arm-time, §6 above).
 - The consumer of the truncating RLEN converter `0x4006e3b2`, now that
   `0x40006dfc` is the one that reaches `arm()`.
-- How the UI turns a displayed `x.y` BPM into the integer tempo24 (round or
-  truncate), and what the MIDI-clock follower writes.
+- What the MIDI-clock follower writes to tempo24 (the UI conversion is
+  measured, §6 above).
 - The TRIG=ONE / SRC3=MAIN default fixup that the descriptor does not carry.
 - SRC3 routing, the AB/CD gain application point, FIN/FOUT fade generation,
   QPL playback machinery (state `+297`), the ONE2 two-phase behaviour, and

--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -1,0 +1,251 @@
+# The RTOS fork (emulator route A) — scope
+
+Scoped 6 Sep 2026. Status: **not started**; feasibility **measured**, kernel
+**decoded**, plan below. `EMU.md` has the history of route B (detours) that
+this replaces for the paths that need real task interleaving.
+
+Confidence markers as in `CHIP.md`: ✅ measured in the emulator or read
+byte-exact from the image, 🟡 inferred, ❓ open (with how to close it).
+
+## 1. What it is, and what it buys
+
+Every emulator milestone so far (`EMU.md` M1–M5) runs firmware code **cold**:
+a function is called against the warm machine, or an interrupt handler is
+pushed a fake frame and run to its `rte`. Nothing ever runs the firmware's
+own scheduler, so nothing ever runs *two* pieces of firmware in the order the
+firmware would run them. Three things are out of reach that way:
+
+- **Task interleaving.** The engine task, the storage task, the UI task and
+  the voice task all block on kernel queues and wake each other. Route B
+  stepped one task at a time by hand (`engine_run_once`) and satisfied every
+  wait with a hook. Anything that depends on *which* task runs *when* — a
+  key press reaching the engine, the engine posting to the DSP task, the
+  recorder-arm action being staged and then promoted by the tick (M5's
+  "path B", `EMU.md` M5) — cannot be driven cold without re-implementing the
+  kernel's ordering by hand, one case at a time.
+- **Pre-emption at the frame boundary.** M5's one un-modelled thing: the
+  tick is a forced interrupt the frame handler raises, and on hardware it may
+  pre-empt the frame handler mid-way. Only a real interrupt model shows that.
+- **Real waits.** Route B's card model completes ATA commands from a hook on
+  the event wait because the ATA interrupt is never taken. Under route A the
+  interrupt fires, the handler streams the sector, the kernel wakes the
+  storage task. Same for the two PIT timers.
+
+What it does **not** buy: audio. The DSP side stays in `dsp_host`; the frame
+handler's host-port handshake stays faked as in M5.
+
+## 2. The kernel, decoded ✅
+
+The whole scheduler is about 0x200 bytes at `0x40000550`–`0x40000760`. Read
+6 Sep 2026 with `scripts/disasm.sh emac`; every address below is byte-exact.
+
+**TCB layout** (`0x400005fc` builds it, `0x40000550`/`0x4000056e` save and
+restore it):
+
+| offset | field |
+|---|---|
+| `+0x00` / `+0x04` | next / prev in the priority's circular list |
+| `+0x08` | pointer to the priority level's list head, `0x800068dc + 4·prio` |
+| `+0x0c`–`+0x4b` | saved `d0–d7, a0–a7` (`moveml`; **`a7` at `+0x48`**) |
+| `+0x4c` | ready flag (1 = on a ready list) |
+| `+0x50` | cleared at create; unread here |
+
+`ARCHITECTURE.md` §4's "SP at 0x38" is wrong: the `moveml d0-sp` block starts
+at `+0x0c`, so `a7` is at `+0x48` (create writes it there, `0x4000062c`).
+
+**Globals:** current TCB `0x800068fc`; top-priority pointer `0x800068d8`
+(points *into* the `0x800068dc[8]` array of list heads; higher index = higher
+priority; the scheduler takes the head of the list it points at, and the
+block path scans downward for the next non-empty level, `0x40000852`);
+`0x80006900` is a scratch slot for `a0` on entry.
+
+**Scheduler entry `0x40000550`** — one handler for **two vectors**: `trap #0`
+(vector 32) and the **PIT0 timer interrupt (vector 171)**; the boot writes
+`0x40000550` into both slots at `0x400005d8`/`0x400005dc`. It masks
+interrupts, saves all registers into the current TCB, takes the head of the
+top ready list, clears the reschedule bit (`0xfc04c010 &= ~0x800`), **re-arms
+PIT0 with `0xb3f`**, sets the cache control, restores the new task's
+registers with `moveml a0@(12),d0-sp` and `rte`s into it. A freshly created
+task's "saved context" is an exception frame on its own stack —
+`[0x407c][SR 0x2000][entry PC]` with `0x400006e4` (task exit) as the return
+address under it (`0x4000061c`–`0x40000626`).
+
+**Primitives** (all `jsr` targets, so every caller is findable with the
+literal scan): create `0x400005fc(tcb, entry, prio, stack, size)`; make-ready
+`0x4000063c(tcb)`; unlink `0x4000068c(tcb)`; event wait `0x40000818(event)`
+(count > 0: consume and return; else park the current TCB in the event,
+unlink it, `trap #0`); queue post `0x40000c3c(queue, msg)` (ring at
+`queue+0x14`, mask `+0x10`, head `+0x18`; wakes the waiter at `+0x0c` and
+raises its level); event signal `0x40000888`; semaphore take/give
+`0x40000a94`/`0x400009f4` (used by the delay helper); queue init
+`0x40000bd4`; task exit `0x400006e4`. Vector install `0x40000d50(vec, fn)`
+(the frame handler goes on vector `0x41` at `0x4001fbf8`); the default
+handler `0x40000d74` is a trampoline that calls one settable pointer
+`[0x460ba970]` (set by `0x40000da4`) and `rte`s.
+
+**Tasks — eight** ✅ (seven `create` sites plus the boot's main task; entries
+and priorities read from the pushed arguments):
+
+| prio | TCB | entry | stack | what (🟡 by neighbourhood) |
+|---|---|---|---|---|
+| 6 | `0x46c7fb0c` | `0x40005540` | `0x46c7ea20` +0x1000 | voice / DSP mailbox task |
+| 5 | `0x460bcc2c` | `0x4001ee30` | `0x460bc42c` +0x800 | storage (FAT/ATA) |
+| 4 | `0x460d4f80` | `0x4005593c` | `0x460d4780` +0x800 | UI |
+| 2 | `0x460fab80` | `0x40091d18` | `0x460fabd4` +0x2000 | ❓ |
+| 2 | `0x460ffd44` | `0x400921c4` | `0x460fdd44` +0x2000 | ❓ |
+| 1 | `0x460ddde4` | `0x4008445c` | `0x460d9de4` +0x4000 | **engine** (the 46-opcode dispatcher, `EXTERNAL.md` §6) |
+| 1 | `0x46105508` | `0x40098a5c` | `0x4610555c` +0x2000 | ❓ |
+| 0 | `0x46c7ae84` | `0x4001f834` | top `0x46c7becc` | **main** — runs the init list, then parks |
+
+At the handoff only main is on a ready list (measured: level 0, one TCB);
+the current TCB `0x46c7ae30` is the pre-multitasking context that the first
+`trap #0` saves and never resumes. The other seven are created by main's
+init list — the same list `card_init` runs by hand today.
+
+**Interrupt controllers — two** ✅. INTC0 at `0xfc048000` takes vectors
+`64 + source`: the DSP frame handler is source 1 (vector `0x41`, level 5,
+`0x4001fc30`) and M5's forced tick is `INTFRCH` bit 0 (`0xfc048010`, source
+32, vector `0x60`). INTC1 at `0xfc04c000` takes vectors `128 + source`: PIT0
+is source 43 (ICR `0xfc04c06b` := level 1; vector 171 = `0x2ac/4`) and the
+ATA interrupt is source 54 (vector `0xb6`). **VBR is `0x40000000`** — the
+image's own first KB is the vector table (`[0x400b9668]`), which is why the
+no-op `movec` never mattered. At the handoff exactly two slots are
+non-default: 32 and 171, both `0x40000550`.
+
+**The time-slice** ✅: PIT0 at `0xfc080000`, prescaler 2¹¹ (PCSR `0x0b36`
+at init, `0x0b3f` on every switch), PMR `264,000,000 / 409,600 − 1 = 643`
+→ **5.0 ms per tick = 220.5 samples = 13.8 audio frames**. PIT1
+(`0xfc084000`, PCSR `0x0b3a`, PMR 2014) is the storage layer's delay timer
+(`0x40020c7c`, waits ≥ 15,000 units on a semaphore).
+
+## 3. Feasibility — measured 6 Sep 2026 ✅
+
+A synthetic spike (`rte_spike4.py`, in the session scratch; four cases) on
+Unicorn 2.1.4's CFV4E core:
+
+| case | result |
+|---|---|
+| `trap #0` dispatched by hand in the `UC_HOOK_INTR` hook (push frame, set SP/SR/PC), handler's `rte` popped by hand | **PASS** |
+| same, `rte` left to the core | FAIL — the core raises intno **256** at `rte` and does not execute it |
+| an interrupt raised by hand at an arbitrary instruction (frame for vector 171, jump to handler), `rte` popped by hand | **PASS** |
+| same, native `rte` | FAIL, as above |
+
+So the whole exception mechanism is ours to run, and it works: dispatch in
+the INTR hook, `rte` = pop `[fmt/vec][SR][PC]` and set the three registers
+plus `SP += 8`. Three details that cost the first three spike versions:
+- **`SR` must be written before `A7`** — Unicorn banks `a7` on the S bit, so
+  a stack pointer written in user state vanishes when S is set (the harness
+  already does it in that order, `emu_bringup.boot`).
+- The core **never dispatches natively**, even with the table at 0 — the
+  hook fires on the same `trap` forever.
+- For a trap the hooked PC is the trap instruction itself: the frame's
+  return PC is `pc + 2`. For an interrupt raised between instructions the
+  return PC is the current PC.
+
+`_run_until`'s existing shims (ISA_C ops, misaligned `movem`, EMAC-with-load)
+all work by letting the burst stop on the exception and fixing it up after
+`emu_start` returns; the INTR hook already sees those (`intno` 4 etc.) and
+must keep letting them through unchanged.
+
+## 4. Design
+
+One new module, `tools/emu_rtos.py`, on top of `emu_bringup` (unchanged) and
+`emu_card`'s card model (kept; its wait hook becomes optional).
+
+**Time is counted in samples, not instructions.** The two hardware clocks the
+firmware cares about are fixed ratios of the sample clock: a frame interrupt
+every 16 samples, a PIT0 tick every 220.5 samples. The one free parameter is
+**instructions per sample** — how much ColdFire work fits between events
+(264 MHz × 16/44,100 = 95,782 cycles per frame; at a guessed CPI of 1.5 that
+is ~64k instructions). It is a knob with a default, not a truth, and the
+plan's fidelity gate (§6) is what checks whether it matters.
+
+**The run loop** replaces `emu_frames`' `run_frame`/`Clock`: a priority
+queue of pending events in sample time (frame IRQ, PIT0, PIT1 expiry, ATA
+completion, forced `INTFRC` bits), and bursts of `emu_start(count=…)` sized
+to the next event. At a burst end an interrupt is delivered if its level
+exceeds the SR mask (else it stays pending); delivery = push the ColdFire
+frame with the vector, jump to `[VBR + 4·vector]`. Resolution is the burst,
+which is fine: events are thousands of instructions apart.
+
+**The INTR hook** does three things: vector 32 → dispatch to `[VBR+0x80]`;
+intno 256 → `rte` pop; anything else → return (the existing shims handle it
+after the burst, as today).
+
+**Peripheral models** (all small, all register-level): PIT0/PIT1 (PCSR with
+PIF write-1-clear and the enable/interrupt bits, PMR, a count that expires
+into an event); INTC0/INTC1 (ICR levels, IMR masks — the injector consults
+them, `INTFRC` writes become pending events); the DSP host port as in M5
+(ping index, command register). ATA is the existing model, completing by
+raising vector `0xb6` instead of finishing inside the wait hook.
+
+**Idle** ❓: what the kernel does when *no* task is ready is not read yet
+(the block path scans down to level 0, where main lives, and main parks —
+whether it parks by blocking or by spinning decides whether an "idle" level
+must be modelled). Read `0x4001f834`'s tail before M6a.
+
+## 5. Milestones, and which model each wants
+
+Sam asked (6 Sep) to be told when the judgment work is done so a cheaper
+model can take the mechanical parts. Tagged accordingly.
+
+- **M6a — first real context switch.** *(judgment)* The INTR dispatcher,
+  the `rte` pop, the PIT0 model and the event loop; boot to `trap #0`, let
+  the dispatcher take it, and run until all eight tasks have been created and
+  every one has run at least once. Exit gate: the task table above matches
+  what the emulator observes; `emu_bringup`'s cold path is untouched
+  (`refhash`-style: M1–M5 outputs identical with route A off).
+- **M6b — waits become real.** *(mechanical once M6a exists)* PIT1 model;
+  ATA completion through vector `0xb6`; retire `emu_card`'s `0x40000818`
+  hook (keep it behind a flag). Exit gate: the RIG project loads through the
+  real storage and engine tasks with the hook off, part bytes identical to
+  M4's proof.
+- **M6c — the sequencer under the real scheduler.** *(judgment)* Frame IRQ
+  on vector `0x41`, the forced tick through `INTFRCH`, transport started by
+  the real UI path or by the M5 detour. Exit gate — **the fidelity check for
+  the whole fork**: M5's one-trig test (`out/_testproj`, `--poke-trig 2`)
+  must land the same byte in `0x46104d15[0]` at the same frame (344, `0xb6`)
+  under route A as it does cold. If it doesn't, the difference *is* the
+  pre-emption M5 could not model, and it needs reading before anything is
+  built on it.
+- **M6d — input.** *(mechanical)* Feed key events into the UI task's queue
+  (the post primitive against whichever queue `0x4005593c` blocks on — to be
+  read in M6c) so PLAY and the REC-arm action run the firmware's own path.
+  This is what makes Bryan's recorder test reachable without RAM pokes
+  (`EMU.md` M5, "path B").
+- **M6e — use it.** *(judgment)* The recorder-arm trace for Bryan; the tick
+  pre-emption question; whatever the kit/parts work needs.
+
+Rough sizes, from M4/M5 as the yardstick: M6a and M6c one session each,
+M6b and M6d one each on the cheaper model, M6e open.
+
+## 6. Risks, each with the measurement that closes it
+
+- **Instructions-per-sample is a guess.** Close: M6c's gate. If the trig
+  frame moves with the knob, the firmware has a real data-dependent timing
+  path and the knob needs calibrating against a hardware observable (the
+  PIT/frame ratio is fixed; a candidate is the number of frames the bank
+  loader takes on hardware, which Bryan's or Sam's unit could time).
+- **Speed.** ~64k instructions per frame × 2,756 frames per emulated second
+  is ~180M instructions per second of audio; Unicorn does tens of millions
+  per second, so expect **3–5× slower than real time**. Acceptable for
+  seconds-long tests; a bank load (~35 s cold) will be minutes.
+- **Hooks that assume a single thread.** The draw capture, the message and
+  sprintf hooks, the ATA completion — all written for cold detours where
+  nothing else runs. Under route A a hook can fire in any task. Most are
+  read-only observers and don't care; `_emulate_rts` (the wait hook) does,
+  which is why M6b retires it.
+- **Peripherals the tasks poll that nobody has met.** The MIDI UART, the
+  panel scan, the DSP host port beyond the ping. The stall detector in
+  `_run_until` exists for exactly this; each one found is a small model.
+- **The kernel's idle behaviour** ❓ (§4).
+- **The card image is written by the storage task** now, not by a hook: the
+  log-append path that once wiped an image (`EMU.md` M4) runs for real. Keep
+  images disposable.
+
+## 7. First step
+
+Read `0x4001f834`'s tail (idle), then build M6a against the raw image with
+the card attached, stopping at "eight tasks created, each ran once". Nothing
+in `emu_bringup`, `emu_card` or `emu_frames` changes until M6c's gate
+passes.

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -55,6 +55,7 @@ MENU_COUNT = 0x400cbda0      # current display list: row count
 MENU_FOCUS = 0x400cbda8      # focus descriptor
 CALL_SP = 0x47f00000         # scratch stack for a detour call
 CALL_RET = 0x000000f0        # sentinel return address a detour stops at
+EXTRA_OVERRIDES = {}         # extra peripheral read replies, merged into boot()'s map
 
 # EFFECT 1 / EFFECT 2 SETUP window openers (docs/MAINMENU.md §7) — the chooser
 # + dials. FX1 is page_kind 3 (id byte +0x8ed80); our inserts are all FX2, so
@@ -141,6 +142,8 @@ def boot(image=None, count=BUDGET, on_draw=None):
         # Clock/PLL: firmware halts (0x4000fa8c) unless (reg>>24)*12MHz==264MHz,
         # so the top byte must be 22 (0x16). entry 0x40000418, gate 0x4000fa78.
         0xfc0c4000: 0x16000000,
+        # callers (tools/emu_card.py) add peripheral replies here before boot()
+        **EXTRA_OVERRIDES,
     }
     seen = set()
     def _log(kind, pc, addr, size, val=None):
@@ -213,6 +216,7 @@ def boot(image=None, count=BUDGET, on_draw=None):
     st = {"wc": 0}
     mu.hook_add(UC_HOOK_MEM_WRITE,
                 lambda u, ac, ad, sz, v, x: st.update(wc=st["wc"] + 1))
+    r._wc = st                     # _run_until reads it to tell a poll from slow progress
 
     # -- burst execution ----------------------------------------------------
     # A per-instruction Python hook over ~7M instructions costs ~16s; native
@@ -249,6 +253,7 @@ def boot(image=None, count=BUDGET, on_draw=None):
                 stop["stuck"] = (pc, pc); break
 
     r.uc = mu
+    mu.octa_boot = r            # lets _call see traps raised inside a detour
     if r.trap:
         r.stopped = (f"trap #{r.trap[0]-32} at 0x{r.trap[1]:08x} "
                      "(RTOS handoff)")
@@ -310,12 +315,110 @@ def read_menu_tree(uc, desc=MENU_ROOT_DESC, depth=0, _seen=None):
     return out
 
 
+# ColdFire ISA_C ops Unicorn's CFV4E core does NOT implement — it raises the
+# illegal-instruction exception (vector 4) on each. 437 sites in the image
+# (147 bitrev, 219 byterev, 71 ff1); the FAT code is full of byterev and the
+# RTOS event-bit allocator uses bitrev+ff1, so every storage detour hits them.
+# Found 5 Sep 2026 when card init stopped silently at 0x40015a22 (`bitrev %d1`).
+# objdump prints them as `.short 0x00c1` etc. — it cannot decode them either.
+ISA_C_OPS = {0x00C0: "bitrev", 0x02C0: "byterev", 0x04C0: "ff1"}
+_DREGS = None
+
+
+class DetourTrap(Exception):
+    """A firmware function run cold raised an exception the shims do not cover."""
+    def __init__(self, vector, pc, where):
+        self.vector, self.pc, self.where = vector, pc, where
+        super().__init__(f"trap vector {vector} at 0x{pc:08x} inside {where}")
+
+
+def _movem_shim(uc, r):
+    """ColdFire executes misaligned MOVEM (the firmware's memset clears 16 B at
+    a time into odd addresses); Unicorn's core raises an address error
+    (vector 3). Emulate the long-form movem at the faulting PC and step over."""
+    if not r.trap or r.trap[0] not in (2, 3):
+        return None
+    for pc in (r.trap[1], r.trap[1] - 4):
+        w = int.from_bytes(uc.mem_read(pc, 2), "big")
+        if (w & 0xFB80) != 0x4880 or not (w & 0x0040):     # movem.l only
+            continue
+        to_regs = bool(w & 0x0400)
+        mode, reg = (w >> 3) & 7, w & 7
+        mask = int.from_bytes(uc.mem_read(pc + 2, 2), "big")
+        regs = [UC_M68K_REG_D0, UC_M68K_REG_D1, UC_M68K_REG_D2, UC_M68K_REG_D3,
+                UC_M68K_REG_D4, UC_M68K_REG_D5, UC_M68K_REG_D6, UC_M68K_REG_D7,
+                UC_M68K_REG_A0, UC_M68K_REG_A1, UC_M68K_REG_A2, UC_M68K_REG_A3,
+                UC_M68K_REG_A4, UC_M68K_REG_A5, UC_M68K_REG_A6, UC_M68K_REG_A7]
+        an = regs[8 + reg]
+        base = uc.reg_read(an) & 0xFFFFFFFF
+        size = 4
+        if mode == 2:   ea, post, ilen = base, None, 4
+        elif mode == 3: ea, post, ilen = base, "inc", 4
+        elif mode == 4:
+            n = bin(mask).count("1")
+            ea, post, ilen = (base - size * n) & 0xFFFFFFFF, "dec", 4
+            mask = int(f"{mask:016b}"[::-1], 2)          # predecrement lists reversed
+        elif mode == 5:
+            d16 = int.from_bytes(uc.mem_read(pc + 4, 2), "big", signed=True)
+            ea, post, ilen = (base + d16) & 0xFFFFFFFF, None, 6
+        else:
+            return None
+        a = ea
+        for i in range(16):
+            if mask & (1 << i):
+                if to_regs:
+                    uc.reg_write(regs[i], int.from_bytes(uc.mem_read(a, 4), "big"))
+                else:
+                    uc.mem_write(a, (uc.reg_read(regs[i]) & 0xFFFFFFFF).to_bytes(4, "big"))
+                a += 4
+        if post == "inc":
+            uc.reg_write(an, a & 0xFFFFFFFF)
+        elif post == "dec":
+            uc.reg_write(an, ea)
+        r.trap = None
+        r.movem_shims = getattr(r, "movem_shims", 0) + 1
+        return pc + ilen
+    return None
+
+
+def _isa_c_shim(uc, r):
+    """If the recorded trap is vector 4 on an ISA_C op, emulate it and return
+    the PC to resume at; else None."""
+    global _DREGS
+    if not r.trap or r.trap[0] != 4:
+        return None
+    pc = r.trap[1]
+    w = int.from_bytes(uc.mem_read(pc, 2), "big")
+    op, reg = w & 0xFFF8, w & 7
+    if op not in ISA_C_OPS:
+        return None
+    if _DREGS is None:
+        _DREGS = [UC_M68K_REG_D0, UC_M68K_REG_D1, UC_M68K_REG_D2, UC_M68K_REG_D3,
+                  UC_M68K_REG_D4, UC_M68K_REG_D5, UC_M68K_REG_D6, UC_M68K_REG_D7]
+    v = uc.reg_read(_DREGS[reg]) & 0xFFFFFFFF
+    if op == 0x00C0:                                   # bitrev: reverse 32 bits
+        v = int(f"{v:032b}"[::-1], 2)
+    elif op == 0x02C0:                                 # byterev: swap the 4 bytes
+        v = int.from_bytes(v.to_bytes(4, "big")[::-1], "big")
+    else:                                              # ff1: leading-zero count
+        sr = uc.reg_read(UC_M68K_REG_SR) & ~0x0F       # N Z from the SOURCE; V C clear
+        sr |= 0x08 if v & 0x80000000 else 0
+        sr |= 0x04 if v == 0 else 0
+        uc.reg_write(UC_M68K_REG_SR, sr)
+        v = 32 - v.bit_length()
+    uc.reg_write(_DREGS[reg], v)
+    r.trap = None
+    r.isa_c_shims = getattr(r, "isa_c_shims", 0) + 1
+    return pc + 2
+
+
 def _call(uc, addr, args=(), count=20_000_000):
     """Invoke a firmware function on a warm machine and run until it returns.
 
     Sets a scratch stack with a sentinel return address (and cdecl args above
     it) and executes until the function's rts pops it back. Faults propagate
-    as UcError.
+    as UcError. ISA_C instructions the core lacks are emulated and stepped
+    over (`_isa_c_shim`); any other trap ends the call with `r.trap` set.
     """
     sp = CALL_SP - 4 * len(args)
     uc.reg_write(UC_M68K_REG_A7, sp)
@@ -323,7 +426,56 @@ def _call(uc, addr, args=(), count=20_000_000):
     for i, a in enumerate(args):
         uc.mem_write(sp + 4 + 4 * i, (a & 0xFFFFFFFF).to_bytes(4, "big"))
     uc.reg_write(UC_M68K_REG_SR, 0x2700)
-    uc.emu_start(addr, CALL_RET, count=count)
+    trap = _run_until(uc, addr, CALL_RET, count)
+    if trap is not None:
+        raise DetourTrap(trap[0], trap[1], f"0x{addr:08x}")
+
+
+def _run_until(uc, pc, until, count=20_000_000):
+    """emu_start(pc -> until) with the ISA_C shim: an illegal-instruction trap
+    on bitrev/byterev/ff1 is emulated and execution resumes after it."""
+    r = getattr(uc, "octa_boot", None)
+    budget = 8_000_000_000        # a bank load is ~1M instructions per sector
+    burst = min(count, 5_000_000)
+    window = collections.deque(maxlen=4)   # (pc, write count) per burst
+    while budget > 0:
+        if r is not None:
+            r.trap = None
+        uc.emu_start(pc, until, count=burst)
+        if r is None:
+            return None
+        npc = _isa_c_shim(uc, r) or _movem_shim(uc, r)
+        if npc is not None:
+            pc = npc               # a shimmed burst is short: don't charge it
+            continue
+        budget -= burst
+        if r.trap is not None:
+            return r.trap          # (vector, pc) — a real exception
+        pc = uc.reg_read(UC_M68K_REG_PC)
+        if pc == until:
+            return None            # clean stop
+        # the burst ran out mid-way. A PC pinned to one small window for four
+        # bursts (20M instructions) is a poll on a peripheral we answer
+        # wrongly, not progress: give up fast with the address.
+        wc = r._wc["wc"] if hasattr(r, "_wc") else 0
+        window.append((pc, wc))
+        if len(window) == 4:
+            pcs = [w[0] for w in window]
+            writes = window[-1][1] - window[0][1]
+            if STALL_DETECT and max(pcs) - min(pcs) <= 64 and writes < 2000:
+                raise DetourStall(pc, until)
+    raise DetourStall(pc, until, exhausted=True)
+
+
+STALL_DETECT = True
+
+
+class DetourStall(Exception):
+    """A cold-run function spun in place (a poll we answer wrongly)."""
+    def __init__(self, pc, until, exhausted=False):
+        self.pc = pc
+        what = "run budget exhausted" if exhausted else "stalled"
+        super().__init__(f"{what} at 0x{pc:08x} (running to 0x{until:08x})")
 
 
 def _prime_menu(r):

--- a/tools/emu_bringup.py
+++ b/tools/emu_bringup.py
@@ -55,7 +55,8 @@ MENU_COUNT = 0x400cbda0      # current display list: row count
 MENU_FOCUS = 0x400cbda8      # focus descriptor
 CALL_SP = 0x47f00000         # scratch stack for a detour call
 CALL_RET = 0x000000f0        # sentinel return address a detour stops at
-EXTRA_OVERRIDES = {}         # extra peripheral read replies, merged into boot()'s map
+EXTRA_OVERRIDES = {}         # extra peripheral read replies (value or f(uc, addr, size)),
+                             # merged into boot()'s map
 
 # EFFECT 1 / EFFECT 2 SETUP window openers (docs/MAINMENU.md §7) — the chooser
 # + dials. FX1 is page_kind 3 (id byte +0x8ed80); our inserts are all FX2, so
@@ -154,7 +155,10 @@ def boot(image=None, count=BUDGET, on_draw=None):
     def periph_read(uc, off, size, b):
         a = b + off
         _log("R", uc.reg_read(UC_M68K_REG_PC), a, size)
-        return OVERRIDES.get(a, (1 << (size * 8)) - 1)
+        v = OVERRIDES.get(a, (1 << (size * 8)) - 1)
+        if callable(v):                    # a stateful reply (e.g. a ping index that toggles)
+            v = v(uc, a, size)
+        return v
 
     def periph_write(uc, off, size, val, b):
         _log("W", uc.reg_read(UC_M68K_REG_PC), b + off, size, val)
@@ -431,6 +435,81 @@ def _call(uc, addr, args=(), count=20_000_000):
         raise DetourTrap(trap[0], trap[1], f"0x{addr:08x}")
 
 
+TRAMP = 0x47ef0000           # scratch page for the EMAC-with-load trampoline
+_AREGS = None
+
+
+def _emac_load_shim(uc, r):
+    """Unicorn's CFV4E executes the plain EMAC forms (`macl Ry,Rx,ACC`,
+    `movclrl`) but raises illegal-instruction on the MAC-WITH-PARALLEL-LOAD
+    form (`msacl Ry,Rx,<ea>,Rw,ACC`), which the sequencer's trig-time loop at
+    0x4000aef6 uses. Do the parallel load and the address update here, then
+    execute the equivalent plain form natively from a trampoline so the
+    accumulator state stays inside the core. Returns the resume PC or None.
+    Encoding per binutils' reading of this image: load form opcode
+    `1010 Rw 0 a mmm rrr` (acc bit 0 INVERTED), ext `Rx U/L sc sc msac ? ? m acc1 ? Ry`;
+    plain form opcode `1010 Rx 0 a 000 Ry` with the acc bit straight."""
+    global _AREGS, _DREGS
+    if not r.trap or r.trap[0] != 4:
+        return None
+    pc = r.trap[1]
+    op = int.from_bytes(uc.mem_read(pc, 2), "big")
+    if (op & 0xF100) != 0xA000 or (op & 0x0030) == 0:
+        return None                                    # not a MAC with load
+    ext = int.from_bytes(uc.mem_read(pc + 2, 2), "big")
+    if _DREGS is None:
+        _DREGS = [UC_M68K_REG_D0, UC_M68K_REG_D1, UC_M68K_REG_D2, UC_M68K_REG_D3,
+                  UC_M68K_REG_D4, UC_M68K_REG_D5, UC_M68K_REG_D6, UC_M68K_REG_D7]
+    if _AREGS is None:
+        _AREGS = [UC_M68K_REG_A0, UC_M68K_REG_A1, UC_M68K_REG_A2, UC_M68K_REG_A3,
+                  UC_M68K_REG_A4, UC_M68K_REG_A5, UC_M68K_REG_A6, UC_M68K_REG_A7]
+    rw = (op >> 9) & 7
+    mode, reg = (op >> 3) & 7, op & 7
+    acc = ((~op >> 7) & 1) | ((ext >> 3) & 2)
+    rx, ry = (ext >> 12) & 0xF, ext & 0xF              # 4-bit: 0-7 = Dn, 8-15 = An
+    size_l = (ext >> 11) & 1
+    width = 4                                          # the parallel load is always a longword
+    an = _AREGS[reg]
+    base = uc.reg_read(an) & 0xFFFFFFFF
+    ilen = 4
+    if mode == 2:   ea = base
+    elif mode == 3: ea = base; uc.reg_write(an, (base + width) & 0xFFFFFFFF)
+    elif mode == 4: ea = (base - width) & 0xFFFFFFFF; uc.reg_write(an, ea)
+    elif mode == 5:
+        d16 = int.from_bytes(uc.mem_read(pc + 4, 2), "big", signed=True)
+        ea = (base + d16) & 0xFFFFFFFF; ilen = 6
+    else:
+        return None
+    val = int.from_bytes(uc.mem_read(ea, width), "big")
+    if ext & 0x0020:                                   # '&' form: AND with the MASK register
+        return None                                    # not modelled; surface it
+    uc.reg_write(_DREGS[rw], val)
+    # plain form: msacl/macl Ry,Rx,ACC — same ext bits minus the load-form fields
+    # plain form (from the image: `macl %d5,%d0,%acc0` = a005, `macl %a1,%d0,%acc1`
+    # = a089): Ry in bits 3:0 with bit 3 = A/D, Rx in bits 11:9 with A/D at bit 6,
+    # acc bit 0 at bit 7 (straight, unlike the load form)
+    plain_op = 0xA000 | ((rx & 7) << 9) | (((rx >> 3) & 1) << 6) | ((acc & 1) << 7) | ry
+    plain_ext = (ext & 0x0F00) | (size_l << 11) | ((acc >> 1) << 4)
+    try:
+        uc.mem_map(TRAMP, 0x1000)
+    except UcError:
+        pass
+    nxt = pc + ilen
+    # plain form, then jump to a nop at TRAMP+0x100 and stop there: stopping
+    # AT `nxt` is unsafe when `nxt` is itself an instruction the core rejects
+    # (a byterev followed one of these) — the exception beats the stop.
+    park = TRAMP + 0x100
+    uc.mem_write(TRAMP, plain_op.to_bytes(2, "big") + plain_ext.to_bytes(2, "big")
+                 + b"\x4e\xf9" + park.to_bytes(4, "big"))
+    uc.mem_write(park, b"\x4e\x71\x4e\x71")           # nop nop
+    r.trap = None
+    uc.emu_start(TRAMP, park, count=3)
+    if r.trap is not None or uc.reg_read(UC_M68K_REG_PC) != park:
+        return None                                    # the plain form failed too
+    r.emac_shims = getattr(r, "emac_shims", 0) + 1
+    return nxt
+
+
 def _run_until(uc, pc, until, count=20_000_000):
     """emu_start(pc -> until) with the ISA_C shim: an illegal-instruction trap
     on bitrev/byterev/ff1 is emulated and execution resumes after it."""
@@ -444,7 +523,7 @@ def _run_until(uc, pc, until, count=20_000_000):
         uc.emu_start(pc, until, count=burst)
         if r is None:
             return None
-        npc = _isa_c_shim(uc, r) or _movem_shim(uc, r)
+        npc = _isa_c_shim(uc, r) or _movem_shim(uc, r) or _emac_load_shim(uc, r)
         if npc is not None:
             pc = npc               # a shimmed burst is short: don't charge it
             continue

--- a/tools/emu_card.py
+++ b/tools/emu_card.py
@@ -1,0 +1,822 @@
+#!/usr/bin/env python3
+"""CompactFlash card emulation for the ColdFire emulator (docs/EMU.md, M4).
+
+Three pieces:
+
+  1. A pure-Python FAT16 image builder (`build_image`) that turns a directory
+     tree — a SET folder holding a PROJECT folder — into an MBR + FAT16 card
+     image the firmware's own mount code accepts (`0x400168e8`: MBR signature,
+     partition type 4/6/0x0e, 512-byte sectors; `0x40017ad4`: BPB, FAT size
+     <= 16384 sectors). Long names are written as VFAT LFN entries.
+  2. An ATA task-file model (`AtaCard`) mapped at the FlexBus window
+     0x90000000 (data 0xa0, features/error 0xa4, count 0xa8, LBA 0xac/b0/b4,
+     device 0xb8, command/status 0xbc, alt status 0xd8 — docs/ARCHITECTURE.md
+     §5). IDENTIFY advertises PIO only, so the driver's variant detection
+     (`0x40015e28`) never programs the on-chip DMA channel.
+  3. The detour past the RTOS. The PIO handlers (`0x40014b94` READ, `0x40014c48`
+     WRITE, `0x400159bc` IDENTIFY) only program the registers; the DATA PHASE is
+     the ATA interrupt handler at `0x40015304`, which streams 256 words per
+     sector and then signals an RTOS event the queue primitive `0x4001568c`
+     is blocked on (`0x40000818`). We never take the interrupt: `attach()`
+     hooks `0x40000818`, and when a command is in flight (`0x46c8c58a`) it
+     performs the transfer the handler would have — same bookkeeping words
+     (`0x46c8c592` count, `0x46c8c594` buffer, `0x46c8c593` command,
+     `0x460bac18` IDENTIFY buffer, `0x460bae18` lock) — and returns as if the
+     event had fired. Everything else in the storage stack then runs
+     unmodified, cold, exactly like the FX-page detours.
+
+Run:  .venv/bin/python3 tools/emu_card.py --project <dir> [--set NAME]
+      (builds out/emu_card.img, boots the raw image, attaches, runs card init)
+"""
+import argparse
+import os
+import pathlib
+import struct
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import emu_bringup as eb  # noqa: E402
+
+SECTOR = 512
+
+# ---------------------------------------------------------------------------
+# FAT16 image builder
+# ---------------------------------------------------------------------------
+
+_SKIP = {".DS_Store"}
+
+
+def _short_name(name, used):
+    """8.3 name for `name` (upper-cased, invalid chars -> '_'); returns
+    (basis11, needs_lfn)."""
+    stem, _, ext = name.rpartition(".") if "." in name else (name, "", "")
+    if not stem:                      # ".foo"
+        stem, ext = ext, ""
+    def clean(s):
+        out = ""
+        for c in s.upper():
+            out += c if (c.isalnum() or c in "$%'-_@~`!(){}^#&") else "_"
+        return out
+    cs, ce = clean(stem).replace(" ", ""), clean(ext).replace(" ", "")[:3]
+    lossy = (cs != stem or ce != ext or len(cs) > 8 or " " in name
+             or name != name.upper() and name != name.lower() or
+             name != (stem + ("." + ext if ext else "")))
+    if len(cs) <= 8 and not lossy and stem == stem.upper() and ext == ext.upper():
+        basis = cs.ljust(8) + ce.ljust(3)
+        if basis not in used:
+            used.add(basis)
+            return basis, False
+    # generate a ~N tail
+    for n in range(1, 10000):
+        tail = f"~{n}"
+        b = (cs[:8 - len(tail)] + tail).ljust(8) + ce.ljust(3)
+        if b not in used:
+            used.add(b)
+            return b, True
+    raise RuntimeError("too many name collisions")
+
+
+def _lfn_checksum(basis11):
+    s = 0
+    for c in basis11.encode("ascii"):
+        s = (((s & 1) << 7) | (s >> 1)) + c
+        s &= 0xFF
+    return s
+
+
+def _lfn_entries(name, basis11):
+    """VFAT long-name directory entries (reverse order, as stored)."""
+    u = name.encode("utf-16-le")
+    u += b"\x00\x00"
+    while len(u) % 26:
+        u += b"\xff\xff"
+    chunks = [u[i:i + 26] for i in range(0, len(u), 26)]
+    cs = _lfn_checksum(basis11)
+    out = []
+    for i, ch in enumerate(chunks):
+        seq = i + 1 | (0x40 if i == len(chunks) - 1 else 0)
+        e = bytes([seq]) + ch[0:10] + bytes([0x0F, 0, cs]) + ch[10:22] + b"\x00\x00" + ch[22:26]
+        assert len(e) == 32
+        out.append(e)
+    return list(reversed(out))
+
+
+def _dir_entry(basis11, attr, first_cluster, size):
+    # constant timestamp: 2026-09-05 12:00:00
+    t = (12 << 11) | (0 << 5) | 0
+    d = ((2026 - 1980) << 9) | (9 << 5) | 5
+    return (basis11.encode("ascii") + bytes([attr, 0, 0]) +
+            struct.pack("<HHHHHHHI", t, d, d, (first_cluster >> 16) & 0xFFFF, t, d,
+                        first_cluster & 0xFFFF, size))
+
+
+class _Fat16:
+    def __init__(self, total_sectors, sectors_per_cluster, part_start):
+        self.spc = sectors_per_cluster
+        self.cluster_bytes = SECTOR * self.spc
+        self.reserved = 1
+        self.nfats = 2
+        self.root_entries = 512
+        self.root_sectors = self.root_entries * 32 // SECTOR
+        self.total = total_sectors
+        # solve sectors per FAT
+        data_est = self.total - self.reserved - self.root_sectors
+        clusters = data_est // self.spc
+        self.spf = (clusters + 2) * 2 + SECTOR - 1
+        self.spf //= SECTOR
+        self.data_start = self.reserved + self.nfats * self.spf + self.root_sectors
+        self.nclusters = (self.total - self.data_start) // self.spc
+        if not 4085 <= self.nclusters <= 65524:
+            raise ValueError(f"{self.nclusters} clusters is not FAT16 (4085..65524); "
+                             "change the image size or cluster size")
+        if self.spf > 16384:
+            raise ValueError("firmware refuses FAT larger than 16384 sectors")
+        self.fat = [0] * (self.nclusters + 2)
+        self.fat[0] = 0xFFF8
+        self.fat[1] = 0xFFFF
+        self.next_free = 2
+        self.data = bytearray(self.nclusters * self.cluster_bytes)
+        self.root = bytearray(self.root_sectors * SECTOR)
+        self.part_start = part_start
+
+    def alloc_chain(self, payload):
+        n = max(1, (len(payload) + self.cluster_bytes - 1) // self.cluster_bytes)
+        if self.next_free + n > self.nclusters + 2:
+            raise ValueError("image full")
+        first = self.next_free
+        for i in range(n):
+            c = first + i
+            self.fat[c] = c + 1 if i < n - 1 else 0xFFFF
+            off = (c - 2) * self.cluster_bytes
+            self.data[off:off + self.cluster_bytes] = payload[i * self.cluster_bytes:(i + 1) * self.cluster_bytes].ljust(self.cluster_bytes, b"\x00")
+        self.next_free += n
+        return first
+
+    def build_dir(self, path, parent_cluster, is_root, log):
+        """Return (entries_bytes, first_cluster) for directory `path`."""
+        entries = bytearray()
+        used = set()
+        names = sorted(p for p in os.listdir(path)
+                       if p not in _SKIP and not p.startswith("._"))
+        subdirs = []
+        # a subdirectory's own cluster must exist before we can write '..'
+        my_cluster = 0 if is_root else self.next_free
+        if not is_root:
+            entries += _dir_entry(".".ljust(11), 0x10, my_cluster, 0)
+            entries += _dir_entry("..".ljust(11), 0x10, parent_cluster, 0)
+        # reserve our cluster(s) later: size unknown until entries are counted
+        placeholder = []
+        for name in names:
+            full = os.path.join(path, name)
+            basis, lfn = _short_name(name, used)
+            if os.path.isdir(full):
+                placeholder.append((name, basis, lfn, None))
+            else:
+                data = pathlib.Path(full).read_bytes()
+                first = self.alloc_chain(data) if data else 0
+                if lfn:
+                    for e in _lfn_entries(name, basis):
+                        entries += e
+                entries += _dir_entry(basis, 0x20, first, len(data))
+                log.append((name, basis, first, len(data)))
+        if not is_root:
+            # allocate this directory now, so children see a valid parent cluster;
+            # size the chain for the entries we will have (dirs add <= 20 each).
+            est = len(entries) + sum(32 * 21 for _ in placeholder) + 32
+            my_cluster = self.alloc_chain(b"\x00" * est)
+            # fix '.' entry cluster (we guessed next_free; alloc_chain confirms it)
+            entries[26:28] = struct.pack("<H", my_cluster & 0xFFFF)
+        for name, basis, lfn, _ in placeholder:
+            sub_entries, sub_first = self.build_dir(os.path.join(path, name), my_cluster, False, log)
+            if lfn:
+                for e in _lfn_entries(name, basis):
+                    entries += e
+            entries += _dir_entry(basis, 0x10, sub_first, 0)
+            log.append((name + "/", basis, sub_first, 0))
+        if is_root:
+            if len(entries) > len(self.root):
+                raise ValueError("too many root entries")
+            self.root[:len(entries)] = entries
+            return bytes(entries), 0
+        off = (my_cluster - 2) * self.cluster_bytes
+        cap = self.cluster_bytes * self._chain_len(my_cluster)
+        if len(entries) > cap:
+            raise ValueError(f"directory {path} overflowed its cluster reservation")
+        self.data[off:off + len(entries)] = entries
+        return bytes(entries), my_cluster
+
+    def _chain_len(self, c):
+        n = 0
+        while c != 0xFFFF and c != 0 and n < 100000:
+            n += 1
+            c = self.fat[c]
+        return n
+
+    def volume(self, label):
+        bpb = bytearray(SECTOR)
+        bpb[0:3] = b"\xEB\x3C\x90"
+        bpb[3:11] = b"MSWIN4.1"
+        struct.pack_into("<HBHBHHBHHHII", bpb, 11, SECTOR, self.spc, self.reserved,
+                         self.nfats, self.root_entries,
+                         self.total if self.total < 0x10000 else 0, 0xF8, self.spf,
+                         63, 255, self.part_start, self.total if self.total >= 0x10000 else 0)
+        bpb[36] = 0x80
+        bpb[38] = 0x29
+        struct.pack_into("<I", bpb, 39, 0x0C7A0BA8)          # volume serial
+        bpb[43:54] = label.upper().ljust(11)[:11].encode("ascii")
+        bpb[54:62] = b"FAT16   "
+        bpb[510:512] = b"\x55\xAA"
+        fat = bytearray(self.spf * SECTOR)
+        struct.pack_into(f"<{len(self.fat)}H", fat, 0, *self.fat)
+        return bytes(bpb) + bytes(fat) * self.nfats + bytes(self.root) + bytes(self.data)
+
+
+def build_image(tree_dir, size_mb=64, label="OCTABAM", part_start=2048, log=None):
+    """MBR + one FAT16 partition holding the directory tree at `tree_dir`."""
+    total = size_mb * 1024 * 1024 // SECTOR
+    part_sectors = total - part_start
+    spc = 4 if size_mb <= 128 else (8 if size_mb <= 256 else 16)
+    fs = _Fat16(part_sectors, spc, part_start)
+    log = log if log is not None else []
+    fs.build_dir(tree_dir, 0, True, log)
+    vol = fs.volume(label)
+    mbr = bytearray(SECTOR)
+    struct.pack_into("<BBBBBBBBII", mbr, 446, 0x00, 0xFE, 0xFF, 0xFF, 0x06, 0xFE, 0xFF, 0xFF,
+                     part_start, part_sectors)
+    mbr[510:512] = b"\x55\xAA"
+    img = bytearray(total * SECTOR)
+    img[0:SECTOR] = mbr
+    img[part_start * SECTOR:part_start * SECTOR + len(vol)] = vol
+    return bytes(img)
+
+
+# ---------------------------------------------------------------------------
+# ATA task-file model
+# ---------------------------------------------------------------------------
+
+ATA_BASE = 0x90000000
+R_DATA, R_FEAT, R_COUNT, R_LBA0, R_LBA1, R_LBA2, R_DEV, R_CMD, R_ALT = (
+    0xa0, 0xa4, 0xa8, 0xac, 0xb0, 0xb4, 0xb8, 0xbc, 0xd8)
+ST_DRDY, ST_DSC, ST_DRQ = 0x40, 0x10, 0x08
+
+# firmware bookkeeping (docs/EXTERNAL.md §6 / this file's header)
+FW_INFLIGHT, FW_COUNT, FW_CMD, FW_BUF, FW_EVENT = (
+    0x46c8c58a, 0x46c8c592, 0x46c8c593, 0x46c8c594, 0x46c8c598)
+FW_IDENT_BUF, FW_LOCK, FW_ERR = 0x460bac18, 0x460bae18, 0x46c85fe6
+FW_WAIT_EVENT = 0x40000818        # RTOS event wait the queue primitive blocks in
+FW_QUEUE_NOWAIT_RET = 0x40015786  # 0x4001568c's return when called with the no-wait
+                                  # flag: the command is in flight and nobody waits
+FW_ATA_HOST_STATUS = 0xfc0a4039   # bit 3 must be CLEAR (movew ->ccr; bpl)
+FW_SHOW_MESSAGE = 0x4005a2b8      # (str, kind): storage layer's error popup
+FW_ATA_INIT = 0x400160f8          # ATA subsystem init: ISR on vector 0xb6, the two
+                                  # command queues (64/32 entries), 16 event objects
+# The main init task (0x4001fc00..0x4001fc9c) runs these after the ATA init and
+# before parking in `bra *`; the RTOS tasks they create never run in a detour,
+# but the queues, tables and objects they set up are what every later detour
+# needs (the engine queue 0x460d17ce among them).
+FW_SYSTEM_INITS = (0x400209c0, 0x40092178, 0x40040b94, 0x400054c4, 0x4009ae48,
+                   0x400a1050, 0x40091ce8, 0x40098a2c)
+FW_QUEUES_INIT = 0x40040b14       # creates the three engine-side queues 0x460d17ce/ee/ae
+                                  # (1024-entry rings at 0x460d8de4/0x460dde38/0x460d5de4)
+FW_CARD_INIT = 0x40061648         # (mode): 1 = detect/init/mount
+FW_CARD_READY = 0x460d1cb8        # := 1 after a successful init+mount
+FW_SPRINTF = 0x40013a08           # (dst, fmt, ...): every path is built here
+FW_SET_NAME = 0x100f8480          # current SET folder name (0x104 bytes)
+FW_PROJECT_NAME = 0x100f8378      # current PROJECT folder name (0x104 bytes)
+FW_SET_PROJECT_EXISTS = 0x400255ec  # () -> nonzero if SET/PROJECT exists on the card
+FW_POST_LOAD_PROJECT = 0x40023c7c   # (name*) -> posts engine command 4 (load project)
+FW_POST_RELOAD_BANK = 0x40022778  # (bank) -> posts engine command 20 (RELOADING BANK)
+FW_CUR_BANK = 0x80000002          # current bank byte (ARCHITECTURE.md / EXTERNAL.md §6)
+FW_ENGINE_QUEUE = 0x460d17ce      # the engine task's command queue (Bryan T, EXTERNAL.md §6)
+FW_QUEUE_RECV = 0x40000d00        # (queue) -> message pointer (blocks when empty)
+FW_ENGINE_LOOP = 0x4008484e       # engine task loop head; every handler jumps back here
+FW_ENGINE_TABLE = 0x40084870      # 46 x s16 offsets from the table base
+PART_PTR = 0x46c82456             # project database pointer (null until a project loads)
+
+
+def identify_words(total_sectors):
+    w = [0] * 256
+    w[0] = 0x848A                          # CF signature
+    cyl, heads, spt = 1024, 16, 63
+    w[1], w[3], w[6] = cyl, heads, spt
+    w[7], w[8] = (total_sectors >> 16) & 0xFFFF, total_sectors & 0xFFFF
+    def s(idx, n, text):
+        b = text.ljust(n * 2)[:n * 2].encode("ascii")
+        for i in range(n):
+            w[idx + i] = (b[2 * i] << 8) | b[2 * i + 1]
+    s(10, 10, "OCTABAM0001")
+    s(23, 4, "1.0")
+    s(27, 20, "OCTABAM EMULATED CF")
+    w[47] = 0x8001
+    w[49] = 0x0200                          # LBA supported, NO DMA (bit 8 clear)
+    w[51] = 0x0200                          # PIO mode 2
+    w[53] = 0x0000                          # words 54-58 / 64-70 not valid -> PIO path
+    w[54], w[55], w[56] = cyl, heads, spt
+    w[57], w[58] = total_sectors & 0xFFFF, (total_sectors >> 16) & 0xFFFF
+    w[60], w[61] = total_sectors & 0xFFFF, (total_sectors >> 16) & 0xFFFF
+    return w
+
+
+class AtaCard:
+    """ATA/CF device behind the FlexBus task-file window, backed by an image."""
+
+    def __init__(self, image, log=None):
+        self.img = bytearray(image)
+        self.nsect = len(self.img) // SECTOR
+        self.regs = {R_FEAT: 0, R_COUNT: 0, R_LBA0: 0, R_LBA1: 0, R_LBA2: 0, R_DEV: 0xE0}
+        self.status = ST_DRDY | ST_DSC
+        self.error = 0
+        self.data = b""
+        self.dpos = 0
+        self.wbuf = bytearray()
+        self.wlba, self.wremaining = 0, 0
+        self.cmd = 0
+        self.log = log if log is not None else []
+        self.reads = self.writes = 0
+
+    # -- register access -----------------------------------------------------
+    def lba(self):
+        return (self.regs[R_LBA0] | (self.regs[R_LBA1] << 8) | (self.regs[R_LBA2] << 16)
+                | ((self.regs[R_DEV] & 0x0F) << 24))
+
+    def count(self):
+        return self.regs[R_COUNT] or 256
+
+    def read(self, off, size):
+        if off == R_DATA:
+            if self.dpos + 1 < len(self.data):
+                v = (self.data[self.dpos] << 8) | self.data[self.dpos + 1]
+                self.dpos += 2
+                if self.dpos >= len(self.data):
+                    self.status &= ~ST_DRQ
+                return v
+            return 0
+        if off in (R_CMD, R_ALT):
+            return self.status
+        if off == R_FEAT:
+            return self.error
+        return self.regs.get(off, 0)
+
+    def write(self, off, size, val):
+        if off == R_DATA:
+            if self.wremaining:
+                self.wbuf += bytes([(val >> 8) & 0xFF, val & 0xFF])
+                if len(self.wbuf) >= SECTOR:
+                    self._commit_sector(bytes(self.wbuf[:SECTOR]))
+                    self.wbuf = self.wbuf[SECTOR:]
+            return
+        if off == R_CMD:
+            self.command(val & 0xFF)
+            return
+        if off in self.regs:
+            self.regs[off] = val & 0xFF
+
+    # -- commands ------------------------------------------------------------
+    def command(self, c):
+        self.cmd = c
+        self.error = 0
+        self.status = ST_DRDY | ST_DSC
+        if c == 0xEC:                                   # IDENTIFY DEVICE
+            self.data = struct.pack("<256H", *identify_words(self.nsect))
+            self.dpos = 0
+            self.status |= ST_DRQ
+            self.log.append(("IDENTIFY",))
+        elif c == 0x20:                                 # READ SECTORS
+            l, n = self.lba(), self.count()
+            self.data = bytes(self.img[l * SECTOR:(l + n) * SECTOR])
+            self.dpos = 0
+            self.status |= ST_DRQ
+            self.reads += n
+            self.log.append(("READ", l, n))
+        elif c == 0x30:                                 # WRITE SECTORS
+            l, n = self.lba(), self.count()
+            self.wbuf = bytearray()
+            self.wlba, self.wremaining = l, n
+            self.status |= ST_DRQ
+            self.log.append(("WRITE", l, n))
+        elif c == 0x87:                                 # CFA TRANSLATE SECTOR
+            self.data = bytes(SECTOR)
+            self.dpos = 0
+            self.status |= ST_DRQ
+            self.log.append(("CFA-TRANSLATE", self.lba()))
+        elif c in (0xE0, 0xE1, 0xE2, 0xE3, 0xE6, 0xEF, 0xC0, 0x03, 0x91, 0xC6):
+            if c == 0xE5:
+                self.regs[R_COUNT] = 0xFF
+            self.log.append((f"CMD-{c:02x}",))
+        elif c == 0xE5:                                 # CHECK POWER MODE
+            self.regs[R_COUNT] = 0xFF
+            self.log.append(("CHECK-POWER",))
+        else:
+            self.error = 0x04                           # ABRT
+            self.status |= 0x01
+            self.log.append((f"UNSUPPORTED-{c:02x}",))
+
+    def _commit_sector(self, data):
+        """One sector of a WRITE, in order: the handler streams the first
+        sector through the data register itself (0x40014c48 after the
+        command), the interrupt handler would stream the rest."""
+        l = self.wlba
+        if l < self.nsect:
+            self.img[l * SECTOR:(l + 1) * SECTOR] = data
+        self.writes += 1
+        self.wlba += 1
+        self.wremaining -= 1
+        if self.wremaining <= 0:
+            self.wremaining = 0
+            self.status &= ~ST_DRQ
+
+    # -- the data phase the interrupt handler would do -------------------------
+    def complete(self, uc):
+        """Perform the transfer for the command the firmware has in flight, with
+        the bookkeeping `0x40015304` does, minus the RTOS signal."""
+        cmd = uc.mem_read(FW_CMD, 1)[0]
+        count = uc.mem_read(FW_COUNT, 1)[0] or (256 if cmd == 0x20 else 0)
+        buf = int.from_bytes(uc.mem_read(FW_BUF, 4), "big")
+        if cmd == 0xEC:
+            words = identify_words(self.nsect)
+            uc.mem_write(FW_IDENT_BUF, struct.pack(">256H", *words))
+            self.data, self.dpos = b"", 0
+        elif cmd == 0x20:
+            n = count
+            uc.mem_write(buf, bytes(self.data[:n * SECTOR]).ljust(n * SECTOR, b"\x00"))
+            uc.mem_write(FW_BUF, (buf + n * SECTOR).to_bytes(4, "big"))
+            uc.mem_write(FW_COUNT, b"\x00")
+            self.data, self.dpos = b"", 0
+        elif cmd == 0x30:
+            # the count byte is SECTORS REMAINING: the handler already streamed
+            # the first sector and decremented it (a 1-sector write reads 0
+            # here — treating that as 256 wiped a whole card, 5 Sep 2026)
+            rem = uc.mem_read(FW_COUNT, 1)[0]
+            if rem and self.wremaining:
+                rem = min(rem, self.wremaining)
+                data = bytes(uc.mem_read(buf, rem * SECTOR))
+                for i in range(rem):
+                    self._commit_sector(data[i * SECTOR:(i + 1) * SECTOR])
+                uc.mem_write(FW_BUF, (buf + rem * SECTOR).to_bytes(4, "big"))
+            uc.mem_write(FW_COUNT, b"\x00")
+        elif cmd == 0x87:
+            uc.mem_write(buf, bytes(SECTOR))
+        elif cmd == 0xE5:
+            uc.mem_write(FW_ERR, bytes([self.regs[R_COUNT]]))
+        self.status &= ~ST_DRQ
+        uc.mem_write(FW_INFLIGHT, (0).to_bytes(4, "big"))
+        uc.mem_write(FW_CMD, b"\x00")
+        uc.mem_write(FW_EVENT, (0).to_bytes(4, "big"))
+        uc.mem_write(FW_LOCK, (0).to_bytes(4, "big"))
+
+
+# ---------------------------------------------------------------------------
+# attaching to a warm machine
+# ---------------------------------------------------------------------------
+
+class CardSession:
+    def __init__(self, r, card):
+        self.r, self.uc, self.card = r, r.uc, card
+        self.messages = []        # storage-layer popups (error strings)
+        self.paths = []           # every path the firmware formats
+        self.waits = 0            # event waits we satisfied
+        self.wait_log = []        # (caller, event, kind) per satisfied wait
+        self.engine_ops = []      # engine opcodes run by engine_run_once
+        self.async_completions = 0
+
+    def _emulate_rts(self, uc, d0=0):
+        sp = uc.reg_read(eb.UC_M68K_REG_A7)
+        ret = int.from_bytes(uc.mem_read(sp, 4), "big")
+        uc.reg_write(eb.UC_M68K_REG_A7, sp + 4)
+        uc.reg_write(eb.UC_M68K_REG_D0, d0)
+        uc.reg_write(eb.UC_M68K_REG_PC, ret)
+
+
+def attach(r, image, log=None):
+    """Map the card into a warm machine (after `emu_bringup.boot`)."""
+    uc = r.uc
+    card = AtaCard(image, log)
+    s = CardSession(r, card)
+    # SDRAM the storage stack uses that the boot never touched: sector buffers
+    # at 0x4ece3000 / 0x4eceb200 and the file-system state around them.
+    # The boot maps 32 MB of SDRAM; the storage stack and the project loader
+    # use the rest of the 256 MB: the PCM pool 0x40A955E0..0x45F..., sector
+    # buffers 0x4ece3000/0x4eceb200, the delay rings 0x4F502C10. Map it all,
+    # plus the on-chip SRAM around the boot's 0x100b0000 window (names at
+    # 0x100f8480, object tables 0x100b14f0..0x100f7f30).
+    # (the boot already maps 0x40000000 +32 MB, 0x46000000 +32 MB, 0x48000000
+    # +1 MB and 0x100b0000 +64 KB; mem_map refuses overlaps, so fill the gaps)
+    for base, size in ((0x42000000, 0x04000000),
+                       (0x48100000, 0x07f00000),
+                       (0x10000000, 0x000b0000),
+                       (0x100c0000, 0x00040000)):
+        try:
+            uc.mem_map(base, size)
+        except eb.UcError:
+            pass
+    # replace the generic peripheral stub on the task-file window
+    uc.mem_unmap(ATA_BASE, 0x1000)
+    uc.mmio_map(ATA_BASE, 0x1000,
+                lambda u, off, size, d: card.read(off, size), None,
+                lambda u, off, size, val, d: card.write(off, size, val), None)
+
+    def on_wait(u, addr, size, user):
+        # Every RTOS event wait in a cold detour returns at once. The ATA wait
+        # first gets its data phase; a timer wait (the storage layer's delay
+        # helper 0x40020c7c programs 0xfc084000 then blocks here) just passes
+        # instantly; anything else is logged so a silently-satisfied wait for
+        # something that never happened can be recognised in the record.
+        sp = u.reg_read(eb.UC_M68K_REG_A7)
+        ret = int.from_bytes(u.mem_read(sp, 4), "big")
+        ev = int.from_bytes(u.mem_read(sp + 4, 4), "big")
+        # READ/WRITE set both the in-flight flag and the command byte; the
+        # IDENTIFY getter (0x400159bc) sets only the command byte and the lock.
+        pending = u.mem_read(FW_CMD, 1)[0]
+        kind = f"ata-{pending:02x}" if pending else "other"
+        if pending:
+            card.complete(u)
+        s.waits += 1
+        s.wait_log.append((ret, ev, kind))
+        s._emulate_rts(u, 0)
+    uc.hook_add(eb.UC_HOOK_CODE, on_wait, begin=FW_WAIT_EVENT, end=FW_WAIT_EVENT)
+
+    def on_nowait(u, addr, size, user):
+        # An asynchronous command (queue primitive called with flag bit 1)
+        # would complete on the interrupt while the caller works on. With no
+        # interrupt it would hold the lock forever, every later command would
+        # queue behind it, and the caller would spin on a full queue (seen 5
+        # Sep 2026 in the bank loader). Complete it here, before the caller
+        # continues; its later event wait then finds nothing pending.
+        if u.mem_read(FW_CMD, 1)[0]:
+            card.complete(u)
+            s.async_completions += 1
+    uc.hook_add(eb.UC_HOOK_CODE, on_nowait, begin=FW_QUEUE_NOWAIT_RET, end=FW_QUEUE_NOWAIT_RET)
+
+    def on_message(u, addr, size, user):
+        sp = u.reg_read(eb.UC_M68K_REG_A7)
+        p = int.from_bytes(u.mem_read(sp + 4, 4), "big")
+        s.messages.append(eb._cstr(u, p, 64))
+    uc.hook_add(eb.UC_HOOK_CODE, on_message, begin=FW_SHOW_MESSAGE, end=FW_SHOW_MESSAGE)
+
+    def on_sprintf(u, addr, size, user):
+        sp = u.reg_read(eb.UC_M68K_REG_A7)
+        fmt = int.from_bytes(u.mem_read(sp + 8, 4), "big")
+        f = eb._cstr(u, fmt, 64)
+        if "/" in f or "." in f:
+            args = []
+            for i in range(f.count("%")):
+                a = int.from_bytes(u.mem_read(sp + 12 + 4 * i, 4), "big")
+                try:
+                    raw = bytes(u.mem_read(a, 64)) if "%s" in f else b""
+                    args.append(raw.split(b"\x00")[0].decode("ascii", "replace") if raw else hex(a))
+                except eb.UcError:
+                    args.append(hex(a))
+            s.paths.append((f, args))
+    uc.hook_add(eb.UC_HOOK_CODE, on_sprintf, begin=FW_SPRINTF, end=FW_SPRINTF)
+    uc.ctl_flush_tb()
+    r.card = s
+    return s
+
+
+def card_init(s):
+    """Run the firmware's storage bring-up cold: the ATA subsystem init the
+    storage task would have done (`0x400160f8`, once), then card
+    detect/init/mount (`0x40061648(1)`)."""
+    uc = s.uc
+    if not getattr(s, "_ata_inited", False):
+        eb._call(uc, FW_ATA_INIT, [])
+        s.init_log = []
+        for fn in (FW_QUEUES_INIT,) + FW_SYSTEM_INITS:
+            try:
+                eb._call(uc, fn, [], count=50_000_000)
+                s.init_log.append((fn, "ok" if not s.r.trap else f"trap {s.r.trap}"))
+            except (eb.UcError, eb.DetourTrap, eb.DetourStall) as e:
+                s.init_log.append((fn, f"fault {e} pc={uc.reg_read(eb.UC_M68K_REG_PC):#x}"))
+        s._ata_inited = True
+    eb._call(uc, FW_CARD_INIT, [1])
+    d0 = uc.reg_read(eb.UC_M68K_REG_D0) & 0xFFFFFFFF
+    ready = int.from_bytes(uc.mem_read(FW_CARD_READY, 4), "big")
+    return d0, ready
+
+
+FW_ENGINE_TASK = 0x4008445c       # engine task entry (NOTES.md FUN_4008445c)
+FW_ENGINE_RECV_SITE = 0x40084854  # the loop's `jsr 0x40000d00` — our step boundary
+ENGINE_SP = 0x47f80000            # a stack for the cold-run engine task
+_REGS = None
+
+
+def _regs():
+    global _REGS
+    if _REGS is None:
+        _REGS = [getattr(eb, f"UC_M68K_REG_D{i}") for i in range(8)] + \
+                [getattr(eb, f"UC_M68K_REG_A{i}") for i in range(8)] + \
+                [eb.UC_M68K_REG_SR]
+    return _REGS
+
+
+def engine_start(s):
+    """Run the engine task from its entry to its first receive: the prologue
+    creates its own queue (`0x460d17ce`) and state, so this must happen before
+    anything is posted to it."""
+    uc = s.uc
+    if hasattr(s, "_engine_regs"):
+        return
+    uc.reg_write(eb.UC_M68K_REG_A7, ENGINE_SP)
+    uc.reg_write(eb.UC_M68K_REG_SR, 0x2700)
+    trap = eb._run_until(uc, FW_ENGINE_TASK, FW_ENGINE_RECV_SITE)
+    s._engine_regs = [uc.reg_read(r) for r in _regs()]
+    if trap is not None:
+        raise eb.DetourTrap(trap[0], trap[1], "engine task prologue")
+
+
+def engine_run_once(s):
+    """Run the engine task cold, one message at a time.
+
+    The handlers address locals through the task's frame pointer, so they can
+    only run inside the task: the first call runs the task from its entry to
+    the loop's receive call (prologue done, queue empty is fine — we stop
+    BEFORE the receive would block); each later call resumes at that call
+    with a message queued and runs until the loop comes back round to it.
+    The task's registers are kept across calls. Returns the opcode handled,
+    or None if the queue was empty."""
+    uc = s.uc
+    engine_start(s)
+    # queue layout (0x40000c3c post / 0x40000d00 receive): +4 pending count,
+    # +12 waiting task, +16 index mask, +20 ring of message pointers,
+    # +24 write index, +28 read index
+    q = FW_ENGINE_QUEUE
+    count = int.from_bytes(uc.mem_read(q + 4, 4), "big")
+    if count == 0:
+        return None
+    ring = int.from_bytes(uc.mem_read(q + 20, 4), "big")
+    rd = int.from_bytes(uc.mem_read(q + 28, 4), "big")
+    msg = int.from_bytes(uc.mem_read(ring + 4 * rd, 4), "big")
+    op = uc.mem_read(msg, 1)[0] if msg else None
+    for reg, v in zip(_regs(), s._engine_regs):
+        uc.reg_write(reg, v)
+    # emu_start(begin == until) runs nothing, so step in two legs: through the
+    # receive call to the instruction after it, then round the loop back to it.
+    trap = eb._run_until(uc, FW_ENGINE_RECV_SITE, FW_ENGINE_RECV_SITE + 6)
+    if trap is None:
+        trap = eb._run_until(uc, FW_ENGINE_RECV_SITE + 6, FW_ENGINE_RECV_SITE)
+    s._engine_regs = [uc.reg_read(r) for r in _regs()]
+    if trap is not None:
+        raise eb.DetourTrap(trap[0], trap[1], f"engine op {op}")
+    s.engine_ops.append(op)
+    return op
+
+
+def set_names(s, set_name, project_name):
+    """The set name is an ABSOLUTE path on the card: the firmware's own
+    default is "/PRESETS" (0x400b46ef) and its log names bank files
+    "/PRESETS/<project>/bank01.work". Without the slash the project loads
+    (relative to the root) and then every bank is "missing" (measured 5 Sep
+    2026: the loader had changed into the project directory)."""
+    uc = s.uc
+    if not set_name.startswith("/"):
+        set_name = "/" + set_name
+    uc.mem_write(FW_SET_NAME, set_name.encode("ascii")[:0x100] + b"\x00")
+    uc.mem_write(FW_PROJECT_NAME, project_name.encode("ascii")[:0x100] + b"\x00")
+
+
+def reload_bank(s, bank):
+    """Post RELOAD BANK for `bank` (0-based) and run the engine command: this
+    is what pulls bank%02d.work into the bank blob. LOAD PROJECT alone reads
+    project.work, markers.work and the arrangements (measured 5 Sep 2026).
+    The command's word argument is a BITMASK of banks (the loader
+    `0x4008f0b0` loops over set bits and formats bank%02d for each, 1-based),
+    so bank 0 is mask 1."""
+    uc = s.uc
+    engine_start(s)
+    eb._call(uc, FW_POST_RELOAD_BANK, [1 << bank])
+    ops = []
+    for _ in range(4):
+        op = engine_run_once(s)
+        if op is None:
+            break
+        ops.append(op)
+    return ops
+
+
+def load_project(s, set_name, project_name, banks=()):
+    """Name the set and project the way the storage task would have, confirm
+    the firmware can see them on the card, post LOAD PROJECT and run the
+    engine command. LOAD PROJECT reads project.work, markers.work, the
+    arrangements and ALL SIXTEEN bank files itself (given the absolute set
+    path); `banks` posts extra RELOAD BANK commands. Returns
+    (exists, posted, ops_run, part_ptr)."""
+    uc = s.uc
+    engine_start(s)
+    set_names(s, set_name, project_name)
+    eb._call(uc, FW_SET_PROJECT_EXISTS, [])
+    exists = uc.reg_read(eb.UC_M68K_REG_D0) & 0xFFFFFFFF
+    eb._call(uc, FW_POST_LOAD_PROJECT, [FW_PROJECT_NAME])
+    posted = uc.reg_read(eb.UC_M68K_REG_D0) & 0xFFFFFFFF
+    ops = []
+    for _ in range(8):
+        op = engine_run_once(s)
+        if op is None:
+            break
+        ops.append(op)
+    for b in banks:
+        ops += reload_bank(s, b)
+    part = int.from_bytes(uc.mem_read(PART_PTR, 4), "big")
+    return exists, posted, ops, part
+
+
+def boot_with_card(image_path=None, card_image=None, log=None):
+    """Boot (with the ATA host status override) and attach the card."""
+    eb.EXTRA_OVERRIDES[FW_ATA_HOST_STATUS] = 0x00
+    # 0x40040b94 (system init) polls 0xfc05c02c until bits 4-7 read 2; the
+    # all-ones default spins forever.
+    eb.EXTRA_OVERRIDES[0xfc05c02c] = 0x00000020
+    r = eb.boot(image_path)
+    if not r.reached_handoff:
+        return r, None
+    s = attach(r, card_image, log)
+    return r, s
+
+
+def _cli():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--project", help="project directory (bank*.work, project.work, ...)")
+    ap.add_argument("--set", default="OCTABAM", help="SET folder name on the card")
+    ap.add_argument("--name", default=None, help="PROJECT folder name (default: dir name)")
+    ap.add_argument("--audio", action="store_true", help="include .wav/.ot files")
+    ap.add_argument("--size", type=int, default=64, help="image size, MB")
+    ap.add_argument("--image", default="out/emu_card.img", help="card image path to write")
+    ap.add_argument("--firmware", default=None, help="MAIN OS image (default: emu_bringup's)")
+    ap.add_argument("--image-only", action="store_true", help="build the card image and stop")
+    ap.add_argument("--load", nargs=2, metavar=("SET", "PROJECT"), default=None,
+                    help="after card init, load SET/PROJECT through the engine command")
+    a = ap.parse_args()
+
+    tree = pathlib.Path("out/_emu_card_tree")
+    if a.project:
+        import shutil
+        src = pathlib.Path(a.project)
+        name = a.name or src.name
+        if tree.exists():
+            shutil.rmtree(tree)
+        dst = tree / a.set / name
+        dst.mkdir(parents=True)
+        (tree / a.set / "AUDIO").mkdir()
+        for p in sorted(src.iterdir()):
+            if p.name.startswith("._") or p.name in _SKIP:
+                continue
+            if not a.audio and p.suffix.lower() in (".wav", ".ot"):
+                continue
+            if p.is_file():
+                shutil.copy2(p, dst / p.name)
+        files = []
+        img = build_image(str(tree), a.size, log=files)
+        pathlib.Path(a.image).parent.mkdir(parents=True, exist_ok=True)
+        pathlib.Path(a.image).write_bytes(img)
+        print(f"card image : {a.image}  ({len(img) // 1048576} MB, {len(files)} entries, "
+              f"/{a.set}/{name}/)")
+    else:
+        img = pathlib.Path(a.image).read_bytes()
+        print(f"card image : {a.image} (existing)")
+    if a.image_only:
+        return
+
+    t0 = time.time()
+    ata_log = []
+    r, s = boot_with_card(a.firmware, img, ata_log)
+    print(f"boot       : {r.stopped}  ({time.time() - t0:.1f}s)")
+    if s is None:
+        sys.exit(1)
+    try:
+        d0, ready = card_init(s)
+        for fn, res in s.init_log:
+            print(f"  init     : {fn:#x} {res}")
+        print(f"card init  : d0=0x{d0:08x} ready={ready}  event-waits satisfied={s.waits}")
+    except (eb.UcError, eb.DetourTrap, eb.DetourStall) as e:
+        print(f"card init  : FAULT {e} at pc=0x{s.uc.reg_read(eb.UC_M68K_REG_PC):08x}")
+    for m in s.messages:
+        print(f"  message  : {m!r}")
+    load = a.load or ((a.set, a.name or pathlib.Path(a.project).name) if a.project else None)
+    if load:
+        try:
+            exists, posted, ops, part = load_project(s, *load)
+            print(f"load       : /{load[0].lstrip('/')}/{load[1]}  exists={exists} posted={posted} "
+                  f"engine ops={ops}  PART=0x{part:08x}")
+            if part:
+                uc = s.uc
+                fx1 = [uc.mem_read(part + 0x8ed80 + t, 1)[0] for t in range(8)]
+                fx2 = [uc.mem_read(part + 0x8ed88 + t, 1)[0] for t in range(8)]
+                print(f"  part 1   : FX1 ids {fx1}  FX2 ids {fx2}  (bank A, from bank01.work)")
+        except (eb.UcError, eb.DetourTrap, eb.DetourStall) as e:
+            print(f"load       : FAULT {e} at pc=0x{s.uc.reg_read(eb.UC_M68K_REG_PC):08x}")
+        for m in s.messages:
+            print(f"  message  : {m!r}")
+    print(f"ATA        : {len(ata_log)} commands, {s.card.reads} sectors read, "
+          f"{s.card.writes} written")
+    for e in ata_log[:40]:
+        print("  ", e)
+    for f, args in s.paths[:40]:
+        print(f"  path     : {f!r} {args}")
+    import collections
+    waits = collections.Counter((hex(c), k) for c, _, k in s.wait_log)
+    for (c, k), n in waits.most_common(12):
+        print(f"  wait     : caller {c} {k} x{n}")
+
+
+if __name__ == "__main__":
+    _cli()

--- a/tools/emu_frames.py
+++ b/tools/emu_frames.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Run the firmware's audio-frame interrupt handler cold, one frame at a time,
+and log the per-track trigger word the per-frame dispatcher reads.
+
+Why: Bryan T's session-5 ask (docs/EXTERNAL.md §6, 6 Sep 2026) — with a
+project loaded and the sequencer running, does the low nibble of the
+per-track trigger word (the trig's sample offset within the 16-sample frame)
+walk from pass to pass when the pattern length in samples is not an integer
+number of frames? Static reading cannot show an accumulator moving; a
+frame-by-frame trace can.
+
+What runs: the frame builder `0x4000aad0` is the DSP-frame INTERRUPT handler
+(prologue `lea sp@(-252) / moveml d0-fp`, re-entry guard `0x46104d4e`, ping
+swap `0x800000e0 -> e4`, ..., the per-track dispatcher `0x4000d2a0`, the
+packer `0x4000d3fc`, `rte`). We push a ColdFire exception frame whose return
+PC is the detour sentinel and run it to the `rte`. The dispatcher reads each
+track's word through the slot `%sp@(144)` = `0x46104d26 + 2*track` at
+`0x4000d32e` (Bryan's anchor; the pointer is planted at `0x4000c87c`) — a hook
+there logs (frame, track, word).
+
+Run:  .venv/bin/python3 tools/emu_frames.py --project <dir> --frames 3000 [--bpm 128]
+"""
+import argparse
+import collections
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import emu_bringup as eb  # noqa: E402
+import emu_card as ec     # noqa: E402
+
+FW_FRAME_ISR = 0x4000aad0        # DSP-frame interrupt handler = the frame builder
+FW_TICK_ISR = 0x400a1e10         # sequencer tick interrupt handler (MIDI clock rate, 24 PPQN):
+                                 # acks the INTC, sends 0xF8, advances the tick clock 0x4610757c by
+                                 # 2,646,000 (= a 16th step / 6) and re-syncs the frame clock
+                                 # 0x46104cf4 to it, then steps the sequencer
+TICK_UNITS = 2_646_000           # tick clock units: 1 sample = tempo24 units
+FW_FORCE_TICKS = (0x4000ae00, 0x4000aea0)  # frame handler: `orl %d0,0xfc048010` — the regular tick force
+                                 # forced interrupt when its countdown (0x46107568, decremented by
+                                 # tempo24<<4 per frame) expires; the tick handler acks it on entry
+FW_MIDI_SETTINGS = 0x80000028    # project MIDI byte: bit 0 = clock receive (external clock)
+FW_DISPATCH_READ = 0x4000d32e    # `mvzw %a0@,%d2` — the per-track trigger word
+FW_TRIG_WORDS = 0x46104d26       # 8 x u16, one per track (Bryan T §14.10)
+FW_SEQ_STATE = 0x800065b8        # 0 stopped, 1 playing, 2 (seen in 0x4009f5bc)
+FW_TRANSPORT = 0x4009b964        # (arg) sequencer transport routine; start case at 0x4009c458
+FW_TEMPO24 = 0x80001814
+FW_TEMPO_SHADOW = 0x80000020
+FRAME_SP = 0x47f70000            # stack for the cold-run interrupt handler
+
+
+def run_frame(s):
+    """One frame: fake exception frame, run the handler to its rte."""
+    uc = s.uc
+    sp = FRAME_SP - 8
+    # ColdFire exception stack frame: format/vector word, SR, return PC
+    uc.mem_write(sp, (0x40C0).to_bytes(2, "big") + (0x2000).to_bytes(2, "big")
+                 + eb.CALL_RET.to_bytes(4, "big"))
+    uc.reg_write(eb.UC_M68K_REG_A7, sp)
+    uc.reg_write(eb.UC_M68K_REG_SR, 0x2700)
+    trap = eb._run_until(uc, FW_FRAME_ISR, eb.CALL_RET)
+    if trap is not None and trap[0] == 256:
+        return                      # the handler's own `rte` (0x4000d9ae): the frame is done
+    if trap is not None:
+        raise eb.DetourTrap(trap[0], trap[1], "frame handler")
+
+
+def run_isr(s, entry, sp_top):
+    uc = s.uc
+    sp = sp_top - 8
+    uc.mem_write(sp, (0x40C0).to_bytes(2, "big") + (0x2000).to_bytes(2, "big")
+                 + eb.CALL_RET.to_bytes(4, "big"))
+    uc.reg_write(eb.UC_M68K_REG_A7, sp)
+    uc.reg_write(eb.UC_M68K_REG_SR, 0x2700)
+    trap = eb._run_until(uc, entry, eb.CALL_RET)
+    if trap is not None and trap[0] == 256:
+        return
+    if trap is not None:
+        raise eb.DetourTrap(trap[0], trap[1], f"isr {entry:#x}")
+
+
+def run_tick(s):
+    """One sequencer tick (the timer interrupt), run cold like the frame."""
+    run_isr(s, FW_TICK_ISR, FRAME_SP - 0x4000)
+
+
+class Clock:
+    """The tick is a FORCED interrupt the frame handler raises when its own
+    countdown expires (no hardware timer): hook that write, and run the tick
+    handler right after the frame that raised it. Interrupt priority is the
+    one thing not modelled — on hardware the forced tick may pre-empt the
+    frame handler before it finishes rather than follow it."""
+    def __init__(self, s, t24):
+        self.t24 = t24
+        self.sample = 0                  # first sample of the next frame
+        self.ticks = 0
+        self.pending = False
+        for site in FW_FORCE_TICKS:
+            s.uc.hook_add(eb.UC_HOOK_CODE, lambda u, a, sz, d: setattr(self, "pending", True),
+                          begin=site, end=site)
+        s.uc.ctl_flush_tb()
+
+    def advance(self, s):
+        """Call AFTER run_frame: run the tick the frame forced, if any."""
+        ran = 0
+        while self.pending:
+            self.pending = False
+            run_tick(s)
+            self.ticks += 1; ran += 1
+            if getattr(s, "tick_trace", None) is not None and self.ticks <= 60:
+                u = s.uc
+                r32 = lambda a: int.from_bytes(u.mem_read(a, 4), "big")
+                s.tick_trace.append((self.ticks, self.sample, r32(0x4610757c), r32(0x46104cf4),
+                                     r32(0x46107568), r32(0x4610756c), r32(0x46107564),
+                                     r32(FW_SEQ_STATE), u.mem_read(0x80006511, 1)[0],
+                                     u.mem_read(0x8000005b, 1)[0], r32(0x800066d4),
+                                     u.mem_read(0x80000028, 1)[0], u.mem_read(0x80001860, 1)[0],
+                                     bytes(u.mem_read(0x80001904, 16)).hex()))
+        self.sample += 16
+        return ran
+
+
+def set_tempo(s, bpm, tenths=0):
+    t24 = 24 * int(bpm) + (23 * tenths + 4) // 9
+    for a in (FW_TEMPO24, FW_TEMPO_SHADOW):
+        s.uc.mem_write(a, t24.to_bytes(4, "big"))
+    return t24
+
+
+def install_trig_log(s):
+    uc = s.uc
+    log = []
+    state = {"frame": 0, "track": 0}
+
+    def on_read(u, addr, size, user):
+        a0 = u.reg_read(eb.UC_M68K_REG_A0)
+        d3 = u.reg_read(eb.UC_M68K_REG_D3)          # the dispatcher's track counter
+        w = int.from_bytes(u.mem_read(a0, 2), "big")
+        state["reads"] = state.get("reads", 0) + 1
+        if w:
+            log.append((state["frame"], d3, w))
+    uc.hook_add(eb.UC_HOOK_CODE, on_read, begin=FW_DISPATCH_READ, end=FW_DISPATCH_READ)
+    uc.ctl_flush_tb()
+    s.trig_log = log
+    s.frame_state = state
+    return log
+
+
+def _cli():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--set", default="OCTABAM")
+    ap.add_argument("--name", default=None)
+    ap.add_argument("--image", default="out/emu_card.img")
+    ap.add_argument("--firmware", default=None)
+    ap.add_argument("--frames", type=int, default=200)
+    ap.add_argument("--bpm", type=float, default=None)
+    ap.add_argument("--start", action="store_true", help="start the sequencer via the transport routine")
+    ap.add_argument("--kick", type=int, default=0, help="force the step countdown word 0x80006514 after start")
+    ap.add_argument("--internal-clock", action="store_true",
+                    help="clear the project's CLOCK RECEIVE bit so the sequencer runs on its own clock")
+    a = ap.parse_args()
+
+    import shutil
+    src = pathlib.Path(a.project); name = a.name or src.name
+    tree = pathlib.Path("out/_emu_frames_tree")
+    if tree.exists():
+        shutil.rmtree(tree)
+    dst = tree / a.set / name; dst.mkdir(parents=True); (tree / a.set / "AUDIO").mkdir()
+    for p in sorted(src.iterdir()):
+        if p.is_file() and not p.name.startswith("._") and p.suffix.lower() not in (".wav", ".ot"):
+            shutil.copy2(p, dst / p.name)
+    img = ec.build_image(str(tree), 64)
+    # The frame handler's DSP handshake: the ping index arrives on the host
+    # port 0x2000001c (must be 0 or 1, else `halt` at 0x4000ab40) and the
+    # command register 0x20000004 is polled until bit 7 clears (0x4000ab26).
+    ping = {"v": 0}
+    def dsp_ping(uc, addr, size):
+        ping["v"] ^= 1
+        return ping["v"]
+    eb.EXTRA_OVERRIDES[0x2000001c] = dsp_ping
+    eb.EXTRA_OVERRIDES[0x20000004] = 0x0000
+    r, s = ec.boot_with_card(a.firmware, img)
+    print("boot       :", r.stopped)
+    print("card init  :", ec.card_init(s))
+    print("load       :", ec.load_project(s, a.set, name)[:3])
+    if a.bpm is not None:
+        print("tempo24    :", set_tempo(s, int(a.bpm), int(round((a.bpm - int(a.bpm)) * 10))))
+    midi = s.uc.mem_read(FW_MIDI_SETTINGS, 1)[0]
+    print(f"midi byte  : 0x{midi:02x} (bit 0 = clock receive)")
+    if a.internal_clock and midi & 1:
+        s.uc.mem_write(FW_MIDI_SETTINGS, bytes([midi & ~1]))
+        print("midi byte  : clock receive cleared -> internal clock")
+    if a.start:
+        # the transport routine 0x4009b964(arg): with the sequencer stopped it
+        # runs the start case (state := 1, phase increment := tempo24 << 4 at
+        # 0x46107570, per-track states, a post to the timer queue 0x460d1664)
+        eb._call(s.uc, FW_TRANSPORT, [0])
+        print("transport  : state", int.from_bytes(s.uc.mem_read(FW_SEQ_STATE, 4), "big"),
+              " phase inc 0x46107570:", int.from_bytes(s.uc.mem_read(0x46107570, 4), "big"))
+    if a.kick:
+        s.uc.mem_write(0x80006514, (a.kick).to_bytes(2, "big"))
+        print(f"kick       : step countdown 0x80006514 := {a.kick}")
+    w6514 = []
+    s.uc.hook_add(eb.UC_HOOK_MEM_WRITE,
+                  lambda u, acc, ad, sz, val, d: len(w6514) < 30 and w6514.append((s.frame_state.get("frame", -1) if hasattr(s, "frame_state") else -1, hex(u.reg_read(eb.UC_M68K_REG_PC)), val)),
+                  begin=0x80006514, end=0x80006515)
+    log = install_trig_log(s)
+    # diagnostics: QREC scheduler calls, immediate-array writes, tick-advance calls
+    diag = collections.Counter()
+    imm_writes = []
+    s.uc.hook_add(eb.UC_HOOK_CODE, lambda u, ad, sz, d: diag.update(["qrec 0x40005178"]), begin=0x40005178, end=0x40005178)
+    s.uc.hook_add(eb.UC_HOOK_CODE, lambda u, ad, sz, d: diag.update(["advance 0x400a1608"]), begin=0x400a1608, end=0x400a1608)
+    gate = []
+    def on_gate(u, ad, sz, d):
+        diag.update(["step engine 0x400a1f68"])
+        if len(gate) < 24:
+            r = lambda a: int.from_bytes(u.mem_read(a, 4), "big")
+            gate.append((r(0x46107568), r(0x4610756c), r(0x46107570), r(0x4610757c)))
+    s.uc.hook_add(eb.UC_HOOK_CODE, on_gate, begin=0x400a1f68, end=0x400a1f68)
+    probe = []
+    def on_probe(u, ad, sz, d):
+        if len(probe) < 24:
+            r = lambda a: int.from_bytes(u.mem_read(a, 4), "big")
+            probe.append((hex(ad), r(0x46107568), r(0x4610756c), r(0x46107570)))
+    for site in (0x400a1e68, 0x400a1eb0, 0x400a1eda, 0x400a1f22):
+        s.uc.hook_add(eb.UC_HOOK_CODE, on_probe, begin=site, end=site)
+    s.uc.hook_add(eb.UC_HOOK_CODE, lambda u, ad, sz, d: diag.update(["step engine skip 0x400a2530"]), begin=0x400a2530, end=0x400a2530)
+    def on_imm(u, access, addr, size, val, d):
+        if len(imm_writes) < 40:
+            imm_writes.append((s.frame_state["frame"], hex(addr), hex(val), hex(u.reg_read(eb.UC_M68K_REG_PC))))
+    s.uc.hook_add(eb.UC_HOOK_MEM_WRITE, on_imm, begin=0x46c7e9fa, end=0x46c7e9fa + 0x20)
+    blocks = collections.Counter()
+    s.uc.hook_add(eb.UC_HOOK_BLOCK, lambda u, ad, sz, d: blocks.update([ad >> 8]))
+    s.uc.ctl_flush_tb()
+    t24 = int.from_bytes(s.uc.mem_read(FW_TEMPO24, 4), "big")
+    clock = Clock(s, t24)
+    seq_before = bytes(s.uc.mem_read(0x800065b0, 0x150))
+    s.tick_trace = []
+    for f in range(a.frames):
+        s.frame_state["frame"] = f
+        try:
+            run_frame(s)
+            if a.start:
+                clock.advance(s)
+        except (eb.DetourTrap, eb.DetourStall) as e:
+            print(f"frame {f}: {e}  pc={s.uc.reg_read(eb.UC_M68K_REG_PC):#x}")
+            break
+    print(f"frames run : {f + 1}  ticks: {clock.ticks}  trig words seen: {len(log)}")
+    print("hot pages  :", [(hex(k << 8), v) for k, v in blocks.most_common(12)])
+    for e in log[:24]:
+        print("   frame %5d track %d word %04x nibble %x flags %02x" % (e[0], e[1], e[2], e[2] & 0xF, e[2] & 0xF0))
+    # per track: sample position of each trig word, and the deltas between them
+    by_track = collections.defaultdict(list)
+    for fr, tr, w in log:
+        by_track[tr].append(fr * 16 + (w & 0xF))
+    for tr in sorted(by_track):
+        pos = by_track[tr]
+        deltas = [b - a for a, b in zip(pos, pos[1:])]
+        print(f"track {tr + 1}: {len(pos)} trigs; positions {pos[:10]}; deltas {deltas[:12]}")
+    print("tick trace (tick, sample, tickclk, frameclk, 7568, 756c, 7564, state, step, plen, 66d4, 0x28, 0x1860, events[0:16]):")
+    for t in s.tick_trace[:40]:
+        print("   ", t)
+    u = s.uc
+    r32 = lambda a: int.from_bytes(u.mem_read(a, 4), "big")
+    print("dispatch reads:", s.frame_state.get("reads", 0), " bypass 0x800018fe:", r32(0x800018fe),
+          " step 0x80006511:", u.mem_read(0x80006511, 1)[0], " plen 0x8000005b:", u.mem_read(0x8000005b, 1)[0],
+          " 0x80006686:", u.mem_read(0x80006686, 1)[0], " countdown 0x46107570:", r32(0x46107570))
+    print("trig words 0x46104d26:", bytes(u.mem_read(FW_TRIG_WORDS, 16)).hex())
+    print("events 0x80001904:", bytes(u.mem_read(0x80001904, 64)).hex())
+    print("tick trace rows:", len(s.tick_trace))
+    seq_after = bytes(u.mem_read(0x800065b0, 0x150))
+    print("seq block 0x800065b0 before:", seq_before[:0x60].hex())
+    print("seq block 0x800065b0 after :", seq_after[:0x60].hex())
+    diffs = [(hex(0x800065b0 + i), seq_before[i], seq_after[i]) for i in range(len(seq_before)) if seq_before[i] != seq_after[i]]
+    print("changed bytes:", diffs[:40])
+    print("playing bank 0x800065bd:", u.mem_read(0x800065bd, 1).hex(), " pattern 0x800065be:", u.mem_read(0x800065be, 1).hex(),
+          " 0x800065bc:", u.mem_read(0x800065bc, 1).hex(), " preroll 0x80006687:", u.mem_read(0x80006687, 1).hex(),
+          " cur bank 0x80000002:", u.mem_read(0x80000002, 1).hex(), " pattern 0x80000004:", u.mem_read(0x80000004, 1).hex())
+    print("diag:", dict(diag))
+    print("writes to 0x80006514 (frame, pc, val):", w6514[:30])
+    print("at step-engine gate (7568, 756c, 7570, tickclk):", gate[:16])
+    print("probes through the tick handler (site, 7568, 756c, 7570):", probe[:24])
+    print("immediate-array writes:", imm_writes[:20])
+    print("tick counter 0x46c7a19c:", r32(0x46c7a19c), " 0x46107574:", r32(0x46107574), " 0x800066d4:", r32(0x800066d4))
+    print("tick clock 0x4610757c:", int.from_bytes(s.uc.mem_read(0x4610757c, 4), "big"),
+          " frame clock 0x46104cf4:", int.from_bytes(s.uc.mem_read(0x46104cf4, 4), "big"))
+    print("seq state  :", int.from_bytes(s.uc.mem_read(FW_SEQ_STATE, 4), "big"),
+          " tempo24:", int.from_bytes(s.uc.mem_read(FW_TEMPO24, 4), "big"),
+          " 0x8000181c:", int.from_bytes(s.uc.mem_read(0x8000181c, 4), "big"),
+          " 0x80001820:", hex(int.from_bytes(s.uc.mem_read(0x80001820, 4), "big")))
+
+
+if __name__ == "__main__":
+    _cli()

--- a/tools/emu_frames.py
+++ b/tools/emu_frames.py
@@ -1,24 +1,44 @@
 #!/usr/bin/env python3
 """Run the firmware's audio-frame interrupt handler cold, one frame at a time,
-and log the per-track trigger word the per-frame dispatcher reads.
+with the sequencer transport started, and log what a step trig actually does
+to the per-track state the frame dispatcher reads.
 
 Why: Bryan T's session-5 ask (docs/EXTERNAL.md §6, 6 Sep 2026) — with a
-project loaded and the sequencer running, does the low nibble of the
-per-track trigger word (the trig's sample offset within the 16-sample frame)
-walk from pass to pass when the pattern length in samples is not an integer
-number of frames? Static reading cannot show an accumulator moving; a
-frame-by-frame trace can.
+project loaded and the sequencer running, does the low nibble of a trig's
+per-track word (its sample offset within the 16-sample frame) walk from pass
+to pass when the pattern length in samples is not an integer number of
+frames? Static reading cannot show an accumulator moving; a frame-by-frame
+trace can.
 
-What runs: the frame builder `0x4000aad0` is the DSP-frame INTERRUPT handler
-(prologue `lea sp@(-252) / moveml d0-fp`, re-entry guard `0x46104d4e`, ping
-swap `0x800000e0 -> e4`, ..., the per-track dispatcher `0x4000d2a0`, the
-packer `0x4000d3fc`, `rte`). We push a ColdFire exception frame whose return
-PC is the detour sentinel and run it to the `rte`. The dispatcher reads each
-track's word through the slot `%sp@(144)` = `0x46104d26 + 2*track` at
-`0x4000d32e` (Bryan's anchor; the pointer is planted at `0x4000c87c`) — a hook
-there logs (frame, track, word).
+What runs, measured in the emulator (docs/EMU.md M5 has the full account):
 
-Run:  .venv/bin/python3 tools/emu_frames.py --project <dir> --frames 3000 [--bpm 128]
+- The frame builder `0x4000aad0` is the DSP-frame interrupt handler; `run_frame`
+  pushes a ColdFire exception frame and runs it to its own `rte`.
+- The sequencer tick `0x400a1e10` is a FORCED interrupt the frame handler
+  raises itself (a countdown at `0x46107570`, decremented by `tempo24<<4` per
+  frame); `Clock` hooks the force sites and runs the tick right after the
+  frame that raised it.
+- The transport `0x4009b964(0)` + per-track `0x4009b5c8(t)` start the
+  sequencer; with a mask bit set, the per-track step handler `0x4009d1e8`
+  schedules an absolute fire time into the event table `0x80001904[track]`.
+- Each frame, the trig-time loop `0x4000aef6` turns "time - now" into a
+  clamped sample offset for every entry and stores it per track at
+  `0x800017d6[]`. The per-frame gate at `0x4000b800` (NOT `0x4000d32e`/
+  `0x46104d26` -- see below) tests the event against the frame clock and,
+  when due and the track isn't muted for it, copies that byte into
+  `0x46104d15[track]` and ORs in flag bits (`0x10` = hold, confirmed here).
+  This is the live artifact: FW_TRIG_WORDS never moved in any run so far.
+
+**Open finding, not yet resolved**: `FW_TRIG_WORDS` (`0x46104d26`, the array
+Bryan named and the one `0x4000d32e` reads) stayed all-zero through every
+run here, including one where a trig demonstrably fired and reached
+`0x46104d15`. `0x4000d378` (its only writer found so far) writes zero to it
+every frame regardless. Bryan's literal ask needs a RECORDER ARMED on the
+track, which this harness has not set up (the test project has an ordinary
+playback trig, not a record-enabled track) -- that is the next step, not
+something this run answers.
+
+Run:  .venv/bin/python3 tools/emu_frames.py --project <dir> --frames 3000 [--bpm 128] --start --internal-clock --poke-trig N
 """
 import argparse
 import collections
@@ -36,14 +56,24 @@ FW_TICK_ISR = 0x400a1e10         # sequencer tick interrupt handler (MIDI clock 
                                  # 2,646,000 (= a 16th step / 6) and re-syncs the frame clock
                                  # 0x46104cf4 to it, then steps the sequencer
 TICK_UNITS = 2_646_000           # tick clock units: 1 sample = tempo24 units
-FW_FORCE_TICKS = (0x4000ae00, 0x4000aea0)  # frame handler: `orl %d0,0xfc048010` — the regular tick force
+FW_FORCE_TICKS = (0x4000ae00, 0x4000aea0)  # frame handler: `orl %d0,0xfc048010` -- the regular tick force
                                  # forced interrupt when its countdown (0x46107568, decremented by
                                  # tempo24<<4 per frame) expires; the tick handler acks it on entry
 FW_MIDI_SETTINGS = 0x80000028    # project MIDI byte: bit 0 = clock receive (external clock)
-FW_DISPATCH_READ = 0x4000d32e    # `mvzw %a0@,%d2` — the per-track trigger word
-FW_TRIG_WORDS = 0x46104d26       # 8 x u16, one per track (Bryan T §14.10)
+FW_DISPATCH_READ = 0x4000d32e    # `mvzw %a0@,%d2` -- reads FW_TRIG_WORDS[track]; stayed zero here
+FW_TRIG_WORDS = 0x46104d26       # 8 x u16, one per track (Bryan T §14.10); NOT the live artifact
+                                 # in an ordinary-trig test -- see module docstring
+FW_LIVE_NIBBLE = 0x46104d15      # 8 x u8, one per track: the byte that DOES change on a fired trig
+                                 # (sub-frame sample offset in the low bits, flags OR'd in above it:
+                                 # 0x10 = hold, confirmed 6 Sep); written at 0x4000b910 (copy) and
+                                 # 0x4000b9bc/0x4000b9f2 (flag OR), gated by the due-check at
+                                 # 0x4000b84c and the mute-check at 0x4000b8de
 FW_SEQ_STATE = 0x800065b8        # 0 stopped, 1 playing, 2 (seen in 0x4009f5bc)
 FW_TRANSPORT = 0x4009b964        # (arg) sequencer transport routine; start case at 0x4009c458
+FW_START_TRACK = 0x4009b5c8      # (track): sets the per-track running state 0x80006500[t] := 1 if
+                                 # the playing pattern marks the track active (pattern rec +84 +
+                                 # 2330*t); the PLAY key path calls it per track, the transport
+                                 # start only promotes tracks already in state 2
 FW_TEMPO24 = 0x80001814
 FW_TEMPO_SHADOW = 0x80000020
 FRAME_SP = 0x47f70000            # stack for the cold-run interrupt handler
@@ -88,7 +118,7 @@ class Clock:
     """The tick is a FORCED interrupt the frame handler raises when its own
     countdown expires (no hardware timer): hook that write, and run the tick
     handler right after the frame that raised it. Interrupt priority is the
-    one thing not modelled — on hardware the forced tick may pre-empt the
+    one thing not modelled -- on hardware the forced tick may pre-empt the
     frame handler before it finishes rather than follow it."""
     def __init__(self, s, t24):
         self.t24 = t24
@@ -107,15 +137,6 @@ class Clock:
             self.pending = False
             run_tick(s)
             self.ticks += 1; ran += 1
-            if getattr(s, "tick_trace", None) is not None and self.ticks <= 60:
-                u = s.uc
-                r32 = lambda a: int.from_bytes(u.mem_read(a, 4), "big")
-                s.tick_trace.append((self.ticks, self.sample, r32(0x4610757c), r32(0x46104cf4),
-                                     r32(0x46107568), r32(0x4610756c), r32(0x46107564),
-                                     r32(FW_SEQ_STATE), u.mem_read(0x80006511, 1)[0],
-                                     u.mem_read(0x8000005b, 1)[0], r32(0x800066d4),
-                                     u.mem_read(0x80000028, 1)[0], u.mem_read(0x80001860, 1)[0],
-                                     bytes(u.mem_read(0x80001904, 16)).hex()))
         self.sample += 16
         return ran
 
@@ -128,22 +149,60 @@ def set_tempo(s, bpm, tenths=0):
 
 
 def install_trig_log(s):
+    """Log every nonzero byte written to FW_LIVE_NIBBLE (a trig actually
+    landing) and every nonzero write FW_TRIG_WORDS ever gets (Bryan's named
+    array; empty in every ordinary-trig run so far -- see module docstring)."""
     uc = s.uc
-    log = []
-    state = {"frame": 0, "track": 0}
+    live = []
+    words = []
+    state = {"frame": 0}
 
-    def on_read(u, addr, size, user):
-        a0 = u.reg_read(eb.UC_M68K_REG_A0)
-        d3 = u.reg_read(eb.UC_M68K_REG_D3)          # the dispatcher's track counter
-        w = int.from_bytes(u.mem_read(a0, 2), "big")
-        state["reads"] = state.get("reads", 0) + 1
-        if w:
-            log.append((state["frame"], d3, w))
-    uc.hook_add(eb.UC_HOOK_CODE, on_read, begin=FW_DISPATCH_READ, end=FW_DISPATCH_READ)
+    def on_live(u, acc, addr, size, val, d):
+        val &= 0xFF
+        if val:
+            live.append((state["frame"], addr - FW_LIVE_NIBBLE, val))
+
+    def on_word(u, acc, addr, size, val, d):
+        val &= 0xFFFF
+        if val:
+            words.append((state["frame"], (addr - FW_TRIG_WORDS) // 2, val))
+
+    uc.hook_add(eb.UC_HOOK_MEM_WRITE, on_live, begin=FW_LIVE_NIBBLE, end=FW_LIVE_NIBBLE + 7)
+    uc.hook_add(eb.UC_HOOK_MEM_WRITE, on_word, begin=FW_TRIG_WORDS, end=FW_TRIG_WORDS + 15)
     uc.ctl_flush_tb()
-    s.trig_log = log
+    s.live_nibble_log = live
+    s.trig_words_log = words
     s.frame_state = state
-    return log
+    return live
+
+
+def start_transport(s):
+    """Run the transport start case, then promote every track. Returns the
+    disassembled block path taken (for diagnosing a cold-start divergence
+    from the PLAY key's path -- see docs/EMU.md M5)."""
+    tblocks = []
+    h = s.uc.hook_add(eb.UC_HOOK_BLOCK,
+                       lambda u, ad, sz, d: 0x4009b964 <= ad < 0x4009c600 and len(tblocks) < 300 and tblocks.append(ad))
+    eb._call(s.uc, FW_TRANSPORT, [0])
+    s.uc.hook_del(h)
+    for t in range(8):
+        eb._call(s.uc, FW_START_TRACK, [t])
+    path = []
+    for b in tblocks:
+        if not path or path[-1] != b:
+            path.append(b)
+    return path
+
+
+def poke_trig(s, step):
+    """Set a trig on track 1 at `step` (1-8) directly in the loaded pattern
+    record (head = track 1's 64-step trig mask, big-endian; byte 7 bit 0 =
+    step 1). Useful for exercising the sequencer without re-saving a
+    project from the unit each time."""
+    blob = int.from_bytes(s.uc.mem_read(0x46c82456, 4), "big")
+    v = s.uc.mem_read(blob + 7, 1)[0] | (1 << (step - 1))
+    s.uc.mem_write(blob + 7, bytes([v]))
+    return v
 
 
 def _cli():
@@ -151,12 +210,11 @@ def _cli():
     ap.add_argument("--project", required=True)
     ap.add_argument("--set", default="OCTABAM")
     ap.add_argument("--name", default=None)
-    ap.add_argument("--image", default="out/emu_card.img")
     ap.add_argument("--firmware", default=None)
     ap.add_argument("--frames", type=int, default=200)
     ap.add_argument("--bpm", type=float, default=None)
     ap.add_argument("--start", action="store_true", help="start the sequencer via the transport routine")
-    ap.add_argument("--kick", type=int, default=0, help="force the step countdown word 0x80006514 after start")
+    ap.add_argument("--poke-trig", type=int, default=0, help="set a trig on track 1 at this step (1-8) in RAM after load")
     ap.add_argument("--internal-clock", action="store_true",
                     help="clear the project's CLOCK RECEIVE bit so the sequencer runs on its own clock")
     a = ap.parse_args()
@@ -192,51 +250,18 @@ def _cli():
         s.uc.mem_write(FW_MIDI_SETTINGS, bytes([midi & ~1]))
         print("midi byte  : clock receive cleared -> internal clock")
     if a.start:
-        # the transport routine 0x4009b964(arg): with the sequencer stopped it
-        # runs the start case (state := 1, phase increment := tempo24 << 4 at
-        # 0x46107570, per-track states, a post to the timer queue 0x460d1664)
-        eb._call(s.uc, FW_TRANSPORT, [0])
+        path = start_transport(s)
+        print("transport path:", " ".join(hex(b) for b in path))
         print("transport  : state", int.from_bytes(s.uc.mem_read(FW_SEQ_STATE, 4), "big"),
-              " phase inc 0x46107570:", int.from_bytes(s.uc.mem_read(0x46107570, 4), "big"))
-    if a.kick:
-        s.uc.mem_write(0x80006514, (a.kick).to_bytes(2, "big"))
-        print(f"kick       : step countdown 0x80006514 := {a.kick}")
-    w6514 = []
-    s.uc.hook_add(eb.UC_HOOK_MEM_WRITE,
-                  lambda u, acc, ad, sz, val, d: len(w6514) < 30 and w6514.append((s.frame_state.get("frame", -1) if hasattr(s, "frame_state") else -1, hex(u.reg_read(eb.UC_M68K_REG_PC)), val)),
-                  begin=0x80006514, end=0x80006515)
-    log = install_trig_log(s)
-    # diagnostics: QREC scheduler calls, immediate-array writes, tick-advance calls
-    diag = collections.Counter()
-    imm_writes = []
-    s.uc.hook_add(eb.UC_HOOK_CODE, lambda u, ad, sz, d: diag.update(["qrec 0x40005178"]), begin=0x40005178, end=0x40005178)
-    s.uc.hook_add(eb.UC_HOOK_CODE, lambda u, ad, sz, d: diag.update(["advance 0x400a1608"]), begin=0x400a1608, end=0x400a1608)
-    gate = []
-    def on_gate(u, ad, sz, d):
-        diag.update(["step engine 0x400a1f68"])
-        if len(gate) < 24:
-            r = lambda a: int.from_bytes(u.mem_read(a, 4), "big")
-            gate.append((r(0x46107568), r(0x4610756c), r(0x46107570), r(0x4610757c)))
-    s.uc.hook_add(eb.UC_HOOK_CODE, on_gate, begin=0x400a1f68, end=0x400a1f68)
-    probe = []
-    def on_probe(u, ad, sz, d):
-        if len(probe) < 24:
-            r = lambda a: int.from_bytes(u.mem_read(a, 4), "big")
-            probe.append((hex(ad), r(0x46107568), r(0x4610756c), r(0x46107570)))
-    for site in (0x400a1e68, 0x400a1eb0, 0x400a1eda, 0x400a1f22):
-        s.uc.hook_add(eb.UC_HOOK_CODE, on_probe, begin=site, end=site)
-    s.uc.hook_add(eb.UC_HOOK_CODE, lambda u, ad, sz, d: diag.update(["step engine skip 0x400a2530"]), begin=0x400a2530, end=0x400a2530)
-    def on_imm(u, access, addr, size, val, d):
-        if len(imm_writes) < 40:
-            imm_writes.append((s.frame_state["frame"], hex(addr), hex(val), hex(u.reg_read(eb.UC_M68K_REG_PC))))
-    s.uc.hook_add(eb.UC_HOOK_MEM_WRITE, on_imm, begin=0x46c7e9fa, end=0x46c7e9fa + 0x20)
-    blocks = collections.Counter()
-    s.uc.hook_add(eb.UC_HOOK_BLOCK, lambda u, ad, sz, d: blocks.update([ad >> 8]))
-    s.uc.ctl_flush_tb()
+              " phase inc 0x46107570:", int.from_bytes(s.uc.mem_read(0x46107570, 4), "big"),
+              " track states 0x80006500:", bytes(s.uc.mem_read(0x80006500, 8)).hex())
+    if a.poke_trig:
+        v = poke_trig(s, a.poke_trig)
+        print(f"poke trig  : track 1 step {a.poke_trig} -> mask byte 7 = {v:#04x}")
+
+    live = install_trig_log(s)
     t24 = int.from_bytes(s.uc.mem_read(FW_TEMPO24, 4), "big")
     clock = Clock(s, t24)
-    seq_before = bytes(s.uc.mem_read(0x800065b0, 0x150))
-    s.tick_trace = []
     for f in range(a.frames):
         s.frame_state["frame"] = f
         try:
@@ -246,49 +271,13 @@ def _cli():
         except (eb.DetourTrap, eb.DetourStall) as e:
             print(f"frame {f}: {e}  pc={s.uc.reg_read(eb.UC_M68K_REG_PC):#x}")
             break
-    print(f"frames run : {f + 1}  ticks: {clock.ticks}  trig words seen: {len(log)}")
-    print("hot pages  :", [(hex(k << 8), v) for k, v in blocks.most_common(12)])
-    for e in log[:24]:
-        print("   frame %5d track %d word %04x nibble %x flags %02x" % (e[0], e[1], e[2], e[2] & 0xF, e[2] & 0xF0))
-    # per track: sample position of each trig word, and the deltas between them
-    by_track = collections.defaultdict(list)
-    for fr, tr, w in log:
-        by_track[tr].append(fr * 16 + (w & 0xF))
-    for tr in sorted(by_track):
-        pos = by_track[tr]
-        deltas = [b - a for a, b in zip(pos, pos[1:])]
-        print(f"track {tr + 1}: {len(pos)} trigs; positions {pos[:10]}; deltas {deltas[:12]}")
-    print("tick trace (tick, sample, tickclk, frameclk, 7568, 756c, 7564, state, step, plen, 66d4, 0x28, 0x1860, events[0:16]):")
-    for t in s.tick_trace[:40]:
-        print("   ", t)
-    u = s.uc
-    r32 = lambda a: int.from_bytes(u.mem_read(a, 4), "big")
-    print("dispatch reads:", s.frame_state.get("reads", 0), " bypass 0x800018fe:", r32(0x800018fe),
-          " step 0x80006511:", u.mem_read(0x80006511, 1)[0], " plen 0x8000005b:", u.mem_read(0x8000005b, 1)[0],
-          " 0x80006686:", u.mem_read(0x80006686, 1)[0], " countdown 0x46107570:", r32(0x46107570))
-    print("trig words 0x46104d26:", bytes(u.mem_read(FW_TRIG_WORDS, 16)).hex())
-    print("events 0x80001904:", bytes(u.mem_read(0x80001904, 64)).hex())
-    print("tick trace rows:", len(s.tick_trace))
-    seq_after = bytes(u.mem_read(0x800065b0, 0x150))
-    print("seq block 0x800065b0 before:", seq_before[:0x60].hex())
-    print("seq block 0x800065b0 after :", seq_after[:0x60].hex())
-    diffs = [(hex(0x800065b0 + i), seq_before[i], seq_after[i]) for i in range(len(seq_before)) if seq_before[i] != seq_after[i]]
-    print("changed bytes:", diffs[:40])
-    print("playing bank 0x800065bd:", u.mem_read(0x800065bd, 1).hex(), " pattern 0x800065be:", u.mem_read(0x800065be, 1).hex(),
-          " 0x800065bc:", u.mem_read(0x800065bc, 1).hex(), " preroll 0x80006687:", u.mem_read(0x80006687, 1).hex(),
-          " cur bank 0x80000002:", u.mem_read(0x80000002, 1).hex(), " pattern 0x80000004:", u.mem_read(0x80000004, 1).hex())
-    print("diag:", dict(diag))
-    print("writes to 0x80006514 (frame, pc, val):", w6514[:30])
-    print("at step-engine gate (7568, 756c, 7570, tickclk):", gate[:16])
-    print("probes through the tick handler (site, 7568, 756c, 7570):", probe[:24])
-    print("immediate-array writes:", imm_writes[:20])
-    print("tick counter 0x46c7a19c:", r32(0x46c7a19c), " 0x46107574:", r32(0x46107574), " 0x800066d4:", r32(0x800066d4))
-    print("tick clock 0x4610757c:", int.from_bytes(s.uc.mem_read(0x4610757c, 4), "big"),
-          " frame clock 0x46104cf4:", int.from_bytes(s.uc.mem_read(0x46104cf4, 4), "big"))
-    print("seq state  :", int.from_bytes(s.uc.mem_read(FW_SEQ_STATE, 4), "big"),
-          " tempo24:", int.from_bytes(s.uc.mem_read(FW_TEMPO24, 4), "big"),
-          " 0x8000181c:", int.from_bytes(s.uc.mem_read(0x8000181c, 4), "big"),
-          " 0x80001820:", hex(int.from_bytes(s.uc.mem_read(0x80001820, 4), "big")))
+    print(f"frames run : {f + 1}  ticks: {clock.ticks}")
+    print(f"FW_LIVE_NIBBLE (0x46104d15) writes ({len(live)}):")
+    for fr, track, val in live:
+        print(f"   frame {fr:5d} track {track} byte {val:#04x}  nibble {val & 0xF:x}  flags {val & 0xF0:#04x}")
+    print(f"FW_TRIG_WORDS (0x46104d26) nonzero writes ({len(s.trig_words_log)}):", s.trig_words_log[:20])
+    print("final FW_TRIG_WORDS bytes  :", bytes(s.uc.mem_read(FW_TRIG_WORDS, 16)).hex())
+    print("final FW_LIVE_NIBBLE bytes :", bytes(s.uc.mem_read(FW_LIVE_NIBBLE, 8)).hex())
 
 
 if __name__ == "__main__":

--- a/tools/recorder_framephase.py
+++ b/tools/recorder_framephase.py
@@ -1,0 +1,87 @@
+"""Frame-phase-band model of the Octatrack recorder "click" (5 Sep 2026).
+
+A MODEL, not the firmware: it says what the hypothesis in docs/EXTERNAL.md §6
+(Sessions 2-4) predicts, so Bryan T's hardware test has numbers to hit or miss.
+
+Recorder: free-running LOOP=ON writer over a buffer of L samples, in 16-sample
+frames (the write path is 0x400068e4, called per frame by 0x4000d2a0).  Flex:
+playback read of the same buffer, retriggered by the sequencer at
+t_k = round(k*P), P = the exact sequencer period in samples.  Both run once per
+frame in a fixed order.  Each buffer sample is stamped with the pass number of
+its last write.  A read frame is a SEAM frame if the pass number changes
+between two consecutive read samples at buffer positions (p, p+1) with p != L-1
+(a change across L-1 -> 0 is consecutive writing: continuous content).
+
+Length: L = round(steps * 15876000 / tempo24) (0x40006dfc).  tempo24 from the
+displayed tempo is the MEASURED UI mapping (0x4009c7c4):
+    tempo24 = 24*bpm + (23*tenths + 4) // 9
+Run:  python3 tools/recorder_framephase.py
+"""
+FRAME = 16
+FS = 44100.0
+
+def run(L, P, order, passes=400, mode="rec-free/play-retrig"):
+    passid = [0] * L
+    wpos = 0; wpass = 1
+    k = 0; t_k = 0; next_trig = int(round(P))
+    seams = {}; frames = {}
+    nframes = int(round(passes * P)) // FRAME
+    for f in range(nframes):
+        t0 = f * FRAME
+        def do_write():
+            nonlocal wpos, wpass
+            for i in range(FRAME):
+                passid[wpos] = wpass; wpos += 1
+                if wpos == L: wpos = 0; wpass += 1
+        def do_read():
+            nonlocal k, t_k, next_trig
+            ids = []; poss = []
+            for i in range(FRAME):
+                t = t0 + i
+                if t == next_trig:
+                    k += 1; next_trig = int(round((k + 1) * P))
+                    if mode == "rec-free/play-retrig": t_k = t
+                rpos = (t - t_k) % L if mode == "rec-free/play-retrig" else t % L
+                poss.append(rpos); ids.append(passid[rpos])
+            seam = any(ids[i] != ids[i-1] and poss[i-1] != L - 1 for i in range(1, FRAME))
+            seams[k] = seams.get(k, 0) + seam
+            frames[k] = frames.get(k, 0) + 1
+        if order == "write-first": do_write(); do_read()
+        else: do_read(); do_write()
+    last = max(frames)
+    return [seams.get(i, 0) / frames[i] for i in range(last) if i in frames]  # drop partial last pass
+
+def summarise(name, L, P, eps, order, mode="rec-free/play-retrig"):
+    s = run(L, P, order, mode=mode)
+    hot = [i for i, v in enumerate(s) if v > 0.05]
+    tag = f"  {name:>8} {order:<11} L={L:<6} eps={eps:+.3f} "
+    if not hot:
+        print(tag + f"clean for all {len(s)} passes"); return
+    # contiguous runs
+    runs = []; start = hot[0]; prev = hot[0]
+    for h in hot[1:]:
+        if h != prev + 1: runs.append((start, prev)); start = h
+        prev = h
+    runs.append((start, prev))
+    desc = "; ".join(f"passes {a}-{b} ({b-a+1} = {(b-a+1)*P/FS:.1f} s, mean seam frac {sum(s[a:b+1])/(b-a+1):.2f})" for a, b in runs)
+    print(tag + "SEAMS " + desc + f"; then clean to pass {len(s)}")
+
+rows = [(199, 4), (298.2, 2), (286.2, 2), (251, 16), (198, 16), (229, 16), (120, 16), (120, 4), (300, 2)]
+obs = {(199, 4): "clicks", (298.2, 2): "clicks", (286.2, 2): "clicks", (251, 16): "clicks",
+       (120, 16): "clean", (120, 4): "clean", (300, 2): "clean"}
+
+def tempo24(bpm):
+    """Measured UI conversion, 0x4009c7c4: integer BPM plus a tenths digit."""
+    b = int(bpm); tenths = int(round((bpm - b) * 10))
+    return 24 * b + (23 * tenths + 4) // 9
+
+for bpm, rlen in rows:
+    t24 = tempo24(bpm); P = rlen * 15876000 / t24; L = int(P + 0.5); eps = P - L
+    print(f"{bpm}/{rlen}: tempo24={t24} P={P:.3f} L={L} (L mod 16 = {L%16})  observed: {obs.get((bpm,rlen),'not recorded')}")
+    for order in ("write-first", "read-first"):
+        summarise(f"{bpm}/{rlen}", L, P, eps, order)
+
+print("\n=== control: both free-running (flex loops at L itself, never retriggered), 199/4 ===")
+t24 = tempo24(199); P = 4 * 15876000 / t24; L = int(P + 0.5)
+for order in ("write-first", "read-first"):
+    summarise("199/4", L, P, P - L, order, mode="both-free")

--- a/tools/recorder_framephase.py
+++ b/tools/recorder_framephase.py
@@ -12,7 +12,8 @@ its last write.  A read frame is a SEAM frame if the pass number changes
 between two consecutive read samples at buffer positions (p, p+1) with p != L-1
 (a change across L-1 -> 0 is consecutive writing: continuous content).
 
-Length: L = round(steps * 15876000 / tempo24) (0x40006dfc).  tempo24 from the
+Length: the firmware's own arithmetic (firmware_length: truncating EMAC, see
+below; round-half-up is wrong on ~1 in 8 cells).  tempo24 from the
 displayed tempo is the MEASURED UI mapping (0x4009c7c4):
     tempo24 = 24*bpm + (23*tenths + 4) // 9
 Run:  python3 tools/recorder_framephase.py
@@ -66,22 +67,36 @@ def summarise(name, L, P, eps, order, mode="rec-free/play-retrig"):
     desc = "; ".join(f"passes {a}-{b} ({b-a+1} = {(b-a+1)*P/FS:.1f} s, mean seam frac {sum(s[a:b+1])/(b-a+1):.2f})" for a, b in runs)
     print(tag + "SEAMS " + desc + f"; then clean to pass {len(s)}")
 
-rows = [(199, 4), (298.2, 2), (286.2, 2), (251, 16), (198, 16), (229, 16), (120, 16), (120, 4), (300, 2)]
+rows = [(199, 4), (298.2, 2), (286.2, 2), (251, 16), (198, 16), (229, 16), (120, 16), (120, 4), (300, 2),
+        (261.3, 2), (128, 16), (128, 4), (128, 32)]
+# Bryan T's hardware log (sessions 4-5). NOTE his epsilon is L - P; ours below is P - L.
 obs = {(199, 4): "clicks", (298.2, 2): "clicks", (286.2, 2): "clicks", (251, 16): "clicks",
-       (120, 16): "clean", (120, 4): "clean", (300, 2): "clean"}
+       (120, 16): "clean", (120, 4): "clean", (300, 2): "clean",
+       (261.3, 2): "clicks (session 5)", (128, 16): "clicks (session 5, predicted)"}
 
 def tempo24(bpm):
     """Measured UI conversion, 0x4009c7c4: integer BPM plus a tenths digit."""
     b = int(bpm); tenths = int(round((bpm - b) * 10))
     return 24 * b + (23 * tenths + 4) // 9
 
+
+def firmware_length(steps, t24):
+    """The converter that feeds arm(), 0x40006dfc-0x40006e10, exactly:
+    Q = trunc(2^31 / tempo24) (0x4000cab8, biased low), A = steps x 31752000,
+    the EMAC multiply truncates (MACSR = 0x20 at 0x4000cf62: fractional,
+    round/truncate bit clear -- Bryan T, 6 Sep 2026), then (x + 1) >> 1.
+    Differs from round-half-up on ~1 in 8 grid cells, never on exact ones."""
+    Q = (1 << 31) // t24
+    return (((steps * 31752000 * Q) >> 31) + 1) >> 1
+
+
 for bpm, rlen in rows:
-    t24 = tempo24(bpm); P = rlen * 15876000 / t24; L = int(P + 0.5); eps = P - L
+    t24 = tempo24(bpm); P = rlen * 15876000 / t24; L = firmware_length(rlen, t24); eps = P - L
     print(f"{bpm}/{rlen}: tempo24={t24} P={P:.3f} L={L} (L mod 16 = {L%16})  observed: {obs.get((bpm,rlen),'not recorded')}")
     for order in ("write-first", "read-first"):
         summarise(f"{bpm}/{rlen}", L, P, eps, order)
 
 print("\n=== control: both free-running (flex loops at L itself, never retriggered), 199/4 ===")
-t24 = tempo24(199); P = 4 * 15876000 / t24; L = int(P + 0.5)
+t24 = tempo24(199); P = 4 * 15876000 / t24; L = firmware_length(4, t24)
 for order in ("write-first", "read-first"):
     summarise("199/4", L, P, P - L, order, mode="both-free")


### PR DESCRIPTION
- docs/EXTERNAL.md §6: Bryan T's recorder sessions 2–5 ingested and re-verified (pool, write path, hard-cut loop point, MACSR truncation, tempo mapping measured; my count denial retracted, his 198/16 slip corrected); tools/recorder_framephase.py with the firmware's arithmetic.
- Emulator M4: CompactFlash card emulation — a project loads through the firmware's own storage stack (tools/emu_card.py, make emu-card).
- Emulator M5: the frame and tick interrupt handlers run cold; a step trig fires end-to-end and lands at 0x46104d15 — not Bryan's 0x46104d26, which belongs to a second, QREC-staged trig path that needs a recorder armed (docs/EMU.md M5).
- Route A scoped: docs/RTOS_FORK.md — kernel decoded byte-exact, Unicorn feasibility spike passed, milestones M6a–e with the fidelity gate. ARCHITECTURE.md TCB SP offset corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)