### PR TITLE
Emulator M6c: the fidelity gate passes — eDMA modelled, forced interrupts unmasked, the sequencer on the saved bank

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -704,14 +704,21 @@ scheduler.
 | M5 frames + ticks, cold | ✅ done, one gap | a step trig fires end to end; the recorder-arm path ("path B") needs real task interleaving |
 | **M6a scheduler runs** | ✅ **done 6 Sep, PR #100** | `make emu-rtos PROJECT=<abs dir>`: eleven tasks start in the real order, the 5 ms tick and every interrupt fire, tasks post to each other; gate passes at 205 ms emulated |
 | M6b real waits + mount | ✅ **done 6 Sep** (one retraction) | `sys` (not engine) mounts the card; a real mount + LOAD PROJECT reach 30,467 real sectors (M4: ~30,955) and the file's saved bank. PR #103's "track-select watcher" reading is WITHDRAWN: the bytes are the current bank; the run ends on bank A because the engine's own reset-time "select bank 0" reaches `sys` after the `BANK=1` parse — a real cross-task ordering with a one-press hardware falsifier (RTOS_FORK §7) |
-| M6c sequencer under the scheduler | 🟡 **in progress, branch `rtos-m6c`** | the fidelity gate: M5's one-trig test lands the same byte at the same frame under route A (needs `out/_testproj` rebuilt) |
+| M6c sequencer under the scheduler | 🟡 **mechanism built, gate blocked on a judgment call** | `out/_testproj` rebuilt (frame 344 reproduces exactly); the frame IRQ, forced tick and M5-detour transport start all wired and confirmed inert-by-default for M6a/M6b. Blocked: the frame handler masks its own interrupt at entry and the path it took under a real load+transport never unmasks it again (`frame_count` stops at 1) — RTOS_FORK §8 has the byte-exact trace and two hypotheses, handed to Fable |
 | M6d key injection | ⏳ mechanical | PLAY and REC-arm through the firmware's own path, no RAM pokes |
 | M6e use it | ⏳ judgment | the recorder-arm trace for Bryan; the tick pre-emption question |
 
-Where to resume: **M6c** — `out/_testproj` needs rebuilding (gone from the
-main checkout; `tools/ot_project.py testproj <src> <dest> <remix>`), then
-M5's one-trig fidelity gate. One hardware question is queued for whenever
-the unit is next on: **load the RIG project and read the bank indicator**
+Where to resume: **M6c's gate** — RTOS_FORK §8 has the byte-exact trace
+of why frame delivery stops after one interrupt and the two hypotheses
+(a missed second unmask site further into the handler body, or the
+"frame interrupt every 16 samples" design assumption itself being wrong
+for this firmware). Read `0x4000aad0`–`0x4000d9ae` in full before
+touching the code further — a Fable pass, per the routing rule below.
+Reproduce with `tools/emu_rtos.py --project out/_testproj --set OCTABAM
+--name RIG --sequencer --poke-trig 2 --frames 400 --ms 6000`.
+
+Also queued, independent of M6c: one hardware question for whenever the
+unit is next on — **load the RIG project and read the bank indicator**
 — the emulator comes up on bank A because the engine's own reset-time
 "select bank 0" reaches `sys` after the file's `BANK=1` is parsed; if the
 unit comes up on B, the emulator's ordering is unfaithful there (RTOS_FORK

--- a/PLAN.md
+++ b/PLAN.md
@@ -704,25 +704,30 @@ scheduler.
 | M5 frames + ticks, cold | ✅ done, one gap | a step trig fires end to end; the recorder-arm path ("path B") needs real task interleaving |
 | **M6a scheduler runs** | ✅ **done 6 Sep, PR #100** | `make emu-rtos PROJECT=<abs dir>`: eleven tasks start in the real order, the 5 ms tick and every interrupt fire, tasks post to each other; gate passes at 205 ms emulated |
 | M6b real waits + mount | ✅ **done 6 Sep** (one retraction) | `sys` (not engine) mounts the card; a real mount + LOAD PROJECT reach 30,467 real sectors (M4: ~30,955) and the file's saved bank. PR #103's "track-select watcher" reading is WITHDRAWN: the bytes are the current bank; the run ends on bank A because the engine's own reset-time "select bank 0" reaches `sys` after the `BANK=1` parse — a real cross-task ordering with a one-press hardware falsifier (RTOS_FORK §7) |
-| M6c sequencer under the scheduler | 🟡 **mechanism built, gate blocked on a judgment call** | `out/_testproj` rebuilt (frame 344 reproduces exactly); the frame IRQ, forced tick and M5-detour transport start all wired and confirmed inert-by-default for M6a/M6b. Blocked: the frame handler masks its own interrupt at entry and the path it took under a real load+transport never unmasks it again (`frame_count` stops at 1) — RTOS_FORK §8 has the byte-exact trace and two hypotheses, handed to Fable |
+| M6c sequencer under the scheduler | ✅ **done 6 Sep — gate passed** | the one-trig test lands the same byte (`0xd3`), same track, 344 frames after the start frame, 28 ticks, under real tasks and real interrupts as it does cold. Three findings on the way (RTOS_FORK §8): the frame source is re-armed by the **eDMA completion ISR** (eDMA now modelled, 16.0-sample period); a **forced interrupt bypasses the mask** (MCF54455RM §17.2.3 — the tick is never unmasked and never needed to be); the load leaves the **sequencer's** playing bank on A by §7's ordering (re-selected through the load's own last step; the hardware falsifier gained a second observable). Sonnet's two §8 hypotheses retracted |
 | M6d key injection | ⏳ mechanical | PLAY and REC-arm through the firmware's own path, no RAM pokes |
 | M6e use it | ⏳ judgment | the recorder-arm trace for Bryan; the tick pre-emption question |
 
-Where to resume: **M6c's gate** — RTOS_FORK §8 has the byte-exact trace
-of why frame delivery stops after one interrupt and the two hypotheses
-(a missed second unmask site further into the handler body, or the
-"frame interrupt every 16 samples" design assumption itself being wrong
-for this firmware). Read `0x4000aad0`–`0x4000d9ae` in full before
-touching the code further — a Fable pass, per the routing rule below.
-Reproduce with `tools/emu_rtos.py --project out/_testproj --set OCTABAM
---name RIG --sequencer --poke-trig 2 --frames 400 --ms 6000`.
+Where to resume: **M6d, key injection** (mechanical) — PLAY and REC-arm
+through the UI task's own queue instead of `call_as_main` on the transport
+routines; the queue `0x4005593c` blocks on is the thing to read first.
+M6c's gate is the regression to keep green while doing it: `tools/emu_rtos.py
+--project out/_testproj --set OCTABAM --name RIG --sequencer
+--internal-clock --poke-trig 2 --frames 400 --ms 20000` must keep landing
+`0xd3` on track 0, 344 frames after the start frame, with 28 ticks. Two
+of M6c's helpers are M5-detour compensation for §7's ordering
+(`select_bank_live`, `seq_select_live`); if the hardware falsifier below
+says the unit ends on the saved bank, the faithful fix is in the load's
+timing, and both helpers should become unnecessary.
 
 Also queued, independent of M6c: one hardware question for whenever the
-unit is next on — **load the RIG project and read the bank indicator**
-— the emulator comes up on bank A because the engine's own reset-time
-"select bank 0" reaches `sys` after the file's `BANK=1` is parsed; if the
-unit comes up on B, the emulator's ordering is unfaithful there (RTOS_FORK
-§7). Reproduce with `tools/emu_rtos.py --project <abs dir> --set OCTABAM
+unit is next on — **load the RIG project, read the bank indicator, then
+press PLAY** — the emulator comes up on bank A because the engine's own
+reset-time "select bank 0" reaches `sys` after the file's `BANK=1` is
+parsed, and M6c found the same ordering leaves the *sequencer* on bank A
+too (the saved pattern would not run). If the unit comes up on B and
+plays the saved pattern, the emulator's ordering is unfaithful there
+(RTOS_FORK §7, §8.3). Reproduce with `tools/emu_rtos.py --project <abs dir> --set OCTABAM
 --name RIG --load-project --ms 6000` (absolute path; a tilde inside the
 quoted make variable is not expanded), or `tools/emu_rtos.py --selftest`
 for the SR trap alone. Keep in view: reading SR through the API at a burst

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -436,7 +436,7 @@ ordinary trig landing in RAM) but does not answer Bryan's literal question.
 needs no new instrumentation — just `--bpm 128` and a pattern length of 4
 vs 32 steps.
 
-## The RTOS fork — M6a and M6b done 6 Sep 2026 (`tools/emu_rtos.py`)
+## The RTOS fork — M6a and M6b done, M6c's mechanism built 6 Sep 2026 (`tools/emu_rtos.py`)
 
 Milestones 2 and 4 took route **B** (detour) and it carries the remixer and
 the card: a menu- or cave-patch is visible and walkable without a flash, and
@@ -489,6 +489,22 @@ subroutine) is unsafe for anything that can genuinely block — main is the
 kernel's only always-ready task, so blocking it starves the scheduler.
 `FW_CARD_INIT` proved this by crashing it; the fix routes blocking calls
 through a real task's own context instead (post it a message).
+
+**M6c (same day): the sequencer mechanism is built; the fidelity gate is
+not.** `out/_testproj` is rebuilt (a project freshly saved on the unit,
+reproduces this doc's own frame-344 finding exactly under a fresh cold
+run). The frame IRQ (source 1 of INTC0, a free-running 16-sample clock,
+opt-in so M6a/M6b stay exactly as verified) and the M5-detour transport
+start (`call_as_main`, confirmed non-blocking) are both wired through the
+same real interrupt-controller model M6a already built. What isn't wired
+yet is a real second frame: the handler masks its own interrupt source at
+entry and, on the code path a real load-and-play run actually takes, never
+unmasks it again — `frame_count` reaches 1 and stops, measured across a
+3-second run. The unmask instruction exists, on a different, conditional
+branch this run didn't take. `RTOS_FORK.md` §8 has the byte-exact trace and
+two live hypotheses (a missed second unmask site vs. the "16-sample frame
+interrupt" design assumption itself being wrong for this firmware) — a
+judgment call, not a guess to make mechanically.
 
 ## Reproduce
 

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -490,21 +490,30 @@ kernel's only always-ready task, so blocking it starves the scheduler.
 `FW_CARD_INIT` proved this by crashing it; the fix routes blocking calls
 through a real task's own context instead (post it a message).
 
-**M6c (same day): the sequencer mechanism is built; the fidelity gate is
-not.** `out/_testproj` is rebuilt (a project freshly saved on the unit,
-reproduces this doc's own frame-344 finding exactly under a fresh cold
-run). The frame IRQ (source 1 of INTC0, a free-running 16-sample clock,
-opt-in so M6a/M6b stay exactly as verified) and the M5-detour transport
-start (`call_as_main`, confirmed non-blocking) are both wired through the
-same real interrupt-controller model M6a already built. What isn't wired
-yet is a real second frame: the handler masks its own interrupt source at
-entry and, on the code path a real load-and-play run actually takes, never
-unmasks it again — `frame_count` reaches 1 and stops, measured across a
-3-second run. The unmask instruction exists, on a different, conditional
-branch this run didn't take. `RTOS_FORK.md` §8 has the byte-exact trace and
-two live hypotheses (a missed second unmask site vs. the "16-sample frame
-interrupt" design assumption itself being wrong for this firmware) — a
-judgment call, not a guess to make mechanically.
+**M6c (same day): the sequencer under the real scheduler — the fidelity
+gate passed.** `out/_testproj` is a project freshly saved on the unit;
+cold, it lands track 1's trig at frame 344, byte `0xd3`. Under route A
+(real mount and load, real interrupts, the tick pre-empting the frame
+handler for real) the same trig lands with the same byte, on the same
+track, 344 frames after the transport-start frame, with the same 28 ticks
+and the same six start-frame writes. Three things stood between the
+mechanism and that result, each measured (`RTOS_FORK.md` §8): the frame
+handler masks its own source and the re-arm is state 7 of the **eDMA
+completion interrupt** — the DMA chain the handler kicks (ch1 → 6 → 7 →
+source 15, then the ISR's own SSRTs and the ColdFire's per-frame EMAC
+routine) is now modelled, completing at the DSP's next frame boundary,
+which gives a 16.0-sample period exactly; the sequencer tick is a
+**forced** interrupt the firmware never unmasks, and the reference manual
+says a forced request is not affected by the mask (§17.2.3) — the INTC
+model now agrees; and the load's last step copies the bank byte into the
+sequencer's own playing-bank byte at a moment when `sys` has already
+applied the engine's reset-time "select bank 0" in the handler's real card
+waits, so the sequencer walked bank A's empty pattern — the tool re-issues
+that last step with the file's bytes (`seq_select_live`), and §7's
+one-press hardware falsifier gained a second observable (does PLAY run the
+saved pattern?). Frame mode counts instructions exactly (`exact_clock`)
+rather than by quantum, which over-charged 2.1×. The previous paragraph
+here, and §8's two hypotheses, were wrong and are retracted in place.
 
 ## Reproduce
 
@@ -514,6 +523,8 @@ make remix                           # then press e to boot the built image
 .venv/bin/python3 tools/emu_bringup.py [image]   # or the CLI directly
 make emu-rtos PROJECT=<project dir>  # route A: the scheduler running, M6a gate (RTOS_FORK.md §5)
 .venv/bin/python3 tools/emu_rtos.py --project <dir> --set OCTABAM --name RIG --load-project --ms 6000
+.venv/bin/python3 tools/emu_rtos.py --project out/_testproj --set OCTABAM --name RIG \
+  --sequencer --internal-clock --poke-trig 2 --frames 400 --ms 20000   # M6c: the trig under real tasks
 .venv/bin/python3 tools/emu_rtos.py --selftest   # the SR-read trap, pinned
 ```
 

--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -337,7 +337,9 @@ model can take the mechanical parts. Tagged accordingly.
   must land the same byte in `0x46104d15[0]` at the same frame (344, `0xb6`)
   under route A as it does cold. If it doesn't, the difference *is* the
   pre-emption M5 could not model, and it needs reading before anything is
-  built on it.
+  built on it. **Mechanism built 6 Sep 2026 (Sonnet), fidelity gate NOT yet
+  reached — a judgment question, flagged for Fable, is in the way.** §8 has
+  the measured facts and the two live hypotheses.
 - **M6d — input.** *(mechanical)* Feed key events into the UI task's queue
   (the post primitive against whichever queue `0x4005593c` blocks on — to be
   read in M6c) so PLAY and the REC-arm action run the firmware's own path.
@@ -537,3 +539,80 @@ task), `--watch-calls A,B` (entries with caller and first argument),
 (O(1), tcb → its most recent block) and `Rtos.blocks` (the full log).
 `emu_bringup` and `emu_frames` are untouched; `emu_card` gained the one
 flag.
+
+## 8. M6c — the mechanism is built; the fidelity gate is blocked on a judgment call
+
+`out/_testproj` (gone from the checkout, per §7's own note that this was
+needed) is rebuilt as a symlink to a project **freshly saved on the unit
+6 Sep 2026** (`OCTABAM_RIG_20260906_cleared`, `~/octa/backups/`) — chosen
+because a cold run against it reproduces this document's own frame-344
+claim exactly (`tools/emu_frames.py --project out/_testproj --frames 400
+--start --internal-clock --poke-trig 2`: track 1's live nibble fires at
+frame 344, matching the M5 write-up byte-for-byte on the frame number).
+The BYTE differs from the old note (`0xd3` measured here vs `0xb6`
+written down at the time) — not chased further; the fidelity gate below
+never got far enough to need it, and self-consistency between cold and
+route A on THIS byte, whatever it is today, is the actual target, not a
+historical number.
+
+**Mechanism built (Sonnet, mechanical — the scope in §5 specifies both
+pieces byte-exact):**
+- The frame clock: source 1 of INTC0, a free-running 16-sample period
+  with no registers (unlike PIT0/PIT1), delivered through the exact same
+  generic `Intc` model M6a already built. **Opt-in** (`Rtos(frame=True)` /
+  CLI `--sequencer`, default off): main's boot tail unmasks source 1
+  unconditionally as part of its normal, already-verified init sequence,
+  so modelling it un-gated would make it fire in every M6a/M6b run
+  regardless of need — confirmed this stays inert by default (M6a's gate
+  re-run clean with `frame=False`, the default, after every change below).
+- `Rtos.start_transport_live()` / `Rtos.poke_trig()`: the M5 detour
+  (`FW_TRANSPORT`, `FW_START_TRACK`, the pattern's trig mask) driven
+  through `call_as_main`, exactly as §5 allows for M6c. Both confirmed
+  non-blocking the same way `request_card_mount` is — no repeat of the
+  `FW_CARD_INIT` crash `call_as_main`'s docstring warns about.
+- `--sequencer` CLI action: gate, load, start transport, poke, run N
+  frames, report `FW_LIVE_NIBBLE`/`FW_TRIG_WORDS` — the same shape as
+  `emu_frames.py`'s cold run, so the two are directly comparable once the
+  gate below is passable.
+
+**Why the gate can't run yet — measured, not guessed.** The frame handler
+(`0x4000aad0`) masks its OWN interrupt source at entry
+(`moveb #1,0xfc04801c` — confirmed a genuine SIMR write by tracing every
+INTC0 mask-register write across a 3-second, fully-loaded, transport-running
+run) and is **never unmasked again on the path it actually took**:
+`frame_count` reaches exactly 1 and stops, for the whole 3-second window.
+The unmask instruction exists (`moveb #1,0xfc04801d` at `0x4000a918`), but
+only on a conditional early-exit branch (`0x4000ab0e`: if `0x4001c9b0()` —
+a one-line getter of `0x460bb422` — returns nonzero, ping the DSP with host
+command `139`, re-arm, and skip straight to the handler's tail; if zero, as
+measured here every time, take the long path through the full per-track
+dispatcher). A whole-image literal scan for `0xfc04801d` (CIMR) found no
+second unmask site anywhere, including inside the long path's own body.
+`0x460bb422` is cleared by a handler in `sys`'s message table
+(`0x4001e52a`, in the storage/card message range) but no site in the image
+sets it nonzero via an immediate move — it may be reached only through a
+base-register-relative store a literal-address scan can't see, unexamined.
+
+**Two live hypotheses, neither chased down (the judgment call this needs):**
+- The long path is genuinely missing its own re-arm further into the
+  handler's body (it is large — per-track dispatcher, the trig-time loop,
+  the packer — and this pass did not disassemble all of it). A full
+  disassembly of `0x4000aad0`–`0x4000d9ae` would settle this directly.
+- Or the design assumption this whole document makes in §4 — "a frame
+  interrupt every 16 samples" driving the sequencer continuously — is
+  wrong for what this firmware revision actually does, and ordinary
+  operation hands frame-rate timing to something else (the voice/DSP
+  mailbox task, priority 6, is the obvious candidate) once the ColdFire's
+  one bootstrap interrupt has kicked it off. Route A surfacing a wrong
+  design assumption would not be a first — M6b's bank-ordering finding
+  (§7) was the same shape: a plausible story that turned out to need a
+  hardware-grade re-read rather than a second guess.
+
+Reproduce:
+```sh
+.venv/bin/python3 tools/emu_rtos.py --project out/_testproj --set OCTABAM --name RIG \
+  --sequencer --poke-trig 2 --frames 400 --ms 6000
+```
+Expect `frame_count: 1` and no further `FW_LIVE_NIBBLE` writes past
+whatever the handler does on its one delivery — that is the measured,
+reproducible state this section describes, not a crash to fix.

--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -337,9 +337,14 @@ model can take the mechanical parts. Tagged accordingly.
   must land the same byte in `0x46104d15[0]` at the same frame (344, `0xb6`)
   under route A as it does cold. If it doesn't, the difference *is* the
   pre-emption M5 could not model, and it needs reading before anything is
-  built on it. **Mechanism built 6 Sep 2026 (Sonnet), fidelity gate NOT yet
-  reached — a judgment question, flagged for Fable, is in the way.** §8 has
-  the measured facts and the two live hypotheses.
+  built on it. **Done 6 Sep 2026 — gate passed** (same byte `0xd3`, same
+  track, 344 frames after the start frame, 28 ticks, under route A as
+  cold; the `0xb6` above was the historical byte, `0xd3` is today's cold
+  reference). Three things stood in the way and §8 has each measured: the
+  frame source is re-armed by the eDMA completion ISR (the eDMA block is
+  now modelled), a forced interrupt is not subject to the mask (reference
+  manual, §17.2.3), and the load leaves the *sequencer* on bank A by the
+  same ordering §7 flagged (re-selected through the load's own last step).
 - **M6d — input.** *(mechanical)* Feed key events into the UI task's queue
   (the post primitive against whichever queue `0x4005593c` blocks on — to be
   read in M6c) so PLAY and the REC-arm action run the firmware's own path.
@@ -507,7 +512,12 @@ read the bank indicator. If the unit comes up on **B**, the emulator's
 p2c traffic or its timing knob is unfaithful here and M6c gains a second
 calibration point; if it comes up on **A**, the firmware really does
 apply its own stale reset and route B has been hiding it. Recorded as
-the falsifier; not resolved in this pass.
+the falsifier; not resolved in this pass. **M6c found the same ordering
+has a second victim (§8.3):** the load's last step copies the bank byte
+into the *sequencer's* own playing-bank byte, so the reset arriving
+mid-handler leaves the sequencer on bank A too — press PLAY after the
+load and see whether the saved pattern runs; that is the second
+observable of the same one-press test.
 
 **A diagnostic rule found the hard way in this pass:** never call
 `Rtos._sr()` (or anything that runs `emu_start`) from inside a Unicorn
@@ -540,79 +550,176 @@ task), `--watch-calls A,B` (entries with caller and first argument),
 `emu_bringup` and `emu_frames` are untouched; `emu_card` gained the one
 flag.
 
-## 8. M6c — the mechanism is built; the fidelity gate is blocked on a judgment call
+## 8. M6c — the fidelity gate, and the three things that stood between it and route A (Fable review, 6 Sep 2026)
 
-`out/_testproj` (gone from the checkout, per §7's own note that this was
-needed) is rebuilt as a symlink to a project **freshly saved on the unit
-6 Sep 2026** (`OCTABAM_RIG_20260906_cleared`, `~/octa/backups/`) — chosen
-because a cold run against it reproduces this document's own frame-344
-claim exactly (`tools/emu_frames.py --project out/_testproj --frames 400
---start --internal-clock --poke-trig 2`: track 1's live nibble fires at
-frame 344, matching the M5 write-up byte-for-byte on the frame number).
-The BYTE differs from the old note (`0xd3` measured here vs `0xb6`
-written down at the time) — not chased further; the fidelity gate below
-never got far enough to need it, and self-consistency between cold and
-route A on THIS byte, whatever it is today, is the actual target, not a
-historical number.
+`out/_testproj` is a symlink to a project **freshly saved on the unit
+6 Sep 2026** (`OCTABAM_RIG_20260906_cleared`, `~/octa/backups/`): a cold
+run against it (`tools/emu_frames.py --project out/_testproj --frames 400
+--start --internal-clock --poke-trig 2`) lands track 1's live nibble at
+**frame 344, byte `0xd3`** — the frame this document's M5 claim named; the
+byte differs from the `0xb6` written down at the time and the cold number
+measured today is the reference, not the historical one.
 
-**Mechanism built (Sonnet, mechanical — the scope in §5 specifies both
-pieces byte-exact):**
-- The frame clock: source 1 of INTC0, a free-running 16-sample period
-  with no registers (unlike PIT0/PIT1), delivered through the exact same
-  generic `Intc` model M6a already built. **Opt-in** (`Rtos(frame=True)` /
-  CLI `--sequencer`, default off): main's boot tail unmasks source 1
-  unconditionally as part of its normal, already-verified init sequence,
-  so modelling it un-gated would make it fire in every M6a/M6b run
-  regardless of need — confirmed this stays inert by default (M6a's gate
-  re-run clean with `frame=False`, the default, after every change below).
-- `Rtos.start_transport_live()` / `Rtos.poke_trig()`: the M5 detour
-  (`FW_TRANSPORT`, `FW_START_TRACK`, the pattern's trig mask) driven
-  through `call_as_main`, exactly as §5 allows for M6c. Both confirmed
-  non-blocking the same way `request_card_mount` is — no repeat of the
-  `FW_CARD_INIT` crash `call_as_main`'s docstring warns about.
-- `--sequencer` CLI action: gate, load, start transport, poke, run N
-  frames, report `FW_LIVE_NIBBLE`/`FW_TRIG_WORDS` — the same shape as
-  `emu_frames.py`'s cold run, so the two are directly comparable once the
-  gate below is passable.
+**Retraction of this section's previous text (Sonnet's M6c pass).** Both
+hypotheses were wrong, and the "whole-image literal scan found no second
+unmask site" claim was false: the re-arm is a literal `moveb %d1,0xfc04801d`
+with `d1 = 1` at `0x40004bc2`, in a *different* handler. The frame handler
+masks source 1 at entry on purpose; the source is re-armed by **state 7 of
+the eDMA completion interrupt**, and the eDMA block was simply not modelled,
+so the chain the frame handler kicks never completed and the unmask never
+came. Everything below is measured unless marked.
 
-**Why the gate can't run yet — measured, not guessed.** The frame handler
-(`0x4000aad0`) masks its OWN interrupt source at entry
-(`moveb #1,0xfc04801c` — confirmed a genuine SIMR write by tracing every
-INTC0 mask-register write across a 3-second, fully-loaded, transport-running
-run) and is **never unmasked again on the path it actually took**:
-`frame_count` reaches exactly 1 and stops, for the whole 3-second window.
-The unmask instruction exists (`moveb #1,0xfc04801d` at `0x4000a918`), but
-only on a conditional early-exit branch (`0x4000ab0e`: if `0x4001c9b0()` —
-a one-line getter of `0x460bb422` — returns nonzero, ping the DSP with host
-command `139`, re-arm, and skip straight to the handler's tail; if zero, as
-measured here every time, take the long path through the full per-track
-dispatcher). A whole-image literal scan for `0xfc04801d` (CIMR) found no
-second unmask site anywhere, including inside the long path's own body.
-`0x460bb422` is cleared by a handler in `sys`'s message table
-(`0x4001e52a`, in the storage/card message range) but no site in the image
-sets it nonzero via an immediate move — it may be reached only through a
-base-register-relative store a literal-address scan can't see, unexamined.
+### 8.1 The frame exchange is a DMA chain, and the re-arm is its last state ✅
 
-**Two live hypotheses, neither chased down (the judgment call this needs):**
-- The long path is genuinely missing its own re-arm further into the
-  handler's body (it is large — per-track dispatcher, the trig-time loop,
-  the packer — and this pass did not disassemble all of it). A full
-  disassembly of `0x4000aad0`–`0x4000d9ae` would settle this directly.
-- Or the design assumption this whole document makes in §4 — "a frame
-  interrupt every 16 samples" driving the sequencer continuously — is
-  wrong for what this firmware revision actually does, and ordinary
-  operation hands frame-rate timing to something else (the voice/DSP
-  mailbox task, priority 6, is the obvious candidate) once the ColdFire's
-  one bootstrap interrupt has kicked it off. Route A surfacing a wrong
-  design assumption would not be a first — M6b's bank-ordering finding
-  (§7) was the same shape: a plausible story that turned out to need a
-  hardware-grade re-read rather than a second guess.
+The chip is the MCF5445x family (`docs/CHIP.md`: MCF54454; the register map
+below matches `MCF54455RM` rev 5 chapter 17 for the INTC and chapter 19 for
+the eDMA, and the `Intc` docstring's "MCF547x" was wrong). INTC0 at
+`0xfc048000` (vectors `64+source`), INTC1 at `0xfc04c000` (`128+source`);
+eDMA control at `0xfc044000` (CINT `+0x1c`, SSRT `+0x1e`, CDNE `+0x1f`),
+TCDs at `0xfc045000`, 32 bytes per channel (SADDR `+0`, NBYTES `+8`, DADDR
+`+0x10`, CITER `+0x14`, BITER `+0x1c`, CSR `+0x1e`; CSR START `0x1`,
+INTMAJOR `0x2`, MAJORELINK `0x20`, MAJORLINKCH bits 8–12, DONE `0x80`).
+INTC0 sources 8..23 are eDMA channels 0..15 (vector table dumped live:
+sources 8, 9 and 15 all go to `0x40004840`).
+
+The frame handler (`0x4000aad0`, INTC0 source 1, level 5) masks itself
+(`SIMR := 1` at `0x4000aada`), kicks channel 1 with CSR `0x621` (START,
+link → 6; channel 6's `0x720` links → 7; channel 7's `0x0002` raises source
+15), clears `0x46104d3a`/`0x46104d3e` and runs the per-track work. The
+completion handler `0x40004840` is a jump table at `0x400ab61a` on the
+state word `0x46104d3e`: states 0–5 each SSRT channel 1 then channel 0
+(sources 9, 8 — the 256-byte control transfers over the host port); state
+5 drops to IPL 5 and calls `0x400031a0`, the ColdFire's per-frame EMAC
+routine (~7,400 instructions; it STARTs channel 2, a memory-to-memory copy
+from the delay ring `0x4f502c10` linked to channel 3, and polls channel 3's
+DONE at `0x400035a8` — the "64k+ instructions" read earlier was this poll
+never ending); then the DONE check → `0x40004b44` → state 7, and **state 7
+(`0x40004bc0`) is the CIMR unmask of source 1.** One frame is the sequence
+15, 9, 8×5, 7.
+
+The model (`class Edma`) moves no data — audio is out of route A's scope,
+§1 — and gets the one thing that matters right, completion *timing*, by
+what a transfer touches: a CSR.START of a channel whose SADDR or DADDR is
+in the DSP host-port window (`0x20000000`–`0x20001000`) is the frame's
+audio stream and completes, chain and all, at the DSP's next frame
+boundary; an SSRT and a memory-to-memory START complete at once. Each of
+the three wrong versions on the way produced a specific, reproducible
+symptom worth keeping: instant completion re-raised source 15 before state
+0 had acknowledged it and the ISR spun forever in state 6; a one-frame
+latency applied to channel 2 as well held `0x400031a0` in its DONE poll
+forever; completing "kick + 16 samples" instead of "at the next boundary"
+gave an 18.5-sample frame period (every sixth frame dropped). With the
+boundary rule the period is **16.0 samples exactly**, the exchange takes
+about two samples of the sixteen, and a frame costs ≈63.8k instructions —
+`ips × 16`, which is what the `ips` knob promises.
+
+**Exact clock.** The quantum accounting M6a uses (charge the burst's
+requested count) over-charged frame work about 2.1× — an interrupt ends a
+burst early and the whole quantum was still billed. `Rtos.exact_clock()`
+counts executed instructions with a code hook and charges those; frame
+mode turns it on. Slower, and the right number.
+
+### 8.2 The sequencer tick is a forced interrupt that is never unmasked — and does not need to be ✅
+
+With frames running, transport started and the clock internal, the
+sequencer still did nothing: 400 frames, **zero** ticks (cold: 28). The
+frame handler's countdown (`0x46107570`, decremented by `tempo24 << 4` per
+frame, `0x4000ad50`) expired and forced INTC0 source 32 (`orl #1,
+0xfc048010` at `0x4000ae00`) exactly as the M5 write-up says, but INTC0 had
+the source **masked**: the sequencer init (`0x400a1050`) installs vector
+`0x60` → `0x400a1e0c` and writes ICR 32 := 3 at `0x400a10a4`, and nothing
+in the image ever unmasks it — all fifteen CIMR sites read (values 1, 8, 9,
+15, 22, 26, 27, 28, 33, 34, 36, 37, 43 and the two ISR re-arms of source
+1), no IMRH/IMRL write anywhere, no INTC0 base address ever loaded into a
+register, and the pre-handoff boot's INTC writes are ICR/CIMR 27 and
+ICR/CIMR 43 only. The other forced sources (34, 36, 37 and the kernel's
+own 43) *are* unmasked explicitly. The reference manual settles it,
+verbatim (MCF54455RM rev 5, §17.2.3): *"The assertion of an interrupt
+request via the interrupt force register is not affected by the interrupt
+mask register."* The `Intc` model now ORs INTFRC into the pending set
+regardless of IMR (ICR 0 still never delivers). Result: 28 ticks in 400
+frames, at frames 1, 16, 30, 45, 59, 73, … — the same count as cold, with
+the tick clock advancing `2,646,000` every fourth tick as EMU.md describes.
+The kernel's explicit unmask of 43 is belt and braces, not evidence.
+
+Also needed, and easy to forget because cold has the same switch:
+`--internal-clock`. The project saves CLOCK RECEIVE set (the Rytm is
+master); with it set the frame handler takes the external-clock path
+(`0x4000acbc`) and the countdown never moves.
+
+### 8.3 The load leaves the SEQUENCER on bank A — §7's ordering has a second consequence ✅
+
+Ticks alone did not land the trig. The step handler (`0x4009d1e8`) was
+called once, scheduled every track three frames out, and never came back;
+cold calls it at frame 0 and again at frame 345, and the frame-0 trig path
+schedules the event that fires at 344. The difference is two bytes:
+**`0x800065bd` is the sequencer's own playing bank and `0x800065be` its
+playing pattern** — `FW_START_TRACK` (`0x4009b5c8`) and the step handler
+both index the bank blob by them (`bank × 635712 + 0x400e21e0`, `pattern
+× 36568`). Cold has (1, 0), the file's `BANK=1` / `PATTERN=0`; route A had
+(0, 0), so the sequencer was walking bank A's empty pattern record while
+`0x80000002` and `PART_PTR` said bank B.
+
+Who writes them: one setter, `0x400a0570` (bank, pattern, …), reached
+through `0x400a1030(bank, pattern)`, and the LOAD PROJECT handler's **last
+step** is exactly `0x400a1030(0x80000002, 0x80000004)` at `0x40025b16`.
+Cold calls it with (0, 0) twice during the load and (1, 0) at the end.
+Route A calls it with (0, 0) at the end (sample 55,047 of the run) —
+because the handler blocks on real card reads, `sys` runs in those waits
+and applies the engine's own reset-time "select bank 0" (§7) *before* the
+handler reaches its last step, which then reads a bank byte of 0. The
+`sys` select-bank case (`0x40062288`) sets `PART_PTR`, copies the blob
+(`0x4000faf0`), writes `0x80000002` and the UI mirror `0x100b14ce`, and
+does **not** touch the sequencer bytes — so re-selecting the bank through
+`sys` (M6b's `select_bank_live`) fixed the bank and not the sequencer.
+
+The tool now does what the load's own last step does, after the bank is
+what the file says: `Rtos.seq_select_live(bank, pattern)` calls
+`0x400a1030` through `call_as_main` (plain stores plus `0x40009e00`; never
+blocked). Both are M5-detour moves §5 allows for M6c, and both compensate
+for the same unfaithful-or-not ordering §7 already flagged. **The hardware
+falsifier from §7 now has two observables**: after LOAD PROJECT, which
+bank does the unit show — and does PLAY run the saved pattern? If the unit
+comes up on B playing pattern 1, the emulator's `sys` timing (the p2c
+traffic ahead of the reset message, or the engine's card-wait length) is
+what is unfaithful, and `load_project_live` should end where the unit
+does without help.
+
+### 8.4 The gate
+
+**Passed, 6 Sep 2026.** Route A (real tasks, real mount and load, the
+sequencer re-selected onto the file's bank and pattern through the load's
+own last step, internal clock, transport by the M5 detour, `--poke-trig
+2`, 400 frames) against cold (`emu_frames.py`, same project, same flags):
+
+| | cold (M5) | route A (M6c) |
+|---|---|---|
+| ticks in 400 frames | 28 | 28 (frames 1, 16, 30, 45, 59, 73, …) |
+| transport-start writes | `0x10` on tracks 0, 1, 1, 2, 4, 7 | the same six, same order |
+| the trig | track 0, byte **`0xd3`**, 344 frames after the start frame | track 0, byte **`0xd3`**, 344 frames after the start frame |
+
+Frame numbering differs by one between the two tools (cold counts the
+first frame after the start as 0, the route-A script counted it as 1; the
+CLI reports frames since the transport-start frame, so its number is
+comparable to cold's directly). Same byte, same track, same distance from
+the start — with the sequencer's tick pre-empting the frame handler for
+real, the interleaving M5 could not model changed nothing in this test.
+That is the result §5 asked for and no more: one trig, one project, one
+tempo; the `ips` risk in §6 is closed only to the extent that the trig
+frame did not move at the default knob.
+
+Regressions with every change above in place: the M6a gate passes
+(`--until-gate --project out/_testproj --ms 1000` — it needs the card and
+the 1 s budget; without `--project` the run faults at once on an unmapped
+read of `0x100fff04` from `0x4001fa4e`, on HEAD too, a pre-existing gap
+in the no-card mapping, noted not fixed), `make verify` is identical to
+the trusted baseline (254 PASS), `--selftest` passes. Frame mode stays
+opt-in; the eDMA and INTFRC rules are always on and changed nothing in
+M6a/M6b's runs (forced source 43 was already unmasked; no other INTC0
+force is written outside frame mode).
 
 Reproduce:
 ```sh
 .venv/bin/python3 tools/emu_rtos.py --project out/_testproj --set OCTABAM --name RIG \
-  --sequencer --poke-trig 2 --frames 400 --ms 6000
+  --sequencer --internal-clock --poke-trig 2 --frames 400 --ms 20000
 ```
-Expect `frame_count: 1` and no further `FW_LIVE_NIBBLE` writes past
-whatever the handler does on its one delivery — that is the measured,
-reproducible state this section describes, not a crash to fix.

--- a/tools/emu_rtos.py
+++ b/tools/emu_rtos.py
@@ -131,6 +131,11 @@ FW_TRANSPORT = 0x4009b964          # (arg) transport start/stop; start posts to 
 FW_START_TRACK = 0x4009b5c8        # (track) promote a track to running (emu_frames.py names both)
 FW_LIVE_NIBBLE = 0x46104d15        # per-track byte a fired trig actually changes (emu_frames.py)
 FW_TRIG_WORDS = 0x46104d26         # per-track word Bryan named; stays zero in every run so far
+FW_MIDI_SETTINGS = 0x80000028      # project MIDI byte: bit 0 = CLOCK RECEIVE (emu_frames.py)
+FW_SEQ_SELECT = 0x400a1030         # sequencer select(bank, pattern): the LOAD PROJECT handler's
+                                   # last step (0x40025b16), also the sequencer init's (0x400a1088)
+FW_SEQ_BANK = 0x800065bd           # the sequencer's own playing bank byte (FW_START_TRACK: x 635712)
+FW_SEQ_PATTERN = 0x800065be        # ...and playing pattern (x 36568)
 
 
 class Pit:
@@ -205,7 +210,9 @@ class Pit:
 
 
 class Intc:
-    """MCF547x interrupt controller: IMRH/L +0x08/+0x0c, INTFRCH/L +0x10/+0x14,
+    """MCF5445x interrupt controller (MCF54455RM rev 5 ch. 17; "MCF547x" here
+    until 6 Sep 2026 was wrong -- same register map, different chip): IMRH/L
+    +0x08/+0x0c, INTFRCH/L +0x10/+0x14,
     SIMR/CIMR bytes at +0x1c/+0x1d (value = source, 0x40 = all), ICRn at
     +0x40+n. IPRH/L (+0x00/+0x04) read back the asserted sources. Vector =
     `vec_base + source`. `lines` maps a source to a callable giving its level.
@@ -226,10 +233,22 @@ class Intc:
         return a
 
     def pending(self):
-        """[(level, source)] asserted and unmasked, highest level first."""
+        """[(level, source)] asserted and unmasked, highest level first.
+
+        A FORCED request ignores the mask: "The assertion of an interrupt
+        request via the interrupt force register is not affected by the
+        interrupt mask register" (MCF54455RM rev 5, 17.2.3, read 6 Sep 2026).
+        The firmware depends on it -- the sequencer tick (INTFRCH0 bit 0,
+        source 32) is installed with ICR 3 at 0x400a10a4 and never unmasked
+        anywhere in the image (15 CIMR sites, none names 32; no IMRH/IMRL
+        write at all), and masking it here left the sequencer silent: 400
+        frames, zero ticks. The kernel's own reschedule (source 43) IS
+        unmasked at 0x400005ea, so nothing changes for it. A source with
+        ICR 0 is still never delivered."""
         a = self.asserted() & ~self.imr
         if self.imr & 1:
             a = 0
+        a |= self.intfrc
         out = [(self.icr[s], s) for s in range(1, 64) if a >> s & 1 and self.icr[s]]
         out.sort(reverse=True)
         return out
@@ -364,6 +383,129 @@ MEDIA_KICK_VAL = 0x00020002
 # mean for the branch we know should be taken, not from a spec for the block.
 
 
+EDMA = 0xfc044000                  # MCF5445x eDMA: control at +0x0000, TCDs at +0x1000
+EDMA_TCD = 0xfc045000              # 16 channels x 32 bytes: SADDR +0, ATTR/SOFF +4, NBYTES +8,
+                                   # SLAST +0xc, DADDR +0x10, CITER +0x14, DOFF +0x16,
+                                   # DLAST_SGA +0x18, BITER +0x1c, CSR +0x1e
+
+
+class Edma:
+    """The MCF5445x eDMA, as far as the DSP frame exchange and the ColdFire's
+    per-frame EMAC work use it (read 6 Sep 2026, Fable review of M6c).
+
+    Registers: TCDs at 0xfc045000, 32 bytes per channel (SADDR +0, NBYTES
+    +8, DADDR +0x10, CITER +0x14, BITER +0x1c, CSR +0x1e); control bytes at
+    0xfc04401c CINT (clear a channel's request; 0x40 = all), +0x1e SSRT
+    (software-start a channel), +0x1f CDNE (clear DONE). A channel starts by
+    SSRT or by CSR.START (bit 0). On completion: DONE (CSR bit 7) is set; if
+    CSR.INTMAJOR (bit 1) its INTC0 source (8 + channel) is asserted until
+    CINT; if CSR.MAJORELINK (bit 5) the channel MAJORLINKCH (CSR bits 8-12)
+    starts. That last rule IS the audio chain the frame handler kicks: ch1
+    CSR 0x621 links to ch6, ch6's 0x720 links to ch7, ch7's 0x0002 raises
+    source 15 -- and the seven-step completion ISR (0x40004840, jump table
+    on 0x46104d3e at 0x400ab61a, state 7 = the frame-source unmask at
+    0x40004bc0) then SSRTs ch1 and ch0 in turn (sources 9, 8).
+
+    No data moves (audio is out of route A's scope, RTOS_FORK.md section 1;
+    M5 ran 12,000 frames with no DSP at all). Completion TIMING is the one
+    thing that has to be right, because the exchange is a two-frame
+    pipeline with ~64k+ instructions of EMAC work (0x400031a0) inside it.
+    Three kinds of transfer, told apart by how they start and what they
+    touch (TCDs read 6 Sep 2026: ch0 RAM->0x2000001c, ch1/6/7 0x2000001c->RAM,
+    ch2/3 0x4f502c10->RAM, i.e. the delay ring the stock-delay finding
+    named):
+    - a CSR.START of a host-port channel is the frame's audio stream; the
+      chain it links (1 -> 6 -> 7) is one frame of DSP data and completes
+      at the DSP's next 16-sample boundary, as a whole -- the DSP delivers
+      on its own clock, not "kick + 16" (that gave an 18.5-sample period and
+      dropped every sixth frame), and not instantly (that re-raised source
+      15 before state 0 could ack it and the ISR spun in state 6);
+    - an SSRT is one of the ISR's 256-byte control transfers over the same
+      host port: bus-speed, completes at once;
+    - a CSR.START of a memory-to-memory channel (0x400031a0's ch2, linked
+      to ch3) is a copy the caller busy-waits for at 0x400035a8: at once --
+      holding it for a frame spun forever.
+    ch0 and ch1 carry INTMAJOR from boot (CSR 0x0002 at the handoff), so
+    nothing here asserts a source the TCD doesn't ask for.
+    """
+    SSRT, CINT, CDNE = 0x1e, 0x1c, 0x1f
+    START, INTMAJOR, MAJORELINK, DONE = 0x0001, 0x0002, 0x0020, 0x0080
+    HOSTPORT = (0x20000000, 0x20001000)
+
+    def __init__(self):
+        self.tcd = bytearray(16 * 32)
+        self.regs = {}
+        self.irq = [False] * 16
+        self.started = 0
+        self.due = {}                       # channel -> sample at which it completes
+        self.now = 0.0                      # kept current by Rtos._tick_timers
+        self.boundary = FRAME_PERIOD        # the DSP's next frame boundary (Rtos keeps it current)
+
+    def _u(self, ch, off, n):
+        return int.from_bytes(self.tcd[ch * 32 + off:ch * 32 + off + n], "big")
+
+    def _csr(self, ch):
+        return self._u(ch, 0x1e, 2)
+
+    def _set_csr(self, ch, v):
+        self.tcd[ch * 32 + 0x1e:ch * 32 + 0x20] = (v & 0xffff).to_bytes(2, "big")
+
+    def _paced(self, ch):
+        lo, hi = self.HOSTPORT
+        return any(lo <= self._u(ch, o, 4) < hi for o in (0, 0x10))
+
+    def _start(self, ch, paced):
+        self._set_csr(ch, self._csr(ch) & ~self.DONE)
+        self.started += 1
+        if paced:                            # the DSP delivers its frame on ITS clock
+            self.due.setdefault(ch, self.boundary)
+        else:
+            self._complete(ch)
+
+    def _complete(self, ch):
+        csr = self._csr(ch)
+        self._set_csr(ch, (csr & ~self.START) | self.DONE)
+        if csr & self.INTMAJOR:
+            self.irq[ch] = True
+        if csr & self.MAJORELINK:                # the linked channel is the same
+            self._start((csr >> 8) & 0x1f, False)  # burst: completes with its parent
+
+    def advance(self, now):
+        self.now = now
+        for ch in [c for c, t in self.due.items() if now >= t]:
+            del self.due[ch]
+            self._complete(ch)
+
+    def read(self, a, size):
+        if EDMA_TCD <= a < EDMA_TCD + len(self.tcd):
+            off = a - EDMA_TCD
+            return int.from_bytes(self.tcd[off:off + size], "big")
+        return self.regs.get(a, 0)
+
+    def write(self, a, size, val, replay=False):
+        if EDMA_TCD <= a < EDMA_TCD + len(self.tcd):
+            off = a - EDMA_TCD
+            self.tcd[off:off + size] = (val & ((1 << (8 * size)) - 1)).to_bytes(size, "big")
+            if not replay and off % 32 + size > 0x1e and (val & self.START):
+                ch = off // 32
+                self._start(ch, paced=self._paced(ch))
+            return
+        off = a - EDMA
+        if off == self.SSRT and size == 1:
+            if not replay:
+                self._start(val & 0x0f, paced=False)
+        elif off == self.CINT and size == 1:
+            if val & 0x40:
+                self.irq = [False] * 16
+            else:
+                self.irq[val & 0x0f] = False
+        elif off == self.CDNE and size == 1:
+            for c in (range(16) if val & 0x40 else [val & 0x0f]):
+                self._set_csr(c, self._csr(c) & ~self.DONE)
+        else:
+            self.regs[a] = val
+
+
 class RtosFault(Exception):
     pass
 
@@ -411,22 +553,27 @@ class Rtos:
         self.pit0, self.pit1 = Pit("PIT0", pit_clock_hz), Pit("PIT1", pit_clock_hz)
         self.uart64, self.uart68 = Uart("UART@fc064000", 0xfc064000), Uart("UART@fc068000", 0xfc068000)
         self.dspi = Dspi()
-        # M6c: the DSP frame clock (source 1, FRAME_PERIOD above). A count,
-        # not a flag -- more than one boundary can cross in a single burst
-        # if the burst was sized loosely; _next_expiry keeps that rare.
-        # Cleared on delivery (INFERRED as edge-triggered: no ack register
-        # for it appears anywhere in the docs, unlike PIT0's PIF or the
-        # ATA/UART status reads -- the frame ISR's own `rte`, per emu_frames,
-        # is what "finishes" a frame in the cold model, so one push = one
-        # frame taken).
+        self.edma = Edma()
+        # M6c: the DSP frame clock (source 1, FRAME_PERIOD above). A latch:
+        # set at every 16-sample boundary, cleared when delivered. Not a
+        # count -- while the source is masked (boot, and the handler's own
+        # self-mask for the whole DSP exchange) a real edge source remembers
+        # one edge, not how many it missed; a count here delivered ~540
+        # phantom frames back to back after main's unmask (measured 6 Sep
+        # 2026). The handler re-arms itself only through the eDMA exchange
+        # (RTOS_FORK.md section 8); the ISR's `rte` is not the ack.
         self.next_frame = FRAME_PERIOD
-        self.frame_pending = 0
+        self.frame_pending = False
         self.frame_count = 0
         # INTC0 sources: 1 = DSP frame (vector 0x41); 27/28 -> vectors
         # 0x5b/0x5c -> handlers 0x400109bc/0x40010b88 (vector-install scan,
         # 6 Sep 2026); INTC1 source 43 = PIT0.
+        # INTC0 sources 8..23 = eDMA channels 0..15 (MCF5445x); 8, 9 and 15
+        # are the ones the frame exchange raises (RTOS_FORK.md section 8).
+        edma_lines = {8 + c: (lambda c=c: self.edma.irq[c]) for c in range(16)}
         self.intc0 = Intc("INTC0", 64, {1: lambda: self.frame and bool(self.frame_pending),
-                                        27: lambda: self.uart64.irq, 28: lambda: self.uart68.irq})
+                                        27: lambda: self.uart64.irq, 28: lambda: self.uart68.irq,
+                                        **edma_lines})
         self.ata_irq = False                 # the card's INTRQ (INTC1 source 54, vector 0xb6)
         # INTC1: 43 = PIT0 (vector 171, the scheduler), 44 = PIT1 (vector 0xac,
         # the storage layer's delay timer, handler 0x40020d38), 54 = ATA (0xb6)
@@ -481,6 +628,25 @@ class Rtos:
         self.uc.ctl_flush_tb()
         return self
 
+    def exact_clock(self):
+        """Charge bursts the instructions they actually executed (a global
+        UC_HOOK_CODE counter) instead of their full quantum. ~10x slower, so
+        it is switched on only where timing is load-bearing: from
+        `start_transport_live` on. Why: the quantum rule bills a burst that
+        stopped early on a hook or shim in full -- ~2.1x over the frame
+        exchange (35.2M charged vs 16.5M executed over one window, 6 Sep
+        2026) -- and the DSP exchange is a two-frame pipeline with ~64k
+        instructions of EMAC work inside it, which a 2x clock error breaks."""
+        if getattr(self, "_exact", None) is not None:
+            return self
+        self._exact = {"n": 0}
+
+        def on_code(u, a, sz, x):
+            self._exact["n"] += 1
+        self.uc.hook_add(eb.UC_HOOK_CODE, on_code, begin=1, end=0xffffffff)
+        self.uc.ctl_flush_tb()
+        return self
+
     def watch_pc(self, addrs):
         """Log registers each time one of `addrs` is about to execute."""
         regs = [("d0", eb.UC_M68K_REG_D0), ("d1", eb.UC_M68K_REG_D1), ("a0", eb.UC_M68K_REG_A0),
@@ -526,6 +692,8 @@ class Rtos:
             except eb.UcError:
                 pass
         uc.mem_write(SR_TRAMP, bytes.fromhex("40c0" "4e71"))     # movew %sr,%d0 ; nop
+        if self.frame:
+            self.exact_clock()               # frame mode is timing-load-bearing throughout
         # the whole window, not a sub-range: Unicorn's MMIO split is unproven here
         uc.mem_unmap(PERIPH_BASE, PERIPH_SIZE)
         uc.mmio_map(PERIPH_BASE, PERIPH_SIZE,
@@ -601,6 +769,8 @@ class Rtos:
                 return u.read(a - u.base, size)
         if DSPI <= a < DSPI + 0x100:
             return self.dspi.read(a - DSPI, size)
+        if EDMA <= a < EDMA + 0x2000:
+            return self.edma.read(a, size)
         if a == MEDIA_KICK:
             return MEDIA_KICK_VAL
         v = PLL_VAL if a == PLL_REG else eb.EXTRA_OVERRIDES.get(a, (1 << (size * 8)) - 1)
@@ -619,6 +789,8 @@ class Rtos:
             self.pit1.write(a - PIT1, size, val, self.sample)
         elif DSPI <= a < DSPI + 0x100:
             self.dspi.write(a - DSPI, size, val, replay=replay)
+        elif EDMA <= a < EDMA + 0x2000:
+            self.edma.write(a, size, val, replay=replay)
         else:
             for u in (self.uart64, self.uart68):
                 if u.base <= a < u.base + 0x20:
@@ -739,7 +911,7 @@ class Rtos:
         sr = self._sr()
         self._push(vec, self.pc, (sr & ~0x8700) | 0x2000 | (level << 8))
         if name == "INTC0" and src == 1:
-            self.frame_pending -= 1
+            self.frame_pending = False
             self.frame_count += 1
         self._t(f"irq {name} src {src} vec {vec} level {level} -> {self.pc:#x} (was ipl {ipl})")
         return True
@@ -783,9 +955,14 @@ class Rtos:
         self._force_stop = None
         self._sr_cache = None
         t0 = time.perf_counter()
+        ex = getattr(self, "_exact", None)
+        if ex is not None:
+            ex["n"] = 0
         uc.emu_start(self.pc, 0, count=n)
         self.wall += time.perf_counter() - t0
         self.bursts += 1
+        if ex is not None:
+            n = ex["n"]                      # what actually ran, not the quantum
         self.instrs += n
         self.sample += n / self.ips
         self.trap = self.r.trap
@@ -799,8 +976,10 @@ class Rtos:
         self.pit1.advance(self.sample)
         if self.frame:
             while self.sample >= self.next_frame:
-                self.frame_pending += 1
-                self.next_frame += FRAME_PERIOD
+                self.frame_pending = True       # a latch, not a count: a masked
+                self.next_frame += FRAME_PERIOD  # edge source remembers ONE edge
+        self.edma.boundary = self.next_frame
+        self.edma.advance(self.sample)
 
     def run(self, ms=None, until=None, max_bursts=None):
         """Run until `ms` emulated milliseconds elapse, `until(self)` is true,
@@ -868,6 +1047,47 @@ class Rtos:
         (`tstb a2@(1)`, else the handler returns having done nothing)."""
         self.uc.mem_write(SYS_MSG_SCRATCH, bytes([16, 1]))
         return self.post_message(SYS_QUEUE, SYS_MSG_SCRATCH)
+
+    def select_bank_live(self, bank, ms=500):
+        """Switch the working bank through sys's own case (opcode 21, table[20]
+        = 0x40062288 -- the very message the engine's reset posts with bank
+        0, RTOS_FORK.md section 7): PART_PTR := the bank's blob, 0x4000faf0
+        copies it into SRAM, the bank byte follows. Returns the bank byte."""
+        self.run(until=lambda r: r.pc == MAIN_SPIN)
+        self.uc.mem_write(SYS_MSG_SCRATCH, bytes([21, bank & 0x0f]))
+        self.post_message(SYS_QUEUE, SYS_MSG_SCRATCH)
+        self.run(ms=ms, until=lambda r: r.uc.mem_read(CUR_BANK, 1)[0] == bank)
+        return self.uc.mem_read(CUR_BANK, 1)[0]
+
+    def seq_select_live(self, bank, pattern):
+        """The sequencer's own bank/pattern select, `0x400a1030(bank,
+        pattern)`: the LOAD PROJECT handler's LAST step (0x40025b16, called
+        with the project's bank and pattern bytes) and the sequencer init's
+        (0x400a1088). It writes the sequencer's playing bank/pattern
+        (0x800065bd/0x800065be and their mirrors, via 0x400a0570) -- the
+        bytes FW_START_TRACK and the step handler index the bank blob by.
+        Route A needs it re-issued after the load: the handler reads the
+        bank byte at its end, and by then `sys` has applied the engine's
+        own reset-time "select bank 0" (it runs in the handler's real card
+        waits, RTOS_FORK.md section 7), so the sequencer is left on bank A
+        with the pattern record of an empty bank (measured 6 Sep 2026: the
+        step handler scheduled every track 3 frames out and never came
+        back; cold, with no waits, gets the parsed bank). Non-blocking
+        (plain stores + 0x40009e00), safe under call_as_main. Returns the
+        sequencer's (bank, pattern) bytes."""
+        self.run(until=lambda r: r.pc == MAIN_SPIN)
+        self.call_as_main(FW_SEQ_SELECT, args=(bank, pattern))
+        return self.uc.mem_read(FW_SEQ_BANK, 1)[0], self.uc.mem_read(FW_SEQ_PATTERN, 1)[0]
+
+    def internal_clock(self):
+        """Clear the project's CLOCK RECEIVE bit (0x80000028 bit 0) so the
+        sequencer runs on its own clock -- with it set, as Sam's projects
+        save it (the Rytm is master), the engine waits for MIDI clock that
+        never comes: 400 frames, zero ticks, no trig (measured 6 Sep 2026).
+        The same switch as emu_frames.py's --internal-clock."""
+        midi = self.uc.mem_read(FW_MIDI_SETTINGS, 1)[0]
+        self.uc.mem_write(FW_MIDI_SETTINGS, bytes([midi & ~1]))
+        return midi
 
     def load_project_live(self, set_name, project_name, run_ms=6000, mount_ms=3000):
         """M6b: drive a project load the way hardware would, then let the
@@ -940,6 +1160,7 @@ class Rtos:
         `FW_CARD_INIT`, neither ever blocked in testing. This is the "M5
         detour" route RTOS_FORK.md §5 explicitly allows for M6c -- real key
         injection into the UI queue is M6d's job, not required here."""
+        self.exact_clock()
         self.run(until=lambda r: r.pc == MAIN_SPIN)
         self.call_as_main(FW_TRANSPORT, args=(0,))
         for t in range(8):
@@ -1011,10 +1232,14 @@ class Rtos:
                          f"{'ok' if ok else 'NOT IN TABLE'}")
         lines.append(f"dispatches ({len(self.dispatches)}, {self.switches} switches):")
         last = None
+        rows = []
         for s, t, pc in self.dispatches:
             if t != last:
-                lines.append(f"  [{s:9.1f}] {self._name(t):8s} pc={pc:#x}")
+                rows.append(f"  [{s:9.1f}] {self._name(t):8s} pc={pc:#x}")
             last = t
+        if len(rows) > 80:                  # a 20 s sequencer run switches ~13,000 times
+            rows = rows[:40] + [f"  ... {len(rows) - 80} switches elided ..."] + rows[-40:]
+        lines.extend(rows)
         lines.append("last block per task (trap site, caller, object):")
         last = {}
         for smp, t, pc, caller, obj, owner in self.blocks:
@@ -1170,6 +1395,10 @@ def _cli():
     ap.add_argument("--poke-trig", type=int, default=0,
                     help="with --sequencer: set a trig on track 1 at this step (1-8) after loading")
     ap.add_argument("--frames", type=int, default=400, help="with --sequencer: DSP frames to run")
+    ap.add_argument("--internal-clock", action="store_true",
+                    help="with --sequencer: clear CLOCK RECEIVE so the sequencer runs on its own clock")
+    ap.add_argument("--bank", type=int, default=None,
+                    help="with --sequencer: switch to this bank via sys before starting (default: the file's saved bank)")
     a = ap.parse_args()
 
     card = None
@@ -1178,7 +1407,7 @@ def _cli():
         card, staged_name = stage_project(a.project, a.set, a.name)
     t0 = time.perf_counter()
     r, rt = attach(a.image, card, ips=a.ips, pit_clock_hz=a.pit_clock, quantum=a.quantum,
-                   step_quantum=a.step_quantum, tick=not a.no_tick, frame=a.sequencer,
+                   step_quantum=a.step_quantum, tick=not a.no_tick,
                    trace=(lambda s: print(s, flush=True)) if a.trace else None)
     if a.watch_calls:
         rt.watch_calls([int(x, 0) for x in a.watch_calls.split(",")])
@@ -1206,12 +1435,36 @@ def _cli():
                 rt.run(ms=1000, until=lambda x: x.gate_m6a()[0])
             mounted, posted, saved_bank, final_bank, elapsed = rt.load_project_live(
                 a.set, staged_name, run_ms=a.ms)
+            # The frame clock and the exact instruction clock come on here,
+            # after the boot and the load: both are ~10x slower and neither
+            # matters to the sequencer until it runs (on hardware the frame
+            # exchange runs from boot; nothing the trig test reads depends
+            # on it having done so). Rtos(frame=True) still gives the
+            # from-boot form for Python callers.
+            bank = a.bank if a.bank is not None else saved_bank
+            if bank is not None and final_bank != bank:
+                # The load ends on bank A (sys applies the engine's own
+                # reset-time "select bank 0" after the BANK= parse -- section
+                # 7's open ordering question); the cold reference sits on the
+                # SAVED bank. Put the run there through sys's own switch.
+                final_bank = rt.select_bank_live(bank)
+            pattern = rt.uc.mem_read(CUR_PATTERN, 1)[0]
+            seq_bank, seq_pattern = rt.seq_select_live(final_bank, pattern)
+            if a.internal_clock:
+                rt.internal_clock()
+            rt.frame = True
+            rt.next_frame = rt.sample + FRAME_PERIOD
+            rt.exact_clock()
             rt.start_transport_live()
             if a.poke_trig:
                 v = rt.poke_trig(a.poke_trig)
                 print(f"poke trig  : track 1 step {a.poke_trig} -> mask byte 7 = {v:#04x}")
             rt.install_trig_log()
-            target = rt.frame_count + a.frames
+            # Frame 0 = the first frame delivered after the transport start
+            # returned, which is what emu_frames.py's cold run calls frame 0:
+            # the two reports compare directly (cold: the trig at 344).
+            frame0 = rt.frame_count + 1
+            target = frame0 + a.frames
             rt.run(ms=a.frames * FRAME_PERIOD / SAMPLE_HZ * 1000.0 * 5 + 2000,
                    until=lambda x: x.frame_count >= target)
         except (RtosFault, eb.UcError) as e:
@@ -1220,11 +1473,14 @@ def _cli():
             print(rt.starvation())
             return 1
         print(rt.report())
-        print(f"load       : mounted={mounted} saved_bank={saved_bank} final_bank={final_bank}")
-        print(f"frames run : {rt.frame_count} (target {target})")
-        print(f"FW_LIVE_NIBBLE (0x{FW_LIVE_NIBBLE:x}) writes ({len(rt.live_nibble_log)}):")
+        print(f"sequencer  : playing bank {seq_bank} pattern {seq_pattern} (re-selected through the load's own last step)")
+        print(f"load       : mounted={mounted} saved_bank={saved_bank} bank={final_bank} "
+              f"clock={'internal' if a.internal_clock else 'external (CLOCK RECEIVE as saved)'}")
+        print(f"frames run : {rt.frame_count - frame0} since transport start (target {a.frames}; "
+              f"{frame0} before it), eDMA transfers {rt.edma.started}")
+        print(f"FW_LIVE_NIBBLE (0x{FW_LIVE_NIBBLE:x}) writes ({len(rt.live_nibble_log)}), frames since transport start:")
         for frame, track, val in rt.live_nibble_log:
-            print(f"   frame {frame:5d} track {track} byte {val:#04x}  nibble {val & 0xf:x}  flags {val & 0xf0:#04x}")
+            print(f"   frame {frame - frame0:5d} track {track} byte {val:#04x}  nibble {val & 0xf:x}  flags {val & 0xf0:#04x}")
         print(f"FW_TRIG_WORDS (0x{FW_TRIG_WORDS:x}) nonzero writes ({len(rt.trig_words_log)}): {rt.trig_words_log}")
         ok = rt.frame_count >= target
         if not ok:

--- a/tools/emu_rtos.py
+++ b/tools/emu_rtos.py
@@ -118,6 +118,20 @@ PLL_REG, PLL_VAL = 0xfc0c4000, 0x16000000       # emu_bringup's one load-bearing
 
 SAMPLE_HZ = 44100.0
 
+# M6c: the DSP audio-frame interrupt (INTC0 source 1, vector 0x41) is a
+# free-running hardware clock, unlike PIT0/PIT1 -- fixed period, no enable
+# bit, no registers (RTOS_FORK.md §4: "a frame interrupt every 16 samples").
+# Its ICR level and CIMR unmask are programmed by main's own boot tail
+# (0x4001fc2e..0x4001fc3e, byte-exact from the M6a scan) and its handler
+# installed on the vector by main's own init (0x4001fbf8) -- both run for
+# real under our scheduler, so nothing needs seeding here, only the source.
+FRAME_PERIOD = 16.0                # samples per DSP-frame interrupt
+FW_FRAME_ISR = 0x4000aad0          # the frame builder (emu_frames.FW_FRAME_ISR)
+FW_TRANSPORT = 0x4009b964          # (arg) transport start/stop; start posts to the UI queue
+FW_START_TRACK = 0x4009b5c8        # (track) promote a track to running (emu_frames.py names both)
+FW_LIVE_NIBBLE = 0x46104d15        # per-track byte a fired trig actually changes (emu_frames.py)
+FW_TRIG_WORDS = 0x46104d26         # per-track word Bryan named; stays zero in every run so far
+
 
 class Pit:
     """MCF547x programmable interrupt timer, counted in samples.
@@ -358,11 +372,20 @@ class Rtos:
     """The event loop over a booted machine. Construct via `attach()`."""
 
     def __init__(self, r, ips=3990.0, pit_clock_hz=264e6, quantum=4096,
-                 step_quantum=32, tick=True, trace=None):
+                 step_quantum=32, tick=True, frame=False, trace=None):
         self.r, self.uc = r, r.uc
         self.ips = float(ips)
         self.quantum, self.step_quantum = int(quantum), int(step_quantum)
         self.tick = tick
+        # M6c's frame clock (source 1) is OFF by default: main's own boot
+        # tail unmasks it unconditionally (0x4001fc2e), so once modelled it
+        # fires every 16 samples in EVERY run regardless of whether anything
+        # needs the sequencer -- M6a's gate and M6b's load were built and
+        # verified without it (~16x more dispatches otherwise: PIT0's own
+        # 220-sample period is the coarsest timer beforehand). Same pattern
+        # as `tick`: the register state is real either way, only the model's
+        # assertion is gated.
+        self.frame = frame
         self.trace = trace                   # callable(str) or None
         self.sample = 0.0
         self.instrs = 0
@@ -388,9 +411,22 @@ class Rtos:
         self.pit0, self.pit1 = Pit("PIT0", pit_clock_hz), Pit("PIT1", pit_clock_hz)
         self.uart64, self.uart68 = Uart("UART@fc064000", 0xfc064000), Uart("UART@fc068000", 0xfc068000)
         self.dspi = Dspi()
-        # INTC0 sources 27/28 -> vectors 0x5b/0x5c -> handlers 0x400109bc/0x40010b88
-        # (vector-install scan, 6 Sep 2026); INTC1 source 43 = PIT0.
-        self.intc0 = Intc("INTC0", 64, {27: lambda: self.uart64.irq, 28: lambda: self.uart68.irq})
+        # M6c: the DSP frame clock (source 1, FRAME_PERIOD above). A count,
+        # not a flag -- more than one boundary can cross in a single burst
+        # if the burst was sized loosely; _next_expiry keeps that rare.
+        # Cleared on delivery (INFERRED as edge-triggered: no ack register
+        # for it appears anywhere in the docs, unlike PIT0's PIF or the
+        # ATA/UART status reads -- the frame ISR's own `rte`, per emu_frames,
+        # is what "finishes" a frame in the cold model, so one push = one
+        # frame taken).
+        self.next_frame = FRAME_PERIOD
+        self.frame_pending = 0
+        self.frame_count = 0
+        # INTC0 sources: 1 = DSP frame (vector 0x41); 27/28 -> vectors
+        # 0x5b/0x5c -> handlers 0x400109bc/0x40010b88 (vector-install scan,
+        # 6 Sep 2026); INTC1 source 43 = PIT0.
+        self.intc0 = Intc("INTC0", 64, {1: lambda: self.frame and bool(self.frame_pending),
+                                        27: lambda: self.uart64.irq, 28: lambda: self.uart68.irq})
         self.ata_irq = False                 # the card's INTRQ (INTC1 source 54, vector 0xb6)
         # INTC1: 43 = PIT0 (vector 171, the scheduler), 44 = PIT1 (vector 0xac,
         # the storage layer's delay timer, handler 0x40020d38), 54 = ATA (0xb6)
@@ -702,6 +738,9 @@ class Rtos:
             return False
         sr = self._sr()
         self._push(vec, self.pc, (sr & ~0x8700) | 0x2000 | (level << 8))
+        if name == "INTC0" and src == 1:
+            self.frame_pending -= 1
+            self.frame_count += 1
         self._t(f"irq {name} src {src} vec {vec} level {level} -> {self.pc:#x} (was ipl {ipl})")
         return True
 
@@ -711,6 +750,8 @@ class Rtos:
 
     def _next_expiry(self):
         ex = [p.expiry for p in (self.pit0, self.pit1) if p.expiry is not None]
+        if self.frame:
+            ex.append(self.next_frame)
         return min(ex) if ex else None
 
     # -- the loop ------------------------------------------------------------
@@ -756,6 +797,10 @@ class Rtos:
         if self.pit0.advance(self.sample):
             self._t(f"PIT0 expiry #{self.pit0.fired}")
         self.pit1.advance(self.sample)
+        if self.frame:
+            while self.sample >= self.next_frame:
+                self.frame_pending += 1
+                self.next_frame += FRAME_PERIOD
 
     def run(self, ms=None, until=None, max_bursts=None):
         """Run until `ms` emulated milliseconds elapse, `until(self)` is true,
@@ -883,6 +928,53 @@ class Rtos:
         saved_bank = (saved[-1] - BANK_BLOB) // BANK_STRIDE if saved else None
         final_bank = self.uc.mem_read(CUR_BANK, 1)[0]
         return mounted, posted, saved_bank, final_bank, (self.sample - start) / SAMPLE_HZ * 1000.0
+
+    # -- M6c: the sequencer under the real scheduler --------------------------
+    def start_transport_live(self):
+        """Start the sequencer the way `emu_frames.start_transport` does
+        cold, but through the real tasks: `FW_TRANSPORT(0)`'s start case
+        only sets state and posts to the UI queue (`0x460d1664`, EMU.md
+        M5) -- no wait primitive on that path -- and `FW_START_TRACK(t)`
+        writes a per-track state byte directly, no queue at all. Both
+        confirmed safe under `call_as_main` (6 Sep 2026): unlike
+        `FW_CARD_INIT`, neither ever blocked in testing. This is the "M5
+        detour" route RTOS_FORK.md §5 explicitly allows for M6c -- real key
+        injection into the UI queue is M6d's job, not required here."""
+        self.run(until=lambda r: r.pc == MAIN_SPIN)
+        self.call_as_main(FW_TRANSPORT, args=(0,))
+        for t in range(8):
+            self.run(until=lambda r: r.pc == MAIN_SPIN)
+            self.call_as_main(FW_START_TRACK, args=(t,))
+
+    def poke_trig(self, step):
+        """Set a trig on track 1 at `step` (1-8), same bytes as
+        `emu_frames.poke_trig` (track 1's 64-step mask, big-endian, byte 7
+        bit 0 = step 1) against whichever bank PART_PTR currently names."""
+        blob = int.from_bytes(self.uc.mem_read(ec.PART_PTR, 4), "big")
+        v = self.uc.mem_read(blob + 7, 1)[0] | (1 << (step - 1))
+        self.uc.mem_write(blob + 7, bytes([v]))
+        return v
+
+    def install_trig_log(self):
+        """As `emu_frames.install_trig_log`, keyed by `self.frame_count`
+        (this module's own frame clock) instead of a hand-kept counter."""
+        live, words = [], []
+
+        def on_live(u, acc, addr, size, val, d):
+            val &= 0xFF
+            if val:
+                live.append((self.frame_count, addr - FW_LIVE_NIBBLE, val))
+
+        def on_word(u, acc, addr, size, val, d):
+            val &= 0xFFFF
+            if val:
+                words.append((self.frame_count, (addr - FW_TRIG_WORDS) // 2, val))
+
+        self.uc.hook_add(eb.UC_HOOK_MEM_WRITE, on_live, begin=FW_LIVE_NIBBLE, end=FW_LIVE_NIBBLE + 7)
+        self.uc.hook_add(eb.UC_HOOK_MEM_WRITE, on_word, begin=FW_TRIG_WORDS, end=FW_TRIG_WORDS + 15)
+        self.uc.ctl_flush_tb()
+        self.live_nibble_log, self.trig_words_log = live, words
+        return live
 
     # -- the M6a gate --------------------------------------------------------
     def ran(self):
@@ -1072,6 +1164,12 @@ def _cli():
     ap.add_argument("--watch-pc", default="", help="comma-separated addresses: log registers there")
     ap.add_argument("--load-project", action="store_true",
                     help="M6b: after the gate, drive a project load through the real tasks (needs --project)")
+    ap.add_argument("--sequencer", action="store_true",
+                    help="M6c: enable the frame clock, start transport, run the sequencer for real "
+                         "(needs --project; --load-project is implied)")
+    ap.add_argument("--poke-trig", type=int, default=0,
+                    help="with --sequencer: set a trig on track 1 at this step (1-8) after loading")
+    ap.add_argument("--frames", type=int, default=400, help="with --sequencer: DSP frames to run")
     a = ap.parse_args()
 
     card = None
@@ -1080,7 +1178,7 @@ def _cli():
         card, staged_name = stage_project(a.project, a.set, a.name)
     t0 = time.perf_counter()
     r, rt = attach(a.image, card, ips=a.ips, pit_clock_hz=a.pit_clock, quantum=a.quantum,
-                   step_quantum=a.step_quantum, tick=not a.no_tick,
+                   step_quantum=a.step_quantum, tick=not a.no_tick, frame=a.sequencer,
                    trace=(lambda s: print(s, flush=True)) if a.trace else None)
     if a.watch_calls:
         rt.watch_calls([int(x, 0) for x in a.watch_calls.split(",")])
@@ -1099,6 +1197,40 @@ def _cli():
             acc, addr, size, pc = rt.unmapped
             why += f" unmapped {'write' if acc in (eb.UC_MEM_WRITE_UNMAPPED,) else 'read'} {addr:#x} size {size} at pc {pc:#x}"
         return why
+
+    if a.sequencer:
+        if not a.project:
+            print("--sequencer needs --project"); return 1
+        try:
+            if not rt.gate_m6a()[0]:
+                rt.run(ms=1000, until=lambda x: x.gate_m6a()[0])
+            mounted, posted, saved_bank, final_bank, elapsed = rt.load_project_live(
+                a.set, staged_name, run_ms=a.ms)
+            rt.start_transport_live()
+            if a.poke_trig:
+                v = rt.poke_trig(a.poke_trig)
+                print(f"poke trig  : track 1 step {a.poke_trig} -> mask byte 7 = {v:#04x}")
+            rt.install_trig_log()
+            target = rt.frame_count + a.frames
+            rt.run(ms=a.frames * FRAME_PERIOD / SAMPLE_HZ * 1000.0 * 5 + 2000,
+                   until=lambda x: x.frame_count >= target)
+        except (RtosFault, eb.UcError) as e:
+            print(f"stopped    : {_fault(e)}")
+            print(rt.report())
+            print(rt.starvation())
+            return 1
+        print(rt.report())
+        print(f"load       : mounted={mounted} saved_bank={saved_bank} final_bank={final_bank}")
+        print(f"frames run : {rt.frame_count} (target {target})")
+        print(f"FW_LIVE_NIBBLE (0x{FW_LIVE_NIBBLE:x}) writes ({len(rt.live_nibble_log)}):")
+        for frame, track, val in rt.live_nibble_log:
+            print(f"   frame {frame:5d} track {track} byte {val:#04x}  nibble {val & 0xf:x}  flags {val & 0xf0:#04x}")
+        print(f"FW_TRIG_WORDS (0x{FW_TRIG_WORDS:x}) nonzero writes ({len(rt.trig_words_log)}): {rt.trig_words_log}")
+        ok = rt.frame_count >= target
+        if not ok:
+            print(rt.starvation())
+        print("M6c run    :", "PASS (ran to target)" if ok else "FAIL (stopped short)")
+        return 0 if ok else 1
 
     if a.load_project:
         if not a.project:


### PR DESCRIPTION
Fable review of the M6c pass. The previous body of this PR (mechanism built, gate blocked on a judgment call) is superseded: both of §8's hypotheses were wrong, the "no second unmask site" claim was false, and the gate now passes.

**What stood in the way, each measured (`docs/RTOS_FORK.md` §8):**

1. **The frame source is re-armed by the eDMA completion interrupt** (state 7 of `0x40004840`, unmask at `0x40004bc2`). The DMA chain the frame handler kicks was unmodelled, so it never completed. `class Edma` models completion timing only (host-port STARTs complete at the DSP's next frame boundary; SSRT and memory-to-memory at once) — 16.0-sample period exactly. Frame mode counts instructions exactly (`exact_clock`); quantum billing over-charged 2.1×.
2. **A forced interrupt bypasses the mask.** MCF54455RM rev 5 §17.2.3: "The assertion of an interrupt request via the interrupt force register is not affected by the interrupt mask register." The sequencer tick (INTFRCH0 bit 0, source 32) is never unmasked anywhere in the image; the model masked it → 0 ticks in 400 frames, now 28 (cold's count). Chip family corrected to MCF5445x.
3. **The load leaves the *sequencer* on bank A.** `0x800065bd`/`0x800065be` are the sequencer's playing bank/pattern; the LOAD PROJECT handler's last step copies the project bytes there, and under route A `sys` has already applied the engine's reset-time "select bank 0" in the handler's real card waits. `select_bank_live` + `seq_select_live` re-issue the load's own last step with the file's bytes (M5 detour, compensating for §7's ordering). §7's one-press hardware falsifier now has a second observable: after LOAD PROJECT, does PLAY run the saved pattern?

**Gate:**
```
tools/emu_rtos.py --project out/_testproj --set OCTABAM --name RIG \
  --sequencer --internal-clock --poke-trig 2 --frames 400 --ms 20000
```
Track 0, byte `0xd3`, frame 344, 28 ticks, the same six start-frame writes — identical to `emu_frames.py` cold.

**Regressions:** M6a gate PASS (`--until-gate --project out/_testproj --ms 1000`; without `--project` the run faults on an unmapped read of `0x100fff04`, pre-existing on HEAD, noted in §8.4), `make verify` identical to the trusted baseline (254 PASS), `--selftest` PASS. Frame mode stays opt-in.

PLAN.md status board: M6c ✅, resume point moved to M6d (key injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
