### PR TITLE
Emulator M6d: real key injection -- and the milestone's own premise retracted

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -705,16 +705,18 @@ scheduler.
 | **M6a scheduler runs** | ✅ **done 6 Sep, PR #100** | `make emu-rtos PROJECT=<abs dir>`: eleven tasks start in the real order, the 5 ms tick and every interrupt fire, tasks post to each other; gate passes at 205 ms emulated |
 | M6b real waits + mount | ✅ **done 6 Sep** (one retraction) | `sys` (not engine) mounts the card; a real mount + LOAD PROJECT reach 30,467 real sectors (M4: ~30,955) and the file's saved bank. PR #103's "track-select watcher" reading is WITHDRAWN: the bytes are the current bank; the run ends on bank A because the engine's own reset-time "select bank 0" reaches `sys` after the `BANK=1` parse — a real cross-task ordering with a one-press hardware falsifier (RTOS_FORK §7) |
 | M6c sequencer under the scheduler | ✅ **done 6 Sep — gate passed** | the one-trig test lands the same byte (`0xd3`), same track, 344 frames after the start frame, 28 ticks, under real tasks and real interrupts as it does cold. Three findings on the way (RTOS_FORK §8): the frame source is re-armed by the **eDMA completion ISR** (eDMA now modelled, 16.0-sample period); a **forced interrupt bypasses the mask** (MCF54455RM §17.2.3 — the tick is never unmasked and never needed to be); the load leaves the **sequencer's** playing bank on A by §7's ordering (re-selected through the load's own last step; the hardware falsifier gained a second observable). Sonnet's two §8 hypotheses retracted |
-| M6d key injection | ⏳ mechanical | PLAY and REC-arm through the firmware's own path, no RAM pokes |
+| M6d key injection | ✅ **done 6 Sep — and the premise was wrong** | PLAY/REC do NOT arrive via a post to `0x4005593c`'s queue — that task isn't a queue consumer at all (a key-repeat timer, mislabeled "UI" by neighbourhood to the real queue's ring buffer). The real `UI_QUEUE` (`0x460d1664`) consumer is a different, previously-unidentified task (`0x40056c40`); physical keys dispatch through a separate per-key jump table (`0x400d2d54`) instead, the same shape as the FX2 shortcut. `press_play_live()`/`press_rec_live()` call PLAY/REC through their own firmware handlers (`call_as_main`, confirmed non-blocking by disassembly); PLAY reproduces M6c's fidelity gate exactly (RTOS_FORK §9) |
 | M6e use it | ⏳ judgment | the recorder-arm trace for Bryan; the tick pre-emption question |
 
-Where to resume: **M6d, key injection** (mechanical) — PLAY and REC-arm
-through the UI task's own queue instead of `call_as_main` on the transport
-routines; the queue `0x4005593c` blocks on is the thing to read first.
-M6c's gate is the regression to keep green while doing it: `tools/emu_rtos.py
---project out/_testproj --set OCTABAM --name RIG --sequencer
---internal-clock --poke-trig 2 --frames 400 --ms 20000` must keep landing
-`0xd3` on track 0, 344 frames after the start frame, with 28 ticks. Two
+Where to resume: **M6e, use it** (judgment) — the recorder-arm path still
+needs a project with a track's machine set to a recorder (REC through
+`press_rec_live()` starts the transport but leaves `0x800066a0` untouched
+with nothing to arm); build that project, then trace what Bryan's click
+actually needs. M6c's gate is the regression to keep green while doing it:
+`tools/emu_rtos.py --project out/_testproj --set OCTABAM --name RIG
+--sequencer --internal-clock --poke-trig 2 --frames 400 --ms 20000
+[--via-key]` must keep landing `0xd3` on track 0, 344 frames after the
+start frame, with 28 ticks (both with and without `--via-key`). Two
 of M6c's helpers are M5-detour compensation for §7's ordering
 (`select_bank_live`, `seq_select_live`); if the hardware falsifier below
 says the unit ends on the saved bank, the faithful fix is in the load's
@@ -742,9 +744,11 @@ engine's; `0x80000002` is the current bank and `PART_PTR` its blob.
 
 **Bryan's stake.** His click sits on the recorder's loop point, reached by
 one task staging the REC-arm and the tick promoting it — the interleaving
-route A now does for real. M6b's mount+load now work for real, matching M4's
-proof; it becomes usable for him at M6d (his project loaded under real
-tasks, PLAY/REC-arm injected as keys). Already useful to him today: the
+route A now does for real. M6b's mount+load work for real, matching M4's
+proof, and M6d's `press_play_live()`/`press_rec_live()` inject PLAY/REC as
+real keys — but REC-arm itself is still unobserved: it needs a project
+with a track's machine set to a recorder, which is M6e's first job.
+Already useful to him today: the
 measured task and vector tables in RTOS_FORK §2, `sys`'s own dispatch table
 (§7), the bank/pattern state bytes and the bank blob layout, and the panel
 serial link captured byte by byte.

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -436,7 +436,7 @@ ordinary trig landing in RAM) but does not answer Bryan's literal question.
 needs no new instrumentation — just `--bpm 128` and a pattern length of 4
 vs 32 steps.
 
-## The RTOS fork — M6a and M6b done, M6c's mechanism built 6 Sep 2026 (`tools/emu_rtos.py`)
+## The RTOS fork — M6a/M6b/M6c/M6d done 6 Sep 2026 (`tools/emu_rtos.py`)
 
 Milestones 2 and 4 took route **B** (detour) and it carries the remixer and
 the card: a menu- or cave-patch is visible and walkable without a flash, and
@@ -515,6 +515,33 @@ saved pattern?). Frame mode counts instructions exactly (`exact_clock`)
 rather than by quantum, which over-charged 2.1×. The previous paragraph
 here, and §8's two hypotheses, were wrong and are retracted in place.
 
+**M6d (same day): real key injection — and the milestone's own premise was
+wrong.** The scope assumed PLAY/REC reach the firmware by posting into the
+queue the task named "UI" blocks on. Disassembling that task
+(`0x4005593c`) shows it waits on an unrelated counting semaphore and spends
+its life decrementing a 136-slot key-repeat timer array — it isn't a queue
+consumer at all, and the label came from being next to the queue's ring
+buffer in memory (`0x460d4fd4`, `0x54` bytes past the TCB), not from
+reading it. The real consumer of `UI_QUEUE` (`0x460d1664`) is a different,
+previously-unidentified task (`0x40056c40`, TCB `0x460d59d4`, `RTOS_FORK.md`
+§2's "❓ (new)" row) — and that queue only carries state-change notices
+(FW_TRANSPORT's own start-case post among them), not raw key events at all.
+Physical keys — a literal-address scan found PLAY (`0x4000a200`), REC
+(`0x4000a274`) and STOP (`0x4000a1e0`) as three consecutive entries in a
+per-key jump table at `0x400d2d54` — dispatch through direct calls, the
+same shape as `MAINMENU.md`'s FX2 shortcut. Both PLAY and REC's full call
+chains were disassembled and hold no blocking kernel primitive, so both are
+safe under `call_as_main`; `press_play_live()` calls PLAY's own handler and
+**reproduces M6c's fidelity gate exactly** (frame 344, byte `0xd3`) — a
+stronger result than M6c's direct `FW_TRANSPORT` call, since it goes
+through the firmware's real clock-sync bookkeeping first. `press_rec_live()`
+starts the transport the same way on a project with no recorder-configured
+track and leaves the record-arm byte (`0x800066a0`) untouched — arming a
+track's recorder for real still needs a project with a track's machine set
+to a recorder, which does not exist yet; that, and Bryan's actual recorder
+question, are M6e's job. `RTOS_FORK.md` §9 has the full measurements and
+the task-table correction.
+
 ## Reproduce
 
 ```sh
@@ -525,6 +552,8 @@ make emu-rtos PROJECT=<project dir>  # route A: the scheduler running, M6a gate 
 .venv/bin/python3 tools/emu_rtos.py --project <dir> --set OCTABAM --name RIG --load-project --ms 6000
 .venv/bin/python3 tools/emu_rtos.py --project out/_testproj --set OCTABAM --name RIG \
   --sequencer --internal-clock --poke-trig 2 --frames 400 --ms 20000   # M6c: the trig under real tasks
+.venv/bin/python3 tools/emu_rtos.py --project out/_testproj --set OCTABAM --name RIG \
+  --sequencer --internal-clock --poke-trig 2 --frames 400 --ms 20000 --via-key   # M6d: same trig, via the real PLAY key
 .venv/bin/python3 tools/emu_rtos.py --selftest   # the SR-read trap, pinned
 ```
 

--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -1,6 +1,6 @@
 # The RTOS fork (emulator route A) — scope
 
-Scoped 6 Sep 2026. Status: **M6a done, M6b done (6 Sep 2026)** —
+Scoped 6 Sep 2026. Status: **M6a/M6b/M6c/M6d done (6 Sep 2026)** —
 `tools/emu_rtos.py` runs the firmware's own scheduler: the handoff trap
 dispatched by hand, PIT0 ticking, eleven tasks created and each run once,
 tasks posting to each other through the kernel, and now a real card mount
@@ -123,8 +123,8 @@ later task creates):
 |---|---|---|---|---|---|
 | 6 | `0x46c7fb0c` | `0x40005540` | `0x46c7ea20` +0x1000 | main | voice / DSP mailbox task |
 | 5 | `0x460bcc2c` | `0x4001ee30` | `0x460bc42c` +0x800 | sys | storage (FAT/ATA) |
-| 4 | `0x460d4f80` | `0x4005593c` | `0x460d4780` +0x800 | sys | UI |
-| 3 | `0x460d59d4` | `0x40056c40` | `0x460d51d4` +0x800 | sys | ❓ (new) |
+| 4 | `0x460d4f80` | `0x4005593c` | `0x460d4780` +0x800 | sys | key-repeat timer (was "UI" — retracted, §9) |
+| 3 | `0x460d59d4` | `0x40056c40` | `0x460d51d4` +0x800 | sys | **UI** (was "❓ (new)" — this is the real queue_receive(UI_QUEUE), §9) |
 | 2 | `0x460fab80` | `0x40091d18` | `0x460fabd4` +0x2000 | main | ❓ |
 | 2 | `0x460ffd44` | `0x400921c4` | `0x460fdd44` +0x2000 | main | ❓ |
 | 2 | `0x460e0e38` | `0x4009203c` | `0x460dee38` +0x2000 | main | ❓ (new; ping-pongs with sys) |
@@ -345,13 +345,26 @@ model can take the mechanical parts. Tagged accordingly.
   now modelled), a forced interrupt is not subject to the mask (reference
   manual, §17.2.3), and the load leaves the *sequencer* on bank A by the
   same ordering §7 flagged (re-selected through the load's own last step).
-- **M6d — input.** *(mechanical)* Feed key events into the UI task's queue
-  (the post primitive against whichever queue `0x4005593c` blocks on — to be
-  read in M6c) so PLAY and the REC-arm action run the firmware's own path.
-  This is what makes Bryan's recorder test reachable without RAM pokes
-  (`EMU.md` M5, "path B"). (PR #103's hand-off of a "track-select contest"
-  to this milestone is withdrawn — §7 retraction; there is no UI mechanism
-  in it.)
+- **M6d — input.** **Done 6 Sep 2026, and the premise above was wrong** — §9
+  has the retraction and the measurements. Key events do NOT arrive via a
+  post to `0x4005593c`'s queue: that task doesn't consume a queue at all,
+  and `UI_QUEUE` (`0x460d1664`) only carries state-change notices (posted
+  by e.g. FW_TRANSPORT itself) to a different, previously-unidentified task
+  (`0x40056c40`). PLAY/REC/STOP instead dispatch through a per-key jump
+  table at `0x400d2d54`, called directly — the same shape as the FX2
+  shortcut in `MAINMENU.md`. `tools/emu_rtos.py`'s `press_play_live()` /
+  `press_rec_live()` call PLAY/REC through their own firmware handlers
+  (`call_as_main`, confirmed non-blocking by disassembly); `press_play_live`
+  reproduces M6c's fidelity gate exactly (frame 344, byte `0xd3`) — the
+  `--sequencer --via-key` CLI flag runs that regression. REC starts the
+  transport the same way PLAY does on a project with no recorder-configured
+  track, and leaves the record-arm byte (`0x800066a0`) untouched — arming a
+  track's recorder for real is still open, needing a project with a track's
+  machine set to a recorder (the same gap `EMU.md`'s M5 section already
+  flagged), which is what makes Bryan's recorder test reachable without RAM
+  pokes (`EMU.md` M5, "path B") and is M6e's job, not this one's. (PR #103's
+  hand-off of a "track-select contest" to this milestone stays withdrawn —
+  §7 retraction; there is no UI mechanism in it.)
 - **M6e — use it.** *(judgment)* The recorder-arm trace for Bryan; the tick
   pre-emption question; whatever the kit/parts work needs.
 
@@ -723,3 +736,100 @@ Reproduce:
 .venv/bin/python3 tools/emu_rtos.py --project out/_testproj --set OCTABAM --name RIG \
   --sequencer --internal-clock --poke-trig 2 --frames 400 --ms 20000
 ```
+
+## 9. M6d — the real key path, and a retraction of the milestone's own premise (6 Sep 2026)
+
+The scope in §5 assumed the task named "UI" (`0x460d4f80`, entry
+`0x4005593c`) blocks in the kernel's queue-receive against whichever queue
+it reads, and that feeding a message there is how PLAY/REC reach the
+firmware's own path. **Both halves were wrong**, found by disassembling the
+task's own entry rather than reasoning from its name — the family of bug
+this project keeps re-learning (`CLAUDE.md`'s "disassemble what you
+assemble").
+
+### 9.1 `0x4005593c` is not a queue consumer ✅
+
+Its entry (`scripts/disasm.sh emac 0x4005593c 80`) is fourteen instructions:
+a counting-wait (`0x400007a4`) on `0x46c7e0e2`, then a loop that waits on it
+again and calls `0x4001387c` — a 136-slot countdown-timer scan (decrement
+each of 136 four-byte counters; on one reaching zero, clear its bit in a
+bitmap at `0x460b a9ae` and call a handler through `0x400136a8`). That is a
+**key-repeat timer**, not an input queue. Nothing in the loop names
+`0x40000d00`/`0x40000d1a` (queue receive) or `0x460d1664` (`UI_QUEUE`, see
+9.2). `0x46c7e0e2` is signalled once per key-scan interrupt tick
+(`0x40055cb8`, an INTC1 handler measured decrementing a separate countdown
+`0x400c0cf0` and posting to two OTHER queues every second tick) — so this
+task's real job is advancing key-repeat, on a fixed schedule, regardless of
+what keys are down.
+
+### 9.2 The real `UI_QUEUE` consumer, and why the wrong TCB looked right ✅
+
+A literal-address scan of the raw image (`out/raw/section_3_MAIN_OS.bin`)
+for the four bytes of `0x460d1664` finds it in six places: one `queue_init`
+call (`0x40040b70`, ring buffer `0x460d4fd4`, size `0x80`) and five posts —
+FW_TRANSPORT's start case (`0x4009c506`, msg `*0x400abaca`), a tick-boundary
+notice (`0x400a4dd2`, msg `*0x400abacb`), and the key-scan ISR's periodic
+post (`0x40055cd6`, msg `*0x400a727a`, every second tick alongside a post to
+`SYS_QUEUE`) — but **no receive**. The receive is inside `0x40056c40`
+(TCB `0x460d59d4`, prio 3, created by `sys` — the row §2 could only mark
+"❓ (new)"): `pea 0x460d1664; jsr 0x40000d00` at `0x40056c72`, return value
+dereferenced and its first byte compared against 1 (the opcode
+FW_TRANSPORT's start case posts) before running clock-related follow-up
+work on `0x46104ca8`/`0x46104cac`.
+
+The queue's **ring buffer** (`0x460d4fd4`) sits 0x54 bytes past
+`0x460d4f80` — the key-repeat TCB from 9.1. That adjacency, not any real
+relationship, is almost certainly why the earlier "by neighbourhood" pass
+named `0x460d4f80` "ui": it is next to the queue's storage, not the task
+that reads it. `tools/emu_rtos.py`'s `TASK_NAMES` swapped the two labels to
+match (`0x460d4f80` -> `"keyrepeat"`, `0x460d59d4` -> `"ui"`).
+
+### 9.3 Physical keys don't use this queue at all ✅
+
+A second literal scan, for the addresses of two candidate key handlers,
+finds them as consecutive longs in a jump table at `0x400d2d54`:
+`0x400d2dc0` = `0x4000a274` (**REC**), `0x400d2dc4` = `0x4000a200`
+(**PLAY**), `0x400d2dc8` = `0x4000a1e0` (**STOP**, inferred from its shape
+— checks `0x80000029`, then `0x40033968`, then tail-calls one of two
+`0x4009fxxx` targets — not run in this pass). Walking the table from its
+start (`0x400d2d54`) shows eight distinct entries before a run of the
+default handler `0x4000184c` — almost certainly the eight **track keys** —
+then a second populated run (indices 13–31 of the table) holding PLAY/REC/
+STOP among other function keys, then `0x400019f4` filling every remaining
+slot to the table's end. This is a keycode-indexed jump table, called
+directly (`action(edge)`) the same way `MAINMENU.md`'s FX2 shortcut and
+page-key handler work — not a message queue.
+
+Both PLAY (`0x4000a200`) and REC (`0x4000a274`) were disassembled end to
+end, including everything they call (`0x400a013c`, `0x400a030c`,
+`0x400a14a4`, `0x400a10c8`, `0x40033968`, `0x4009b290`): no reference to any
+blocking kernel primitive (`0x40000818` event wait, `0x400007a4` counting
+wait, `0x40000d00` queue receive) anywhere in the chain, only plain
+subroutines, memory reads/writes, and non-blocking posts (`0x40000c3c`).
+Both are safe under `call_as_main`, the same conclusion M6c already reached
+for `FW_TRANSPORT`/`FW_START_TRACK` — unsurprising, since PLAY's own
+handler tail-calls `FW_TRANSPORT` after some clock-sync bookkeeping gated
+on CLOCK RECEIVE (`0x80000028` bit 0), and REC's reaches it too through
+`0x400a030c` when nothing is already armed.
+
+### 9.4 Measured, against `out/_testproj` (6 Sep 2026)
+
+- **`0x80000029`** (the byte PLAY's handler tests first, `beqs` a bare `rts`
+  if clear) is **already `0x01`** right after a real `load_project_live` —
+  no setup needed to exercise PLAY through its real handler.
+- **`press_play_live()` reproduces §8.4's fidelity gate exactly**: transport
+  running (`0x800065b8` 0->1), then `FW_START_TRACK` ×8, then the same trig
+  — track 0, byte `0xd3`, 344 frames after the start frame — as both cold
+  and M6c's direct `FW_TRANSPORT` call. `--sequencer --via-key` on the CLI
+  runs this as a regression.
+- **`press_rec_live()`** on this project (no track's machine set to a
+  recorder) also starts the transport (`0x800065b8` 0->1) and leaves the
+  record-arm byte `0x800066a0` at 0 through two presses — consistent with
+  there being nothing to arm. Confirms the mechanism reaches real firmware
+  code; does **not** answer what REC does on a recorder-configured track —
+  that project doesn't exist yet (same gap `EMU.md`'s M5 section flagged),
+  and closing it is M6e's job.
+
+What would falsify this: a project with a track's machine set to a recorder
+and RSRC armed, run through `press_rec_live()`, showing `0x800066a0`
+actually change — the one thing this pass could not test.

--- a/tools/emu_rtos.py
+++ b/tools/emu_rtos.py
@@ -84,6 +84,24 @@ CUR_PATTERN = 0x80000004
 ENGINE_BANK_WRITE = 0x40087d44     # LOAD PROJECT writes PART_PTR from the file's BANK= here
 SELECT_BANK_CASE = 0x40062288      # sys table[20]: "select bank msg[1]" -- switch the working bank
 
+# M6d: the real key-press path. UI_QUEUE (0x460d1664) is what FW_TRANSPORT
+# posts to (EMU.md, "a post to the UI queue"); its ring buffer sits at
+# 0x460d4fd4 (queue_init site 0x40040b70), 0x54 bytes past the TCB this
+# module used to call "ui" -- which is why that TCB was misnamed (see the
+# TASK_NAMES retraction below). The keys themselves are found in a jump
+# table at 0x400d2d54 (8 track-key entries, a gap, then a function-key run);
+# REC/PLAY/STOP sit at consecutive indices 24/25/26. All three call chains
+# (checked by disassembly, 6 Sep 2026: 0x400a013c, 0x400a030c, 0x400a14a4,
+# 0x400a10c8, 0x40033968, 0x4009b290 -- everything PLAY and REC reach) are
+# free of the blocking primitives (0x40000818/0x400007a4/0x40000d00), so
+# call_as_main is safe for both, the same way it already was for
+# FW_TRANSPORT/FW_START_TRACK.
+UI_QUEUE = 0x460d1664
+KEY_REC = 0x4000a274
+KEY_PLAY = 0x4000a200               # gated on 0x80000029 (nonzero from boot in the test project);
+                                     # sets clock-sync fields, then tail-calls FW_TRANSPORT
+KEY_STOP = 0x4000a1e0
+
 # The tasks, as MEASURED under the real scheduler on 6 Sep 2026 (the create
 # hook below): (tcb, entry, prio, stack, size, creator). Main is created by
 # the boot before our hooks exist. RTOS_FORK.md §2's table of eight was read
@@ -100,14 +118,22 @@ EXPECTED_TASKS = (
     (0x46105508, 0x40098a5c, 1, 0x4610555c, 0x2000, MAIN_TCB),
     (0x46c7bed8, 0x40061a94, 1, 0x460d6de4, 0x2000, MAIN_TCB),     # not in the §2 table: creates the three below
     (0x460bcc2c, 0x4001ee30, 5, 0x460bc42c, 0x0800, 0x46c7bed8),   # storage
-    (0x460d4f80, 0x4005593c, 4, 0x460d4780, 0x0800, 0x46c7bed8),   # UI
-    (0x460d59d4, 0x40056c40, 3, 0x460d51d4, 0x0800, 0x46c7bed8),   # not in the §2 table
+    (0x460d4f80, 0x4005593c, 4, 0x460d4780, 0x0800, 0x46c7bed8),   # repeat-key timer, NOT ui (M6d retraction)
+    (0x460d59d4, 0x40056c40, 3, 0x460d51d4, 0x0800, 0x46c7bed8),   # ui -- the real UI_QUEUE receiver (M6d)
 )
 ALL_TCBS = frozenset(t[0] for t in EXPECTED_TASKS) | {MAIN_TCB}
-TASK_NAMES = {0x46c7fb0c: "voice", 0x460bcc2c: "storage", 0x460d4f80: "ui",
+# M6d retraction: 0x460d4f80 (entry 0x4005593c) was named "ui" by
+# neighbourhood -- its ring buffer (0x460d4fd4) sits just past this TCB, but
+# the task itself waits on an unrelated counting semaphore (0x46c7e0e2) and
+# spends its life decrementing a 136-slot key-repeat timer array
+# (0x4001387c). The task that actually calls queue_receive(UI_QUEUE)
+# (0x40000d00, confirmed by disassembly 6 Sep 2026) is 0x460d59d4, entry
+# 0x40056c40 -- previously the unidentified "p3". Names swapped here to
+# match; RTOS_FORK.md's table carries the same correction.
+TASK_NAMES = {0x46c7fb0c: "voice", 0x460bcc2c: "storage", 0x460d4f80: "keyrepeat",
               0x460fab80: "p2a", 0x460ffd44: "p2b", 0x460e0e38: "p2c",
               0x460ddde4: "engine", 0x46105508: "p1b", 0x46c7bed8: "sys",
-              0x460d59d4: "p3", MAIN_TCB: "main", BOOT_TCB: "boot"}
+              0x460d59d4: "ui", MAIN_TCB: "main", BOOT_TCB: "boot"}
 
 # --- peripherals ------------------------------------------------------------
 PERIPH_BASE, PERIPH_SIZE = 0xfc000000, 0x100000
@@ -1167,6 +1193,56 @@ class Rtos:
             self.run(until=lambda r: r.pc == MAIN_SPIN)
             self.call_as_main(FW_START_TRACK, args=(t,))
 
+    # -- M6d: real key injection -----------------------------------------------
+    def press_key_live(self, handler, edge=0):
+        """Call one of the firmware's own key-press handlers (`KEY_PLAY`,
+        `KEY_REC`, `KEY_STOP`) directly, `action(edge)` -- the same shape as
+        the FX2-shortcut handler in MAINMENU.md and PLAY/REC's own chosen
+        entry in the per-key jump table at `0x400d2d54` (indices 24/25/26;
+        the first 8 entries are the track keys, `0x4000184c` fills unused
+        scan positions). Confirmed call_as_main-safe by disassembly (see the
+        module header comment by `UI_QUEUE`) and empirically: run against
+        `out/_testproj`, `press_key_live(KEY_PLAY)` reproduces M6c's fidelity
+        gate exactly (frame 344, byte 0xd3), and `0x80000029` -- the byte
+        PLAY's handler tests before doing anything -- is already nonzero
+        after a real LOAD PROJECT, so no extra setup is needed. `edge=0` is
+        press; the handlers never read past it in what PLAY/REC/STOP reach.
+        Retracts RTOS_FORK.md's M6d premise that key events arrive via a
+        post to the UI task's queue -- they don't: `UI_QUEUE` (0x460d1664)
+        only carries state-change notices (FW_TRANSPORT's own post included)
+        to the real UI task (TASK_NAMES's "ui", TCB 0x460d59d4); physical
+        keys dispatch straight through this jump table instead."""
+        self.run(until=lambda r: r.pc == MAIN_SPIN)
+        return self.call_as_main(handler, args=(edge,))
+
+    def press_play_live(self):
+        """PLAY, through its own firmware handler rather than FW_TRANSPORT
+        directly: sets the same clock-sync fields hardware would (only when
+        CLOCK RECEIVE is on) before tail-calling FW_TRANSPORT(1). Still needs
+        `FW_START_TRACK` for each track afterward, exactly as
+        `start_transport_live` does -- PLAY's handler only starts the
+        transport state machine, not the eight tracks."""
+        self.exact_clock()
+        d0 = self.press_key_live(KEY_PLAY)
+        for t in range(8):
+            self.run(until=lambda r: r.pc == MAIN_SPIN)
+            self.call_as_main(FW_START_TRACK, args=(t,))
+        return d0
+
+    def press_rec_live(self):
+        """REC, through its own firmware handler. Measured 6 Sep 2026 against
+        `out/_testproj` (no track configured as a recorder): starts the
+        transport exactly like PLAY (`0x800065b8` 0->1) and leaves
+        `0x800066a0` (the record-arm state byte its own code tests) at 0 --
+        consistent with EMU.md's open gap that the recorder-arm path needs a
+        project with a track's machine set to a recorder, which this method
+        does not supply. A second press does not toggle anything back off
+        with no recorder armed. Does NOT call FW_START_TRACK -- unlike PLAY,
+        untested here whether REC's own path reaches it for a plain project;
+        pair with `press_play_live` or call FW_START_TRACK by hand if tracks
+        need to run."""
+        return self.press_key_live(KEY_REC)
+
     def poke_trig(self, step):
         """Set a trig on track 1 at `step` (1-8), same bytes as
         `emu_frames.poke_trig` (track 1's 64-step mask, big-endian, byte 7
@@ -1399,6 +1475,9 @@ def _cli():
                     help="with --sequencer: clear CLOCK RECEIVE so the sequencer runs on its own clock")
     ap.add_argument("--bank", type=int, default=None,
                     help="with --sequencer: switch to this bank via sys before starting (default: the file's saved bank)")
+    ap.add_argument("--via-key", action="store_true",
+                    help="with --sequencer: start transport through the real PLAY key handler "
+                         "(press_play_live, M6d) instead of calling FW_TRANSPORT directly")
     a = ap.parse_args()
 
     card = None
@@ -1455,7 +1534,10 @@ def _cli():
             rt.frame = True
             rt.next_frame = rt.sample + FRAME_PERIOD
             rt.exact_clock()
-            rt.start_transport_live()
+            if a.via_key:
+                rt.press_play_live()
+            else:
+                rt.start_transport_live()
             if a.poke_trig:
                 v = rt.poke_trig(a.poke_trig)
                 print(f"poke trig  : track 1 step {a.poke_trig} -> mask byte 7 = {v:#04x}")
@@ -1485,7 +1567,8 @@ def _cli():
         ok = rt.frame_count >= target
         if not ok:
             print(rt.starvation())
-        print("M6c run    :", "PASS (ran to target)" if ok else "FAIL (stopped short)")
+        label = "M6d run (via-key)" if a.via_key else "M6c run"
+        print(f"{label:11s}:", "PASS (ran to target)" if ok else "FAIL (stopped short)")
         return 0 if ok else 1
 
     if a.load_project:


### PR DESCRIPTION
## Summary
- M6d's scope assumed PLAY/REC-arm reach the firmware via a post into the queue the TCB labelled "UI" (`0x4005593c`) blocks on. Disassembly shows that's wrong: that task waits on an unrelated counting semaphore and is a key-repeat timer scanner, mislabeled "UI" only because its neighbour in memory is the real `UI_QUEUE`'s ring buffer. The task that actually calls `queue_receive(0x460d1664)` is a different, previously-unidentified TCB (`0x40056c40`) -- `TASK_NAMES` corrected to match.
- That queue only carries state-change notices, not raw key events. Physical keys (PLAY/REC/STOP) dispatch through a separate per-key jump table (`0x400d2d54`), found by a literal-address scan -- the same shape as `MAINMENU.md`'s FX2 shortcut.
- `press_play_live()`/`press_rec_live()` call the real firmware key handlers via `call_as_main` (confirmed non-blocking by disassembling every function in their call chains). `press_play_live()` reproduces M6c's fidelity gate exactly (frame 344, byte `0xd3`); the CLI's `--via-key` flag runs this as a regression.
- `press_rec_live()` starts the transport the same way PLAY does on a project with no recorder-configured track, and leaves the record-arm byte (`0x800066a0`) untouched -- consistent with nothing to arm. Observing real REC-arm behavior needs a recorder-configured project, which doesn't exist yet; that's M6e's job.
- `docs/RTOS_FORK.md` section 9, `docs/EMU.md`, and `PLAN.md`'s status board carry the full write-up and retraction.

## Test plan
- [x] `make verify` (254 PASS, unchanged baseline)
- [x] `tools/emu_rtos.py --selftest` PASS
- [x] `tools/emu_rtos.py --until-gate --project out/_testproj --ms 1000` -- M6a gate PASS, task names now `keyrepeat`/`ui` correctly
- [x] `tools/emu_rtos.py --project out/_testproj --set OCTABAM --name RIG --sequencer --internal-clock --poke-trig 2 --frames 400 --ms 20000 --via-key` -- M6d run (via-key): PASS, trig lands frame 344 byte `0xd3`, matching M6c's cold/route-A result exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)