### PR TITLE
Emulator M6b: real mount + real load, one race open

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -703,28 +703,35 @@ scheduler.
 | M4 card + loaded project | ✅ shipped (route B) | `make emu-card PROJECT=<abs dir>`: the RIG project loads through the real storage stack, one wait hook |
 | M5 frames + ticks, cold | ✅ done, one gap | a step trig fires end to end; the recorder-arm path ("path B") needs real task interleaving |
 | **M6a scheduler runs** | ✅ **done 6 Sep, PR #100** | `make emu-rtos PROJECT=<abs dir>`: eleven tasks start in the real order, the 5 ms tick and every interrupt fire, tasks post to each other; gate passes at 205 ms emulated |
-| M6b real waits + mount | ⏳ **NEXT (mechanical)** | storage parks on its queue, the card sees zero commands: find what requests the mount (RTOS_FORK §5 names the suspects), then the RIG load under real tasks, part bytes = M4's |
+| M6b real waits + mount | 🟡 **started 6 Sep, one race open** | `sys` (not engine) mounts the card; a real mount + LOAD PROJECT reach 30,467 real sectors (M4: ~30,955) and the correct project pointer — then a second real task clobbers it ~13 ms later and the load free-runs without re-setting it. RTOS_FORK §7 has the byte-exact trace and two untried candidates |
 | M6c sequencer under the scheduler | ⏳ judgment | the fidelity gate: M5's one-trig test lands the same byte at the same frame under route A (needs `out/_testproj` rebuilt) |
 | M6d key injection | ⏳ mechanical | PLAY and REC-arm through the firmware's own path, no RAM pokes |
 | M6e use it | ⏳ judgment | the recorder-arm trace for Bryan; the tick pre-emption question |
 
-Where to resume: `docs/RTOS_FORK.md` §5–§7 (M6b's open item and the
-diagnostics that found everything), `tools/emu_rtos.py --selftest`, then
-`make emu-rtos PROJECT=/Users/sambanks/octa/backups/PRESETS_20260905_pretag16/OCTABAM_RIG`
-(absolute path; a tilde inside the quoted make variable is not expanded).
-Two Unicorn facts to keep in view: reading SR through the API at a burst
-boundary corrupts the condition codes (the tool uses a `movew %sr,%d0`
-trampoline), and memory-write hooks fire on MMIO. What route A corrected:
-eleven tasks, not eight; `0x400009f4` is a lock, not a semaphore; a
-reschedule is a forced PIT0 interrupt.
+Where to resume: `docs/RTOS_FORK.md` §7 has the M6b race byte-exact (two
+untried candidates — watch whether INTC1 source 47 re-asserts during a
+load; read `0x40061f7c` onward past `0x40062090` for a self-repost) and
+every diagnostic that found it. Reproduce with
+`tools/emu_rtos.py --project <abs dir> --set OCTABAM --name RIG
+--load-project --ms 5000` (absolute path; a tilde inside the quoted make
+variable is not expanded), or `tools/emu_rtos.py --selftest` for the SR
+trap alone. Keep in view: reading SR through the API at a burst boundary
+corrupts the condition codes (the tool uses a `movew %sr,%d0` trampoline);
+memory-write hooks fire on MMIO; `call_as_main` (borrow main's idle slot)
+is unsafe for any call that can genuinely block — route it through a real
+task's own context instead (`request_card_mount`'s pattern). What route A
+corrected: eleven tasks, not eight; `0x400009f4` is a lock, not a
+semaphore; a reschedule is a forced PIT0 interrupt; the mount is `sys`'s
+job, not the engine's.
 
 **Bryan's stake.** His click sits on the recorder's loop point, reached by
 one task staging the REC-arm and the tick promoting it — the interleaving
 route A now does for real. It becomes usable for him at M6d (his project
-loaded under real tasks, PLAY/REC-arm injected as keys); M6b and M6d are
-the mechanical steps between. Already useful to him: the measured task and
-vector tables in RTOS_FORK §2, and the panel serial link captured byte by
-byte.
+loaded under real tasks, PLAY/REC-arm injected as keys); M6b's mount+load
+now works for real up to the point of the race above, and M6d is the
+mechanical step after it closes. Already useful to him today: the measured
+task and vector tables in RTOS_FORK §2, `sys`'s own dispatch table (§7),
+and the panel serial link captured byte by byte.
 
 Not pursued: a gearmulator-style full-machine port with plugin packaging.
 `dsp_host` already runs on that project's DSP core; the ColdFire half above

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -436,7 +436,7 @@ ordinary trig landing in RAM) but does not answer Bryan's literal question.
 needs no new instrumentation — just `--bpm 128` and a pattern length of 4
 vs 32 steps.
 
-## The RTOS fork — M6a done 6 Sep 2026 (`tools/emu_rtos.py`)
+## The RTOS fork — M6a done, M6b started 6 Sep 2026 (`tools/emu_rtos.py`)
 
 Milestones 2 and 4 took route **B** (detour) and it carries the remixer and
 the card: a menu- or cave-patch is visible and walkable without a flash, and
@@ -463,8 +463,26 @@ cascade in strict priority order, then tasks posting to each other. The
 scope's §2 is corrected in place; §3 records two Unicorn facts that cost the
 session (reading SR through the API at a burst boundary corrupts the
 condition codes — a trampoline `movew %sr,%d0` does not; memory-write hooks
-do fire on MMIO). What remains for M6b: nothing has asked the storage task
-for a mount yet, so the RIG load under route A is still to come.
+do fire on MMIO).
+
+**M6b (same day): the mount and the load, both real, plus one open race.**
+The engine's own LOAD PROJECT handler doesn't mount the card; that's a
+*different* task's job — `sys` (`0x46c7bed8`), which has its own 78-entry
+dispatch table nothing had decoded before. `Rtos.request_card_mount()`
+sends it the message that reaches `FW_CARD_INIT`; `Rtos.load_project_live()`
+then posts LOAD PROJECT exactly as route B builds it. Real ATA IDENTIFY and
+READ commands follow (6,189 commands / 30,467 sectors in one run, matching
+M4's cold proof — ~30,955 sectors — to within 1.5%), and the engine writes
+the project pointer to route B's own known-good value. A second real task
+then overwrites it back to empty ~568 samples later, and the load free-runs
+afterward without setting it again — traced byte-exact, not yet closed.
+`RTOS_FORK.md` §7 has the full trace, what's ruled out (not a settle-timing
+issue; tried and it didn't move the gap), and the two remaining candidates.
+Also found: `call_as_main` (borrow main's idle slot to call a plain OS
+subroutine) is unsafe for anything that can genuinely block — main is the
+kernel's only always-ready task, so blocking it starves the scheduler.
+`FW_CARD_INIT` proved this by crashing it; the fix routes blocking calls
+through a real task's own context instead (post it a message).
 
 ## Reproduce
 
@@ -473,6 +491,7 @@ make emu-setup                       # uv sync --extra emu -> .venv with unicorn
 make remix                           # then press e to boot the built image
 .venv/bin/python3 tools/emu_bringup.py [image]   # or the CLI directly
 make emu-rtos PROJECT=<project dir>  # route A: the scheduler running, M6a gate (RTOS_FORK.md §5)
+.venv/bin/python3 tools/emu_rtos.py --project <dir> --set OCTABAM --name RIG --load-project --ms 5000
 .venv/bin/python3 tools/emu_rtos.py --selftest   # the SR-read trap, pinned
 ```
 

--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -1,11 +1,16 @@
 # The RTOS fork (emulator route A) — scope
 
-Scoped 6 Sep 2026. Status: **M6a done (6 Sep 2026)** — `tools/emu_rtos.py`
-runs the firmware's own scheduler: the handoff trap dispatched by hand, PIT0
-ticking, eleven tasks created and each run once, tasks posting to each other
-through the kernel. §5 carries the measured result and what it corrected in
-§2 (the task table was wrong in five rows); M6b is next. `EMU.md` has the history of route B (detours) that
-this replaces for the paths that need real task interleaving.
+Scoped 6 Sep 2026. Status: **M6a done (6 Sep 2026)**, **M6b started the same
+day, one race open** — `tools/emu_rtos.py` runs the firmware's own
+scheduler: the handoff trap dispatched by hand, PIT0 ticking, eleven tasks
+created and each run once, tasks posting to each other through the kernel,
+and now a real card mount plus a real LOAD PROJECT reaching the firmware's
+own correct project pointer — which a second real task then clobbers a few
+hundred samples later. §5 carries both measured results and what M6a
+corrected in §2 (the task table was wrong in five rows); §7 has the M6b
+race, byte-exact, as the pick-up point. `EMU.md` has the history of route B
+(detours) that this replaces for the paths that need real task
+interleaving.
 
 Confidence markers as in `CHIP.md`: ✅ measured in the emulator or read
 byte-exact from the image, 🟡 inferred, ❓ open (with how to close it).
@@ -297,19 +302,26 @@ model can take the mechanical parts. Tagged accordingly.
   unchanged: `make verify` and the M4 card load reproduce their step-0
   captures with route A off (`emu_card.attach(..., cold_hooks=True)` is the
   default; `emu_bringup`/`emu_frames` untouched).
-- **M6b — waits become real.** *(mechanical once M6a exists)* Pulled
-  forward into M6a because the gate needed them: the PIT1 model (generic
-  `Pit`, wired to source 44) and **ATA completion through vector `0xb6`**
-  (`Rtos.attach_card`: INTRQ per sector, cleared by a status read, over
-  `emu_card`'s untouched card model); `emu_card.attach(cold_hooks=False)`
-  leaves the `0x40000818`/`0x40015786` hooks out. **Still open**: the mount
-  itself — under route A the storage task parks on its queue (`0x460bb3a8`)
-  and the card sees **zero commands** in 2 s; nothing has asked for a
-  mount. Find what posts it (card-detect on `0xfc0a4039`/`0xfc0a403a`? a
-  UI/sys request after start-up? `0x4001e594` on vector `0xaf`, installed
-  beside the storage create, is the first suspect). Exit gate unchanged:
-  the RIG project loads through the real storage and engine tasks, part
-  bytes identical to M4's proof.
+- **M6b — waits become real.** *(mechanical once M6a exists — mostly held;
+  §7 below has one judgment-shaped race in it)* PIT1 (source 44) and **ATA
+  completion through vector `0xb6`** (`Rtos.attach_card`) were pulled
+  forward into M6a because the gate needed them; `emu_card.attach(...,
+  cold_hooks=False)` leaves the `0x40000818`/`0x40015786` hooks out. The rest
+  landed 6 Sep 2026: `Rtos.request_card_mount` and `Rtos.load_project_live`
+  drive a real mount and a real LOAD PROJECT through the real `sys` and
+  `engine` tasks — no `engine_run_once`, no hand-run init list. Measured:
+  the mount alone reads real ATA IDENTIFY/READ commands and the project load
+  reaches **6,189 ATA commands / 30,467 sectors**, matching M4's cold proof
+  (~30,955 sectors) to within 1.5%, and the engine writes PART_PTR to
+  route B's own known-good value (`0x4017d520`, confirmed against a fresh
+  `emu_card.load_project()` run on the same image) from a real dispatch site
+  (`0x40087d44`). **Still open, found the same day**: `sys`'s card handler
+  (table[15], §2) resets PART_PTR back to its empty value ~568 samples
+  later, from `0x400622aa`, and the load then free-runs for the rest of the
+  budget (20 s tried) without ever setting it again — see §7 for the
+  byte-exact trace and what's ruled in/out. Exit gate unchanged: the RIG
+  project loads through the real tasks, part bytes identical to M4's proof,
+  and stays that way.
 - **M6c — the sequencer under the real scheduler.** *(judgment)* Frame IRQ
   on vector `0x41`, the forced tick through `INTFRCH`, transport started by
   the real UI path or by the M5 detour. Exit gate — **the fidelity check for
@@ -353,14 +365,109 @@ M6b and M6d one each on the cheaper model, M6e open.
   log-append path that once wiped an image (`EMU.md` M4) runs for real. Keep
   images disposable.
 
-## 7. Next step
+## 7. What requests the mount — found 6 Sep 2026, and the race it left open
 
-M6a is done (§5). Next is M6b's open item: find what requests the mount
-and let it happen under the real tasks, then the RIG load. Reproduce M6a:
+**The engine's own LOAD PROJECT handler (opcode 4, table at `0x40084870`,
+index 4 → `0x40085336`) does not mount the card.** It goes straight into
+file-loading calls (`0x4009000c`, `0x40090334`, …). The mount call
+(`0x40061648(1)`, what route B calls by hand) lives in a **different, larger
+dispatch** belonging to the **`sys` task itself** (`0x46c7bed8`,
+`0x40061a94`): its own queue receive at `0x40061cd8` (`0x40000d00` on
+`0x460d17ae`), a **78-entry** table at `0x40061cfa` (index = `msg[0]-1`,
+range-checked against 77 at `0x40061cea`), decoded in full 6 Sep 2026.
+`table[15] = 0x40061f7c` is the case that checks `0x460d1cb8` (card ready)
+and calls `FW_CARD_INIT` if it's clear — reached with `msg[0]=16`, and it
+also requires `msg[1]` nonzero (`tstb a2@(1)` at `0x40061f82`, else it
+returns having done nothing).
+
+**A card-detect hardware interrupt exists and was traced but is NOT this
+path.** Vector `0xaf` (INTC1 source 47, handler `0x4001e594`) is a real,
+correctly-configured interrupt (`icr[47]=4`, unmasked, confirmed live in the
+emulator) whose own state machine — traced instruction-by-instruction 6 Sep
+2026 — reads/acks a block at `0xfc0b0144`/`0xfc0b01ac`/`0xfc0b01bc` nobody
+had met (`0xfc0b01bc` is a start/busy register: write `0x00010001`, poll
+until bits 0/16 clear, then bits 1/17 of a re-read gate two further posts to
+the **storage** queue `0x460bb3a0` — modelled as a constant `0x00020002`
+reply, `MEDIA_KICK`/`MEDIA_KICK_VAL` in `emu_rtos.py`) — but in every traced
+firing it exits without ever reaching `sys`'s table[15] or posting anything
+that leads there (`0x460bb40c`/`0x460bb408`, the flags gating those two
+storage-queue posts, read zero every time; unproven whether that's because
+nothing preceded the interrupt with the right setup, or because this ISR
+handles a different condition than "mount an already-present card"). **Not
+resolved**: what real event sends `sys` message `[16, 1]`. Likely a UI
+action (this reads like "user opened the load-project screen" or similar),
+not a boot-time automatic. `Rtos.request_card_mount()` sends that message
+directly, bypassing whatever the real trigger is — legitimate for driving
+the mount (§ risk below), same as route B's `card_init()` already does by
+calling `FW_CARD_INIT` directly.
+
+**`call_as_main` is unsafe for anything that can genuinely block**, found by
+crashing it: main (priority 0) is the kernel's only always-ready task (§4,
+idle) — the block path's downward scan has nothing to fall back to if main
+itself goes non-ready. Borrowing main's context to call `FW_CARD_INIT`
+directly (mirroring route B) produced exactly that: main blocked on a real
+ATA wait, nothing else was ready either, and the scheduler dispatched a
+garbage TCB (`rte ... would return to user mode`, current-TCB pointer
+pointing at `TOP_PRIO`, not a task). **Fix, and the actual mount path**:
+`Rtos.request_card_mount()` posts `sys` a message instead (`post_message`,
+the kernel's `0x40000c3c` primitive, provably non-blocking — a post/signal
+can never itself wait) and lets `sys`'s own real task context do the
+blocking. `FW_SET_PROJECT_EXISTS` has the identical hazard *conditionally*:
+harmless (near-instant, no card touched) when no card is mounted, but once
+one is, it does real FAT lookups (`0x40025230`) and blocks — found the same
+way, same fix (drop it; it's a route B diagnostic never used to gate the
+load, `load_project_live` doesn't call it).
+
+**With the mount driven this way, real ATA activity follows immediately**:
+`IDENTIFY`/`READ` commands, PIT1 firing (the storage delay timer), and
+`0x460d1cb8` going ready. Posting `FW_POST_LOAD_PROJECT` (opcode 4, exactly
+as route B builds it) afterward drives the engine into genuine file reads —
+**6,189 commands, 30,467 sectors** in one run, matching M4's cold proof
+(~30,955 sectors, all sixteen banks) to within 1.5%. The engine writes
+`PART_PTR` (`0x46c82456`) to `0x4017d520` from `0x40087d44` — independently
+confirmed as the *correct* value by running route B's own
+`emu_card.load_project()` against the same card image cold.
+
+**The open race**: `sys`'s handler writes `PART_PTR` back to `0x400e21e0`
+(the empty/no-project sentinel — also legitimate, the engine itself writes
+this value earlier from `0x40025aa2` as part of clearing prior state, so
+it's a real firmware constant, not garbage) from `0x400622aa`, **~568
+samples (~13 ms) after** the engine's correct write — reproduced twice,
+sample deltas 13838→14405 and 146029→146597, the SAME ~568-sample gap at
+two completely different absolute times. After the clobber, the load
+free-runs: card activity continues (the 30,467 sectors above is the total
+through a 20-second run, not just the first pass) but `PART_PTR` is never
+written again — `watch_mem` on it over the full 20 s shows exactly the four
+writes above and nothing more, so whatever runs afterward is re-reading
+without ever completing to the same finish line. **Waiting for `sys` to
+return to blocking on its own queue before posting LOAD PROJECT does not
+close the gap** (tried; the clobber still lands ~568 samples after the
+engine's write, unchanged) — `sys` re-enters its handler again regardless of
+how long the wait was, which is what points at the LOAD itself (or the
+consequence of mounting) as the re-trigger, not sluggish start-up. Two
+candidates for the actual cause, neither checked yet:
+- `request_card_mount`'s hand-built message (`msg=[16,1]`) may not be the
+  exact encoding real hardware sends — `msg[1]`'s meaning beyond "nonzero"
+  is unread, and a wrong value could make `sys` treat this as an ongoing
+  poll rather than a one-shot mount, re-queuing itself.
+- The card-detect interrupt (vector `0xaf`) may be genuinely
+  level-triggered and re-assert from something the LOAD touches (an ATA
+  register the file reads pass through that our `MEDIA_KICK`/status-block
+  model doesn't clear the way real hardware would) — worth an INTC1-source-47
+  watch (`rt.intc1.pending()` each step, or `--watch-pc 0x4001e594`) across
+  a load to see if it fires again *during* the read burst, not just once at
+  the start.
+
+**Next step**: instrument INTC1 source 47 across a full `load_project_live`
+run (does it re-assert?) before touching `sys`'s message contents further;
+if it doesn't re-assert, read `0x40061f7c` onward past where the 6 Sep trace
+stopped (`0x40062090`) for a self-re-post (`jsr 0x40000c3c` targeting
+`SYS_QUEUE` again) inside table[15]'s own handler. Reproduce everything in
+this section:
 
 ```sh
-make emu-rtos PROJECT=~/octa/backups/PRESETS_20260905_pretag16/OCTABAM_RIG
-.venv/bin/python3 tools/emu_rtos.py --project <dir> --set OCTABAM --name RIG --ms 400 --until-gate
+make emu-rtos PROJECT=/absolute/path/to/OCTABAM_RIG
+.venv/bin/python3 tools/emu_rtos.py --project <dir> --set OCTABAM --name RIG --load-project --ms 5000
 .venv/bin/python3 tools/emu_rtos.py --selftest      # the SR-read trap, pinned
 ```
 
@@ -368,5 +475,7 @@ Diagnostics that found everything above and stay in the tool: `--trace`
 (every trap, dispatch, irq, create), `--starvation` (burst-end PCs per
 task), `--watch-calls A,B` (entries with caller and first argument),
 `--watch-mem ADDR,LEN` (every write, with task and PC), `--watch-pc A`
-(registers at an instruction). `emu_bringup` and `emu_frames` are untouched;
-`emu_card` gained the one flag.
+(registers at an instruction), and in Python directly: `Rtos.last_block`
+(O(1), tcb → its most recent block) and `Rtos.blocks` (the full log).
+`emu_bringup` and `emu_frames` are untouched; `emu_card` gained the one
+flag.

--- a/tools/emu_rtos.py
+++ b/tools/emu_rtos.py
@@ -64,6 +64,11 @@ HANDOFF = 0x40000e46               # the boot's trap #0
 LOCK_TRAP = 0x40000a78             # the lock primitive's (0x400009f4) block trap
 SR_TRAMP = 0x47ef0800              # `movew %sr,%d0; nop` -- see Rtos._sr (emu_bringup's
                                    # EMAC trampoline lives at 0x47ef0000..0x47ef01ff)
+KERNEL_POST = 0x40000c3c           # post(queue, msg) -- non-blocking, see Rtos.post_message
+SYS_TCB = 0x46c7bed8
+SYS_QUEUE = 0x460d17ae             # the sys task's own command queue
+SYS_MSG_SCRATCH = 0x46c00000       # scratch for a hand-built message -- see request_card_mount;
+                                   # inside the boot's 0x46000000+32MB map, far from any named global
 
 # The tasks, as MEASURED under the real scheduler on 6 Sep 2026 (the create
 # hook below): (tcb, entry, prio, stack, size, creator). Main is created by
@@ -312,6 +317,25 @@ class Dspi:
             self.regs[off] = val
 
 
+MEDIA_KICK = 0xfc0b01bc
+MEDIA_KICK_VAL = 0x00020002
+# The card-detect interrupt handler (0x4001e594, vector 0xaf source 47) kicks
+# whatever sits at 0xfc0b01bc (writes 0x00010001, later 0x00010000 swapped)
+# and spins reading it back until bits 0/16 (the ones the busy mask 0x10001
+# tests) clear -- a start/busy register for a block nothing else in this
+# trace touches (not the ATA task-file window; a card-presence debounce or a
+# small DMA channel, address range unidentified further, 6 Sep 2026). Once
+# clear, the SAME handler re-reads the register and tests bits 1/17
+# separately, gating the two posts to the storage queue (0x4001e844,
+# 0x4001e8fc) that a fully all-ones or fully-zero reply both defeat: all-ones
+# never clears the busy bits (infinite spin, found first); all-zero clears
+# them but also clears 1/17, so neither post fires and the "card present"
+# outcome we know is correct (a card genuinely is attached) never triggers.
+# Modelled as a constant reply with 0/16 clear (instant completion) and 1/17
+# set (the detect IS relevant) -- inferred from what the two readings must
+# mean for the branch we know should be taken, not from a spec for the block.
+
+
 class RtosFault(Exception):
     pass
 
@@ -333,7 +357,8 @@ class Rtos:
         self.pc = None
         self.trap = r.trap                   # the boot's (32, HANDOFF)
         self.created = []                    # (sample, tcb, entry, prio, stack, size, creator)
-        self.blocks = []                     # (sample, tcb, trap pc, caller, object)
+        self.blocks = []                     # (sample, tcb, trap pc, caller, object, owner)
+        self.last_block = {}                  # tcb -> the same tuple, O(1) lookup
         self.dispatches = []                 # (sample, tcb, pc) at every scheduler rte
         self.switches = 0
         self.forces = 0
@@ -344,6 +369,7 @@ class Rtos:
         self.unmapped = None
         self._sr_cache = None
         self._force_stop = False
+        self.card = None                     # set by attach_card
         # peripheral models
         self.pit0, self.pit1 = Pit("PIT0", pit_clock_hz), Pit("PIT1", pit_clock_hz)
         self.uart64, self.uart68 = Uart("UART@fc064000", 0xfc064000), Uart("UART@fc068000", 0xfc068000)
@@ -525,6 +551,8 @@ class Rtos:
                 return u.read(a - u.base, size)
         if DSPI <= a < DSPI + 0x100:
             return self.dspi.read(a - DSPI, size)
+        if a == MEDIA_KICK:
+            return MEDIA_KICK_VAL
         v = PLL_VAL if a == PLL_REG else eb.EXTRA_OVERRIDES.get(a, (1 << (size * 8)) - 1)
         if callable(v):
             v = v(self.uc, a, size)
@@ -620,7 +648,9 @@ class Rtos:
             else:
                 caller, obj = struct.unpack(">II", self.uc.mem_read(sp, 8))
                 owner = None
-            self.blocks.append((self.sample, frm, pc, caller, obj, owner))
+            entry = (self.sample, frm, pc, caller, obj, owner)
+            self.blocks.append(entry)
+            self.last_block[frm] = entry
             self._push(32, pc + 2, (self._sr() | 0x2000) & ~0x8000)
             if self.first_switch is None:
                 self.first_switch = [frm, None]
@@ -726,6 +756,112 @@ class Rtos:
             if max_bursts is not None and n >= max_bursts:
                 self.stop_reason = "bursts"; return self.stop_reason
             self.step(); n += 1
+
+    def call_as_main(self, addr, args=(), budget=4_000_000):
+        """Borrow main's idle slot to call an OS subroutine the way a UI
+        action would call it -- not a cold detour: the normal trap-dispatch
+        loop stays live underneath, so any REAL waits inside the call run
+        correctly against every other task and interrupt. Requires
+        `self.pc == MAIN_SPIN` (run with `until=lambda r: r.pc == MAIN_SPIN`
+        first). Convention matches the sites calling FW_POST_LOAD_PROJECT
+        (`pea a1; pea a0; jsr addr`): retaddr at [sp], args at [sp+4],
+        [sp+8], ... in the order given. Returns D0 once the call `rts`s back
+        to the spin.
+
+        ONLY for a call that CANNOT genuinely block (post/signal, or a query
+        confirmed instant). Main is priority 0 and never legitimately blocks
+        on hardware -- Fact 1, RTOS_FORK.md -- so it is the kernel's de facto
+        idle backstop: main being non-ready is a state the block path never
+        expects. Borrowing main to call FW_CARD_INIT (which waits on a real
+        timer) proved this the hard way (6 Sep 2026): main blocked, nothing
+        else was ready either, and the scheduler dispatched a garbage TCB
+        (`rte ... would return to user mode`). A call that can block belongs
+        to a real task instead -- post it a message and let it run for real
+        (see `request_card_mount`)."""
+        if self.pc != MAIN_SPIN:
+            raise RtosFault(f"call_as_main({addr:#x}): pc is {self.pc:#x}, not the main spin")
+        uc = self.uc
+        sp = uc.reg_read(eb.UC_M68K_REG_A7) - 4 * (1 + len(args))
+        uc.mem_write(sp, struct.pack(f">{1 + len(args)}I", MAIN_SPIN, *args))
+        uc.reg_write(eb.UC_M68K_REG_A7, sp)
+        self.pc = addr
+        n = 0
+        while self.pc != MAIN_SPIN:
+            self.step()
+            n += 1
+            if n > budget:
+                raise RtosFault(f"call_as_main({addr:#x}) did not return in {budget} steps")
+        return uc.reg_read(eb.UC_M68K_REG_D0)
+
+    def post_message(self, queue, msg):
+        """`0x40000c3c(queue, msg)` -- the kernel post primitive, guaranteed
+        non-blocking (a post/signal can never itself wait), so safe through
+        `call_as_main` regardless of what the woken task goes on to do."""
+        return self.call_as_main(KERNEL_POST, args=(queue, msg))
+
+    def request_card_mount(self):
+        """Post to the SYS task's own queue (0x460d17ae) the message its
+        dispatch table (decoded 6 Sep 2026: table at 0x40061cfa, 78 entries,
+        index = msg[0]-1) sends to table[15] = 0x40061f7c -- the case that
+        checks `0x460d1cb8` (card ready) and, if clear, calls FW_CARD_INIT
+        for real from SYS's own task context (priority 1, safe to block).
+        msg[0]=16 selects that case; msg[1] nonzero is required to reach it
+        (`tstb a2@(1)`, else the handler returns having done nothing)."""
+        self.uc.mem_write(SYS_MSG_SCRATCH, bytes([16, 1]))
+        return self.post_message(SYS_QUEUE, SYS_MSG_SCRATCH)
+
+    def load_project_live(self, set_name, project_name, run_ms=3000, mount_ms=3000):
+        """M6b: drive a project load the way hardware would, then let the
+        REAL sys, engine and storage tasks do the rest -- no engine_run_once
+        stand-in, no hand-run init list. Two real actions, neither of which
+        anything at boot does on its own (both are normally UI/button
+        triggers): ask SYS to mount the card (`request_card_mount`, which
+        blocks SYS on real ATA commands completed through vector 0xb6, not
+        main -- see `call_as_main`'s docstring for why that distinction
+        matters), then post LOAD PROJECT (opcode 4) to the engine's queue
+        exactly as `FW_POST_LOAD_PROJECT` does. Returns (mounted, posted,
+        changed, part_ptr, elapsed_ms); `changed` compares part_ptr against
+        its PRE-load value, not against zero -- the project pointer's rest
+        value is a stale nonzero code address, not null. `changed` becoming
+        true is evidence a load started, not proof it finished: a full load
+        reads all sixteen banks (M4's cold proof: ~30,955 sectors) and this
+        runs only `run_ms` of it.
+
+        Deliberately does NOT call `FW_SET_PROJECT_EXISTS`: with no card
+        mounted it returns near-instantly (a genuine short-circuit, which is
+        why it looked call_as_main-safe at first), but once a card IS
+        present it does real FAT lookups (`0x40025230`) and blocks -- the
+        same main-blocks-and-nothing-else-is-ready crash `FW_CARD_INIT` hit,
+        found the same way (6 Sep 2026). It is a pure diagnostic in route B
+        (its result is never used to gate the load); dropping it costs
+        nothing here."""
+        self.run(until=lambda r: r.pc == MAIN_SPIN)
+        before = int.from_bytes(self.uc.mem_read(ec.PART_PTR, 4), "big")
+        mount_req = self.sample
+        self.request_card_mount()
+        self.run(ms=mount_ms, until=lambda r: int.from_bytes(
+            r.uc.mem_read(0x460d1cb8, 4), "big") != 0)
+        mounted = int.from_bytes(self.uc.mem_read(0x460d1cb8, 4), "big")
+        # SYS's opcode-15 handler does not finish the instant 0x460d1cb8
+        # goes ready: it runs on for a while afterward and, once, was seen
+        # writing PART_PTR back to its empty-sentinel value on its way out
+        # (0x400622aa, ~1500 samples after ready) -- clobbering a load
+        # started in that window. Wait for SYS to return to blocking on its
+        # OWN queue (its handler provably finished) before posting the load.
+        self.run(ms=mount_ms, until=lambda r: (
+            b := r.last_block.get(SYS_TCB)) and b[0] > mount_req and b[4] == SYS_QUEUE)
+        self.run(until=lambda r: r.pc == MAIN_SPIN)
+        ec.set_names(self, set_name, project_name)
+        posted = self.call_as_main(ec.FW_POST_LOAD_PROJECT, args=(ec.FW_PROJECT_NAME,))
+        start = self.sample
+        # No early stop on "part_ptr changed": that fires on the FIRST write
+        # (project.work alone), while a full load reads all sixteen banks --
+        # M4's cold proof took ~30,955 sectors. Run the whole budget and
+        # report what actually accumulated; this is proof the mount+post
+        # mechanism works for real, not yet a parity check against M4.
+        self.run(ms=run_ms)
+        part = int.from_bytes(self.uc.mem_read(ec.PART_PTR, 4), "big")
+        return mounted, posted, part != before, part, (self.sample - start) / SAMPLE_HZ * 1000.0
 
     # -- the M6a gate --------------------------------------------------------
     def ran(self):
@@ -913,11 +1049,14 @@ def _cli():
     ap.add_argument("--watch-calls", default="", help="comma-separated addresses to log entries to")
     ap.add_argument("--watch-mem", default="", help="ADDR,LEN: log every write into that range")
     ap.add_argument("--watch-pc", default="", help="comma-separated addresses: log registers there")
+    ap.add_argument("--load-project", action="store_true",
+                    help="M6b: after the gate, drive a project load through the real tasks (needs --project)")
     a = ap.parse_args()
 
     card = None
+    staged_name = a.name
     if a.project:
-        card, _ = stage_project(a.project, a.set, a.name)
+        card, staged_name = stage_project(a.project, a.set, a.name)
     t0 = time.perf_counter()
     r, rt = attach(a.image, card, ips=a.ips, pit_clock_hz=a.pit_clock, quantum=a.quantum,
                    step_quantum=a.step_quantum, tick=not a.no_tick,
@@ -932,14 +1071,44 @@ def _cli():
     print(f"boot       : {r.stopped} ({time.perf_counter() - t0:.1f} s)")
     print(f"PIT0       : period {rt.pit0.period_samples():.2f} samples "
           f"({rt.pit0.period_samples() / SAMPLE_HZ * 1000:.3f} ms) at pit clock {a.pit_clock:.0f} Hz")
-    until = (lambda x: x.gate_m6a()[0]) if a.until_gate else None
-    try:
-        why = rt.run(ms=a.ms, until=until)
-    except (RtosFault, eb.UcError) as e:
+
+    def _fault(e):
         why = f"FAULT {e} pc={rt.pc:#x} task={rt._name(rt._cur())}"
         if rt.unmapped:
             acc, addr, size, pc = rt.unmapped
             why += f" unmapped {'write' if acc in (eb.UC_MEM_WRITE_UNMAPPED,) else 'read'} {addr:#x} size {size} at pc {pc:#x}"
+        return why
+
+    if a.load_project:
+        if not a.project:
+            print("--load-project needs --project"); return 1
+        try:
+            if not rt.gate_m6a()[0]:
+                rt.run(ms=1000, until=lambda x: x.gate_m6a()[0])
+            mounted, posted, changed, part, elapsed = rt.load_project_live(
+                a.set, staged_name, run_ms=a.ms)
+        except (RtosFault, eb.UcError) as e:
+            print(f"stopped    : {_fault(e)}")
+            print(rt.report())
+            print(rt.starvation())
+            return 1
+        print(rt.report())
+        print(f"mount      : ready={mounted} posted={posted} part_changed={changed} "
+              f"part={part:#x} ({elapsed:.1f} ms emulated after posting)")
+        if rt.card:
+            print(f"card       : {len(rt.card.log)} commands, {rt.card.reads} sectors read, "
+                  f"{rt.card.writes} written; last: {rt.card.log[-8:]}")
+        ok = bool(mounted)
+        if not ok:
+            print(rt.starvation())
+        print("M6b mount  :", "PASS" if ok else "FAIL")
+        return 0 if ok else 1
+
+    until = (lambda x: x.gate_m6a()[0]) if a.until_gate else None
+    try:
+        why = rt.run(ms=a.ms, until=until)
+    except (RtosFault, eb.UcError) as e:
+        why = _fault(e)
     print(f"stopped    : {why}")
     print(rt.report())
     ok, problems = rt.gate_m6a()


### PR DESCRIPTION
## Summary
- **Found what M6a's scope left open**: mounting the card is the **SYS task's** job (`0x46c7bed8`), not the engine's. Decoded SYS's own 78-entry dispatch table in full — `table[15] = 0x40061f7c` is the case that calls `FW_CARD_INIT`.
- `Rtos.request_card_mount()` posts SYS the message that reaches the mount; `Rtos.load_project_live()` then posts LOAD PROJECT exactly as route B builds it, and lets the real engine/storage/sys tasks do the rest — no `engine_run_once` stand-in, no hand-run init list.
- **Measured**: 6,189 real ATA commands / 30,467 sectors in one run, matching M4's cold proof (~30,955 sectors) to within 1.5%; the engine writes the project pointer to route B's own independently-confirmed known-good value, from a real dispatch site.
- **Found along the way**: `Rtos.call_as_main` (borrow main's idle slot to call a plain OS subroutine) is unsafe for anything that can genuinely block — main is the kernel's only always-ready task, so blocking it starves the scheduler. Crashed it trying to call `FW_CARD_INIT` directly (mirroring what route B does safely, cold). Fixed by routing blocking calls through a real task's own context instead. `FW_SET_PROJECT_EXISTS` has the same hazard once a card is mounted and is dropped from the critical path (a route B diagnostic, never load-bearing there either).
- **One race still open**, traced byte-exact: ~568 samples (~13 ms) after the engine writes the correct project pointer, SYS's own handler writes it back to the empty sentinel, and the load free-runs afterward without setting it again. Waiting longer before posting the load doesn't move the gap — `docs/RTOS_FORK.md` §7 has the full trace and two untried candidates (does INTC1 source 47 re-assert during the load? does table[15]'s handler self-repost past where the 6 Sep trace stopped?).

## Verification
- `tools/emu_rtos.py --project <abs dir> --set OCTABAM --name RIG --load-project --ms 5000` → real mount, real ATA activity, `M6b mount: PASS`.
- `tools/emu_rtos.py --selftest` → PASS (unchanged).
- M6a gate (`--until-gate`) still passes at 205 ms after these changes.
- `make verify` and `tools/emu_card.py` (route B, cold) before/after: only a build-cache line and a wall-clock timing string differ — `emu_bringup`/`emu_frames` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)