### PR TITLE
RTOS §10.9: at RLEN=MAX no length converter runs; ot_project recorder-setup + set-tempo

### DIFF
--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -1289,3 +1289,32 @@ told to start sampling (nothing here writes the host port), what the
 ([[octabam-recorder-control-path]]) — the click is in the recorder's
 PLAYBACK block chain, which this milestone has only just reached the
 allocation of.
+
+### 10.9 At RLEN = MAX no length converter runs — and the tempo/setup words are refreshed every frame (6 Sep 2026, late — measured)
+
+Runs E/F on the step-2 copy (T1's RECORDING SETUP as saved by the unit:
+`INAB 1, INCD 1, RLEN 64 = MAX, TRIG 0, SRC3 0, LOOP 1 | FIN 0, FOUT 0,
+AB 0, QREC 255, QPL 255, CD 0`), 1,600 frames, the trig at ~1,379:
+
+- **None of the three length converters ran**: `0x4006e3b2` (truncating,
+  `EXTERNAL.md` §6), `0x400060c4` (the pickup FOUT length) and
+  `0x40006d48` — **0 entries each**, while the trig's `0x22` post, its
+  handler and the `0x25` handler all ran once. So at MAX the arm computes
+  no length, which is the primer's "at MAX the recording runs until the
+  next record trig" seen from the code side. The converter question
+  (§8.2 of `EXTERNAL.md`) therefore needs a fixed-RLEN fixture — built as
+  `ot_project.py recorder-setup <proj> 1 1 0 RLEN 3` + `set-tempo <proj>
+  128.0` (Bryan's own clicking default, 128 / RLEN 4 / 1×); run H.
+- **`0x80001820` (= −2³¹/tempo24) is rewritten every 16 samples**, twice
+  per frame, by `0x4000ac9a` and `0x4000cabc` in `main` — value
+  `0xfff49f4a` = −745,654 = −2³¹/2880 ✓ (120 BPM). The tempo reciprocal
+  is a per-frame publication, not a set-once word.
+- **The live RECORDING SETUP page `0x80000cf4` is re-copied from staging
+  every 2 frames** (`0x400208f2`, `main`): `0x01014000 0x00010000
+  0x00ffff00` = exactly the twelve bytes above. So a change to those bytes
+  in the part reaches the recorder within two frames — the "afresh on
+  every arm" the primer describes has the fresh values available on
+  every frame, whichever converter consumes them.
+- `0x40099680` (open/arm, Bryan's opcode-`0x25` function) at the trig is
+  entered from the `0x25` handler with `d0 = 0x80` — 290 entries over the
+  run, the rest at load time from `0x40023ad4/aee` and `0x4002585a`.

--- a/tools/ot_project.py
+++ b/tools/ot_project.py
@@ -249,6 +249,40 @@ def set_pattern_trig(pdir, banknum, pattern, track, step, mask=0x00, guard=True)
     print(f"bank{banknum:02d} pattern{pattern} T{track+1} mask {mask:#04x} "
           f"step {step} set")
 
+REC_FIELDS = ["INAB", "INCD", "RLEN", "TRIG", "SRC3", "LOOP",
+              "FIN", "FOUT", "AB", "QREC", "QPL", "CD"]   # descriptor order, EXTERNAL.md section 6
+REC_SETUP_OFF = 0x60b   # part-relative file offset of track 0's 12 recorder-setup bytes
+                        # (RAM 0x8f382 vs the machine-type byte's 0x8eda2, + the +9 IFF shift)
+
+def set_recorder_setup(pdir, banknum, part, track, field, value, guard=True):
+    """Write one RECORDING SETUP byte for a track, in part `part` (1-4) AND
+    its saved mirror (part+4). RLEN is stored raw: display 1..64 -> 0..63,
+    MAX -> 64. Measured 6 Sep 2026: the live page at 0x80000cf4 reads back
+    these bytes verbatim ([1,1,64,0,0,1 | 0,0,0,255,255,0] for the RIG)."""
+    fi = REC_FIELDS.index(field.upper())
+    def mut(data):
+        for pi in (part - 1, part - 1 + NPARTS):
+            off = PART_BASE + pi * PART_STRIDE + REC_SETUP_OFF + track * 12 + fi
+            data[off] = value & 0xFF
+    _bank_write(pdir, banknum, mut, guard=guard)
+    print(f"bank{banknum:02d} part {part}(+{part+NPARTS}) T{track+1} {field.upper()} = {value}")
+
+def tempo24_of(bpm):
+    """The UI setter's conversion (0x4009c7c4, measured): 24*whole + (23*tenths+4)//9."""
+    whole = int(bpm); tenths = round((bpm - whole) * 10)
+    return 24 * whole + (23 * tenths + 4) // 9
+
+def set_tempo(pdir, bpm):
+    """Set project.work's TEMPOx24 from a displayed BPM."""
+    path = pdir / "project.work"
+    raw = path.read_bytes().decode("latin1")
+    t = tempo24_of(float(bpm))
+    new, k = re.subn(r"(TEMPOx24=)\d+", lambda m: m.group(1) + str(t), raw, count=1)
+    if k != 1:
+        sys.exit("TEMPOx24 not found in project.work")
+    path.write_bytes(new.encode("latin1"))
+    print(f"TEMPOx24={t} ({bpm} BPM)")
+
 def pattern_masks(pdir, banknum):
     """Every non-zero step mask in the bank: {(pattern, track, mask): value}."""
     data = (pdir / f"bank{banknum:02d}.work").read_bytes()
@@ -605,6 +639,12 @@ if __name__ == "__main__":
     elif cmd == "pattern-diff":
         # <projectA> <projectB> <bank>
         pattern_diff(sys.argv[2], sys.argv[3], int(sys.argv[4]))
+    elif cmd == "recorder-setup":
+        # <project> <bank> <part> <track0> <FIELD> <value>  (RLEN raw: display-1, MAX=64)
+        set_recorder_setup(pdir, int(sys.argv[3]), int(sys.argv[4]), int(sys.argv[5]), sys.argv[6], int(sys.argv[7], 0))
+    elif cmd == "set-tempo":
+        # <project> <bpm>   (TEMPOx24 via the measured UI conversion)
+        set_tempo(pdir, sys.argv[3])
     elif cmd == "machine-type":
         # <project> <bank> <part> <track> <type>; writes the part's saved
         # mirror too, the way a bank's eight PART records require


### PR DESCRIPTION
- Runs E/F on the step-2 fixture (RLEN MAX as the unit saved it): the three length converters got **0 entries** while the trig's `0x22` post, its handler and the `0x25` handler each ran once. At MAX the arm computes no length — the primer's "runs until the next record trig", from the code side.
- `0x80001820` (−2³¹/tempo24) is rewritten twice per frame; the live RECORDING SETUP page `0x80000cf4` is re-copied from staging every two frames and reads back the part's twelve bytes verbatim.
- `ot_project.py recorder-setup` (twelve named fields, part + mirror, checksum) and `set-tempo` (TEMPOx24 via the measured UI conversion). Used to build the 128 BPM / RLEN 4 fixture — Bryan's default clicking case — which is running now.

Docs + tool. Merged on Sam's standing "merge as you go".

🤖 Generated with [Claude Code](https://claude.com/claude-code)