### PR TITLE
RTOS: bank falsifier answered on the unit, recorder-trig masks measured, and the recorder path lights up from a project file

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -703,8 +703,8 @@ scheduler.
 | M4 card + loaded project | ✅ shipped (route B) | `make emu-card PROJECT=<abs dir>`: the RIG project loads through the real storage stack, one wait hook |
 | M5 frames + ticks, cold | ✅ done, one gap | a step trig fires end to end; the recorder-arm path ("path B") needs real task interleaving |
 | **M6a scheduler runs** | ✅ **done 6 Sep, PR #100** | `make emu-rtos PROJECT=<abs dir>`: eleven tasks start in the real order, the 5 ms tick and every interrupt fire, tasks post to each other; gate passes at 205 ms emulated |
-| M6b real waits + mount | ✅ **done 6 Sep** (one retraction) | `sys` (not engine) mounts the card; a real mount + LOAD PROJECT reach 30,467 real sectors (M4: ~30,955) and the file's saved bank. PR #103's "track-select watcher" reading is WITHDRAWN: the bytes are the current bank; the run ends on bank A because the engine's own reset-time "select bank 0" reaches `sys` after the `BANK=1` parse — a real cross-task ordering with a one-press hardware falsifier (RTOS_FORK §7) |
-| M6c sequencer under the scheduler | ✅ **done 6 Sep — gate passed** | the one-trig test lands the same byte (`0xd3`), same track, 344 frames after the start frame, 28 ticks, under real tasks and real interrupts as it does cold. Three findings on the way (RTOS_FORK §8): the frame source is re-armed by the **eDMA completion ISR** (eDMA now modelled, 16.0-sample period); a **forced interrupt bypasses the mask** (MCF54455RM §17.2.3 — the tick is never unmasked and never needed to be); the load leaves the **sequencer's** playing bank on A by §7's ordering (re-selected through the load's own last step; the hardware falsifier gained a second observable). Sonnet's two §8 hypotheses retracted |
+| M6b real waits + mount | ✅ **done 6 Sep** (one retraction) | `sys` (not engine) mounts the card; a real mount + LOAD PROJECT reach 30,467 real sectors (M4: ~30,955) and the file's saved bank. PR #103's "track-select watcher" reading is WITHDRAWN: the bytes are the current bank; the run ends on bank A because the engine's own reset-time "select bank 0" reaches `sys` after the `BANK=1` parse — a real cross-task ordering with a one-press hardware falsifier (RTOS_FORK §7). ✅ **Falsifier run on the unit 6 Sep evening: B01, and PLAY runs the pattern** — the EMULATOR's ordering is the unfaithful one; `select_bank_live`/`seq_select_live` are compensation for an emulator defect and go once the load's timing is fixed (open) |
+| M6c sequencer under the scheduler | ✅ **done 6 Sep — gate passed** | the one-trig test lands the same byte (`0xd3`), same track, 344 frames after the start frame, 28 ticks, under real tasks and real interrupts as it does cold. Three findings on the way (RTOS_FORK §8): the frame source is re-armed by the **eDMA completion ISR** (eDMA now modelled, 16.0-sample period); a **forced interrupt bypasses the mask** (MCF54455RM §17.2.3 — the tick is never unmasked and never needed to be); the load leaves the **sequencer's** playing bank on A by §7's ordering (re-selected through the load's own last step; the hardware falsifier gained a second observable — and the unit answered it: the saved pattern runs, so the re-select is compensating for the emulator, RTOS_FORK §8.3). Sonnet's two §8 hypotheses retracted |
 | M6d key injection | ✅ **done 6 Sep — and the premise was wrong** | PLAY/REC do NOT arrive via a post to `0x4005593c`'s queue — that task isn't a queue consumer at all (a key-repeat timer, mislabeled "UI" by neighbourhood to the real queue's ring buffer). The real `UI_QUEUE` (`0x460d1664`) consumer is a different, previously-unidentified task (`0x40056c40`); physical keys dispatch through a separate per-key jump table (`0x400d2d54`) instead, the same shape as the FX2 shortcut. `press_play_live()`/`press_rec_live()` call PLAY/REC through their own firmware handlers (`call_as_main`, confirmed non-blocking by disassembly); PLAY reproduces M6c's fidelity gate exactly (RTOS_FORK §9) |
 | M6e use it | 🟡 in progress (6 Sep) | the recorder-project fixture exists (`ot_project.py machine-type` + the `tools/scratch/` wrapper: track 1 -> machine type 4, verified by RAM readback) and with it track 1 stops writing `FW_LIVE_NIBBLE` at all, 8 writes -> 5. ❌ **The first pass's reading of that — "confirms machine-type-branched trig dispatch" — is RETRACTED**: type 7, out of range for the 0..4 dispatch, gives the IDENTICAL signature and type 3 (NEIGHBOR) gives the baseline, so it reads "type >= 4 / not started"; and the vanished writes include the **frame-0 transport-start** one, so the track never starts and nothing measured happens at the trig. §9.4's own falsifier finally ran (`--via-rec`, PLAY-then-REC) and was **aimed at the wrong mechanism**: REC leaves `0x800066a0` at 0 on the recorder-configured project as on the plain one, and per the manual it would — `[REC]` activates GRID RECORDING mode, and a **recorder trig** is what starts a track recorder sampling. Two instrument defects found on the way, both silent: `--watch-calls`/`--watch-mem` printed nothing without `--trace` (fixed; the zero-call flag re-derived and it holds), and `0x800065b8`/`0x800066a0` are longwords that read as a flat 0 byte-wise. The arm/record path is still unlocated; `0x4000b800` gets zero calls even on a successful trig, and `watch_calls` is a code hook, so that means never executed by any route. RTOS_FORK §10 |
 
@@ -713,23 +713,27 @@ reading has been retracted (RTOS_FORK §10). The on-disk **trig fixture is built
 proven** (`ot_project.py pattern-trig`: step 2 written to the file, no RAM
 poke, lands `0xd3` on track 0 at frame 344 — M6c's own gate), along with
 the pattern format it needed (RTOS_FORK §10.6). ⚠️ Not `+0x8f385`: that is
-the recorder SETUP page's TRIG *mode* byte, in the part. **The open half is
-which step mask holds the recorder's trigs**, and the emulator did not
-settle it — `ot_project.py pattern-diff` against two projects saved on the
-unit (one with a recorder trig, one without) answers it in one command, and
-that is a 30-second job at the hardware. Then Bryan's
-click question.
+the recorder SETUP page's TRIG *mode* byte, in the part. ✅ **The recorder
+trig's masks are SETTLED on the unit (6 Sep evening): `0x20`+`0x28`+`0x30`,
+all three for one trig** (one per REC source, inferred) — `pattern-diff`
+against the `RECTRIG` project Sam saved with one trig on T1 step 9
+(RTOS_FORK §10.6; fixture `out/_recproj`). Next: run that fixture under
+`emu_rtos` with `--frames 3000` (step 9 is ~2,750 frames in; 400 never
+reaches it) and watch the staged/immediate/armed recorder slots for what
+the trig actually does — that is Bryan's click question.
 M6c's gate is the regression to keep green while doing it:
 `tools/emu_rtos.py --project out/_testproj --set OCTABAM --name RIG
 --sequencer --internal-clock --poke-trig 2 --frames 400 --ms 20000
 [--via-key]` must keep landing `0xd3` on track 0, 344 frames after the
 start frame, with 28 ticks (both with and without `--via-key`). Two
 of M6c's helpers are M5-detour compensation for §7's ordering
-(`select_bank_live`, `seq_select_live`); if the hardware falsifier below
-says the unit ends on the saved bank, the faithful fix is in the load's
-timing, and both helpers should become unnecessary.
+(`select_bank_live`, `seq_select_live`); the hardware falsifier below
+HAS said the unit ends on the saved bank (6 Sep evening), so the faithful
+fix is in the load's timing, and both helpers are to be removed once it
+is made. Open.
 
-Also queued, independent of M6c: one hardware question for whenever the
+✅ ANSWERED 6 Sep evening (B01, plays — emulator unfaithful; kept for the
+reasoning): one hardware question for whenever the
 unit is next on — **load the RIG project, read the bank indicator, then
 press PLAY** — the emulator comes up on bank A because the engine's own
 reset-time "select bank 0" reaches `sys` after the file's `BANK=1` is

--- a/docs/EMU.md
+++ b/docs/EMU.md
@@ -497,7 +497,9 @@ run ends on bank A because the LOAD PROJECT handler's own first step is a
 reset that posts "select bank 0" to `sys`, and `sys` — busy with p2c
 traffic ahead of it in its FIFO — applies it ~870 samples later, after the
 engine has parsed `BANK=1`. A real cross-task ordering, measured, with a
-one-press hardware falsifier (does the unit come up on the saved bank?).
+one-press hardware falsifier (does the unit come up on the saved bank?) —
+**answered on the unit 6 Sep evening: it comes up on B and plays**, so
+the ordering is the emulator's defect (`RTOS_FORK.md` §7), still to fix.
 `load_project_live` reports the bank the engine parsed beside the bank
 the run ended on.
 Also found: `call_as_main` (borrow main's idle slot to call a plain OS
@@ -527,7 +529,8 @@ applied the engine's reset-time "select bank 0" in the handler's real card
 waits, so the sequencer walked bank A's empty pattern — the tool re-issues
 that last step with the file's bytes (`seq_select_live`), and §7's
 one-press hardware falsifier gained a second observable (does PLAY run the
-saved pattern?). Frame mode counts instructions exactly (`exact_clock`)
+saved pattern? — it does, unit 6 Sep evening; the re-issue is compensation
+for the emulator's own ordering and goes when the load's timing is fixed). Frame mode counts instructions exactly (`exact_clock`)
 rather than by quantum, which over-charged 2.1×. The previous paragraph
 here, and §8's two hypotheses, were wrong and are retracted in place.
 

--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -525,7 +525,20 @@ read the bank indicator. If the unit comes up on **B**, the emulator's
 p2c traffic or its timing knob is unfaithful here and M6c gains a second
 calibration point; if it comes up on **A**, the firmware really does
 apply its own stale reset and route B has been hiding it. Recorded as
-the falsifier; not resolved in this pass. **M6c found the same ordering
+the falsifier; not resolved in this pass.
+
+✅ **RESOLVED ON THE UNIT, 6 Sep 2026 (Sam, ~21:30): load OCTABAM_RIG →
+the bank indicator reads B01, and PLAY runs the saved pattern.** Both
+observables of the one-press test came back on the "emulator is
+unfaithful" branch: the firmware does NOT apply its own reset-time "select
+bank 0" after the `BANK=` parse. So the ~870-sample lag `sys` shows here
+is the emulator's — the p2c traffic ahead of the reset in `sys`'s FIFO,
+or the engine's card-wait length, is not what the hardware does. The two
+compensating helpers (`select_bank_live`, `seq_select_live`) are now
+known to be papering over an emulator defect, not a firmware behaviour;
+the faithful fix is in the load's timing, after which both should be
+deleted and `load_project_live` should end on bank B unaided. Not yet
+done — this pass only recorded the measurement. **M6c found the same ordering
 has a second victim (§8.3):** the load's last step copies the bank byte
 into the *sequencer's* own playing-bank byte, so the reset arriving
 mid-handler leaves the sequencer on bank A too — press PLAY after the
@@ -697,6 +710,12 @@ comes up on B playing pattern 1, the emulator's `sys` timing (the p2c
 traffic ahead of the reset message, or the engine's card-wait length) is
 what is unfaithful, and `load_project_live` should end where the unit
 does without help.
+
+✅ **It does come up on B, playing (unit, 6 Sep 2026 — §7).** Both helpers
+are therefore compensation for an emulator defect and are to be removed
+once the load's timing is fixed; until then every `--sequencer` run
+carries them, and the "re-selected through the load's own last step" line
+in the tool's output is the reminder.
 
 ### 8.4 The gate
 
@@ -1049,8 +1068,48 @@ disk, no RAM poke anywhere — lands `0xd3` on track 0 at **frame 344**, the
 same byte, track and frame as `--poke-trig 2`, which is M6c's own fidelity
 gate. File -> card -> real LOAD PROJECT -> sequencer, with nothing poked.
 
-❓ **Which mask is the RECORDER trig is still open**, and the emulator did
-not settle it. Setting step 2 in every candidate mask on the type-4 track
+✅ **SETTLED ON THE UNIT, 6 Sep 2026 — a recorder trig is masks `0x20`,
+`0x28` and `0x30`, all three at once.** Procedure: a byte-exact copy of the
+cleared baseline went onto the card as project `RECTRIG`; Sam loaded it on
+bank A pattern A01, selected track 1, opened RECORDING SETUP 1
+(`[FUNC]`+`[REC1]`), entered GRID RECORDING, pressed `[TRIG]` 9 once (red),
+quick-saved (`[FUNC]`+`[PROJ]`), synced. `pattern-diff <baseline> <RECTRIG>
+1`:
+
+```
+pattern  0 T1 mask 0x20: 0000000000000000 -> 0000000000000100  steps [9]
+pattern  0 T1 mask 0x28: 0000000000000000 -> 0000000000000100  steps [9]
+pattern  0 T1 mask 0x30: 0000000000000000 -> 0000000000000100  steps [9]
+```
+
+A whole-file byte diff of `bank01.work` shows exactly those three bits
+(`+0x26`, `+0x2e`, `+0x36` from TRAC(0,0)) and the bank checksum
+(`0x9b4d0`, `0x4c` → `0x4f`) — nothing else. These are the three masks the
+format note above maps to bits 12/13/14 of the per-track flag word at
+`0x46c7a6c0`. **Three masks for one trig** lines up with the manual's "a
+recorder trig defaults to sampling from all three input sources": the
+reading that `0x20`/`0x28`/`0x30` are REC1/REC2/REC3 respectively was
+then half-measured the same evening: Sam held `[TRIG]` 9 in RECORDING
+SETUP 1 and pressed the second source key to toggle REC2 off, saved, and
+`pattern-diff` between the two saves shows **only `0x28` cleared** (file
+byte `0x55` `01` → `00`, plus the checksum) — so **`0x28` = REC2 ✅
+measured**, and `0x20` = REC1 / `0x30` = REC3 follow by order 🟡 (not
+separately toggled). Second save: `~/octa/backups/RECTRIG_20260906_step9_noREC2`.
+The returned project is
+`~/octa/backups/RECTRIG_20260906_step9` (work + strd files only; its
+`project.work` came back with `BANK=0`/`TRACK=0`, so unlike the baseline
+this fixture does not meet §7's ordering at all) and `out/_recproj`
+points at it. **`+0x8f385` stays what §10.5 says it is**: the part's TRIG
+mode byte, not the trig.
+
+⚠️ A run budget trap that cost one run: at 120 BPM a sixteenth is 344
+frames, so **step 9 is at ~2,750 frames** — `--frames 400` (the gate's
+budget, sized for step 2) ends 145 ms after the transport starts and never
+reaches it; the run passes the gate and reports nothing, which looks like
+"the recorder trig does nothing". Use `--frames 3000 --ms 30000`.
+
+The paragraph below is the state before that measurement, kept for the
+method: the emulator did not settle it. Setting step 2 in every candidate mask on the type-4 track
 produces exactly one call to `0x40005ff0` (the "arm caller") where the same
 run without the pokes produces none — but bisecting into halves gives one
 call from *either* half, so that observable is not specific enough to name a
@@ -1094,3 +1153,77 @@ cp -R <a real project dir> out/_recproj
   --sequencer --internal-clock --poke-trig 2 --frames 400 --ms 20000 [--via-rec]
 # the control is the same command against out/_testproj
 ```
+
+### 10.7 The recorder trig under emulation (6 Sep 2026, evening) — the path LIGHTS UP from a RAM poke, and the on-disk fixture never reached it
+
+All runs: `--sequencer --internal-clock --frames 3000 --ms 30000` (step 9
+needs ~2,750 frames — §10.6's budget trap), watches as named. The
+fixture is `out/_recproj` (bank A, pattern A01, T1: note trig step 1 +
+recorder trig step 9 = masks `0x20`/`0x28`/`0x30`).
+
+**The fixture, five instruments, five nulls ✅ (measured):**
+
+| watch | result over 3,000 frames |
+|---|---|
+| `FW_LIVE_NIBBLE` / `FW_TRIG_WORDS` | only the frame-0 start writes (T1, T6 ×2, T8 — bank A's step-1 trigs); `0x46104d26` never nonzero |
+| eight arm-path candidates (`0x40005ff0`, `0x40097168`, `0x400977cc`, `0x40006dfc`, `0x40083544`, `0x4000b308`, `0x4000b800`) | 0 entries each; `0x4000c8e0` 24,000 = 8/frame, the frame builder |
+| staged slots `0x800018be..e6`, immediate slot `0x46c7e9fa`, armed bitmask `0x8000184a` | no writes (the bitmask gets three zero stores at the run's last sample, `main` `0x4000bf22/30` — teardown) |
+| per-track flag word `0x46c7a6c0..e0` | 120 writes, ALL zero (15 clears × 8 words, `0x4009e3cc`) |
+| the three mask tests `0x4009d93c/96e/99a` | entered 160× each; the follow-on at `0x4009d9f6` (taken only when a bit was set) **0×** |
+| `--watch-pattern 0x40` (reads of T1's mask rows) | rows `+0x04, 0x0c, 0x14, 0x1c, 0x24, 0x2c, 0x34` read **3× each** — low 32-bit halves only |
+
+The disassembly (`scripts/disasm.sh emac 0x4009d900`) says what §10.6's
+table called "sets bit 12" is the **test**: `andl %a0@(0,%a3:l),%d0` with
+`d0` = the step bit, then `bset #13,%d3` on nonzero; the OR'd `d3` is
+stored to `0x46c7a6c0` at `0x4009da12` only if nonzero. So a zero flag
+word means the step bit never matched a mask row in RAM — the code
+path is consistent with itself, and the question became whether the
+sequencer ever evaluated step 9 of THIS pattern.
+
+**Control: the same three masks poked into RAM at step 9 of the BASELINE
+(bank B, pattern 0, T1), `--poke-trig 9 --poke-mask 0x20,0x28,0x30
+--poke-mask-track 0` — everything fires ✅ (measured):**
+
+```
+frame  2756 track 0 byte 0x35  nibble 5  flags 0x30     <- the note trig, step 9 (344 x 8 = 2752)
+[0x46c7a6c0] <- 0x7020  at pc 0x4009da12 in main         <- bits 12/13/14 (+ bit 5), the store above
+watch-call : 0x4009d9f6 entered 1 time(s)
+watch-call : 0x40005ff0 entered 1 time(s), callers 0x4000d35c   <- the arm caller, once
+FW_TRIG_WORDS (0x46104d26) nonzero writes (245): (2757, 0, 0x7235), then (frame, 0, 5) every frame to 3000
+```
+
+`0x46104d26` — Bryan's anchor, zero in every run since M5 — goes
+nonzero one frame after the trig (`0x7235`, then a steady `5` per frame).
+The live byte carries flags `0x30` instead of the note trig's `0xd0`.
+**This is path B** ([[octabam-emu-frames]]: staged → immediate →
+`0x4000c8e0` word assembly → `0x46104d26` + arm caller), reached by the
+sequencer's own recorder masks with no REC key and no machine-type change
+— the M6e first pass was looking for it on the wrong track and with the
+wrong lever. Two tool fixes on the way: `poke_trig`/`poke_mask` only knew
+steps 1–8 (`bytes must be in range` at step 9), now 64; and
+`--watch-mem` printed 12 writes and hid the rest.
+
+**Why the on-disk fixture did not fire — settled ✅ (measured): bank A's
+pattern A01 steps at ONE QUARTER the rate, and step 9 is ~11,000 frames
+in, not 2,750.** The same three masks written ON DISK at step 2 of a copy
+of the fixture (`pattern-trig … 1 0 0 2 0x20`, `0x28`, `0x30`; no RAM
+poke) fire the identical chain — flag word `0x7020` at `0x4009da12`,
+`0x4009d9f6` ×1, arm caller ×1 from `0x4000d35c`, `0x46104d26` `0x7257`
+then `7`/frame — at **frame 1379**, which is 4 × 344 + 3. The read watch
+agrees: T1's rows are read at 0, ~1379, ~2758 — three evaluations in
+3,000 frames, one per step at that scale; the baseline under the same
+watch reads its rows **9×**, one per 344-frame step. (The baseline's bank B pattern
+steps at 344, which is where the 344-frame gate and the "step 9 ≈ 2,750"
+arithmetic came from; the RIG's A01 evidently carries a 1/4× scale or
+equivalent length setting — not located in the PTRN record, inferred
+from the timing 🟡.) So Sam's step-9 recorder trig is at ~11,032 frames;
+a run to 11,500 is in flight to land it.
+
+**What this establishes (measured, one emulator, no hardware audio):**
+a recorder trig on disk → card → real LOAD PROJECT → the sequencer's mask
+tests → the flag word → the frame builder's arm caller → Bryan's trig
+word, with nothing poked. That is the mechanism the recorder question
+needs, reachable from a project file. Not yet measured: what the arm
+caller does next (`0x40005ff0` ran once — its class-2 path, the sample-
+slot control record, the DSP-side start), and whether the byte-`0x30`
+live flag is what the DSP's recorder reads.

--- a/tools/emu_rtos.py
+++ b/tools/emu_rtos.py
@@ -1255,12 +1255,16 @@ class Rtos:
         return self.press_key_live(KEY_REC)
 
     def poke_trig(self, step):
-        """Set a trig on track 1 at `step` (1-8), same bytes as
+        """Set a trig on track 1 at `step` (1-64), same bytes as
         `emu_frames.poke_trig` (track 1's 64-step mask, big-endian, byte 7
         bit 0 = step 1) against whichever bank PART_PTR currently names."""
+        # 64 steps: byte 7 - (step-1)//8, bit (step-1)%8 -- the same layout
+        # ot_project.set_pattern_trig writes on disk. The 1-8 form threw
+        # "bytes must be in range" at step 9 (6 Sep 2026).
         blob = int.from_bytes(self.uc.mem_read(ec.PART_PTR, 4), "big")
-        v = self.uc.mem_read(blob + 7, 1)[0] | (1 << (step - 1))
-        self.uc.mem_write(blob + 7, bytes([v]))
+        at = blob + 7 - (step - 1) // 8
+        v = self.uc.mem_read(at, 1)[0] | (1 << ((step - 1) % 8))
+        self.uc.mem_write(at, bytes([v]))
         return v
 
     def watch_reads(self, addr, length, cap=200000):
@@ -1307,8 +1311,9 @@ class Rtos:
         0x30 -> bit 14 and 0x38 -> bits 5+8 (0x4009d93c..0x4009da12).
         """
         base = self.pattern_base() + track * TRAC_STRIDE + off
-        v = self.uc.mem_read(base + 7, 1)[0] | (1 << (step - 1))
-        self.uc.mem_write(base + 7, bytes([v]))
+        at = base + 7 - (step - 1) // 8          # 64 steps, as poke_trig
+        v = self.uc.mem_read(at, 1)[0] | (1 << ((step - 1) % 8))
+        self.uc.mem_write(at, bytes([v]))
         return v
 
     def install_trig_log(self):
@@ -1508,6 +1513,10 @@ def _cli():
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     ap.add_argument("--image", default=None, help="MAIN OS image (default: the raw stock image)")
     ap.add_argument("--project", default=None, help="project dir to put on an emulated card")
+    ap.add_argument("--tree", default="out/_emu_rtos_tree",
+                    help="scratch dir the emulated card is staged in; it is WIPED at "
+                         "start, so two concurrent runs need two trees (three runs "
+                         "launched together died on this, 6 Sep 2026)")
     ap.add_argument("--set", default="OCTABAM")
     ap.add_argument("--name", default=None)
     ap.add_argument("--ms", type=float, default=100.0, help="emulated milliseconds to run")
@@ -1557,7 +1566,7 @@ def _cli():
     card = None
     staged_name = a.name
     if a.project:
-        card, staged_name = stage_project(a.project, a.set, a.name)
+        card, staged_name = stage_project(a.project, a.set, a.name, tree=a.tree)
     t0 = time.perf_counter()
     r, rt = attach(a.image, card, ips=a.ips, pit_clock_hz=a.pit_clock, quantum=a.quantum,
                    step_quantum=a.step_quantum, tick=not a.no_tick,
@@ -1599,11 +1608,16 @@ def _cli():
             # -- the addresses below say which is which.
             print(f"watch-mem  : {len(writes)} write(s) logged "
                   f"(the load's own watch shares this list)")
-            for sample, task, pc, addr_, size, val in writes[:12]:
+            # Print them ALL (capped only against a flood): the first
+            # version showed 12 and "... 111 more", and the 111 were the
+            # only writes that mattered -- a watch that hides its hits is
+            # the silent-instrument trap again (RTOS_FORK section 10.3b).
+            cap = 4000
+            for sample, task, pc, addr_, size, val in writes[:cap]:
                 print(f"   [{sample:10.1f}] [{addr_:#x}] <- {val:#x} ({size}) "
                       f"at pc {pc:#x} in {rt._name(task)}")
-            if len(writes) > 12:
-                print(f"   ... {len(writes) - 12} more")
+            if len(writes) > cap:
+                print(f"   ... {len(writes) - cap} more (raise cap in emu_rtos.py)")
 
     def _fault(e):
         why = f"FAULT {e} pc={rt.pc:#x} task={rt._name(rt._cur())}"
@@ -1628,10 +1642,12 @@ def _cli():
             # from-boot form for Python callers.
             bank = a.bank if a.bank is not None else saved_bank
             if bank is not None and final_bank != bank:
-                # The load ends on bank A (sys applies the engine's own
-                # reset-time "select bank 0" after the BANK= parse -- section
-                # 7's open ordering question); the cold reference sits on the
-                # SAVED bank. Put the run there through sys's own switch.
+                # The load ends on bank A here (sys applies the engine's own
+                # reset-time "select bank 0" after the BANK= parse). The UNIT
+                # does not: it comes up on the saved bank and plays it
+                # (measured 6 Sep 2026, RTOS_FORK section 7), so this switch
+                # and seq_select_live below compensate for an emulator timing
+                # defect; both go once the load's timing is made faithful.
                 final_bank = rt.select_bank_live(bank)
             pattern = rt.uc.mem_read(CUR_PATTERN, 1)[0]
             seq_bank, seq_pattern = rt.seq_select_live(final_bank, pattern)


### PR DESCRIPTION
## Hardware (Sam at the unit, 6 Sep evening)
- **M6b/M6c bank falsifier**: LOAD OCTABAM_RIG → **B01, and PLAY runs the pattern**. The firmware does not apply its stale "select bank 0"; the emulator's ordering is the unfaithful one. `select_bank_live`/`seq_select_live` are compensation for an emulator defect — the load's timing is the fix, still open. Propagated to RTOS_FORK §7/§8.3, PLAN §5, EMU.md, and the tool comment.
- **Recorder trig masks**: `RECTRIG` (byte-exact copy of the cleared baseline) + one recorder trig on T1 step 9 → `pattern-diff`: masks `0x20`, `0x28`, `0x30` all set, nothing else but the checksum. Toggling REC2 off clears only `0x28` → **`0x28` = REC2 measured**; `0x20`/`0x30` = REC1/REC3 by order.

## Emulator (RTOS_FORK §10.7)
- Five instruments on the fixture at step 9 were all null — because **bank A's pattern A01 steps at 1/4 rate** (1379 frames/step): a step-2 on-disk trig fires at frame 1379, and the read watch shows 3 evaluations vs the baseline's 9. Step 9 is ~11,000 frames in; a run to 11,500 is in flight and will land as a follow-up commit.
- The same three masks, on disk or poked, fire the whole chain: flag word `0x7020`, the `0x4009d9f6` follow-on, the arm caller `0x40005ff0` (from `0x4000d35c`), and **`0x46104d26` — Bryan's trig word — nonzero for the first time in any run**. An on-disk recorder trig now reaches path B with nothing poked.
- `0x4009d93c/96e/99a` are the mask *tests*, not the setters (disassembled).

## Tool
- `poke_trig`/`poke_mask` cover 64 steps (step 9 raised `bytes must be in range`).
- `--watch-mem` prints every write — the 12-line cap hid the only writes that mattered.
- `--tree` so concurrent runs stop wiping each other's staging dir.

Docs/tools only; no build change. `python3 -m py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)