### PR TITLE
Emulator M6b: retract the "track-select watcher" — the bytes are the bank

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -703,37 +703,39 @@ scheduler.
 | M4 card + loaded project | ✅ shipped (route B) | `make emu-card PROJECT=<abs dir>`: the RIG project loads through the real storage stack, one wait hook |
 | M5 frames + ticks, cold | ✅ done, one gap | a step trig fires end to end; the recorder-arm path ("path B") needs real task interleaving |
 | **M6a scheduler runs** | ✅ **done 6 Sep, PR #100** | `make emu-rtos PROJECT=<abs dir>`: eleven tasks start in the real order, the 5 ms tick and every interrupt fire, tasks post to each other; gate passes at 205 ms emulated |
-| M6b real waits + mount | ✅ **done 6 Sep** | `sys` (not engine) mounts the card; a real mount + LOAD PROJECT reach 30,467 real sectors (M4: ~30,955) and the correct project pointer, for real. One loose end root-caused and handed to M6d: a live UI-screen mechanism (only active because the UI isn't driven yet) independently keeps forcing track 0 current, reverting the pointer — not a mount/load defect, RTOS_FORK §7 has the trace |
+| M6b real waits + mount | ✅ **done 6 Sep** (one retraction) | `sys` (not engine) mounts the card; a real mount + LOAD PROJECT reach 30,467 real sectors (M4: ~30,955) and the file's saved bank. PR #103's "track-select watcher" reading is WITHDRAWN: the bytes are the current bank; the run ends on bank A because the engine's own reset-time "select bank 0" reaches `sys` after the `BANK=1` parse — a real cross-task ordering with a one-press hardware falsifier (RTOS_FORK §7) |
 | M6c sequencer under the scheduler | 🟡 **in progress, branch `rtos-m6c`** | the fidelity gate: M5's one-trig test lands the same byte at the same frame under route A (needs `out/_testproj` rebuilt) |
-| M6d key injection | ⏳ mechanical | PLAY and REC-arm through the firmware's own path, no RAM pokes; also inherits the track-select contest below |
+| M6d key injection | ⏳ mechanical | PLAY and REC-arm through the firmware's own path, no RAM pokes |
 | M6e use it | ⏳ judgment | the recorder-arm trace for Bryan; the tick pre-emption question |
 
 Where to resume: **M6c** — `out/_testproj` needs rebuilding (gone from the
-main checkout), then M5's one-trig fidelity gate. `docs/RTOS_FORK.md` §7 has
-M6b's track-select finding byte-exact if M6d needs it first: a generic
-"select track" routine (`0x40062288`) reacts to the current track changing
-away from 0 and reverts it (and the project pointer with it) within a few
-thousand samples, every time — a live UI-screen behaviour, root-caused, not
-a bug in the mount or the load. Reproduce with `tools/emu_rtos.py --project
-<abs dir> --set OCTABAM --name RIG --load-project --ms 6000` (absolute
-path; a tilde inside the quoted make variable is not expanded), or
-`tools/emu_rtos.py --selftest` for the SR trap alone. Keep in view: reading
-SR through the API at a burst boundary corrupts the condition codes (the
-tool uses a `movew %sr,%d0` trampoline); memory-write hooks fire on MMIO;
-`call_as_main` (borrow main's idle slot) is unsafe for any call that can
-genuinely block — route it through a real task's own context instead
-(`request_card_mount`'s pattern). What route A corrected: eleven tasks, not
-eight; `0x400009f4` is a lock, not a semaphore; a reschedule is a forced
-PIT0 interrupt; the mount is `sys`'s job, not the engine's.
+main checkout; `tools/ot_project.py testproj <src> <dest> <remix>`), then
+M5's one-trig fidelity gate. One hardware question is queued for whenever
+the unit is next on: **load the RIG project and read the bank indicator**
+— the emulator comes up on bank A because the engine's own reset-time
+"select bank 0" reaches `sys` after the file's `BANK=1` is parsed; if the
+unit comes up on B, the emulator's ordering is unfaithful there (RTOS_FORK
+§7). Reproduce with `tools/emu_rtos.py --project <abs dir> --set OCTABAM
+--name RIG --load-project --ms 6000` (absolute path; a tilde inside the
+quoted make variable is not expanded), or `tools/emu_rtos.py --selftest`
+for the SR trap alone. Keep in view: reading SR through the API at a burst
+boundary corrupts the condition codes (the tool uses a `movew %sr,%d0`
+trampoline) and never run the trampoline from inside a hook; memory-write
+hooks fire on MMIO; `call_as_main` (borrow main's idle slot) is unsafe for
+any call that can genuinely block — route it through a real task's own
+context instead (`request_card_mount`'s pattern). What route A corrected:
+eleven tasks, not eight; `0x400009f4` is a lock, not a semaphore; a
+reschedule is a forced PIT0 interrupt; the mount is `sys`'s job, not the
+engine's; `0x80000002` is the current bank and `PART_PTR` its blob.
 
 **Bryan's stake.** His click sits on the recorder's loop point, reached by
 one task staging the REC-arm and the tick promoting it — the interleaving
 route A now does for real. M6b's mount+load now work for real, matching M4's
 proof; it becomes usable for him at M6d (his project loaded under real
-tasks, PLAY/REC-arm injected as keys, and the same UI-driving work that
-closes the track-select contest above). Already useful to him today: the
+tasks, PLAY/REC-arm injected as keys). Already useful to him today: the
 measured task and vector tables in RTOS_FORK §2, `sys`'s own dispatch table
-(§7), and the panel serial link captured byte by byte.
+(§7), the bank/pattern state bytes and the bank blob layout, and the panel
+serial link captured byte by byte.
 
 Not pursued: a gearmulator-style full-machine port with plugin packaging.
 `dsp_host` already runs on that project's DSP core; the ColdFire half above

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -472,18 +472,18 @@ nothing had decoded before. `Rtos.request_card_mount()` sends it the
 message that reaches `FW_CARD_INIT`; `Rtos.load_project_live()` then posts
 LOAD PROJECT exactly as route B builds it. Real ATA IDENTIFY and READ
 commands follow (6,189 commands / 30,467 sectors in one run, matching M4's
-cold proof — ~30,955 sectors — to within 1.5%), and the engine writes the
-project pointer to route B's own known-good value. A **separate, generic
-"select track" routine independently insists track 0 is current** and
-reverts both the current-track byte and the project pointer within a few
-thousand samples of the engine setting track 1 — reactive to the track
-change itself (confirmed with a register-state watch at the write site),
-not a timer and not something reposting the load can outrun. It's a live
-UI-screen behaviour, firing only because the emulator doesn't yet drive the
-UI to the screen a real load flow would be on — root-caused and hard-owned
-by **M6d**, not a defect in the mount or the load. `RTOS_FORK.md` §7 has
-the full trace; `load_project_live` reports `loaded=True` the instant the
-pointer is ever seen correct, independent of what happens to it after.
+cold proof — ~30,955 sectors — to within 1.5%), and the engine parses the
+project file's `BANK=1` and switches to bank B, the saved bank. **Then a
+retraction** (`RTOS_FORK.md` §7): two readings shipped the same day called
+that pointer "empty" vs "correct" and blamed a "track-select watcher"; the
+bytes are the current *bank* and the two values are bank A and bank B. The
+run ends on bank A because the LOAD PROJECT handler's own first step is a
+reset that posts "select bank 0" to `sys`, and `sys` — busy with p2c
+traffic ahead of it in its FIFO — applies it ~870 samples later, after the
+engine has parsed `BANK=1`. A real cross-task ordering, measured, with a
+one-press hardware falsifier (does the unit come up on the saved bank?).
+`load_project_live` reports the bank the engine parsed beside the bank
+the run ended on.
 Also found: `call_as_main` (borrow main's idle slot to call a plain OS
 subroutine) is unsafe for anything that can genuinely block — main is the
 kernel's only always-ready task, so blocking it starves the scheduler.

--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -5,11 +5,12 @@ Scoped 6 Sep 2026. Status: **M6a done, M6b done (6 Sep 2026)** —
 dispatched by hand, PIT0 ticking, eleven tasks created and each run once,
 tasks posting to each other through the kernel, and now a real card mount
 plus a real LOAD PROJECT reaching the firmware's own correct project
-pointer for real, matching the cold proof's read count. One loose end was
-root-caused and handed to **M6d**: a UI-screen mechanism (live only because
-the emulator doesn't yet drive the UI) insists on track 0 and reverts the
-just-loaded pointer — not a defect in the mount or the load, §7 has the
-byte-exact trace. §5 carries both measured results and what M6a corrected
+pointer for real, matching the cold proof's read count. §7 carries a
+**retraction**: PR #103's "track-select watcher" reading of the load's end
+state was wrong — the bytes are the current *bank*, the run ends on bank A
+because the engine's own reset-time "select bank 0" is applied by `sys`
+after the file's `BANK=1` was parsed, and whether hardware orders it the
+same way is the open question, with a one-press falsifier. §5 carries both measured results and what M6a corrected
 in §2 (the task table was wrong in five rows). `EMU.md` has the history of
 route B (detours) that this replaces for the paths that need real task
 interleaving.
@@ -317,18 +318,18 @@ model can take the mechanical parts. Tagged accordingly.
   (~30,955 sectors) to within 1.5%, and the engine writes PART_PTR to
   route B's own known-good value (`0x4017d520`, confirmed against a fresh
   `emu_card.load_project()` run on the same image) from a real dispatch site
-  (`0x40087d44`). **Root-caused, same day**: a separate, generic
-  "select track" routine (`0x40062288`) independently insists track 0 is
-  current and reverts both the current-track byte and PART_PTR ~500-3,000
-  samples after the engine sets track 1 — reactive to the track change, not
-  a one-shot or a timer, so reposting the load never outruns it (tried).
-  This is a live UI-screen behaviour firing only because the emulator never
-  puts the UI on the screen a real load flow would have it on — **M6d's
-  territory, not a defect in the mount or the load.** §7 has the full trace.
-  Exit gate: `load_project_live` returns `loaded=True` the instant PART_PTR
-  is ever seen correct during the run (a permanent watch, independent of
-  what a live screen does to it afterward) — the honest claim this milestone
-  can make, and the one M6d inherits.
+  (`0x40087d44`). **Then misread, then corrected (§7 retraction)**: the
+  engine's final state is bank B because the project file says `BANK=1`
+  (`0x80000002` is the current BANK, not the track; `0x400e21e0` and
+  `0x4017d520` are bank A's and bank B's blobs, not "empty" and "correct").
+  Under route A the LOAD PROJECT handler's own first step — a reset to
+  bank A that posts "select bank 0" to `sys` — is consumed by `sys` after
+  the engine has already parsed `BANK=1`, so the run ends on bank A. Real
+  cross-task ordering, not a load failure; whether hardware orders it the
+  same way is an open question with a one-press hardware falsifier (§7).
+  Exit gate: `load_project_live` reports the bank the engine parsed from
+  the file (the load reached its finish line) beside the bank the run
+  ended on.
 - **M6c — the sequencer under the real scheduler.** *(judgment)* Frame IRQ
   on vector `0x41`, the forced tick through `INTFRCH`, transport started by
   the real UI path or by the M5 detour. Exit gate — **the fidelity check for
@@ -341,10 +342,9 @@ model can take the mechanical parts. Tagged accordingly.
   (the post primitive against whichever queue `0x4005593c` blocks on — to be
   read in M6c) so PLAY and the REC-arm action run the firmware's own path.
   This is what makes Bryan's recorder test reachable without RAM pokes
-  (`EMU.md` M5, "path B"). **Also inherits M6b's track-select contest** (§7):
-  find what calls the "select track 0" routine from `0x400d64b9` and put the
-  UI on whatever screen makes it stop, so a loaded project's track stays
-  current.
+  (`EMU.md` M5, "path B"). (PR #103's hand-off of a "track-select contest"
+  to this milestone is withdrawn — §7 retraction; there is no UI mechanism
+  in it.)
 - **M6e — use it.** *(judgment)* The recorder-arm trace for Bryan; the tick
   pre-emption question; whatever the kit/parts work needs.
 
@@ -438,62 +438,90 @@ as route B builds it) afterward drives the engine into genuine file reads —
 confirmed as the *correct* value by running route B's own
 `emu_card.load_project()` against the same card image cold.
 
-**The race, root-caused (not the earlier vaguer "SYS clobbers it").** Two
-independent, real mechanisms both write the current-track byte (`0x80000002`)
-and `PART_PTR` together, and they disagree:
-- The **engine**, finishing LOAD PROJECT, sets track **1** current
-  (`0x40087d26`), immediately before its own correct `PART_PTR` write
-  (`0x40087d44`).
-- A separate, generic **"select track N" routine** (`0x40062288`) computes
-  `PART_PTR := 0x400e21e0 + N·635712` — a per-track **factory-default table
-  baked into the image**, unrelated to any loaded project — and is invoked
-  **repeatedly across the whole run**, always with `N=0`, always called with
-  the *same fixed argument pointer* (`0x400d64b9`, static data — not our
-  message, not `sys`'s queue message at all: `a2` at entry is constant
-  across every firing, so this is reached via a completely different call
-  path than the `table[15]` dispatch that mounts the card). It reacts within
-  ~500–3,000 samples of the current track **actually changing away from
-  0** (confirmed with a register-state watch at `0x40062288`/`0x400622aa`:
-  `d2=0` and the write target both track it exactly), then goes quiet until
-  the next change — a live watcher, not a one-shot step. `sys` also writes
-  `0x80000002 := 0` in the same handler (`0x400622b8`), confirmed by
-  watching that byte directly: engine sets it to `1` at sample 13838, `sys`
-  sets it back to `0` at 14406.
+**Retraction (6 Sep 2026, correction pass on Fable): the "track-select
+watcher" story that shipped in PR #103 was wrong, and so was PR #102's
+"empty sentinel".** What was measured then (the addresses, the timings, the
+fact that reposting the load never wins) stands; what it *meant* was
+misread by trusting the cold path's frozen value as ground truth and by
+not cross-checking a constant this repo had already named. The corrected
+reading, every step of it re-measured:
 
-**So whichever fires second wins, and reposting LOAD PROJECT does not
-help** — tried directly (three attempts, `run_ms=6000` apart): every repost
-sets track 1 again, and the watcher notices and corrects it back to 0 again,
-on the same short delay, every single time (samples 13838→14406,
-278477→279009, 543079→543611 — three attempts, the identical ~530-sample
-gap each time). It isn't sluggish start-up and it isn't periodic on a fixed
-timer; it's reactive to the track change itself, so nothing short of not
-changing the track (or changing what the watcher thinks the "right" track
-is) makes it stop. The interrupt path (vector `0xaf`) is unrelated — checked
-directly, it never fires during a `request_card_mount`-driven load (the
-mount posts straight to `sys`'s queue, bypassing the interrupt entirely).
+- **`0x80000002` is the current BANK** (`emu_card.FW_CUR_BANK`, already
+  named there), and `0x80000004` the current PATTERN. The engine's LOAD
+  PROJECT handler parses the project file's `BANK=` and `PATTERN=` keys
+  (strings at `0x400b39be`/`0x400b4c8b`, atoi at `0x40087d0a`, clamped
+  0–15 at `0x40087d1e`) and writes them there (`0x40087d26`, `0x40087d82`).
+- **`PART_PTR = 0x400e21e0 + bank × 635,712`** is the current bank's blob
+  in RAM (`0x40087d34`–`0x40087d44`, and `0x4000faf0(bank)` copies 585,088
+  bytes from it into SRAM at `0x1001614e` — that is the bank switch). So
+  `0x400e21e0` is **bank A**, `0x4017d520` is **bank B**
+  (`0x400e21e0 + 635,712` exactly). Neither is empty; nothing here is
+  per-track.
+- **The RIG project saves `BANK=1`** (`[STATES]` in `project.work`). The
+  engine ending on bank B is therefore the *saved* state, and route B's
+  `0x4017d520` was right for that reason — not because the cold path is
+  ground truth, but because it happens to freeze at the engine's value.
+- **The "select bank 0" message is posted by the engine itself.** The
+  static message at `0x400d64b9` is opcode 21 (`sys` table index 20 =
+  `0x40062288`, "select bank msg[1]"), and both sites that post it
+  (`0x4000a150`, `0x40009638`) write the bank byte from a register first —
+  it was never a hard-coded 0. Call chain, measured off the stack at the
+  post: `0x40085336` (LOAD PROJECT, opcode 4) → `0x400909d8` at
+  `0x4008534c` → `0x40025aa2…` → the pattern-load routine → post. That is
+  the handler's **first step: a reset to bank A / pattern 1**, before any
+  file is read. It runs twice (samples 12,407 and 13,535 in the trace),
+  then the files are read, then `BANK=` is parsed (13,838) and PART_PTR
+  goes to bank B.
+- **`sys` consumes those queued resets whenever it next runs.** The first
+  it consumed within one sample (12,408; bank already 0, so a no-op). The
+  second pair it consumed at 14,405 — *after* the engine had parsed
+  `BANK=1` — and switched the working bank back to A (`0x400622aa`,
+  `0x400622b8`). That is the whole "race": the engine's own reset-time
+  request, applied late by the task it was sent to, overriding the saved
+  bank the engine had set in the meantime.
 
-**Whose bug is this, really: none, on real hardware — it's an artifact of
-not driving the UI.** `0x400d64b9`'s repeated calls, always for track 0,
-look like a screen that assumes or enforces track 0 is current — plausibly
-whatever the unit is sitting on before a project gets loaded through it.
-`Rtos.request_card_mount` and `load_project_live` post kernel messages
-straight to `sys` and the engine, which is exactly what let M6b prove the
-mount and the load work without needing any UI machinery — but it also
-means the emulator never puts the UI on the screen a real load flow would
-have it on, so this screen's "keep showing track 0" behaviour keeps firing
-when it normally wouldn't be live at all. **This is M6d's territory (real
-key injection)**, not something to paper over in M6b: find what selects
-track 0 from `0x400d64b9`'s caller and see when it should legitimately stop
-running, or drive the UI to a screen where it doesn't.
+Two things that looked like evidence for the old story and were not: the
+posts recurring "throughout the run" were the reset step of *each* load
+attempt (the tool was reposting the load); and "reacts to the track
+changing" was the case handler's own guard (`cmpl` current bank against
+the request at `0x40062296` — it only writes when they differ), which
+made the no-op consumes invisible and the late one look reactive.
 
-**Where this leaves M6b's exit gate.** `Rtos.load_project_live` now returns
-`loaded` — true the instant `PART_PTR` is *ever* seen at a value other than
-the empty sentinel during the run (via a permanent `watch_mem`), independent
-of whatever happens to it afterward. That is the honest, checkable claim:
-the mount and the load mechanism both work, for real, through real tasks,
-matching M4's read-count proof — the subsequent contest over which track is
-"current" is a separate, now precisely-understood problem with a named
-owner (M6d), not a reason to call the load itself broken.
+**Why `sys` applied the second pair late — measured.** It was not
+starved: between the posts (13,535/13,539) and the consume (14,405) the
+scheduler dispatched `sys` fifteen times, alternating with the engine's
+ATA-wait wakeups, every time into `0x400934d0` — the p2c↔sys exchange
+that M6a's dispatch log already showed as a ping-pong. `sys`'s queue is
+FIFO; the two "select bank 0" messages sat behind a run of p2c traffic
+and were serviced ~870 samples after they were posted, by which point the
+engine (blocking and resuming on ATA reads throughout) had reached the
+`BANK=` parse (13,838). So the emulator's ordering is a plain consequence
+of queue depth and round-robin at priority 1, not of anything the tool
+does. **Whether hardware orders it the same way is the open question, and
+it is the right kind for route A**: a cross-task ordering whose answer
+decides whether the unit comes up on the saved bank after LOAD PROJECT.
+The hardware observable is one button press — load the RIG project and
+read the bank indicator. If the unit comes up on **B**, the emulator's
+p2c traffic or its timing knob is unfaithful here and M6c gains a second
+calibration point; if it comes up on **A**, the firmware really does
+apply its own stale reset and route B has been hiding it. Recorded as
+the falsifier; not resolved in this pass.
+
+**A diagnostic rule found the hard way in this pass:** never call
+`Rtos._sr()` (or anything that runs `emu_start`) from inside a Unicorn
+hook callback. It is re-entrant, undefined, and silently derails the run
+— one trace logged a single post instead of six before this was spotted.
+Read registers directly in hooks; read SR only between bursts.
+
+**Where this leaves M6b's exit gate.** `Rtos.load_project_live` returns
+`(mounted, posted, saved_bank, final_bank, elapsed_ms)`: `saved_bank` is
+the bank the engine parsed from the file and wrote to PART_PTR (None if
+the load never got that far), `final_bank` is where the run ended. The CLI
+passes on `saved_bank` being set — the mount and the load work, for real,
+through real tasks, at M4's read-count scale — and prints the two side by
+side, naming the stale-reset ordering when they differ. The "M6d
+inherits a UI-screen contest" hand-off in PR #103 is withdrawn; there is
+no UI mechanism in this story.
 
 ```sh
 make emu-rtos PROJECT=/absolute/path/to/OCTABAM_RIG

--- a/tools/emu_rtos.py
+++ b/tools/emu_rtos.py
@@ -69,9 +69,20 @@ SYS_TCB = 0x46c7bed8
 SYS_QUEUE = 0x460d17ae             # the sys task's own command queue
 SYS_MSG_SCRATCH = 0x46c00000       # scratch for a hand-built message -- see request_card_mount;
                                    # inside the boot's 0x46000000+32MB map, far from any named global
-PART_EMPTY = 0x400e21e0            # the firmware's own "no project loaded" sentinel for
-                                   # ec.PART_PTR -- a fixed OS constant, not project-specific data
-                                   # (the engine itself writes it, from 0x40025aa2, before loading)
+# The bank blobs in RAM: PART_PTR (ec.PART_PTR, 0x46c82456) = BANK_BLOB +
+# bank * BANK_STRIDE, i.e. the CURRENT BANK's data; 0x400e21e0 is bank A,
+# 0x4017d520 bank B. 0x80000002 is the current BANK (emu_card.FW_CUR_BANK),
+# 0x80000004 the current pattern. Read 6 Sep 2026 from the engine's LOAD
+# PROJECT handler, which parses the project file's BANK= and PATTERN= keys
+# (0x40087d0e..0x40087d44) -- correcting an earlier reading of this module
+# that called 0x400e21e0 an "empty sentinel" and 0x80000002 the current
+# track (docs/RTOS_FORK.md section 7 has the retraction).
+BANK_BLOB = 0x400e21e0
+BANK_STRIDE = 635712
+CUR_BANK = 0x80000002
+CUR_PATTERN = 0x80000004
+ENGINE_BANK_WRITE = 0x40087d44     # LOAD PROJECT writes PART_PTR from the file's BANK= here
+SELECT_BANK_CASE = 0x40062288      # sys table[20]: "select bank msg[1]" -- switch the working bank
 
 # The tasks, as MEASURED under the real scheduler on 6 Sep 2026 (the create
 # hook below): (tcb, entry, prio, stack, size, creator). Main is created by
@@ -823,39 +834,28 @@ class Rtos:
         main -- see `call_as_main`'s docstring for why that distinction
         matters), then post LOAD PROJECT (opcode 4) to the engine's queue
         exactly as `FW_POST_LOAD_PROJECT` does. Returns (mounted, posted,
-        loaded, part_ptr, elapsed_ms). `loaded` is True the instant `PART_PTR`
-        is EVER seen at its correct value during the run, even if something
-        later overwrites it -- see below, that overwrite is real and
-        currently expected. `part_ptr` is the value at the end.
+        saved_bank, final_bank, elapsed_ms): `saved_bank` is the bank the
+        engine parsed from the project file's BANK= key and wrote to
+        PART_PTR (None if that write never happened -- the load did not get
+        that far); `final_bank` is the current bank at the end of the run.
 
-        THE RACE, ROOT-CAUSED 6 Sep 2026 (not the vaguer "SYS clobbers it
-        once" writeup this replaces): two independent, real mechanisms both
-        write the current-track byte (`0x80000002`) and `PART_PTR` together,
-        and they disagree.
-        - The engine, finishing LOAD PROJECT, sets track 1 current
-          (`0x40087d26`, immediately before its own correct `PART_PTR` write
-          at `0x40087d44`).
-        - A SEPARATE, generic "select track N" routine (`0x40062288`,
-          `PART_PTR := 0x400e21e0 + N*635712`, a per-track factory-default
-          table baked into the image) is invoked REPEATEDLY throughout the
-          WHOLE run -- observed firing before the mount even starts, and
-          again periodically after -- always with N=0, always called with
-          the same fixed argument pointer (`0x400d64b9`, static data, not
-          our message). It reacts within ~500-3000 samples of the track
-          ACTUALLY changing away from 0, then goes quiet again until the
-          next change: not a one-shot housekeeping step, a live watcher.
-
-        So whichever fires second wins, and reposting LOAD PROJECT does NOT
-        help (tried, 6 Sep 2026): every repost sets track 1 again, and the
-        watcher notices and corrects it back to 0 again, on the same short
-        delay, every time. The watcher's trigger (`0x400d64b9`, and whatever
-        decides to call the select-track routine with it) is a UI/screen
-        state question -- almost certainly a screen that assumes track 0 is
-        current, live because we never drove the UI to the screen a real
-        project-load flow would be on. That is M6d's territory (real key
-        injection), not something to paper over here. Fix belongs there:
-        drive the UI to a track-1-appropriate (or track-agnostic) screen
-        before posting the load, or find what selects track 0 and see why.
+        THE TWO CAN DIFFER, and that is a real cross-task ordering, not a
+        load failure (root-caused 6 Sep 2026, correcting an earlier reading
+        of this code that mistook the bank byte for the current track and
+        bank A's blob for an "empty" sentinel). The engine's LOAD PROJECT
+        handler starts with a reset to bank A / pattern 1 that, among other
+        things, posts "select bank 0" to SYS's queue (from the pattern-load
+        routine, sites 0x4000a150/0x40009638, twice), then reads the files,
+        then parses BANK= and switches PART_PTR to the saved bank. SYS
+        consumes the reset's queued "select bank 0" whenever the scheduler
+        next gives it the CPU -- and if that is AFTER the engine's BANK=
+        parse, SYS switches the working bank back to A, overriding the
+        saved bank. Route B (cold) never showed this because SYS never ran
+        at all there, so it froze on the engine's value. Whether hardware
+        orders it the same way is exactly the class of question route A
+        exists to ask; the run's dispatch log answers it for the emulator,
+        and the cheap hardware observable is: does the unit come up on the
+        saved bank after LOAD PROJECT?
 
         Deliberately does NOT call `FW_SET_PROJECT_EXISTS`: with no card
         mounted it returns near-instantly (a genuine short-circuit, which is
@@ -876,12 +876,13 @@ class Rtos:
         if not getattr(self, "_watching_part_ptr", False):
             self.watch_mem(ec.PART_PTR, 4)
             self._watching_part_ptr = True
-        write_count_before = len(self.mem_writes)
+        n0 = len(self.mem_writes)
         posted = self.call_as_main(ec.FW_POST_LOAD_PROJECT, args=(ec.FW_PROJECT_NAME,))
         self.run(ms=run_ms)
-        part = int.from_bytes(self.uc.mem_read(ec.PART_PTR, 4), "big")
-        loaded = any(val != PART_EMPTY for *_, val in self.mem_writes[write_count_before:])
-        return mounted, posted, loaded, part, (self.sample - start) / SAMPLE_HZ * 1000.0
+        saved = [val for _, _, pc, _, _, val in self.mem_writes[n0:] if pc == ENGINE_BANK_WRITE]
+        saved_bank = (saved[-1] - BANK_BLOB) // BANK_STRIDE if saved else None
+        final_bank = self.uc.mem_read(CUR_BANK, 1)[0]
+        return mounted, posted, saved_bank, final_bank, (self.sample - start) / SAMPLE_HZ * 1000.0
 
     # -- the M6a gate --------------------------------------------------------
     def ran(self):
@@ -1105,7 +1106,7 @@ def _cli():
         try:
             if not rt.gate_m6a()[0]:
                 rt.run(ms=1000, until=lambda x: x.gate_m6a()[0])
-            mounted, posted, loaded, part, elapsed = rt.load_project_live(
+            mounted, posted, saved_bank, final_bank, elapsed = rt.load_project_live(
                 a.set, staged_name, run_ms=a.ms)
         except (RtosFault, eb.UcError) as e:
             print(f"stopped    : {_fault(e)}")
@@ -1113,18 +1114,19 @@ def _cli():
             print(rt.starvation())
             return 1
         print(rt.report())
-        stuck = loaded and part == PART_EMPTY
-        print(f"mount      : ready={mounted} posted={posted} loaded={loaded} "
-              f"part={part:#x}{' (raced away, see docstring)' if stuck else ''} "
-              f"({elapsed:.1f} ms emulated total)")
+        part = int.from_bytes(rt.uc.mem_read(ec.PART_PTR, 4), "big")
+        print(f"load       : ready={mounted} posted={posted} saved_bank={saved_bank} "
+              f"final_bank={final_bank} PART_PTR={part:#x} ({elapsed:.1f} ms emulated total)")
+        if saved_bank is not None and final_bank != saved_bank:
+            print("             final bank != saved bank: SYS applied the engine's own reset-time "
+                  "'select bank 0' after the BANK= parse (RTOS_FORK.md section 7)")
         if rt.card:
             print(f"card       : {len(rt.card.log)} commands, {rt.card.reads} sectors read, "
                   f"{rt.card.writes} written; last: {rt.card.log[-8:]}")
-        ok = bool(mounted) and loaded
+        ok = bool(mounted) and saved_bank is not None
         if not ok:
             print(rt.starvation())
-        print("M6b load   :", "PASS" if ok else "FAIL",
-              "(raced away by the track-select watcher after loading correctly)" if stuck else "")
+        print("M6b load   :", "PASS" if ok else "FAIL")
         return 0 if ok else 1
 
     until = (lambda x: x.gate_m6a()[0]) if a.until_gate else None


### PR DESCRIPTION
## Summary
- **Retraction of PR #103's reading** (and PR #102's "empty sentinel"): the measured mechanism stands, the interpretation was wrong. `0x80000002` is the current **bank** (`emu_card.FW_CUR_BANK` — already named), `PART_PTR = 0x400e21e0 + bank × 635,712` is the current bank's blob; `0x400e21e0` is bank A, `0x4017d520` bank B. The engine's LOAD PROJECT parses the file's `BANK=`/`PATTERN=` keys and the RIG project saves `BANK=1`, so bank B is the saved state.
- **The "select bank 0" post comes from the engine itself** — LOAD PROJECT's own first step is a reset to bank A that posts it (call chain read off the stack). `sys`, working through a backlog of p2c traffic in its FIFO, applies it ~870 samples later, after the engine has parsed `BANK=1`, so the run ends on bank A. A real cross-task ordering, not a UI mechanism; the M6d hand-off in #103 is withdrawn.
- **Open question with a one-press hardware falsifier**: load RIG on the unit — does it come up on bank B (emulator ordering unfaithful) or bank A (firmware applies its own stale reset; route B was hiding it)?
- `load_project_live` now returns `saved_bank` and `final_bank`; the CLI prints both and names the ordering when they differ. Constants renamed to what they are. New diagnostic rule: never run `emu_start` (the SR trampoline included) inside a Unicorn hook.

## Verification
- `tools/emu_rtos.py --project <abs dir> --set OCTABAM --name RIG --load-project --ms 6000` → `saved_bank=1 final_bank=0`, `M6b load: PASS`.
- `--selftest` PASS; M6a gate unaffected (no changes to that path).
- `make verify` before/after: only the known build-cache line. `tools/emu_card.py` cold load: byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)