### PR TITLE
RTOS: retract §10.12's FLEX framing (1-based setter, track 0 wrote +0x2a); --stage-audio

### DIFF
--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -1432,3 +1432,22 @@ and watch `0x80004f1c` during the load; if the record fills, re-run the
 at `0x40006edc`, and the length word in the buffer's state record). Also
 worth one line to Bryan: on hardware, does a fixed-RLEN recorder trig on a
 THRU track (no sample slot) record at all? The code says no.
+
+
+**❌ RETRACTION of §10.12's framing (7 Sep 2026, 00:50, by a raw dump):**
+the three "FLEX fixtures" were not FLEX. `ot_project.py machine-type`
+takes a **1-based** track and I passed 0, so each call wrote the byte
+BEFORE T1's machine-type slot (`+0x2a`, one of a run of three `108`s in
+the part record — 108 → 0 or 1, a corruption of unknown effect) and left
+T1's own byte untouched. Worse, that byte reads **0 in the cleared
+baseline and in every fixture** (`+0x2b..+0x32` = eight zeros), while
+§10.1's RAM readback of the same project reported `[2, 2, 0, 0, 0, 0, 0,
+1]` — so **the file offset or the encoding of the machine-type byte is
+unverified**: either the RAM word is derived at load (from the slot
+assignment?) or §10.1's readback location was wrong. What survives from
+§10.12: the sample-slot control record got 0 writes in every run, load
+included, and the tool stages no samples — that finding does not depend
+on the machine type. What does not survive: any statement about FLEX.
+The setter now refuses track 0. A run with the slot-1 STATIC sample
+actually staged (`--stage-audio`, new) is in flight to see whether the
+record fills at all.

--- a/tools/emu_rtos.py
+++ b/tools/emu_rtos.py
@@ -1427,9 +1427,18 @@ class Rtos:
         return "\n".join(lines)
 
 
-def stage_project(project, set_name, name, tree="out/_emu_rtos_tree"):
-    """Copy a project directory into <tree>/<SET>/<NAME> (no audio) and build
-    a 64 MB card image from it -- the same staging emu_frames does."""
+def stage_project(project, set_name, name, tree="out/_emu_rtos_tree",
+                  audio=(), image_mb=64):
+    """Copy a project directory into <tree>/<SET>/<NAME> and build a card
+    image from it -- the same staging emu_frames does.
+
+    No audio by default: every .wav/.ot is skipped, which is why no sample
+    slot ever became valid under route A (RTOS_FORK section 10.12 -- the
+    sample-slot control record 0x80004f1c got 0 writes in every run). `audio`
+    is a list of "<src file>:<card-relative path>" pairs to stage as well,
+    e.g. "~/octa/pool/x.wav:AUDIO/Loopmasters/x.wav" (relative to the SET
+    folder, the way project.work's PATH=../AUDIO/... resolves). The image
+    grows to `image_mb`."""
     import shutil
     src = pathlib.Path(project)
     name = name or src.name
@@ -1442,7 +1451,13 @@ def stage_project(project, set_name, name, tree="out/_emu_rtos_tree"):
     for p in sorted(src.iterdir()):
         if p.is_file() and not p.name.startswith("._") and p.suffix.lower() not in (".wav", ".ot"):
             shutil.copy2(p, dst / p.name)
-    return ec.build_image(str(tree), 64), name
+    for spec in audio:
+        f, rel = spec.split(":", 1)
+        f = pathlib.Path(f).expanduser()
+        out = tree / set_name / rel
+        out.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(f, out)
+    return ec.build_image(str(tree), image_mb), name
 
 
 def attach(image=None, card_image=None, log=None, **kw):
@@ -1534,6 +1549,10 @@ def _cli():
                     help="scratch dir the emulated card is staged in; it is WIPED at "
                          "start, so two concurrent runs need two trees (three runs "
                          "launched together died on this, 6 Sep 2026)")
+    ap.add_argument("--stage-audio", default="",
+                    help="';'-separated '<file>:<SET-relative card path>' pairs to stage "
+                         "beside the project (default: no audio at all -- see stage_project)")
+    ap.add_argument("--image-mb", type=int, default=64, help="emulated card image size")
     ap.add_argument("--set", default="OCTABAM")
     ap.add_argument("--name", default=None)
     ap.add_argument("--ms", type=float, default=100.0, help="emulated milliseconds to run")
@@ -1583,7 +1602,9 @@ def _cli():
     card = None
     staged_name = a.name
     if a.project:
-        card, staged_name = stage_project(a.project, a.set, a.name, tree=a.tree)
+        card, staged_name = stage_project(a.project, a.set, a.name, tree=a.tree,
+                                          audio=[x for x in a.stage_audio.split(";") if x],
+                                          image_mb=a.image_mb)
     t0 = time.perf_counter()
     r, rt = attach(a.image, card, ips=a.ips, pit_clock_hz=a.pit_clock, quantum=a.quantum,
                    step_quantum=a.step_quantum, tick=not a.no_tick,

--- a/tools/ot_project.py
+++ b/tools/ot_project.py
@@ -189,6 +189,11 @@ def set_track_slot(pdir, banknum, part, track, slot_1based):
 MTYPE_OFF, MTYPE_MIRROR = 0x02b, 4      # + track; part N's saved copy is part N+4
 
 def set_machine_type(pdir, banknum, part, track, mtype, mirror=True, guard=True):
+    """part and track are 1-BASED (part 1-4, track 1-8). A track of 0 wrote
+    the byte BEFORE T1's (+0x2a, a run of 108s) in three fixtures on 7 Sep
+    2026 and was only caught by a raw dump -- hence the check."""
+    if not (1 <= part <= NPARTS and 1 <= track <= 8):
+        sys.exit(f"machine-type: part {part} / track {track} must be 1-based (1-4 / 1-8)")
     parts = (part, part + MTYPE_MIRROR) if mirror else (part,)
     def mut(data):
         for p in parts:


### PR DESCRIPTION
- ❌ The three "FLEX fixtures" in §10.12 were not FLEX: `ot_project.py machine-type` takes a **1-based** track; I passed 0, which wrote the byte before T1's slot (`+0x2a`) and left the machine type alone. T1's byte reads 0 in the baseline file while §10.1's RAM readback said 2, so the machine-type file offset/encoding is now flagged **unverified**. The sample-slot-record-never-written finding stands; nothing about FLEX does. The setter refuses track 0.
- `emu_rtos --stage-audio` / `--image-mb`: stage real samples on the emulated card. A run with the slot-1 STATIC sample staged is in flight.

Docs + tool; merged on Sam's standing "merge as you go".

🤖 Generated with [Claude Code](https://claude.com/claude-code)