### PR TITLE
RTOS: the unit's recorder trig fires under route A; the chain past the arm caller is measured to the engine's buffer allocation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -717,10 +717,15 @@ the recorder SETUP page's TRIG *mode* byte, in the part. ✅ **The recorder
 trig's masks are SETTLED on the unit (6 Sep evening): `0x20`+`0x28`+`0x30`,
 all three for one trig** (one per REC source, inferred) — `pattern-diff`
 against the `RECTRIG` project Sam saved with one trig on T1 step 9
-(RTOS_FORK §10.6; fixture `out/_recproj`). Next: run that fixture under
-`emu_rtos` with `--frames 3000` (step 9 is ~2,750 frames in; 400 never
-reaches it) and watch the staged/immediate/armed recorder slots for what
-the trig actually does — that is Bryan's click question.
+(RTOS_FORK §10.6; fixture `out/_recproj`). ✅ **And the trig FIRES under
+route A, from the file, with nothing poked** (§10.7: bank A's A01 steps at
+1/4 rate, step 9 = frame 11026; flag word, arm caller, Bryan's trig word
+`0x46104d26` nonzero for the first time), and the chain past the arm
+caller is measured (§10.8): engine opcode `0x22` → handler `0x40085bde` →
+recorder buffer released + re-allocated from the PCM pool (`track+128`).
+Next: time the opcode-`0x25` post, find how the DSP is told to sample
+(no host-port write seen yet), then the playback block chain where the
+click lives.
 M6c's gate is the regression to keep green while doing it:
 `tools/emu_rtos.py --project out/_testproj --set OCTABAM --name RIG
 --sequencer --internal-clock --poke-trig 2 --frames 400 --ms 20000

--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -1216,8 +1216,12 @@ watch reads its rows **9×**, one per 344-frame step. (The baseline's bank B pat
 steps at 344, which is where the 344-frame gate and the "step 9 ≈ 2,750"
 arithmetic came from; the RIG's A01 evidently carries a 1/4× scale or
 equivalent length setting — not located in the PTRN record, inferred
-from the timing 🟡.) So Sam's step-9 recorder trig is at ~11,032 frames;
-a run to 11,500 is in flight to land it.
+from the timing 🟡.) ✅ **Sam's own step-9 trig, landed** (`--frames
+11500`, the unmodified `out/_recproj`): flag word `0x7020`, `0x4009d9f6`
+×1, arm caller ×1 from `0x4000d35c`, `0x46104d26` `0x72d2` at **frame
+11026** then `2`/frame — 8 × 1378.25, the same chain as the step-2 copy
+and the RAM-poke control. The trig the unit wrote, through the file, the
+card model, the real load and the real sequencer, with nothing poked.
 
 **What this establishes (measured, one emulator, no hardware audio):**
 a recorder trig on disk → card → real LOAD PROJECT → the sequencer's mask
@@ -1227,3 +1231,61 @@ needs, reachable from a project file. Not yet measured: what the arm
 caller does next (`0x40005ff0` ran once — its class-2 path, the sample-
 slot control record, the DSP-side start), and whether the byte-`0x30`
 live flag is what the DSP's recorder reads.
+
+### 10.8 Past the arm caller: the trig becomes an ENGINE message, and the engine allocates the recorder buffer (6 Sep 2026, late — measured)
+
+Runs on the step-2 copy of the fixture (`--frames 1600`), `--watch-calls`
+over the arm caller's callees (static: `0x40005ff0` runs `0x40005ff0..
+0x40006712`, calling only `0x40005c7c`, `0x40097168`, `0x40005304`) and
+the engine's handlers.
+
+**The arm caller posts an engine message.** `0x40005304` entered once,
+from `0x400066b6` inside the arm caller; `0x40097168` (the machine==4
+classifier) 0× — the track's machine is THRU (type 2), so the PICKUP
+branch is not taken, and the recorder still arms. `0x40005304` is a
+poster: an 8-byte record at `0x46104d52 + track*8` — opcode `0x22`,
+byte 1 = 1, word 2 = track, long 4 = 1 (pending) — posted with
+`0x40000c3c` to **`0x460d17ce`, the engine task's command queue** (the
+same queue LOAD PROJECT and RELOAD BANK use, EMU.md; Bryan's "central
+engine-command queue" is corroborated a second time). Not touched by the
+trig: the sample-slot control record `0x80004f1c..+84` (0 writes) and
+`0x800066a0` (only the load's zero stores — three fixtures now say that
+word is not the recorder arm).
+
+**The engine handles it.** Its dispatcher (`0x4008484e`: `queue_receive`
+on `0x460d17ce`, opcode ≤ 45, 16-bit offset table at `0x40084870`, base
+`0x40000400` for the raw image) sends opcode `0x22` to **`0x40085bde`**:
+
+```
+[1355822.8] [0x46104d52] <- 0x22   main   0x4000531a   <- the post (opcode, flag=1, track=0, pending=1)
+[1355825.0] [0x46104d53] <- 0x0    engine 0x40085bee   <- 2.2 samples later: handler takes the flag
+            0x40095a90(track)  from 0x40085c02          <- release the track's recorder state
+            0x400948cc(track)  from 0x40085c0a          <- allocate a chain from the PCM pool
+[1355975.2] [0x46104d56] <- 0x0    engine 0x40085c2c   <- 152 samples later: pending cleared
+```
+
+Both callees index **`track + 128`** — the recorder-buffer object ids
+Bryan named — into the arena at `0x46c2e9c0` (strides `0x390a` /
+`0x7214` per `(track+2)`), the table `0x461053a8[track]` and
+`0x46c75e88`. `0x400948cc` reads the pool pointers `0x8000691c`/
+`0x80006920` and returns **−5** when there is no room; the handler turns
+−5 into a message to `sys` (`0x400d1662`, track in byte 1) — the "no
+memory" path. Each also ran 16× more from `0x4009636c`/`0x40097132`
+(load-time, 8 tracks × 2 🟡 by count, not timed).
+
+**Opcode `0x25` (Bryan's "arm" opcode) ALSO ran once** — handler
+`0x40085c88` → `0x40099680(1, track)` (the open/arm function, 290× in
+the run, the rest from load-time sites `0x40023ad4/aee`, `0x4002585a`).
+Whether that one post came at the trig or during the load is **not
+timed** (the call summary has no timestamps) — the next run should
+`--watch-mem` the `0x25` record and `--watch-pc 0x40085c88`.
+
+**What this establishes:** recorder trig (disk) → sequencer mask tests →
+flag word → frame builder → arm caller → engine opcode `0x22` → recorder
+buffer released and re-allocated from the PCM pool, ~3.4 ms of engine
+work, all under the real scheduler. **What it does not:** how the DSP is
+told to start sampling (nothing here writes the host port), what the
+`0x22`/`0x25` split means (start vs. arm?), and the loop-point click
+([[octabam-recorder-control-path]]) — the click is in the recorder's
+PLAYBACK block chain, which this milestone has only just reached the
+allocation of.

--- a/tools/emu_rtos.py
+++ b/tools/emu_rtos.py
@@ -690,9 +690,17 @@ class Rtos:
                 ("a1", eb.UC_M68K_REG_A1), ("a3", eb.UC_M68K_REG_A3), ("sp", eb.UC_M68K_REG_A7),
                 ("sr", eb.UC_M68K_REG_SR)]
 
+        # Kept in a list AND traced: the trace-only form printed nothing
+        # without --trace -- the third silent instrument of 6 Sep 2026
+        # (after --watch-calls and --watch-mem). The CLI prints the list.
+        self.pc_hits = getattr(self, "pc_hits", [])
+
         def on_pc(u, addr, size, user):
             vals = " ".join(f"{n}={u.reg_read(r) & 0xffffffff:#x}" for n, r in regs)
-            self._t(f"at {addr:#x} {vals} cur={self._cur():#x} in {self._name(self._cur())}")
+            line = f"at {addr:#x} {vals} cur={self._cur():#x} in {self._name(self._cur())}"
+            if len(self.pc_hits) < 2000:
+                self.pc_hits.append((self.sample, line))
+            self._t(line)
         for a in addrs:
             self.uc.hook_add(eb.UC_HOOK_CODE, on_pc, begin=a, end=a)
         self.uc.ctl_flush_tb()
@@ -1601,6 +1609,11 @@ def _cli():
                 n, callers = seen.get(a_, (0, set()))
                 where = (", callers " + ", ".join(f"{c:#x}" for c in sorted(callers)[:4])) if callers else ""
                 print(f"watch-call : {a_:#x} entered {n} time(s){where}")
+        hits = getattr(rt, "pc_hits", None)
+        if hits is not None:
+            print(f"watch-pc   : {len(hits)} hit(s)")
+            for sample, line in hits:
+                print(f"   [{sample:10.1f}] {line}")
         writes = getattr(rt, "mem_writes", None)
         if writes is not None:
             # ⚠️ `load_project_live` installs its own watch_mem and shares


### PR DESCRIPTION
Follow-up to #109. Docs + one tool fix; no build change.

## Measured (RTOS_FORK §10.7 tail, §10.8)
- **Sam's step-9 recorder trig, unmodified project, `--frames 11500`**: lands at frame 11026 (bank A's A01 steps at 1/4 rate) — flag word `0x7020`, the `0x4009d9f6` follow-on, the arm caller, and `0x46104d26` nonzero. File → card model → real load → real sequencer, nothing poked.
- **Past the arm caller**: `0x40005ff0` → `0x40005304` posts **engine opcode `0x22`** (record `0x46104d52+track*8`, queue `0x460d17ce` — the same queue LOAD PROJECT uses). The engine dispatcher (`0x4008484e`, 16-bit offset table at `0x40084870`; raw-image base is `0x40000400`) runs **`0x40085bde`**, which calls `0x40095a90(track)` then `0x400948cc(track)`: the recorder buffer (object id `track+128`) is released and re-allocated from the PCM pool; `-5` = no room → a `sys` message. ~152 samples of engine work, 2.2 samples after the post.
- The machine==4 classifier is **not** taken (the track is THRU) and the recorder still arms. `0x800066a0` and the sample-slot control record are untouched by three fixtures — ruled out as the recorder arm.
- Opcode `0x25`'s handler (`0x40085c88` → `0x40099680(1, track)`) also ran once; **not yet timed** against the trig.

## Tool
- `watch_pc` logged only through the trace channel, so `--watch-pc` printed nothing without `--trace` — the third silent instrument of the day. It records and prints now.

## Open
How the DSP is told to sample (no host-port write seen on this path), the `0x22`/`0x25` split, and the playback block chain where the loop-point click lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)