### PR TITLE
dsp_host boots BOTH payloads: the whole rig renders locally on two cores (tier 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,9 +208,11 @@ both on 17 Aug 2026, both costing hours:
   damage into a multi-second tail. It shipped a cross-core race for months.
 **Before trusting a null result, ask what the instrument physically cannot
 see.** A reverb cannot show you a discontinuity. A harmonic metric cannot show
-you an inharmonic one. A single-core emulator cannot show you a race between
-two cores — and `dsp_host` is single-core, so NO local test will ever
-reproduce a bus timing defect. When local says clean and hardware says
+you an inharmonic one. A lock-step emulator cannot show you a race between
+two cores — `dsp_host` boots both payloads since 7 Sep 2026 and `-skew` can
+interleave them, but that is a fuzz of the hardware's timing, not the
+timing, so a local "clean" is still NOT evidence a bus timing defect is
+gone (a local red IS a defect). When local says clean and hardware says
 broken, believe the hardware and go looking for what the harness omits.
 
 **A BUS CLIENT THAT REGISTERS BUT CONTRIBUTES NOTHING STEALS EVERYONE ELSE'S

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,18 @@ render-delay: ## Build the DELAY hatch (all 3 servers real) and render BusDelay 
 	REMIX=$(REMIX) DEV=1 XBUS=1 python3 tools/build_bus.py
 	python3 tools/send_probe.py --mem out/dsp/mem_dev_A.mem --layout DS
 
+.PHONY: render-rig
+render-rig: bus ## Render ALL EIGHT TRACKS on both cores (the real image, tracks 1-4 on B, 5-8 on A). TRACKS=T1=D,T2=S,.. STEMS=dir
+	@# tools/rig_render.py --help for --project/--set/--stem/--skew. The
+	@# image is this remix's `make bus`; both payloads are dumped from it.
+	python3 tools/rig_render.py --image out/mainos_bus.bin --remix $(REMIX) \
+	  $(if $(TRACKS),--tracks "$(TRACKS)",--tracks "T1=D,T2=S,T3=S,T4=S,T5=R,T6=S,T7=S,T8=S" --set T2:-VRB=100 --set T3:-DEL=100 --set T6:-VRB=100 --set T7:-DEL=80 --set T1:-VRB=100) \
+	  $(if $(STEMS),--stems $(STEMS),--stems out/test_audio --seconds 4) $(RIGARGS)
+
+.PHONY: verify-twocore
+verify-twocore: ## Two-core gate: servers on their REAL cores == the DEV hatch, bit for bit, and under 4 skews (~1 min)
+	python3 tools/verify_twocore.py
+
 .PHONY: verify-midi
 verify-midi: ## Local check of note->PITCH interval (DNOTE override, ~40 s)
 	python3 tools/verify_midi.py
@@ -138,6 +150,7 @@ verify: ## Verify the ColdFire menu edits, module ledger (+ burn probe when it f
 	python3 tools/verify_grains.py $(REMIX)
 	REMIX=$(REMIX) python3 tools/verify_menu.py
 	python3 tools/verify_burn.py
+	python3 tools/verify_twocore.py
 
 .PHONY: verify-roll
 verify-roll: ## Prove an alternate engine is bit-identical: make verify-roll CAND=modules/busverb/reverb_lforoll.asm

--- a/PLAN.md
+++ b/PLAN.md
@@ -51,6 +51,30 @@ What ships:
   (never init-build tables in Y through `(r1)+` — R48–R50 killed every
   voice). `docs/PARAM_PAGES.md` §7 decodes the formatter ABI.
 
+- **The whole rig renders locally, on BOTH cores (7 Sep 2026, tier 1 of
+  the emulator uplift).** `tools/dsp_host` boots payload A *and* payload B
+  as two DSPs in one process with the shared window `0x30000–0x3FFFF`
+  really shared (a patch to the vendored emulator's `Memory`), each core
+  running its own setup routine (payload B's found by opcode pattern at
+  `P:0x17a`; the year-old "cannot boot payload B" was three hardcoded
+  payload-A addresses). `tools/rig_render.py` / `make render-rig` drives
+  all eight tracks — T1–T4 on core 1, T5–T8 on core 0, FX1→FX2 chained per
+  track, ids and knob bytes from a real project part or by name, stems in,
+  per-track + mix wavs and a per-block instruction meter out — at about
+  real time. ✅ **Measured**: SEND and BusDelay on the *real* payload B
+  feeding BusVerb on payload A (send hop, delay hop, delay→reverb series
+  hop, two senders per core) render bit-identical to the DEV hatch, and
+  stay identical under four instruction-level interleave skews
+  (`tools/verify_twocore.py`, in `make check`) — payload B's `$38000`
+  placement had only ever been checked statically. ⚠️ What this is NOT:
+  the chip's timing (lock-step, or a guessed `-skew`: a local mismatch is
+  a defect, identity is not evidence), the cycle cliff (instructions per
+  block, no contention stall), or the ColdFire (knobs poked into `r6`, a
+  unity mixer, stems instead of sample playback). `docs/HARNESS.md` "Two
+  cores". Tiers 2 (the ColdFire's per-frame parameter records replayed
+  into this harness) and 3 (audio through the host port, ~100× slower than
+  real time) are scoped in the 7 Sep session notes and not started.
+
 **Hosting is bank-bound; serving is not.** Either effect serves all eight
 tracks over the bus, but each can only be *hosted* on its own core's bank —
 and picking one on the wrong bank runs a SEND instead (the absent server's

--- a/docs/BUS.md
+++ b/docs/BUS.md
@@ -974,8 +974,10 @@ FX2 slots are still spent; two servers still mean two hosts. Two blocks of
 latency on the return (~0.7 ms) on top of the send's. ⚠️ Unmeasured: whether
 an insert on a master-configured T8 sees the summed mix — the rig already
 runs the reverb there as a return, consistent with yes; if no, the return
-lands on an ordinary track and nothing breaks. ⚠️ `dsp_host` is single-core,
-so the delay-wet-across-cores case and the RETD stamp crossing cores are
+lands on an ordinary track and nothing breaks. ⚠️ `dsp_host` was single-core when this was written (both cores since
+7 Sep 2026, lock-step: the delay wet crossing cores now renders locally and
+matches the hatch to the bit — `tools/verify_twocore.py`), but the TIMING of
+that crossing and the RETD stamp's are still
 flash-4 claims, like every bus timing claim before them. ⚠️ `0x360d3-5` (the
 words right after the old layout end) were DEAD on hardware for R36's
 per-block state, mechanism unknown — the new words start at `0x360d8`, and
@@ -1001,15 +1003,16 @@ the first suspect.
   (word-for-word against a standalone reassembly); `tools/dsp_host` itself
   can't run payload B at all yet (next bullet), so this couldn't be
   re-verified the same way task 10's other offsets were.
-- **`tools/dsp_host` cannot run payload B.** Its boot-setup step
-  (`runRange(0x372,0x39e)`, then reading frame context from `x:0x415`) is a
-  fixed address range that only produces sane context for payload A's own
-  boot content — pointed at a payload-B dump it reads all zeros and the
-  harness reports "frame count is 0". Pre-existing (this doc already said
-  "emulator testing so far only exercises payload A" before task 13), hit
-  for the first time in task 13 when payload B needed its own check. Not
-  investigated further — would need its own reverse-engineering of whatever
-  payload B's equivalent setup routine is, which is out of scope here.
+- ~~**`tools/dsp_host` cannot run payload B.**~~ ✅ **FIXED 7 Sep 2026.**
+  The boot-setup step was three hardcoded payload-A addresses
+  (`runRange(0x372,0x39e)`, dispatcher exit `0x53e`); payload B keeps the
+  same routine at `P:0x17a..0x1a3` (exit `0x333`), found by matching the
+  opcode sequence, and the harness now detects it by pattern. Payload B's
+  delay renders bit-identical to the DEV copy (`tools/verify_twocore.py`),
+  which closes the "checked statically" caveat above.
+  *(Historical text: pointed at a payload-B dump it read all zeros and
+  reported "frame count is 0"; hit in task 13 when payload B needed its own
+  check.)*
 - **`DELAY SERVER`'s PING knob is L-only at PING=0 by construction, not
   oversight.** An earlier draft fed input into both delay lines so PING=0
   would be an ordinary independent stereo echo; that version's PING knob
@@ -1222,10 +1225,9 @@ id `0x08` or moving memory it uses would find out the hard way.
 - ~~Placing `dsp/reverb_server.asm` / `delay_server.asm` / `send_client.asm`'s
   assembled code in P memory and repointing `X:0x215`/`X:0x235`~~ **decided
   and built, task 13** — see Menu and slot layout.
-- `tools/dsp_host` cannot run payload B at all (Known limitations) — its
-  boot-setup step assumes payload-A-shaped context. Unmeasured whether this
-  is worth fixing versus just accepting static-only verification for payload
-  B indefinitely.
+- ~~`tools/dsp_host` cannot run payload B at all~~ — fixed 7 Sep 2026
+  (Known limitations); payload B is now rendered and gated, not checked
+  statically.
 
 ## Build order, if this goes ahead
 

--- a/docs/CHIP.md
+++ b/docs/CHIP.md
@@ -279,8 +279,13 @@ Retracted. There are ~1 200 usable cycles.
 
 These are **static** counts — words in the sample loop, no memory-contention
 stalls modelled — so they are a floor. `tools/dsp_host` **cannot** measure
-cycles: its `instructions/sample` is a constant divided by whatever frame count
-you ask for.
+cycles either: since 7 Sep 2026 its per-core **meter** counts executed
+instructions per block for a whole layout (`-meter`, printed at the end of
+every run; `tools/rig_render.py` writes `meter.txt`), which is a second
+floor — per block, every instance's real work, inits included — and still
+no stall. For scale: the meter reads BusVerb at ~1,130 instructions/sample
+where the static count is 1,652 words (multi-word instructions count once);
+the same 3,120 wall applies to neither directly. Only the burn sweep measures the ceiling.
 
 **For scale:** the entire BusVerb engine was 758 cycles when the spare was
 measured (~1 133 with the 8-line tank), and 1 392 was room for ~1.8 more complete

--- a/docs/FAILURE_MODES.md
+++ b/docs/FAILURE_MODES.md
@@ -124,5 +124,7 @@ residual on T4 + delay MODE 1).** The shared-window accumulators raced across
 the two cores. `docs/XBUS.md`.
 
 **Fix.** The shipped fixes (four ACC buffers, per-core rotation tracking).
-⚠️ **No local test is evidence here** — `dsp_host` is single-core, so a bus
-race never reproduces off the unit. Believe the hardware.
+⚠️ **No local test is evidence here** — `dsp_host` runs both cores only
+lock-step or under a guessed interleave (`-skew`), so a bus race that fails
+to reproduce locally is not shown absent. A local mismatch under skew IS a
+defect. Believe the hardware.

--- a/docs/FLASHING.md
+++ b/docs/FLASHING.md
@@ -238,9 +238,10 @@ from Elektron's zip (card). Your CF card and projects are not affected.
   anyone — Elektron least of all.
 - Everything checkable without hardware is checked — `make check`, the
   verify gates, and whatever local render your modules support (`make render`
-  for the bus, `send_probe --direct` for an insert) — but the emulator is
-  **single-core**, so
-  no local test can reproduce a cross-core bus timing defect, and its mpy
+  for the bus, `send_probe --direct` for an insert, `make render-rig` for
+  all eight tracks on both cores) — but the emulator's two cores run
+  **lock-step or under a guessed interleave**, so
+  no local test can show a cross-core bus timing defect absent, and its mpy
   semantics and truncation are its own. Treat emulator green as necessary,
   not sufficient, and go in with the recovery net ready.
 - The only truly delicate moment is **"UPDATING FLASH"**: don't cut power

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -185,8 +185,10 @@ perfectly on any spur metric.
 
 ### The DEV hatch (`make render-delay`)
 
-The shipping build (`SPEC=1`) puts BusDelay in payload B only — and
-dsp_host cannot boot payload B. Worse, a SPEC dump *aliases* the absent
+The shipping build (`SPEC=1`) puts BusDelay in payload B only — and until
+7 Sep 2026 dsp_host could not boot payload B (it can now: see "Two cores"
+below; the hatch stays because every single-core gate is stamped against
+it). Worse, a SPEC dump *aliases* the absent
 delay's dispatch id to the SEND client (deliberately, so a wrong chooser
 pick becomes a send), which locally renders a plausible dry passthrough: the
 12 Aug 2026 "delay outputs nothing" session measured a SEND all day. So
@@ -212,15 +214,63 @@ Bit-identity is the harness's superpower: because the arithmetic is emulated
 exactly, "same output hashes" means "same machine behaviour", which turns
 refactoring risk into a mechanical check.
 
+## Two cores — the whole rig locally (7 Sep 2026)
+
+`dsp_host -mem A.mem -memB B.mem` boots **both payloads** as two complete
+DSPs in one process, with X/Y `0x30000–0x3FFFF` of core 1 redirected into
+core 0's arrays (a patch to the vendored emulator's `Memory`,
+`tools/dsp56300.patch`) so the shared window really is shared. Each core
+runs its **own** setup routine: the harness finds it by opcode pattern —
+payload B keeps it at `P:0x17a` where A's is at `P:0x372`, the same code
+relocated (✅ measured by matching the instruction sequence; the old
+"cannot boot payload B" was three hardcoded payload-A addresses). `-core`
+assigns each instance to a core, positions counted per core; `-audioidx`
+lets two instances share one audio buffer in order — a track's FX1 then its
+FX2.
+
+**What it proved on the first day** (`tools/verify_twocore.py`, in `make
+check`): SEND and BusDelay on the *real* payload B feeding BusVerb on
+payload A — the send hop, the delay hop and the delay→reverb series hop —
+render **bit-identical** to the same layouts on one core through the DEV
+hatch. That is the harness proven (a window not shared or a context address
+wrong would show) *and* payload B's copy of the delay proven: its `$38000`
+base substitution and SPEC placement had only ever been checked statically.
+
+**Scheduling.** Lock-step by default (core 0's whole block, then core 1's),
+which is what one core always saw and is blind to the race by construction.
+`-skew N` **interleaves** the two instruction by instruction, core 0 N
+ahead. That is a *fuzz* of the hardware's timing, not the timing: identity
+under skew proves nothing (the gate's four skews all match), a mismatch is a
+real defect — and no local test could show one before.
+
+**The meter.** Every run prints, per core, the maximum and mean instructions
+per block for *this layout* (`-meter FILE` for every block). Instructions,
+not cycles — no contention stall is modelled — so it is a floor like
+`tools/cycle_count.py`, but per block with every instance's real work and
+any init that lands inside a block. The wall is `docs/CHIP.md`'s measured
+budget; the emulator never sees the cliff.
+
+**`tools/rig_render.py`** drives it track by track: `--tracks T1=D,T2=S,…`
+(or `T3=L+S` for FILTER on FX1 into a SEND on FX2), or `--project DIR
+--bank N --part N` for the ids **and knob bytes** of a real part; stems per
+track; T1–T4 on core 1, T5–T8 on core 0 in dispatch order; out come
+`T1.wav…T8.wav`, `mix.wav` (unity sum, −6 dB) and `meter.txt`. About real
+time for eight tracks on two cores. `make render-rig`.
+
+What it still is not: the ColdFire. Knobs are poked into `r6`, AMP/pan and
+the mixer are a unity sum, samples do not play (stems stand in), and the
+stock DELAY is not on the DSP at all.
+
 ## What the harness cannot see
 
 Every item here has cost a real session at least once. Local-clean does not
 mean hardware-clean; when the two disagree, believe the hardware.
 
-* **Anything between two cores.** dsp_host boots one core and cannot boot
-  payload B at all. No local test will ever reproduce a cross-core race —
-  the XBUS accumulator race shipped for months behind a local "clean"
-  (`docs/XBUS.md`).
+* **The hardware's cross-core timing.** Two emulated cores run lock-step
+  or under a chosen interleave, never under the chip's real skew, and no
+  SRAM contention is modelled. A local "clean" under every `-skew` is still
+  not evidence the race fix holds — the XBUS accumulator race shipped for
+  months behind a local "clean" (`docs/XBUS.md`), and it would again.
 * **The cycle budget.** The emulator happily renders an engine the chip
   cannot afford; 432 cycles/sample over once froze the unit. `make cycles`
   bounds it, hardware proves it.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -467,8 +467,9 @@ cleared. With no server and no SEND in the image there is no bus, no
 rotation and nothing to clear, so the question does not arise — and that is
 the only case this is allowed in. `registry.remix()` enforces it.
 
-⚠️ And it could not be settled by measurement either way: `dsp_host` is
-single-core, so **no local test can reproduce a bus timing defect**. The
+⚠️ And it could not be settled by measurement either way: `dsp_host` runs
+both cores lock-step (or under a chosen interleave, which is a fuzz of the
+timing), so **no local test is evidence a bus timing defect is absent**. The
 refusal keeps the question off the table rather than answered by inference.
 
 Declare `bus_client=True` in a module's `Harness` if it writes the shared
@@ -736,17 +737,19 @@ full list. All of them assemble clean and do the wrong thing.
 
 ## Two things that will surprise you
 
-**`dsp_host` cannot boot payload B.** Local testability therefore depends on
-which payload a module lands on — and that is a SERVER's problem, because
-specialization is what puts a server on one core. BusDelay ships on payload
-B and can only be rendered locally through the DEV hatch, which places it out
-of region in payload A; a server on core 1 inherits that constraint.
+**`dsp_host` boots BOTH payloads since 7 Sep 2026** (`-memB`, and
+`tools/rig_render.py` for the whole rig), so a server on core 1 renders on
+core 1 with the shared window shared — BusDelay on payload B is gated
+bit-identical to the DEV hatch's copy by `tools/verify_twocore.py`. The
+hatch remains the single-core instrument every existing gate is stamped
+against.
 
-An insert is in BOTH payloads, so it is always reachable in payload A and
-renders with no hatch at all.
+An insert is in BOTH payloads, so it renders anywhere with no hatch at all.
 
-**No local test can reproduce a cross-core timing defect**, because
-`dsp_host` is single-core. When local says clean and hardware says broken,
+**No local test is evidence that a cross-core timing defect is absent.**
+The two cores run lock-step, or interleaved under a chosen `-skew` — a fuzz
+of the hardware's timing, not the timing (a local mismatch IS a defect;
+identity proves nothing). When local says clean and hardware says broken,
 believe the hardware and go looking for what the harness cannot see. A
 measurement can be structurally blind to the thing you are using it to rule
 out — `CLAUDE.md` has two instances that each cost hours.

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -112,7 +112,9 @@ version:
 
 | tool | what it does |
 |---|---|
-| `tools/dsp_host` | the emulator harness itself — boots a payload dump, calls effects through the recovered ABI, captures audio, polices memory |
+| `tools/dsp_host` | the emulator harness itself — boots a payload dump (both payloads since 7 Sep 2026, `-memB`, shared window shared), calls effects through the recovered ABI, captures audio, polices memory, meters instructions per block |
+| `tools/rig_render.py` (`make render-rig`) | the whole rig locally: eight tracks on both cores, FX1→FX2 chained per track, ids and knobs from a project part or by name, stems in, per-track + mix wavs and `meter.txt` out |
+| `tools/verify_twocore.py` (`make verify-twocore`, in `make check`) | the two-core gate: the servers on their real cores render bit-identical to the DEV hatch, and under four interleave skews |
 | `tools/render_reverb.py` (`make reverb IN=..`) | wav → BusVerb → wav, knobs by name, sweeps, wet-only — the voicing instrument **for the reverb specifically** |
 | `tools/send_probe.py` (`make render`, `make render-delay`) | renders a real SEND→bus→server path and measures it numerically. `--direct` puts audio through one module on its own track instead — **the way an insert is rendered**, since an insert has no bus accumulator to analyse |
 | `scripts/make_test_audio.py` | synthesises the standard audition material into `out/test_audio/` |

--- a/docs/XBUS.md
+++ b/docs/XBUS.md
@@ -180,8 +180,11 @@ it, swapping what ran on track 5 — is in `docs/history/XBUS_LOG.md`.
   time, and it moves when the mode or core 0's load changes. Spot-checks
   have passed builds that a sweep then failed — any "fixed" claim needs a
   track × mode sweep.
-- ⚠️ **No local test is evidence about a cross-core race.** `dsp_host` is
-  single-core and always trivially in lockstep. The bit-identity gate
+- ⚠️ **No local test is evidence about a cross-core race.** `dsp_host`
+  runs both cores since 7 Sep 2026, lock-step by default or under a chosen
+  `-skew` interleave — a fuzz of the hardware's timing, never the timing
+  (`docs/HARNESS.md`, "Two cores"). A mismatch under skew is a real defect;
+  identity is not evidence. The bit-identity gate
   proves a change preserved behaviour; only the unit can say a timing
   defect is gone, and the decisive configuration is the one that exposed
   it: BusDelay on track 1, fed over the bus.

--- a/tools/dsp56300.patch
+++ b/tools/dsp56300.patch
@@ -71,3 +71,63 @@ index f9f8180..714776e 100644
  	void JitOps::op_Maci_xxxx(TWord op)
  	{
  		const bool	ab = getFieldValue<Maci_xxxx, Field_d>(op);
+diff --git a/source/dsp56kEmu/memory.cpp b/source/dsp56kEmu/memory.cpp
+index 98c2226..c408d00 100644
+--- a/source/dsp56kEmu/memory.cpp
++++ b/source/dsp56kEmu/memory.cpp
+@@ -145,6 +145,12 @@ namespace dsp56k
+ 			}
+ 		}
+ */
++		if (m_sharedX && _area != MemArea_P && _offset >= m_sharedLo && _offset < m_sharedHi)
++		{
++			(_area == MemArea_X ? m_sharedX : m_sharedY)[_offset - m_sharedLo] = _value & 0x00ffffff;
++			return true;
++		}
++
+ 		if (_offset < size(_area))		// Fix the amazing "write to wrong address" bug
+ 			m_mem[_area][_offset] = _value & 0x00ffffff;
+ 
+@@ -178,6 +184,9 @@ namespace dsp56k
+ 			return 0;
+ 		}
+ 
++		if (m_sharedX && _area != MemArea_P && _offset >= m_sharedLo && _offset < m_sharedHi)
++			return (_area == MemArea_X ? m_sharedX : m_sharedY)[_offset - m_sharedLo];
++
+ 		const auto res = m_mem[_area][_offset];
+ 
+ #ifdef _DEBUG
+diff --git a/source/dsp56kEmu/memory.h b/source/dsp56kEmu/memory.h
+index 567d068..a409872 100644
+--- a/source/dsp56kEmu/memory.h
++++ b/source/dsp56kEmu/memory.h
+@@ -63,6 +63,14 @@ namespace dsp56k
+ 		TWord*												p;
+ 
+ 		TWord												m_bridgedMemoryAddress;
++
++		// octabam: a window of X and Y that lives in ANOTHER Memory's arrays,
++		// so two DSP instances can share it the way the DSP56721's two cores
++		// share Y:0x30000-0x3FFFF. P is never shared (each core has its own).
++		TWord												m_sharedLo = 0;
++		TWord												m_sharedHi = 0;
++		TWord*												m_sharedX = nullptr;
++		TWord*												m_sharedY = nullptr;
+ 		
+ 		struct STransaction
+ 		{
+@@ -124,6 +132,13 @@ namespace dsp56k
+ 
+ 		const TWord&		getBridgedMemoryAddress() const { return m_bridgedMemoryAddress; }
+ 
++		// octabam: redirect X/Y [_lo,_hi) to _x/_y (pointers into the owner's
++		// arrays at _lo). Pass nullptr to clear.
++		void				setSharedWindow		(TWord _lo, TWord _hi, TWord* _x, TWord* _y)
++		{
++			m_sharedLo = _lo; m_sharedHi = _hi; m_sharedX = _x; m_sharedY = _y;
++		}
++
+ 		TWord*				getMemAreaPtr		(EMemArea _area)
+ 		{
+ 			switch (_area)

--- a/tools/dsp_host/dsp_host.cpp
+++ b/tools/dsp_host/dsp_host.cpp
@@ -35,6 +35,30 @@
 //
 // so FX2 instance k defaults to alloc index 1+2k and state block 0x6000+(2+2k).
 //
+// TWO CORES (7 Sep 2026)
+//
+// The DSP56721 is two cores sharing Y:0x30000-0x3FFFF, and the shipping image
+// is SPECIALIZED: BusVerb exists only in payload A (core 0, tracks 5-8) and
+// BusDelay only in payload B (core 1, tracks 1-4). Until now the harness booted
+// one core, always payload A, so the real image's delay -- and everything that
+// crosses the core boundary -- could only be exercised through the DEV hatch,
+// which packs all three servers into one payload.
+//
+// -memB gives core 1 its own image; -core assigns each instance to a core.
+// Each core is a complete DSP + memory + peripherals, boots its OWN setup
+// routine (found by opcode pattern -- payload B's sits at P:0x17a where A's is
+// at P:0x372, the same code relocated), and X/Y 0x30000-0x3FFFF of core 1 are
+// REDIRECTED into core 0's arrays (a patch to the vendored Memory class,
+// tools/dsp56300.patch) so the shared window really is shared.
+//
+// Default scheduling is lock-step: core 0 runs its whole block, then core 1.
+// That is exactly what one core used to see, so every existing render is
+// bit-identical, and it is structurally blind to the cross-core race
+// (docs/XBUS.md) just as before. -skew N interleaves instead: core 0 runs N
+// instructions ahead, then the two alternate instruction by instruction. That
+// is not the hardware's timing -- it is a FUZZ of it. A green run proves
+// nothing; a red one is a real defect.
+//
 // GUARD
 //
 // -guard shadows Y:0x0000..0xBFFF (all of real Y) and the loaded part of P, and
@@ -45,6 +69,26 @@
 //
 // Usage:
 //   dsp_host -mem out/dsp/mem_A.mem -init <hex> -proc <hex> [options]
+//     -memB FILE            payload B's dump: boots core 1 (tracks 1-4)
+//     -audioidx a,b,..      audio BUFFER per instance (default: its own, k).
+//                           Two instances with the same index on one core
+//                           share a buffer and run in instance order -- an
+//                           FX1 insert followed by the same track's FX2. The
+//                           first owner receives the input, the last owner's
+//                           result is captured.
+//     -core a,b,..          which core runs each instance (0 = payload A,
+//                           1 = payload B; default 0). Positions on a core
+//                           are counted per core, so the k-th instance on a
+//                           core defaults to that core's alloc 1+2k / r7 2+2k.
+//     -skew N               interleave the cores instruction by instruction,
+//                           core 0 N instructions ahead (negative: behind).
+//                           Without it the cores run lock-step, core 0 first.
+//     -meter FILE           per-block instruction counts per core, one line
+//                           per block: "block c0 c1". The block maximum is
+//                           printed at the end either way.
+//     -ctx lo,hi,exit       override the detected setup routine / dispatcher
+//                           exit (hex) -- applies to core 0; -ctxB to core 1
+//     -share lo,hi          the shared window (hex, default 30000,40000)
 //     -init a[,b..]         entry points, hex, one per instance. A single value
 //     -proc a[,b..]         runs the SAME effect on every instance (the original
 //                           behaviour); a LIST runs a different effect per
@@ -73,7 +117,9 @@
 //     -guard [words]        police buffer bounds (default window 0x3800 words)
 //     -frames N             frames per block (default 32)
 //     -blocks N             blocks to run (default 256)
-//     -in file.raw          24-bit mono raw input, else an impulse is used
+//     -in file.raw          24-bit mono raw input, else an impulse is used.
+//                           A LIST gives each instance its own file; "-" is
+//                           silence. (-inmask still gates it.)
 //     -out file.raw         write instance 0; others go to file.raw.i1, .i2, ...
 //     -track a,b,..         r7-relative X words (hex) dumped EVERY block, so a
 //                           rate can be MEASURED by differencing -- -peekx only
@@ -83,10 +129,12 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
+#include <memory>
 #include <string>
 #include <vector>
 #include <fstream>
 #include <iostream>
+#include <algorithm>
 
 #include "dsp56kEmu/dsp.h"
 #include "dsp56kEmu/memory.h"
@@ -102,7 +150,8 @@ public:
 };
 
 struct Args {
-    std::string mem, in, out;
+    std::string mem, memB, out;
+    std::vector<std::string> in;               // one per instance, or one for all
     TWord init = 0, proc = 0, audio = 0x000080, params = 0x000100, state = 0x010000;
     int frames = 32, blocks = 256, trace = 0, diff = 0, spray = 0;
     TWord flags = 0; int pingpong = -1;
@@ -110,7 +159,7 @@ struct Args {
     bool dispatch = false; int fx2tracks = 0; TWord fxid = 0x16;
     int split = 0; TWord prevfx = 0;
     std::vector<int> splitList;            // split per instance
-    std::vector<int> allocIdx, r7Idx;
+    std::vector<int> allocIdx, r7Idx, coreIdx, audioIdx;
     std::vector<TWord> initList, procList;     // entry points, one per instance
     unsigned inmask = ~0u;                     // which instances get the input
     std::vector<std::vector<int>> pv;          // one parameter set per instance
@@ -122,14 +171,22 @@ struct Args {
     std::string trackOut;
     std::vector<std::pair<TWord, TWord>> pokeY;
     double tempo = 0;                      // -tempo BPM: publish r6+$6/$7 like the ColdFire cave
+    long skew = 0; bool interleave = false;
+    std::string meterFile;
+    std::vector<TWord> ctx, ctxB;          // lo,hi,exit overrides
+    TWord shareLo = 0x30000, shareHi = 0x40000;
 };
 
 // Everything the dispatcher would set up for one effect instance.
 struct Instance {
+    int   core  = 0;        // which DSP runs it
+    int   pos   = 0;        // its position on that core (0 = the housekeeper)
     TWord alloc = 0;        // X address of its entry in the base table
     TWord base  = 0;        // Y base that entry holds
     TWord state = 0;        // r7
     TWord audio = 0;        // r0
+    bool  fills = true;     // first owner of its audio buffer: receives the input
+    bool  captures = true;  // last owner: its result is the track's output
     TWord init  = 0;        // this instance's entry points -- per-instance so a
     TWord proc  = 0;        // SEND and a SERVER can run in the same session
     bool  fed   = true;     // does this instance receive the input audio?
@@ -141,6 +198,7 @@ struct Instance {
                             // instances cannot model that at all.
     std::vector<int> pv;
     std::ofstream out;
+    std::vector<int32_t> input; size_t inPos = 0; bool hasInput = false;
     long nonzero = 0;
     long violations = 0;
     long clobbers = 0;
@@ -148,75 +206,18 @@ struct Instance {
     long procCalls = 0;
 };
 
-// Which Y and P words a loaded module occupies. Writing over one of these is
-// the bug that made the reverb hang on two tracks: the base stash was placed in
-// a window that is free in payload A but holds a live 128-word coefficient table
-// in payload B, so the effect corrupted another algorithm and then read that
-// algorithm's data back as its own buffer base.
-std::vector<bool> g_loadedY, g_loadedP;
-
-bool loadMem(DSP& dsp, const std::string& path, int& modules, long& words) {
-    std::ifstream f(path, std::ios::binary);
-    if (!f.is_open()) { std::cerr << "cannot open " << path << "\n"; return false; }
-    modules = 0; words = 0;
-    g_loadedY.assign(0xC000, false);
-    g_loadedP.assign(0x20000, false);
-    for (;;) {
-        uint8_t sp; uint32_t addr, cnt;
-        f.read(reinterpret_cast<char*>(&sp), 1);
-        f.read(reinterpret_cast<char*>(&addr), 4);
-        f.read(reinterpret_cast<char*>(&cnt), 4);
-        if (!f || sp == 0xff) break;
-        for (uint32_t i = 0; i < cnt; ++i) {
-            uint32_t w; f.read(reinterpret_cast<char*>(&w), 4);
-            const TWord ad = addr + i;
-            if (sp == 0) {
-                dsp.memWriteP(ad, w & 0xffffff);
-                if (ad < g_loadedP.size()) g_loadedP[ad] = true;
-            } else if (sp == 1) {
-                dsp.memWrite(MemArea_X, ad, w & 0xffffff);
-            } else {
-                dsp.memWrite(MemArea_Y, ad, w & 0xffffff);
-                if (ad < g_loadedY.size()) g_loadedY[ad] = true;
-            }
-        }
-        ++modules; words += cnt;
-    }
-    return true;
-}
-
-// Run from _pc until the matching rts pops back past the entry stack depth.
-uint32_t g_lastCycles = 0;
-bool runToRts(DSP& dsp, TWord pc, int trace, const char* what, uint32_t maxCycles = 50000000) {
-    // Call through the emulator's own jsr so the return address is pushed the
-    // way the hardware would. The sentinel must be a MAPPED P address -- an
-    // out-of-range one faults as soon as the rts returns to it.
-    const TWord sentinel = 0x03f000;
-    dsp.setPC(sentinel);
-    dsp.jsr(pc);
-    for (uint32_t i = 0; i < maxCycles; ++i) {
-        const TWord cur = dsp.getPC().toWord();
-        if (cur == sentinel) { g_lastCycles = i; return true; }
-        if (trace && static_cast<int>(i) < trace)
-            std::printf("  %s %6u  pc=%06x  a=%012llx r5=%06x n5=%06x m5=%06x x1=%06x n7=%06x\n", what, i, cur,
-                        static_cast<unsigned long long>(dsp.regs().a.var & 0xffffffffffffull),
-                        dsp.regs().r[5].var & 0xffffff, dsp.regs().n[5].var & 0xffffff,
-                        dsp.regs().m[5].var & 0xffffff,
-                        (unsigned)(dsp.regs().x.var >> 24) & 0xffffff,
-                        dsp.regs().n[7].var);
-        dsp.execInterpreter();   // single-step; exec() may JIT past the sentinel
-    }
-    std::cerr << what << ": did not return after " << maxCycles << " cycles (pc="
-              << std::hex << dsp.getPC().toWord() << ")\n";
-    return false;
-}
-
-// Run a straight-line range of P memory (used for the frame context setup).
-void runRange(DSP& dsp, TWord lo, TWord hi) {
-    dsp.setPC(lo);
-    while (dsp.getPC().toWord() <= hi)
-        dsp.execInterpreter();
-}
+// The frame-context addresses that differ between the two payloads: the setup
+// routine the harness runs to derive the control words, the track loop it
+// falls into, and where the dispatcher exits. Payload A's were read from the
+// listing (P:0x372..0x39e, loop 0x385, exit 0x53e); payload B's are the same
+// code relocated (P:0x17a..0x1a3, loop 0x18b, exit 0x333; measured 7 Sep 2026
+// by matching the opcode sequence). Detected by pattern so a re-linked payload
+// cannot silently run the wrong range -- which is what "cannot boot payload B"
+// was for a year.
+struct Ctx {
+    TWord setupLo = 0, setupHi = 0, loop = 0, exit = 0;
+    bool ok() const { return setupLo && setupHi && exit; }
+};
 
 // A shadow of the memory an effect must not touch. Y is only real up to 0xC000
 // (measured with dsp/ymemprobe.asm); P is checked over the loaded image so a
@@ -226,9 +227,12 @@ struct Guard {
     static const TWord P_HI = 0x20000;
     std::vector<TWord> y, p;
     bool armed = false;
+    const std::vector<bool>* loadedY = nullptr;
+    const std::vector<bool>* loadedP = nullptr;
 
-    void arm(Memory& mem) {
+    void arm(Memory& mem, const std::vector<bool>& ly, const std::vector<bool>& lp) {
         y.resize(Y_HI); p.resize(P_HI);
+        loadedY = &ly; loadedP = &lp;
         snap(mem);
         armed = true;
     }
@@ -262,7 +266,7 @@ struct Guard {
             const bool bad = changed && !(ad >= lo && ad < hi);
             if (bad) {
                 if (!inRun) { runLo = ad; inRun = true; }
-                if (g_loadedY[ad]) runClob = true;
+                if ((*loadedY)[ad]) runClob = true;
             } else flush(ad, "Y");
         }
         flush(Y_HI, "Y");
@@ -271,13 +275,146 @@ struct Guard {
             if (v != p[ad]) {
                 p[ad] = v;
                 if (!inRun) { runLo = ad; inRun = true; }
-                if (g_loadedP[ad]) runClob = true;
+                if ((*loadedP)[ad]) runClob = true;
             } else flush(ad, "P");
         }
         flush(P_HI, "P");
         return stray;
     }
 };
+
+// One DSP core: its own memory image, peripherals, frame context and guard.
+struct Core {
+    int id = 0;
+    std::string path;
+    AllowAll validator;
+    std::unique_ptr<Memory> mem;
+    std::unique_ptr<Peripherals56362> periphX;
+    std::unique_ptr<Peripherals56367> periphY;
+    std::unique_ptr<DSP> dsp;
+    std::vector<bool> loadedY, loadedP;   // which words a loaded module occupies
+    Ctx ctx;
+    TWord pblock = 0, stateBase = 0, cnt = 0, ctlA = 0, ctlB = 0;
+    Guard guard;
+    std::vector<int> insts;               // global instance indices, dispatch order
+    // the meter: instructions per block on this core
+    long blockInstr = 0, maxBlockInstr = 0; int maxBlock = -1;
+    long initInstr = 0;
+    std::vector<long> meter;
+};
+
+// Which Y and P words a loaded module occupies. Writing over one of these is
+// the bug that made the reverb hang on two tracks: the base stash was placed in
+// a window that is free in payload A but holds a live 128-word coefficient table
+// in payload B, so the effect corrupted another algorithm and then read that
+// algorithm's data back as its own buffer base.
+bool loadMem(Core& c, int& modules, long& words) {
+    std::ifstream f(c.path, std::ios::binary);
+    if (!f.is_open()) { std::cerr << "cannot open " << c.path << "\n"; return false; }
+    modules = 0; words = 0;
+    c.loadedY.assign(0xC000, false);
+    c.loadedP.assign(0x20000, false);
+    for (;;) {
+        uint8_t sp; uint32_t addr, cnt;
+        f.read(reinterpret_cast<char*>(&sp), 1);
+        f.read(reinterpret_cast<char*>(&addr), 4);
+        f.read(reinterpret_cast<char*>(&cnt), 4);
+        if (!f || sp == 0xff) break;
+        for (uint32_t i = 0; i < cnt; ++i) {
+            uint32_t w; f.read(reinterpret_cast<char*>(&w), 4);
+            const TWord ad = addr + i;
+            if (sp == 0) {
+                c.dsp->memWriteP(ad, w & 0xffffff);
+                if (ad < c.loadedP.size()) c.loadedP[ad] = true;
+            } else if (sp == 1) {
+                c.dsp->memWrite(MemArea_X, ad, w & 0xffffff);
+            } else {
+                c.dsp->memWrite(MemArea_Y, ad, w & 0xffffff);
+                if (ad < c.loadedY.size()) c.loadedY[ad] = true;
+            }
+        }
+        ++modules; words += cnt;
+    }
+    return true;
+}
+
+// Find the frame-context setup routine and the dispatcher exit by opcode
+// pattern. The anchor is `move #>$6000,x0 / move x0,x:>$20a` (44f400 006000
+// 447000 00020a): the state-base seed no other code writes. The routine
+// starts at the `move #$0,x0` (240000) that precedes the run of two-word
+// `move x0,x:>$nnn` stores before it, and its last store is
+// `move a,x:>$20e` (567000 00020e). The exit is the `move x:>$415,a`
+// (56f000 000415) that follows the loop's `bne` (0d1042 ffxxxx).
+Ctx detectCtx(Memory& mem) {
+    Ctx c;
+    auto P = [&](TWord a) { return mem.get(MemArea_P, a); };
+    for (TWord a = 0; a + 4 < 0x2000; ++a) {
+        if (P(a) == 0x44f400 && P(a + 1) == 0x006000 && P(a + 2) == 0x447000 && P(a + 3) == 0x00020a) {
+            TWord s = a;
+            while (s >= 2 && P(s - 2) == 0x447000) s -= 2;
+            if (s >= 1 && P(s - 1) == 0x240000) c.setupLo = s - 1;
+            for (TWord e = a; e < a + 0x40; ++e)
+                if (P(e) == 0x567000 && P(e + 1) == 0x00020e) { c.setupHi = e + 1; break; }
+            break;
+        }
+    }
+    // The track loop: the first `move x:>$415,r2` (62f000 000415) after the setup start.
+    if (c.setupLo)
+        for (TWord a = c.setupLo; a < c.setupLo + 0x40; ++a)
+            if (P(a) == 0x62f000 && P(a + 1) == 0x000415) { c.loop = a; break; }
+    for (TWord a = 0; a + 3 < 0x2000; ++a)
+        if (P(a) == 0x0d1042 && (P(a + 1) & 0xff0000) == 0xff0000 &&
+            P(a + 2) == 0x56f000 && P(a + 3) == 0x000415) { c.exit = a + 2; break; }
+    return c;
+}
+
+// Run from _pc until the matching rts pops back past the entry stack depth.
+uint32_t g_lastCycles = 0;
+const TWord SENTINEL = 0x03f000;   // must be a MAPPED P address -- an
+                                   // out-of-range one faults as soon as the
+                                   // rts returns to it
+bool runToRts(DSP& dsp, TWord pc, int trace, const char* what, uint32_t maxCycles = 50000000) {
+    // Call through the emulator's own jsr so the return address is pushed the
+    // way the hardware would.
+    dsp.setPC(SENTINEL);
+    dsp.jsr(pc);
+    for (uint32_t i = 0; i < maxCycles; ++i) {
+        const TWord cur = dsp.getPC().toWord();
+        if (cur == SENTINEL) { g_lastCycles = i; return true; }
+        if (trace && static_cast<int>(i) < trace)
+            std::printf("  %s %6u  pc=%06x  a=%012llx r5=%06x n5=%06x m5=%06x x1=%06x n7=%06x\n", what, i, cur,
+                        static_cast<unsigned long long>(dsp.regs().a.var & 0xffffffffffffull),
+                        dsp.regs().r[5].var & 0xffffff, dsp.regs().n[5].var & 0xffffff,
+                        dsp.regs().m[5].var & 0xffffff,
+                        (unsigned)(dsp.regs().x.var >> 24) & 0xffffff,
+                        dsp.regs().n[7].var);
+        dsp.execInterpreter();   // single-step; exec() may JIT past the sentinel
+    }
+    std::cerr << what << ": did not return after " << maxCycles << " cycles (pc="
+              << std::hex << dsp.getPC().toWord() << ")\n";
+    return false;
+}
+
+// Run a straight-line range of P memory (used for the frame context setup).
+void runRange(DSP& dsp, TWord lo, TWord hi) {
+    dsp.setPC(lo);
+    while (dsp.getPC().toWord() <= hi)
+        dsp.execInterpreter();
+}
+
+void dumpRegs(DSP& dsp, Memory& mem) {
+    std::printf("  r0=%06x r1=%06x r2=%06x r3=%06x r4=%06x r5=%06x r6=%06x r7=%06x\n",
+                dsp.regs().r[0].var, dsp.regs().r[1].var, dsp.regs().r[2].var,
+                dsp.regs().r[3].var, dsp.regs().r[4].var, dsp.regs().r[5].var,
+                dsp.regs().r[6].var, dsp.regs().r[7].var);
+    std::printf("  m0=%06x m1=%06x m2=%06x m3=%06x m4=%06x m5=%06x n7=%06x\n",
+                dsp.regs().m[0].var, dsp.regs().m[1].var, dsp.regs().m[2].var,
+                dsp.regs().m[3].var, dsp.regs().m[4].var, dsp.regs().m[5].var,
+                dsp.regs().n[7].var);
+    std::printf("  x:0x20a=%06x x:0x213=%06x x:0x418=%06x\n",
+                mem.get(MemArea_X, 0x20a), mem.get(MemArea_X, 0x213),
+                mem.get(MemArea_X, 0x418));
+}
 
 std::vector<int> parseList(const char* s) {
     std::vector<int> v;
@@ -296,14 +433,33 @@ std::vector<TWord> parseHexList(const char* s) {
     return v;
 }
 
+std::vector<std::string> parseStrList(const char* s) {
+    std::vector<std::string> v;
+    std::string t(s);
+    for (char* p = strtok(&t[0], ","); p; p = strtok(nullptr, ",")) v.push_back(p);
+    return v;
+}
+
+// One effect call as the dispatcher would make it, resumable one instruction
+// at a time so two cores can be interleaved. `begin` sets the registers and
+// pushes the return address through the emulator's own jsr, exactly as
+// runToRts does; `step` executes one instruction and reports whether the
+// sentinel came back.
+struct Call {
+    int inst = -1;
+    bool ctl = false;       // the a=0 sub-block call
+    uint32_t steps = 0;
+};
+
 } // namespace
 
 int main(int argc, char** argv) {
     Args a;
-    for (int i = 1; i < argc - 1; ++i) {
+    for (int i = 1; i < argc; ++i) {
         std::string k = argv[i];
         auto v = [&] { return std::string(argv[++i]); };
         if (k == "-mem") a.mem = v();
+        else if (k == "-memB") a.memB = v();
         else if (k == "-init") { a.initList = parseHexList(argv[++i]); a.init = a.initList[0]; }
         else if (k == "-proc") { a.procList = parseHexList(argv[++i]); a.proc = a.procList[0]; }
         else if (k == "-inmask") a.inmask = strtoul(argv[++i], nullptr, 0);
@@ -320,32 +476,36 @@ int main(int argc, char** argv) {
         else if (k == "-pp") a.pingpong = atoi(argv[++i]);
         else if (k == "-inst") a.inst = atoi(argv[++i]);
         else if (k == "-dirty") a.dirty = strtoul(argv[++i], nullptr, 0);
-        // no --i here: -noctl consumes nothing, and decrementing made the
-        // parse loop re-read it forever -- the flag hung the harness since
-        // the day it was added
-        else if (k == "-noctl") { a.noctl = true; }
+        else if (k == "-noctl") a.noctl = true;
+        else if (k == "-in") a.in = parseStrList(argv[++i]);
+        else if (k == "-out") a.out = v();
         else if (k == "-dispatch") a.fx2tracks = atoi(argv[++i]), a.dispatch = true;
         else if (k == "-fxid") a.fxid = strtoul(argv[++i], nullptr, 16);
         else if (k == "-split") { a.splitList = parseList(argv[++i]);
-                                  a.split = a.splitList[0]; }
+                                  a.split = a.splitList.empty() ? 0 : a.splitList[0]; }
         else if (k == "-prevfx") a.prevfx = strtoul(argv[++i], nullptr, 16);
         else if (k == "-alloc") a.allocIdx = parseList(argv[++i]);
         else if (k == "-r7") a.r7Idx = parseList(argv[++i]);
+        else if (k == "-core") a.coreIdx = parseList(argv[++i]);
+        else if (k == "-audioidx") a.audioIdx = parseList(argv[++i]);
+        else if (k == "-skew") { a.skew = atol(argv[++i]); a.interleave = true; }
+        else if (k == "-meter") a.meterFile = v();
+        else if (k == "-ctx") a.ctx = parseHexList(argv[++i]);
+        else if (k == "-ctxB") a.ctxB = parseHexList(argv[++i]);
+        else if (k == "-share") { auto s = parseHexList(argv[++i]);
+                                  if (s.size() == 2) { a.shareLo = s[0]; a.shareHi = s[1]; } }
         else if (k == "-allocproc") a.allocProc = v();
-        else if (k == "-in") a.in = v();
-        else if (k == "-out") a.out = v();
         else if (k == "-params") {
             auto p = parseList(argv[++i]);
-            // page 1 defaults to 64; page-2 slots default to ABSENT (their
-            // words stay zero). The old fill of 64 up to index 8 predated the
-            // real slot map -- under it, index 7's 64 would have set a MODE
-            // companion of 64.
-            if (p.size() < 6) p.resize(6, 64);
-            a.pv.push_back(p);
+            std::vector<int> pv(8, 64);
+            for (size_t j = 0; j < p.size() && j < 12; ++j) {
+                if (j >= pv.size()) pv.resize(j + 1, 0);
+                pv[j] = p[j];
+            }
+            a.pv.push_back(pv);
         }
         else if (k == "-guard") {
             a.guard = true;
-            // the size is optional: only consume the next argument if it is one
             if (i + 1 < argc && argv[i + 1][0] != '-')
                 a.guardWords = strtoul(argv[++i], nullptr, 0);
         }
@@ -356,96 +516,143 @@ int main(int argc, char** argv) {
         }
         else if (k == "-track") a.track = parseHexList(argv[++i]);
         else if (k == "-trackout") a.trackOut = v();
-        else if (k == "-dumpy") {
-            // -dumpy file,lo,hi : write raw Y[lo..hi) as u32 LE at end of run
-            std::string t(argv[++i]);
-            char* p1 = strtok(&t[0], ","); char* p2 = strtok(nullptr, ",");
-            char* p3 = strtok(nullptr, ",");
-            if (p1 && p2 && p3) { a.dumpyFile = p1;
-                a.dumpyLo = strtoul(p2, nullptr, 16);
-                a.dumpyHi = strtoul(p3, nullptr, 16); }
-        }
         else if (k == "-peekx") {
             std::string t(argv[++i]);
             for (char* p = strtok(&t[0], ","); p; p = strtok(nullptr, ","))
                 a.peekX.push_back(strtoul(p, nullptr, 16));
         }
+        else if (k == "-dumpy") {
+            std::string t(argv[++i]);
+            char* p = strtok(&t[0], ",");
+            a.dumpyLo = strtoul(p, nullptr, 16);
+            a.dumpyHi = strtoul(strtok(nullptr, ","), nullptr, 16);
+            a.dumpyFile = strtok(nullptr, ",");
+        }
         else if (k == "-pokey") {
             std::string t(argv[++i]);
             for (char* p = strtok(&t[0], ","); p; p = strtok(nullptr, ",")) {
-                char* eq = std::strchr(p, '=');
+                char* eq = strchr(p, '=');
                 if (!eq) continue;
                 *eq = 0;
-                a.pokeY.emplace_back(strtoul(p, nullptr, 16), strtoul(eq + 1, nullptr, 16));
+                a.pokeY.push_back({static_cast<TWord>(strtoul(p, nullptr, 16)),
+                                   static_cast<TWord>(strtoul(eq + 1, nullptr, 16))});
             }
         }
     }
-    // -guard may be the last argument, which the loop above cannot see
     if (argc > 1 && std::string(argv[argc - 1]) == "-guard") a.guard = true;
 
     if (a.mem.empty() || !a.proc) {
         std::cerr << "usage: dsp_host -mem <file> -init <hex> -proc <hex> [-params a,b,..]\n"
+                     "                [-memB <file>] [-core a,b] [-skew N] [-meter FILE]\n"
                      "                [-inst N] [-alloc a,b] [-r7 a,b] [-allocproc MODE] [-guard]\n"
-                     "                [-frames N] [-blocks N] [-in raw] [-out raw] [-trace N]\n";
+                     "                [-frames N] [-blocks N] [-in raw[,raw..]] [-out raw] [-trace N]\n";
         return 2;
     }
     if (a.inst < 1) a.inst = 1;
     if (a.pv.empty()) a.pv.push_back(std::vector<int>(8, 64));
 
     setvbuf(stdout, nullptr, _IONBF, 0);
-    std::printf("constructing DSP ...\n");
-    AllowAll validator;
-    Memory mem(validator, 0x080000, 0x800000, 0x200000);   // sizes the library's own tests use
-    Peripherals56362 periphX;
-    Peripherals56367 periphY;
-    DSP dsp(mem, &periphX, &periphY);
 
-    std::printf("DSP constructed; loading memory ...\n");
-    int modules = 0; long words = 0;
-    if (!loadMem(dsp, a.mem, modules, words)) return 1;
-    std::printf("loaded %d modules, %ld words from %s\n", modules, words, a.mem.c_str());
+    // ---- the cores ----------------------------------------------------------
+    const int ncores = a.memB.empty() ? 1 : 2;
+    std::vector<std::unique_ptr<Core>> cores;
+    for (int c = 0; c < ncores; ++c) {
+        cores.emplace_back(new Core);
+        Core& C = *cores.back();
+        C.id = c;
+        C.path = c ? a.memB : a.mem;
+        std::printf("core %d: constructing DSP ...\n", c);
+        C.mem.reset(new Memory(C.validator, 0x080000, 0x800000, 0x200000));   // sizes the library's own tests use
+        C.periphX.reset(new Peripherals56362);
+        C.periphY.reset(new Peripherals56367);
+        C.dsp.reset(new DSP(*C.mem, C.periphX.get(), C.periphY.get()));
+        if (c == 1) {
+            // Core 1's shared window lives in core 0's arrays. Both X and Y:
+            // on the chip P/X/Y all alias there (docs/CHIP.md), and the
+            // emulator keeps each core's X and Y apart exactly as it did
+            // before, so a single-core render is unchanged.
+            Core& C0 = *cores[0];
+            C.mem->setSharedWindow(a.shareLo, a.shareHi,
+                                   C0.mem->getMemAreaPtr(MemArea_X) + a.shareLo,
+                                   C0.mem->getMemAreaPtr(MemArea_Y) + a.shareLo);
+            std::printf("core 1: X/Y 0x%05x..0x%05x shared with core 0\n", a.shareLo, a.shareHi - 1);
+        }
+        int modules = 0; long words = 0;
+        if (!loadMem(C, modules, words)) return 1;
+        std::printf("core %d: loaded %d modules, %ld words from %s\n", c, modules, words, C.path.c_str());
 
-    // ---- frame context ----------------------------------------------------
-    // The effects depend on control words that no module initialises; the DSP's
-    // own setup routine at P:0x372..0x39e derives them from two loaded pointers
-    // (x:0x415, x:0x416). Rather than reconstruct that by hand, run it.
-    //
-    // It reads the frame count out of x:(x:0x415 + 0x1e) as (w >> 8) & 0xf, so
-    // seed that first. The count is capped at 15 frames by the & 0xf.
-    if (a.frames > 15) { std::printf("frames capped to 15 (the & 0xf in setup)\n"); a.frames = 15; }
-    const TWord blkA = mem.get(MemArea_X, 0x415);
-    mem.set(MemArea_X, blkA + 0x1e, (static_cast<TWord>(a.frames) << 8) | a.flags);
-    std::printf("seeded x:0x%05x+0x1e = frames %d\n", blkA, a.frames);
+        // ---- frame context --------------------------------------------------
+        // The effects depend on control words that no module initialises; the
+        // DSP's own setup routine derives them from two loaded pointers
+        // (x:0x415, x:0x416). Rather than reconstruct that by hand, run it --
+        // at whichever address THIS payload keeps it.
+        C.ctx = detectCtx(*C.mem);
+        const std::vector<TWord>& ov = c ? a.ctxB : a.ctx;
+        if (ov.size() == 3) { C.ctx.setupLo = ov[0]; C.ctx.setupHi = ov[1]; C.ctx.exit = ov[2]; }
+        if (!C.ctx.ok()) {
+            std::printf("core %d: !! could not find the frame-context setup routine in this dump "
+                        "(pass -ctx%s lo,hi,exit)\n", c, c ? "B" : "");
+            return 1;
+        }
+        std::printf("core %d: setup P:0x%05x..0x%05x, track loop P:0x%05x, dispatcher exit P:0x%05x\n",
+                    c, C.ctx.setupLo, C.ctx.setupHi, C.ctx.loop, C.ctx.exit);
+        // It reads the frame count out of x:(x:0x415 + 0x1e) as (w >> 8) & 0xf, so
+        // seed that first. The count is capped at 15 frames by the & 0xf.
+        if (a.frames > 15) { std::printf("frames capped to 15 (the & 0xf in setup)\n"); a.frames = 15; }
+        const TWord blkA = C.mem->get(MemArea_X, 0x415);
+        C.mem->set(MemArea_X, blkA + 0x1e, (static_cast<TWord>(a.frames) << 8) | a.flags);
+        std::printf("core %d: seeded x:0x%05x+0x1e = frames %d\n", c, blkA, a.frames);
 
-    runRange(dsp, 0x372, 0x39e);
-    if (a.pingpong >= 0) { mem.set(MemArea_X, 0x41f, static_cast<TWord>(a.pingpong));
-        std::printf("ping-pong selector x:0x41f = %d\n", a.pingpong); }
+        runRange(*C.dsp, C.ctx.setupLo, C.ctx.setupHi);
+        if (a.pingpong >= 0) { C.mem->set(MemArea_X, 0x41f, static_cast<TWord>(a.pingpong));
+            std::printf("ping-pong selector x:0x41f = %d\n", a.pingpong); }
 
-    const TWord ctlA = mem.get(MemArea_X, 0x419);
-    const TWord ctlB = mem.get(MemArea_X, 0x208);
-    const TWord cnt  = mem.get(MemArea_X, 0x20c);
-    std::printf("context: x:0x419=0x%05x  x:0x208=0x%05x  x:0x20c=%u (frames)  "
-                "x:0x20d=%u  x:0x20e=%u\n", ctlA, ctlB, cnt,
-                mem.get(MemArea_X, 0x20d), mem.get(MemArea_X, 0x20e));
-    if (!cnt) { std::printf("  !! frame count is 0 -- the dispatcher would skip the effect\n"); }
+        C.ctlA = C.mem->get(MemArea_X, 0x419);
+        C.ctlB = C.mem->get(MemArea_X, 0x208);
+        C.cnt  = C.mem->get(MemArea_X, 0x20c);
+        std::printf("core %d: context: x:0x419=0x%05x  x:0x208=0x%05x  x:0x20c=%u (frames)  "
+                    "x:0x20d=%u  x:0x20e=%u\n", c, C.ctlA, C.ctlB, C.cnt,
+                    C.mem->get(MemArea_X, 0x20d), C.mem->get(MemArea_X, 0x20e));
+        if (!C.cnt) { std::printf("  !! frame count is 0 -- the dispatcher would skip the effect\n"); }
+        // The dispatcher hands the routine r6 = x:0x208 + 6 and r7 = a state block.
+        C.pblock = C.ctlB + 6;
+        C.stateBase = C.mem->get(MemArea_X, 0x20a);
+    }
+    Core& C0 = *cores[0];
+    Memory& mem = *C0.mem;     // core 0's, for the single-core paths below
+    DSP& dsp = *C0.dsp;
 
     // ---- instances --------------------------------------------------------
-    // The dispatcher hands the routine r6 = x:0x208 + 6 and r7 = a state block.
     // DSP_ALLOC_IDX is kept for the single-instance case that predates -inst.
-    const TWord pblock = ctlB + 6;
     const char* ai = getenv("DSP_ALLOC_IDX");
-    const TWord stateBase = mem.get(MemArea_X, 0x20a);
 
     std::vector<Instance> inst(a.inst);
     for (int k = 0; k < a.inst; ++k) {
         Instance& I = inst[k];
-        int ia = (k < static_cast<int>(a.allocIdx.size())) ? a.allocIdx[k] : 1 + 2 * k;
-        int ir = (k < static_cast<int>(a.r7Idx.size()))    ? a.r7Idx[k]    : 2 + 2 * k;
+        I.core = (k < static_cast<int>(a.coreIdx.size())) ? a.coreIdx[k] : 0;
+        if (I.core < 0 || I.core >= ncores) {
+            std::printf("instance %d: core %d does not exist (%s)\n", k, I.core,
+                        ncores == 1 ? "pass -memB to boot core 1" : "cores are 0 and 1");
+            return 2;
+        }
+        Core& C = *cores[I.core];
+        I.pos = static_cast<int>(C.insts.size());
+        C.insts.push_back(k);
+        // Defaults count positions PER CORE: the k-th instance on a core is
+        // that core's k-th FX2 slot. With one core that is the old k.
+        int ia = (k < static_cast<int>(a.allocIdx.size())) ? a.allocIdx[k] : 1 + 2 * I.pos;
+        int ir = (k < static_cast<int>(a.r7Idx.size()))    ? a.r7Idx[k]    : 2 + 2 * I.pos;
         if (ai && a.inst == 1 && a.allocIdx.empty()) { ia = strtoul(ai, nullptr, 0); ir = ia; }
         I.alloc = 0x255 + ia;
-        I.base  = mem.get(MemArea_X, I.alloc);
-        I.state = stateBase + ir * 0x100;
-        I.audio = a.audio + k * 0x40;               // 15 frames = 30 words, well clear
+        I.base  = C.mem->get(MemArea_X, I.alloc);
+        I.state = C.stateBase + ir * 0x100;
+        const int aidx = (k < static_cast<int>(a.audioIdx.size())) ? a.audioIdx[k] : k;
+        I.audio = a.audio + aidx * 0x40;            // 15 frames = 30 words, well clear
+        // Buffer ownership on this core: the first instance on a buffer is
+        // fed, the last one is captured, the ones between see the previous
+        // instance's output -- the FX1 -> FX2 chain of one track.
+        for (int j = 0; j < k; ++j)
+            if (inst[j].core == I.core && inst[j].audio == I.audio) { I.fills = false; inst[j].captures = false; }
         I.pv    = a.pv[std::min<size_t>(k, a.pv.size() - 1)];
         // Entry points fall back to the LAST list entry, so a single -init/-proc
         // still runs one effect on every instance -- the behaviour every existing
@@ -459,20 +666,36 @@ int main(int argc, char** argv) {
         I.fed   = (a.inmask >> k) & 1;
         I.split = a.splitList.empty() ? a.split
                 : a.splitList[std::min<size_t>(k, a.splitList.size() - 1)];
-        std::printf("instance %d: r7 = X:0x%05x (idx %d), base = Y:0x%05x (X:0x%03x idx %d), "
-                    "audio X:0x%05x, init P:0x%05x proc P:0x%05x%s\n",
-                    k, I.state, ir, I.base, I.alloc, ia, I.audio, I.init, I.proc,
+        std::printf("instance %d: core %d pos %d, r7 = X:0x%05x (idx %d), base = Y:0x%05x (X:0x%03x idx %d), "
+                    "audio X:0x%05x%s, init P:0x%05x proc P:0x%05x%s\n",
+                    k, I.core, I.pos, I.state, ir, I.base, I.alloc, ia, I.audio,
+                    I.fills ? "" : " (chained)", I.init, I.proc,
                     I.fed ? "" : "  [no input]");
         std::printf("            params");
         for (int p : I.pv) std::printf(" %d", p);
         std::printf("\n");
         if (!a.out.empty())
             I.out.open(k ? a.out + ".i" + std::to_string(k) : a.out, std::ios::binary);
+        // -in: one file for everyone (the old behaviour) or one per instance.
+        if (!a.in.empty()) {
+            const std::string& f = a.in.size() == 1 ? a.in[0]
+                                 : (k < static_cast<int>(a.in.size()) ? a.in[k] : std::string("-"));
+            if (f != "-") {
+                std::ifstream fi(f, std::ios::binary);
+                if (!fi.is_open()) { std::cerr << "cannot open input " << f << "\n"; return 1; }
+                int32_t s;
+                while (fi.read(reinterpret_cast<char*>(&s), 4)) I.input.push_back(s);
+            }
+            I.hasInput = true;      // named input, even if "-" (silence, not the impulse)
+        }
     }
-    // Two instances landing on the same buffer or the same state block is not a
-    // configuration the hardware produces; say so rather than debug the result.
+    // Two instances landing on the same buffer or the same state block ON THE
+    // SAME CORE is not a configuration the hardware produces; say so rather
+    // than debug the result. (The same addresses on different cores are the
+    // normal case -- each core has its own private X and Y.)
     for (int k = 1; k < a.inst; ++k)
         for (int j = 0; j < k; ++j) {
+            if (inst[k].core != inst[j].core) continue;
             if (inst[k].base == inst[j].base)
                 std::printf("  !! instances %d and %d share base Y:0x%05x\n", j, k, inst[k].base);
             if (inst[k].state == inst[j].state)
@@ -500,16 +723,16 @@ int main(int argc, char** argv) {
     // Params 0..5 are page 1; 6..11 follow the table. A companion value is
     // written to bits 8-15 of the SAME word as its slot's knob, so both are
     // composed together rather than the last write clobbering the word.
-    auto setParams = [&](const std::vector<int>& pv) {
+    auto setParams = [&](Core& C, const std::vector<int>& pv) {
         for (size_t i = 0; i < 6 && i < pv.size(); ++i)
-            mem.set(MemArea_X, pblock + i, (static_cast<TWord>(pv[i]) & 0x7f) << 16);
+            C.mem->set(MemArea_X, C.pblock + i, (static_cast<TWord>(pv[i]) & 0x7f) << 16);
         for (TWord w = 0; w < 3; ++w) {                    // +$c, +$d, +$e
             const size_t knob = 6 + 2 * w, comp = knob + 1;
             TWord v = 0;
             if (knob < pv.size()) v |= (static_cast<TWord>(pv[knob]) & 0x7f) << 16;
             if (comp < pv.size()) v |= (static_cast<TWord>(pv[comp]) & 0x7f) << 8;
             if (knob < pv.size() || comp < pv.size())
-                mem.set(MemArea_X, pblock + 0xc + w, v);
+                C.mem->set(MemArea_X, C.pblock + 0xc + w, v);
         }
         // -tempo: what modules/tempo-sync/tempo_cave.s publishes on hardware (24 Aug 2026):
         // r6+$6 = BPM*24, r6+$7 = 42336000/tempo24 = samples per MIDI clock
@@ -517,8 +740,8 @@ int main(int argc, char** argv) {
         if (a.tempo > 0) {
             const TWord t24 = static_cast<TWord>(a.tempo * 24 + 0.5);
             const TWord ticks = 42336000u / t24;
-            mem.set(MemArea_X, pblock + 6, (t24 & 0xffff) << 8);
-            mem.set(MemArea_X, pblock + 7, (ticks & 0xffff) << 8);
+            C.mem->set(MemArea_X, C.pblock + 6, (t24 & 0xffff) << 8);
+            C.mem->set(MemArea_X, C.pblock + 7, (ticks & 0xffff) << 8);
         }
     };
 
@@ -527,16 +750,18 @@ int main(int argc, char** argv) {
     // still per-instance during PROC is the open question -- the dispatcher
     // advances it, so by the time blocks are running it may sit past the last
     // effect. -allocproc chooses which model to run.
-    auto setAlloc = [&](TWord v) { mem.set(MemArea_X, 0x213, v); };
+    auto setAlloc = [&](Core& C, TWord v) { C.mem->set(MemArea_X, 0x213, v); };
 
     // Hardware does not hand an effect a zeroed buffer -- it holds whatever the
     // previous algorithm left. The emulator does, which can make a build look
     // fine here and behave differently on the device.
     if (a.dirty) {
-        TWord x = a.dirty;
-        for (TWord ad = 0x1000; ad < 0xC000; ++ad) {
-            x ^= x << 13; x ^= x >> 17; x ^= x << 5; x &= 0xffffff;
-            mem.set(MemArea_Y, ad, x);
+        for (auto& Cp : cores) {
+            TWord x = a.dirty;
+            for (TWord ad = 0x1000; ad < 0xC000; ++ad) {
+                x ^= x << 13; x ^= x >> 17; x ^= x << 5; x &= 0xffffff;
+                Cp->mem->set(MemArea_Y, ad, x);
+            }
         }
         std::printf("Y:0x1000..0xBFFF filled with garbage (seed 0x%x)\n", a.dirty);
     }
@@ -544,17 +769,14 @@ int main(int argc, char** argv) {
     // -pokey addr=val,... : seed arbitrary Y words before any block runs --
     // e.g. planting a fake "last block's bus accumulator" so a server can be
     // tested for whether it actually reads shared bus scratch, without a
-    // second instance running the client code that would normally write it
-    // (the harness only supports one -init/-proc pair, so a true mixed-
-    // effect multi-instance run isn't possible; this is the substitute).
+    // second instance running the client code that would normally write it.
     for (auto& pv : a.pokeY) {
         mem.set(MemArea_Y, pv.first, pv.second);
         std::printf("poked Y:0x%05x = 0x%06x\n", pv.first, pv.second);
     }
 
-    Guard guard;
     if (a.guard) {
-        guard.arm(mem);
+        for (auto& Cp : cores) Cp->guard.arm(*Cp->mem, Cp->loadedY, Cp->loadedP);
         std::printf("guard armed: Y:0x0000..0x%05x + P:0x00000..0x%05x, "
                     "window %u words per instance\n", Guard::Y_HI - 1, Guard::P_HI - 1,
                     a.guardWords);
@@ -562,53 +784,55 @@ int main(int argc, char** argv) {
 
     // ---- init, every instance, before any block ---------------------------
     for (int k = 0; k < a.inst; ++k) {
-        setAlloc(inst[k].alloc);
-        setParams(inst[k].pv);
-        dsp.regs().r[6].var = pblock;
-        dsp.regs().r[7].var = inst[k].state;
+        Core& C = *cores[inst[k].core];
+        setAlloc(C, inst[k].alloc);
+        setParams(C, inst[k].pv);
+        C.dsp->regs().r[6].var = C.pblock;
+        C.dsp->regs().r[7].var = inst[k].state;
         if (inst[k].init) {
-            std::printf("running init @P:0x%05x for instance %d ...\n", inst[k].init, k);
-            if (!runToRts(dsp, inst[k].init, a.trace, "init")) return 1;
-            if (guard.armed) {
+            std::printf("running init @P:0x%05x for instance %d (core %d) ...\n", inst[k].init, k, inst[k].core);
+            const uint64_t i0 = C.dsp->getInstructionCounter();
+            if (!runToRts(*C.dsp, inst[k].init, a.trace, "init")) return 1;
+            C.initInstr += static_cast<long>(C.dsp->getInstructionCounter() - i0);
+            if (C.guard.armed) {
                 char who[32]; std::snprintf(who, sizeof who, "inst %d", k);
                 int cl = 0;
-                inst[k].violations += guard.check(mem, inst[k].base,
-                                                  inst[k].base + a.guardWords,
-                                                  who, "init", 0, false, cl);
+                inst[k].violations += C.guard.check(*C.mem, inst[k].base,
+                                                    inst[k].base + a.guardWords,
+                                                    who, "init", 0, false, cl);
                 inst[k].clobbers += cl;
             }
         }
     }
     if (a.init) std::printf("all inits returned ok\n");
 
-    const TWord allocEnd = 0x255 + (a.allocIdx.empty() ? 1 + 2 * (a.inst - 1) + 1
-                                                       : a.allocIdx.back() + 1);
-    if (a.allocProc == "end") {
-        setAlloc(allocEnd);
-        std::printf("proc-time X:0x213 = 0x%03x for every instance (past the last effect)\n",
-                    allocEnd);
-    } else if (a.allocProc == "keep") {
-        std::printf("proc-time X:0x213 left at 0x%03x from the last init\n",
-                    mem.get(MemArea_X, 0x213));
+    for (auto& Cp : cores) {
+        Core& C = *Cp;
+        if (C.insts.empty()) continue;
+        const int last = C.insts.back();
+        const TWord allocEnd = 0x255 + (a.allocIdx.empty() ? 1 + 2 * inst[last].pos + 1
+                                                           : (last < static_cast<int>(a.allocIdx.size())
+                                                              ? a.allocIdx[last] : a.allocIdx.back()) + 1);
+        if (a.allocProc == "end") {
+            setAlloc(C, allocEnd);
+            std::printf("core %d: proc-time X:0x213 = 0x%03x for every instance (past the last effect)\n",
+                        C.id, allocEnd);
+        } else if (a.allocProc == "keep") {
+            std::printf("core %d: proc-time X:0x213 left at 0x%03x from the last init\n",
+                        C.id, C.mem->get(MemArea_X, 0x213));
+        }
     }
 
-    std::vector<int32_t> input;
-    if (!a.in.empty()) {
-        std::ifstream f(a.in, std::ios::binary);
-        int32_t s;
-        while (f.read(reinterpret_cast<char*>(&s), 4)) input.push_back(s);
-    }
-
-    // ---- FAITHFUL MODE: run the host's own dispatcher ---------------------
+    // ---- FAITHFUL MODE: run the host's own dispatcher (core 0 only) ---------
     // Everything above hand-rolls the calling convention from a reading of the
     // listing, and a mistake in that reading is invisible here -- which is how
     // the A-flag bug survived six builds and why r6 is still the FX1 block.
     //
-    // P:0x372 resets x:0x418/0x20a/0x213/0x20b/0x420 and falls into the track
-    // loop at P:0x385, which runs four times (x:0x418 steps 0x20 to 0x80) and
-    // exits to P:0x53e. Per track it dispatches FX1 then FX2, advancing x:0x20a
-    // three times and x:0x213 twice -- exactly the measured 0x6200/0x6500 and
-    // 0x4000/0x8000.
+    // The setup routine resets x:0x418/0x20a/0x213/0x20b/0x420 and falls into
+    // the track loop, which runs four times (x:0x418 steps 0x20 to 0x80) and
+    // exits to the dispatcher exit. Per track it dispatches FX1 then FX2,
+    // advancing x:0x20a three times and x:0x213 twice -- exactly the measured
+    // 0x6200/0x6500 and 0x4000/0x8000.
     //
     // Each track's config is a 0x20-word block: x:0x416 + t*0x20 is current,
     // x:0x415 + t*0x20 is pending, the FX1 id sits at +$1b and the FX2 id at
@@ -664,18 +888,19 @@ int main(int argc, char** argv) {
         // is what actually unblocks it -- with it clear, writeTX overwrites
         // the head and returns instead of calling waitNotFull(). We keep the
         // drain as well so `hasTX()` stays a useful thing to inspect.
-        periphX.getHDI08().setTransmitDataAlwaysEmpty(false);
+        C0.periphX->getHDI08().setTransmitDataAlwaysEmpty(false);
         auto drainHostTX = [&]() {
-            auto& h = periphX.getHDI08();
+            auto& h = C0.periphX->getHDI08();
             while (h.hasTX()) h.readTX();
         };
         for (int b = 0; b < a.blocks; ++b) {
-            dsp.setPC(0x372);
+            dsp.setPC(C0.ctx.setupLo);
             bool ok = false;
             std::vector<TWord> recent;
+            const uint64_t i0 = dsp.getInstructionCounter();
             for (uint32_t i = 0; i < 400000; ++i) {
                 const TWord pc = dsp.getPC().toWord();
-                if (pc == 0x53e) { ok = true; break; }
+                if (pc == C0.ctx.exit) { ok = true; break; }
                 if (b == 0 && a.trace) {
                     recent.push_back(pc);
                     if (recent.size() > 40) recent.erase(recent.begin());
@@ -686,6 +911,9 @@ int main(int argc, char** argv) {
                 dsp.execInterpreter();
             }
             drainHostTX();
+            const long n = static_cast<long>(dsp.getInstructionCounter() - i0);
+            C0.meter.push_back(n);
+            if (n > C0.maxBlockInstr) { C0.maxBlockInstr = n; C0.maxBlock = b; }
             if (!ok && a.trace && !recent.empty()) {
                 std::printf("  last 40 PCs: ");
                 for (TWord q : recent) std::printf("%05x ", q);
@@ -694,29 +922,21 @@ int main(int argc, char** argv) {
             if (!ok) {
                 std::printf("\nHANG in the dispatcher: block %d, pc=0x%06x\n",
                             b, dsp.getPC().toWord());
-                std::printf("  r0=%06x r1=%06x r2=%06x r3=%06x r4=%06x r5=%06x r6=%06x r7=%06x\n",
-                            dsp.regs().r[0].var, dsp.regs().r[1].var, dsp.regs().r[2].var,
-                            dsp.regs().r[3].var, dsp.regs().r[4].var, dsp.regs().r[5].var,
-                            dsp.regs().r[6].var, dsp.regs().r[7].var);
-                std::printf("  m0=%06x m1=%06x m2=%06x m3=%06x m4=%06x m5=%06x n7=%06x\n",
-                            dsp.regs().m[0].var, dsp.regs().m[1].var, dsp.regs().m[2].var,
-                            dsp.regs().m[3].var, dsp.regs().m[4].var, dsp.regs().m[5].var,
-                            dsp.regs().n[7].var);
-                std::printf("  x:0x20a=%06x x:0x213=%06x x:0x418=%06x\n",
-                            mem.get(MemArea_X, 0x20a), mem.get(MemArea_X, 0x213),
-                            mem.get(MemArea_X, 0x418));
+                dumpRegs(dsp, mem);
                 return 1;
             }
-            if (guard.armed) {
+            if (C0.guard.armed) {
                 int cl = 0; char who[24]; std::snprintf(who, sizeof who, "dispatch");
-                inst[0].violations += guard.check(mem, 0x4000, 0x4000 + a.guardWords,
-                                                  who, "blk", b, b > 2, cl);
+                inst[0].violations += C0.guard.check(mem, 0x4000, 0x4000 + a.guardWords,
+                                                     who, "blk", b, b > 2, cl);
                 inst[0].clobbers += cl;
             }
         }
         std::printf("dispatcher completed %d blocks with %d FX2 track(s) on effect 0x%02x\n",
                     a.blocks, a.fx2tracks, a.fxid);
-        if (guard.armed)
+        std::printf("  meter: max %ld instructions in block %d (%.1f per frame of %d)\n",
+                    C0.maxBlockInstr, C0.maxBlock, double(C0.maxBlockInstr) / a.frames, a.frames);
+        if (C0.guard.armed)
             std::printf("  %ld stray regions, %ld CLOBBERING a loaded module\n",
                         inst[0].violations, inst[0].clobbers);
         return inst[0].clobbers ? 3 : 0;
@@ -728,48 +948,38 @@ int main(int argc, char** argv) {
         std::printf("tracking r7-relative X words every block ->  %s\n",
                     a.trackOut.empty() ? "/tmp/dsp_track.txt" : a.trackOut.c_str());
     }
+    std::ofstream meterFile;
+    if (!a.meterFile.empty()) meterFile.open(a.meterFile);
 
-    size_t inPos = 0;
-    for (int b = 0; b < a.blocks; ++b) {
-        // fill every instance's block: impulse on the first frame unless an
-        // input file is given. All instances see the same audio.
-        for (int f = 0; f < a.frames; ++f) {
-            int32_t s = 0;
-            if (!input.empty()) s = inPos < input.size() ? input[inPos++] : 0;
-            else if (b == 0 && f == 0) s = 0x400000;             // 0.5 full scale
-            for (int k = 0; k < a.inst; ++k) {
-                // -inmask silences an instance's own input so its output is
-                // ONLY what arrived through the shared bus. Feeding a server
-                // dry audio as well would bury the bus contribution under it.
-                const int32_t sk = inst[k].fed ? s : 0;
-                dsp.memWrite(MemArea_X, inst[k].audio + f * 2 + 0, sk & 0xffffff);
-                dsp.memWrite(MemArea_X, inst[k].audio + f * 2 + 1, sk & 0xffffff);
-            }
-        }
-        if (a.spray && b == 0) {
-            // excite every candidate input word: if the effect reads audio from
-            // anywhere in the low X region, this will find it
-            for (TWord ad = 0; ad < static_cast<TWord>(a.spray); ++ad)
-                dsp.memWrite(MemArea_X, ad, 0x400000);
-        }
-        if (a.pingpong >= 0) mem.set(MemArea_X, 0x41f, static_cast<TWord>(a.pingpong));
+    // ---- the block loop -----------------------------------------------------
+    // Per core, per block, the dispatcher's calls in order. Each call is made
+    // exactly as runToRts made it -- the same register setup, the same jsr
+    // through the emulator, the same sentinel -- but resumably, one
+    // instruction per step, so the two cores can be interleaved.
+    struct CoreRun {
+        Core* C = nullptr;
+        std::vector<Call> calls; size_t idx = 0;
+        bool inCall = false; Call cur; uint64_t i0 = 0;
+        int block = 0;
+        bool done() const { return idx >= calls.size() && !inCall; }
+    };
+    std::vector<CoreRun> runs(ncores);
+    for (int c = 0; c < ncores; ++c) runs[c].C = cores[c].get();
 
-        for (int k = 0; k < a.inst; ++k) {
-            Instance& I = inst[k];
-            if (a.allocProc == "perinst") setAlloc(I.alloc);
-            setParams(I.pv);
-            dsp.regs().r[0].var = I.audio;
-            dsp.regs().r[6].var = pblock;
-            dsp.regs().r[7].var = I.state;
-            dsp.regs().n[7].var = cnt;
+    const TWord DIFF_LO = 0x000, DIFF_HI = 0x8000;
+    std::vector<TWord> snap;
+    bool hung = false;
 
-            std::vector<TWord> snap;
-            const TWord DIFF_LO = 0x000, DIFF_HI = 0x8000;
-            if (a.diff && b == a.diff - 1 && k == 0) {
-                snap.resize(DIFF_HI - DIFF_LO);
-                for (TWord ad = DIFF_LO; ad < DIFF_HI; ++ad) snap[ad - DIFF_LO] = mem.get(MemArea_X, ad);
-            }
-
+    // Start a call: what the dispatcher does before `jsr (r2)`.
+    auto beginCall = [&](CoreRun& R, const Call& call) {
+        Core& C = *R.C; Instance& I = inst[call.inst];
+        if (a.allocProc == "perinst") setAlloc(C, I.alloc);
+        setParams(C, I.pv);
+        DSP& D = *C.dsp;
+        D.regs().r[6].var = C.pblock;
+        D.regs().r[7].var = I.state;
+        const int sp = (I.split > 0 && I.split < a.frames) ? I.split : 0;
+        if (call.ctl) {
             // The dispatcher's two calls per block (P:0x4b8..0x4d7, read from
             // the listing): when the track's SPLIT is nonzero it first calls
             // with a = 0, r0 = 0, n7 = split -- the FIRST SUB-BLOCK, frames
@@ -786,28 +996,18 @@ int main(int argc, char** argv) {
             // It used to be made anyway, at r0 = 0 with n7 = cnt, to model what
             // an a=0-rts effect sees. That is now a trap: since v57 the reverb
             // runs its body on BOTH calls, so the harness was executing the
-            // whole engine against r0 = 0 — which on hardware IS the audio
+            // whole engine against r0 = 0 -- which on hardware IS the audio
             // buffer, but here is unrelated low X memory. The engine read that
             // as input and fed it to the tank every block, so the reverb never
             // decayed and looked self-oscillating for hours of investigation,
             // while the hardware decayed perfectly. Model the dispatcher, not a
             // historical special case.
-            char who[32]; std::snprintf(who, sizeof who, "inst %d", k);
-            const int sp = (I.split > 0 && I.split < a.frames) ? I.split : 0;
-            if (!a.noctl && sp) {
-                dsp.regs().r[0].var = sp ? I.audio : 0;
-                dsp.regs().a.var = 0;
-                dsp.regs().n[7].var = sp ? sp : cnt;
-                char cw[40]; std::snprintf(cw, sizeof cw, "inst %d ctl", k);
-                if (!runToRts(dsp, I.proc, 0, cw)) {
-                    std::printf("\nHANG in the a=0 call: instance %d, block %d\n", k, b);
-                    return 1;
-                }
-                dsp.regs().r[6].var = pblock;
-                dsp.regs().r[7].var = I.state;
-            }
-            dsp.regs().r[0].var = I.audio + 2 * sp;
-            dsp.regs().n[7].var = cnt - sp;
+            D.regs().r[0].var = sp ? I.audio : 0;
+            D.regs().a.var = 0;
+            D.regs().n[7].var = sp ? sp : C.cnt;
+        } else {
+            D.regs().r[0].var = I.audio + 2 * sp;
+            D.regs().n[7].var = C.cnt - sp;
             // The dispatcher raises the flag with `move #$1,a`, and a short
             // immediate to an accumulator is LEFT-ALIGNED: a1 = $010000, not
             // a0 = 1. The distinction is invisible to `tst a` (both are
@@ -815,80 +1015,195 @@ int main(int argc, char** argv) {
             // effect that stores the flag and tests the copy reads 0 here if
             // the harness sets the raw var. stageprobe4's audio stage was
             // silently gated off by exactly this.
-            dsp.regs().a.var = 0x010000000000ULL;
-            if (!runToRts(dsp, I.proc, ((b == 0 || (a.diff && b == a.diff - 1)) && k == 0) ? a.trace : 0, who)) {
-                std::printf("\nHANG: instance %d, block %d, pc=0x%06x\n", k, b,
-                            dsp.getPC().toWord());
-                std::printf("  r0=%06x r1=%06x r2=%06x r3=%06x r4=%06x r5=%06x r6=%06x r7=%06x\n",
-                            dsp.regs().r[0].var, dsp.regs().r[1].var, dsp.regs().r[2].var,
-                            dsp.regs().r[3].var, dsp.regs().r[4].var, dsp.regs().r[5].var,
-                            dsp.regs().r[6].var, dsp.regs().r[7].var);
-                std::printf("  m0=%06x m1=%06x m2=%06x m3=%06x m4=%06x m5=%06x\n",
-                            dsp.regs().m[0].var, dsp.regs().m[1].var, dsp.regs().m[2].var,
-                            dsp.regs().m[3].var, dsp.regs().m[4].var, dsp.regs().m[5].var);
-                return 1;
-            }
+            D.regs().a.var = 0x010000000000ULL;
+        }
+        D.setPC(SENTINEL);
+        D.jsr(I.proc);
+        R.cur = call; R.cur.steps = 0; R.inCall = true;
+        R.i0 = D.getInstructionCounter();
+    };
 
-            // -track: sample r7-relative state EVERY block. -peekx only snapshots
-            // after the whole run, which cannot measure a RATE -- an LFO phase has
-            // to be differenced block to block to get its increment.
-            if (!a.track.empty() && k == 0) {
-                if (trackFile.is_open()) {
-                    trackFile << b;
-                    for (TWord off : a.track)
-                        trackFile << ' ' << mem.get(MemArea_X, I.state + off);
-                    trackFile << '\n';
+    // Finish a call: what the harness does after the rts.
+    auto endCall = [&](CoreRun& R) {
+        Core& C = *R.C; Instance& I = inst[R.cur.inst]; DSP& D = *C.dsp;
+        const int k = R.cur.inst, b = R.block;
+        char who[32]; std::snprintf(who, sizeof who, "inst %d", k);
+        R.inCall = false;
+        if (R.cur.ctl) {
+            // the a=0 call: nothing captured, the a=1 call follows
+            return;
+        }
+        // -track: sample r7-relative state EVERY block. -peekx only snapshots
+        // after the whole run, which cannot measure a RATE -- an LFO phase has
+        // to be differenced block to block to get its increment.
+        if (!a.track.empty() && k == 0) {
+            if (trackFile.is_open()) {
+                trackFile << b;
+                for (TWord off : a.track)
+                    trackFile << ' ' << C.mem->get(MemArea_X, I.state + off);
+                trackFile << '\n';
+            }
+        }
+        I.cycles += R.cur.steps; ++I.procCalls;
+        if (C.guard.armed) {
+            int cl = 0;
+            I.violations += C.guard.check(*C.mem, I.base, I.base + a.guardWords, who,
+                                          "proc", b, I.violations + I.clobbers > 12, cl);
+            I.clobbers += cl;
+        }
+        if (a.diff && b == a.diff - 1 && k == 0) {
+            std::printf("X writes during block %d (impulse block):\n", b);
+            int n = 0; TWord runLo = 0; bool inRun = false;
+            for (TWord ad = DIFF_LO; ad < DIFF_HI; ++ad) {
+                const bool ch = C.mem->get(MemArea_X, ad) != snap[ad - DIFF_LO];
+                if (ch && !inRun) { runLo = ad; inRun = true; }
+                if (!ch && inRun) {
+                    if (n < 40) std::printf("   X:0x%05x..0x%05x  (%u words)\n", runLo, ad - 1, ad - runLo);
+                    ++n; inRun = false;
                 }
             }
-
-            I.cycles += g_lastCycles; ++I.procCalls;
-            if (guard.armed) {
-                int cl = 0;
-                I.violations += guard.check(mem, I.base, I.base + a.guardWords, who,
-                                            "proc", b, I.violations + I.clobbers > 12, cl);
-                I.clobbers += cl;
-            }
-
-            if (a.diff && b == a.diff - 1 && k == 0) {
-                std::printf("X writes during block %d (impulse block):\n", b);
-                int n = 0; TWord runLo = 0; bool inRun = false;
-                for (TWord ad = DIFF_LO; ad < DIFF_HI; ++ad) {
-                    const bool ch = mem.get(MemArea_X, ad) != snap[ad - DIFF_LO];
-                    if (ch && !inRun) { runLo = ad; inRun = true; }
-                    if (!ch && inRun) {
-                        if (n < 40) std::printf("   X:0x%05x..0x%05x  (%u words)\n", runLo, ad - 1, ad - runLo);
-                        ++n; inRun = false;
-                    }
-                }
-                if (inRun) std::printf("   X:0x%05x..0x%05x\n", runLo, DIFF_HI - 1);
-                std::printf("   %d changed regions total\n", n);
-                // values of every changed word (capped), so two runs can be
-                // value-diffed, not just region-diffed
-                int nv = 0;
-                for (TWord ad = DIFF_LO; ad < DIFF_HI && nv < 400; ++ad) {
-                    if (mem.get(MemArea_X, ad) != snap[ad - DIFF_LO]) {
-                        std::printf("   XVAL 0x%05x = 0x%06x\n", ad, mem.get(MemArea_X, ad));
-                        ++nv;
-                    }
+            if (inRun) std::printf("   X:0x%05x..0x%05x\n", runLo, DIFF_HI - 1);
+            std::printf("   %d changed regions total\n", n);
+            // values of every changed word (capped), so two runs can be
+            // value-diffed, not just region-diffed
+            int nv = 0;
+            for (TWord ad = DIFF_LO; ad < DIFF_HI && nv < 400; ++ad) {
+                if (C.mem->get(MemArea_X, ad) != snap[ad - DIFF_LO]) {
+                    std::printf("   XVAL 0x%05x = 0x%06x\n", ad, C.mem->get(MemArea_X, ad));
+                    ++nv;
                 }
             }
+        }
+        if (getenv("DSP_DBG") && k == 0 && b < atoi(getenv("DSP_DBG")))
+            std::printf("  dbg blk %3d: $82=%06x $83=%06x $3e=%06x $30=%06x n5=%06x\n", b,
+                        C.mem->get(MemArea_X, I.state + 0x82),
+                        C.mem->get(MemArea_X, I.state + 0x83),
+                        C.mem->get(MemArea_X, I.state + 0x3e),
+                        C.mem->get(MemArea_X, I.state + 0x30),
+                        D.regs().n[5].var);
+        if (!I.captures) return;                 // the next instance on this buffer finishes the track
+        for (int f = 0; f < a.frames; ++f) {
+            for (int ch = 0; ch < 2; ++ch) {
+                TWord w = C.mem->get(MemArea_X, I.audio + f * 2 + ch);
+                int32_t s = static_cast<int32_t>(w << 8) >> 8;   // sign-extend 24 -> 32
+                if (s) ++I.nonzero;
+                if (I.out.is_open()) I.out.write(reinterpret_cast<char*>(&s), 4);
+            }
+        }
+    };
 
-            if (getenv("DSP_DBG") && k == 0 && b < atoi(getenv("DSP_DBG")))
-                std::printf("  dbg blk %3d: $82=%06x $83=%06x $3e=%06x $30=%06x n5=%06x\n", b,
-                            mem.get(MemArea_X, I.state + 0x82),
-                            mem.get(MemArea_X, I.state + 0x83),
-                            mem.get(MemArea_X, I.state + 0x3e),
-                            mem.get(MemArea_X, I.state + 0x30),
-                            dsp.regs().n[5].var);
+    // One instruction on a core. Returns false on a hang.
+    auto stepCore = [&](CoreRun& R) -> bool {
+        if (R.done()) return true;
+        if (!R.inCall) beginCall(R, R.calls[R.idx++]);
+        Core& C = *R.C; DSP& D = *C.dsp;
+        const TWord cur = D.getPC().toWord();
+        if (cur == SENTINEL) { endCall(R); return true; }
+        if (R.cur.steps >= 50000000u) {
+            std::printf("\nHANG%s: instance %d, block %d, pc=0x%06x (core %d)\n",
+                        R.cur.ctl ? " in the a=0 call" : "", R.cur.inst, R.block, cur, C.id);
+            dumpRegs(D, *C.mem);
+            return false;
+        }
+        const bool tr = a.trace && (R.cur.inst == 0) && !R.cur.ctl &&
+                        (R.block == 0 || (a.diff && R.block == a.diff - 1)) &&
+                        static_cast<int>(R.cur.steps) < a.trace;
+        if (tr)
+            std::printf("  inst 0 %6u  pc=%06x  a=%012llx r5=%06x n5=%06x m5=%06x x1=%06x n7=%06x\n",
+                        R.cur.steps, cur,
+                        static_cast<unsigned long long>(D.regs().a.var & 0xffffffffffffull),
+                        D.regs().r[5].var & 0xffffff, D.regs().n[5].var & 0xffffff,
+                        D.regs().m[5].var & 0xffffff,
+                        (unsigned)(D.regs().x.var >> 24) & 0xffffff,
+                        D.regs().n[7].var);
+        D.execInterpreter();
+        ++R.cur.steps;
+        return true;
+    };
+    // Run a core to the end of its block.
+    auto runCore = [&](CoreRun& R) -> bool {
+        while (!R.done()) if (!stepCore(R)) return false;
+        return true;
+    };
 
+    for (int b = 0; b < a.blocks; ++b) {
+        // fill every instance's block: impulse on the first frame unless an
+        // input file is given. Without per-instance files all instances see
+        // the same audio.
+        for (int k = 0; k < a.inst; ++k) {
+            Instance& I = inst[k];
+            Core& C = *cores[I.core];
+            if (!I.fills) continue;              // a chained instance sees its predecessor's output
             for (int f = 0; f < a.frames; ++f) {
-                for (int c = 0; c < 2; ++c) {
-                    TWord w = mem.get(MemArea_X, I.audio + f * 2 + c);
-                    int32_t s = static_cast<int32_t>(w << 8) >> 8;   // sign-extend 24 -> 32
-                    if (s) ++I.nonzero;
-                    if (I.out.is_open()) I.out.write(reinterpret_cast<char*>(&s), 4);
-                }
+                int32_t s = 0;
+                if (I.hasInput) s = I.inPos < I.input.size() ? I.input[I.inPos++] : 0;
+                else if (b == 0 && f == 0) s = 0x400000;             // 0.5 full scale
+                // -inmask silences an instance's own input so its output is
+                // ONLY what arrived through the shared bus. Feeding a server
+                // dry audio as well would bury the bus contribution under it.
+                const int32_t sk = I.fed ? s : 0;
+                C.dsp->memWrite(MemArea_X, I.audio + f * 2 + 0, sk & 0xffffff);
+                C.dsp->memWrite(MemArea_X, I.audio + f * 2 + 1, sk & 0xffffff);
             }
+        }
+        if (a.spray && b == 0) {
+            // excite every candidate input word: if the effect reads audio from
+            // anywhere in the low X region, this will find it
+            for (TWord ad = 0; ad < static_cast<TWord>(a.spray); ++ad)
+                dsp.memWrite(MemArea_X, ad, 0x400000);
+        }
+        if (a.pingpong >= 0)
+            for (auto& Cp : cores) Cp->mem->set(MemArea_X, 0x41f, static_cast<TWord>(a.pingpong));
+        if (a.diff && b == a.diff - 1) {
+            snap.resize(DIFF_HI - DIFF_LO);
+            Core& C = *cores[inst[0].core];
+            for (TWord ad = DIFF_LO; ad < DIFF_HI; ++ad) snap[ad - DIFF_LO] = C.mem->get(MemArea_X, ad);
+        }
+
+        // the calls each core makes this block, in dispatch order
+        for (int c = 0; c < ncores; ++c) {
+            CoreRun& R = runs[c];
+            R.calls.clear(); R.idx = 0; R.inCall = false; R.block = b;
+            for (int k : cores[c]->insts) {
+                Instance& I = inst[k];
+                const int sp = (I.split > 0 && I.split < a.frames) ? I.split : 0;
+                if (!a.noctl && sp) R.calls.push_back(Call{k, true, 0});
+                R.calls.push_back(Call{k, false, 0});
+            }
+        }
+        std::vector<uint64_t> i0(ncores);
+        for (int c = 0; c < ncores; ++c) i0[c] = cores[c]->dsp->getInstructionCounter();
+
+        if (!a.interleave || ncores == 1) {
+            // LOCK-STEP: core 0's whole block, then core 1's. What a single
+            // core always saw; blind to the race by construction.
+            for (int c = 0; c < ncores && !hung; ++c)
+                if (!runCore(runs[c])) hung = true;
+        } else {
+            // INTERLEAVED: the leader runs |skew| instructions alone, then
+            // the two alternate one instruction at a time until both blocks
+            // are done. Not the hardware's timing: a fuzz of it.
+            CoreRun& lead = runs[a.skew >= 0 ? 0 : 1];
+            CoreRun& lag  = runs[a.skew >= 0 ? 1 : 0];
+            for (long i = 0; i < std::labs(a.skew) && !lead.done() && !hung; ++i)
+                if (!stepCore(lead)) hung = true;
+            while (!hung && !(lead.done() && lag.done())) {
+                if (!stepCore(lead)) { hung = true; break; }
+                if (!stepCore(lag))  { hung = true; break; }
+            }
+        }
+        if (hung) return 1;
+
+        for (int c = 0; c < ncores; ++c) {
+            Core& C = *cores[c];
+            const long n = static_cast<long>(C.dsp->getInstructionCounter() - i0[c]);
+            C.meter.push_back(n);
+            if (n > C.maxBlockInstr) { C.maxBlockInstr = n; C.maxBlock = b; }
+        }
+        if (meterFile.is_open()) {
+            meterFile << b;
+            for (int c = 0; c < ncores; ++c) meterFile << ' ' << cores[c]->meter.back();
+            meterFile << '\n';
         }
 
         if (a.spray) {
@@ -951,21 +1266,41 @@ int main(int argc, char** argv) {
             std::printf("   X:0x%05x = 0x%06x\n", ad, mem.get(MemArea_X, ad));
     }
 
-    std::printf("ran %d blocks x %d frames on %d instance(s)\n", a.blocks, a.frames, a.inst);
+    std::printf("ran %d blocks x %d frames on %d instance(s), %d core(s)%s\n", a.blocks, a.frames,
+                a.inst, ncores,
+                ncores == 1 ? "" : (a.interleave ? " interleaved" : " lock-step"));
+    // THE METER. Instructions, not cycles: the emulator counts executed
+    // instructions and models no memory-contention stall, so this is a floor
+    // on the chip's cycles in the same way tools/cycle_count.py is -- but
+    // per BLOCK, for THIS layout, with every instance's real work (and any
+    // init landing inside a block) rather than one composition's sample
+    // loops. The wall is docs/CHIP.md's measured budget.
+    for (auto& Cp : cores) {
+        Core& C = *Cp;
+        if (C.meter.empty()) continue;
+        long sum = 0; for (long n : C.meter) sum += n;
+        std::printf("  core %d meter: max %ld instructions in block %d, mean %.0f "
+                    "(%.1f/sample max, %.1f/sample mean at %d frames); inits %ld\n",
+                    C.id, C.maxBlockInstr, C.maxBlock, double(sum) / C.meter.size(),
+                    double(C.maxBlockInstr) / a.frames, double(sum) / C.meter.size() / a.frames,
+                    a.frames, C.initInstr);
+    }
     long total = 0, bad = 0;
+    bool anyGuard = false;
+    for (auto& Cp : cores) anyGuard |= Cp->guard.armed;
     for (int k = 0; k < a.inst; ++k) {
         std::printf("  instance %d: %.1f instructions/sample (%ld calls)\n", k,
                     inst[k].procCalls ? double(inst[k].cycles) / inst[k].procCalls / a.frames : 0.0,
                     inst[k].procCalls);
         std::printf("  instance %d: %ld non-zero output samples", k, inst[k].nonzero);
-        if (guard.armed)
+        if (anyGuard)
             std::printf(", %ld stray write regions, %ld CLOBBERING a loaded module",
                         inst[k].violations, inst[k].clobbers);
         std::printf("\n");
         total += inst[k].nonzero; bad += inst[k].clobbers;
     }
     if (!total) std::printf("  (all silent -- the effect produced nothing)\n");
-    if (guard.armed && !bad)
+    if (anyGuard && !bad)
         std::printf("  guard clean: nothing written over a loaded module\n");
     return bad ? 3 : 0;
 }

--- a/tools/render_reverb.py
+++ b/tools/render_reverb.py
@@ -20,7 +20,8 @@ What it CANNOT tell you, and still needs a flash (REVERB.md, BUS.md):
     cannot run
   * anything ColdFire-side: menu, descriptors, knob labels, parameter
     ranges. -params pokes r6 directly and bypasses all of it
-  * payload B, which dsp_host cannot boot at all
+  * the ColdFire's timing between the two cores (dsp_host boots both since
+    7 Sep 2026, lock-step; tools/rig_render.py renders the whole rig)
   * multi-instance behaviour under a nonzero split, where there is a known
     unexplained one-vs-two-instance divergence
 

--- a/tools/rig_render.py
+++ b/tools/rig_render.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Render the whole rig locally: eight tracks, both DSP cores, the real image.
+
+    python3 tools/rig_render.py --tracks T1=D,T2=S,T3=S,T4=S,T5=R,T6=S,T7=S,T8=S \\
+        --stems out/test_audio --out out/rig
+
+    python3 tools/rig_render.py --project ~/octa/backups/OCTABAM_RIG --bank 2 --part 1 \\
+        --stems ~/stems --out out/rig            # ids and every knob from the part
+
+Each track is what the unit makes of it: its FX1 and FX2 effects, chained on
+the track's own audio, on the CORE that track lives on -- tracks 5-8 on
+payload A (core 0), 1-4 on payload B (core 1), in dispatch order, with the
+shared window Y:0x30000-0x3FFFF really shared between the two emulated cores
+(tools/dsp_host, 7 Sep 2026). So a SEND on T2 reaches BusVerb on T5 the way
+it does on hardware: across the core boundary, through the bus scratch.
+
+What comes out: T1.wav .. T8.wav (each track's stereo output, dry + wet as
+the DSP emits it), mix.wav (their unity sum, -6 dB), and meter.txt (per-block
+instruction counts per core: the cycle floor of THIS layout).
+
+What this is NOT: the ColdFire. Knobs are poked into r6 the way the harness
+always has (a slot can draw a knob and publish nothing -- docs/PARAM_PAGES.md),
+AMP VOL / pan / the mixer are not modelled (unity sum), samples do not play
+(stems stand in for what the track would play), and the cores are lock-step
+unless --skew interleaves them (a fuzz of the hardware's timing, never a
+proof). docs/HARNESS.md.
+
+IMAGE. --image is a BUILT image (default out/mainos_bus.bin, i.e. `make bus`
+for the remix you want); both payloads are dumped from it into out/dsp/. An
+effect the image does not carry on a track's core dispatches to the SEND
+alias there, exactly as the unit would -- reported, never silently rendered
+as a passthrough (the 12 Aug 2026 trap).
+"""
+import argparse
+import array
+import math
+import os
+import pathlib
+import struct
+import subprocess
+import sys
+import wave
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+import send_probe                      # noqa: E402  (entry_points, dump_mem, HOST)
+from remix import registry             # noqa: E402
+
+SR = 44100
+FRAMES = send_probe.FRAMES             # 15: dsp_host caps a block at 15 frames
+NTRACKS = 8
+# Track -> core. Measured 10 Aug 2026 (marker flash): payload A serves 5-8.
+CORE_OF = {t: (0 if t >= 5 else 1) for t in range(1, NTRACKS + 1)}
+POS_OF = {t: (t - 1) % 4 for t in range(1, NTRACKS + 1)}    # dispatch position on its core
+# Where the per-track audio buffers go in the harness. Hardware runs every
+# track's block at X:0 (the dispatcher copies it in and out); the harness
+# gives each track its own buffer, and puts them ABOVE the loaded modules so
+# a stock effect scratching X:0x20-0xff (the FLANGER lesson, 2 Sep 2026)
+# cannot reach another track's audio.
+AUDIO_BASE = 0x9000
+
+
+def die(msg):
+    sys.exit(f"rig_render: {msg}")
+
+
+# ---- what a track runs -----------------------------------------------------
+class Slot:
+    """One effect on one track's FX1 or FX2 slot."""
+    def __init__(self, module, fx, values):
+        self.module = module            # remix.schema.Module
+        self.fx = fx                    # 1 or 2
+        self.values = list(values)      # 12 knob bytes
+
+    @property
+    def key(self):
+        return self.module.key
+
+
+def remix_id_map(remix_name):
+    """id -> Module for the modules THIS remix places (a station replaces a
+    stock id, so the registry alone is ambiguous), then stock as fallback."""
+    r = registry.remix(remix_name)
+    mods = registry.modules()
+    out = {}
+    for k in r.modules:
+        m = mods.get(k)
+        if m is not None and m.menu is not None:
+            out.setdefault(m.menu.fx2_id, m)
+    for m in mods.values():
+        if m.is_stock and m.menu is not None:
+            out.setdefault(m.menu.fx2_id, m)
+    return out
+
+
+def letter_map():
+    """layout letter (send_probe's alphabet) -> Module."""
+    return {m.harness.layout_char: m for m in registry.modules().values()
+            if m.harness is not None and m.harness.layout_char and m.menu is not None}
+
+
+def defaults_of(m):
+    vals = [(p.default or 0) & 0x7f for p in m.params] + [0] * 12
+    return vals[:12]
+
+
+def parse_tracks(spec, remix_name):
+    """--tracks 'T1=D,T2=S,T5=R,T3=1+S' -> {track: [Slot...]}.
+
+    A letter or a module KEY names the FX2 effect; 'a+b' puts a on FX1 and
+    b on FX2; '.' or omission is an empty track."""
+    letters = letter_map()
+    mods = registry.modules()
+    out = {}
+    for item in filter(None, spec.split(",")):
+        if "=" not in item:
+            die(f"--tracks item {item!r}: want T<n>=<effect>")
+        tn, eff = item.split("=", 1)
+        t = int(tn.strip().upper().lstrip("T"))
+        if not 1 <= t <= NTRACKS:
+            die(f"track {t} out of range")
+        parts = [p.strip() for p in eff.split("+")]
+        fx1, fx2 = (None, parts[0]) if len(parts) == 1 else (parts[0], parts[1])
+        slots = []
+        for fx, name in ((1, fx1), (2, fx2)):
+            if not name or name == ".":
+                continue
+            m = letters.get(name) or mods.get(name.upper())
+            if m is None:
+                die(f"track {t}: unknown effect {name!r} (a layout letter or a module KEY)")
+            slots.append(Slot(m, fx, defaults_of(m)))
+        out[t] = slots
+    return out
+
+
+def part_tracks(project, bank, part, remix_name):
+    """ids and knob bytes from a project's bank file, part `part` (1-based)."""
+    import ot_project as otp
+    pdir = pathlib.Path(project).expanduser()
+    bf = pdir / f"bank{bank:02d}.work"
+    if not bf.is_file():
+        die(f"no {bf}")
+    data = bf.read_bytes()
+    ids = remix_id_map(remix_name)
+    off = otp.PART_BASE + (part - 1) * otp.PART_STRIDE
+    out = {}
+    for i in range(NTRACKS):
+        slots = []
+        for fx, idoff, sub in ((1, otp.FX1_OFF, 0), (2, otp.FX2_OFF, 6)):
+            fid = data[off + idoff + i]
+            if fid == 0:
+                continue
+            m = ids.get(fid)
+            if m is None:
+                print(f"  T{i+1} FX{fx}: id 0x{fid:02x} is not in remix {remix_name!r} or stock -- skipped")
+                continue
+            a = off + otp.P1_OFF + i * otp.TRACK_STRIDE + sub
+            b = off + otp.P2_OFF + i * otp.P2_STRIDE + sub
+            vals = list(data[a:a + 6]) + list(data[b:b + 6])
+            slots.append(Slot(m, fx, [v & 0x7f for v in vals]))
+        if slots:
+            out[i + 1] = slots
+    return out
+
+
+def apply_sets(tracks, sets):
+    """--set T2:-VRB=100 (or T2:FX1:-VRB=100 when both slots carry the name)."""
+    for spec in sets:
+        try:
+            lhs, val = spec.split("=")
+            bits = lhs.split(":")
+            t = int(bits[0].upper().lstrip("T"))
+            fx = int(bits[1].upper().lstrip("FX")) if len(bits) == 3 else None
+            name = bits[-1].upper()
+        except ValueError:
+            die(f"--set {spec!r}: want T<n>[:FX<1|2>]:<KNOB>=<0..127>")
+        hit = False
+        for s in tracks.get(t, []):
+            if fx is not None and s.fx != fx:
+                continue
+            kmap = s.module.knob_map_all() if not s.module.is_stock else {
+                p.name.decode().strip(): i for i, p in enumerate(s.module.params) if p.name}
+            if name in kmap:
+                s.values[kmap[name]] = int(val) & 0x7f
+                hit = True
+        if not hit:
+            die(f"--set {spec!r}: no such knob on track {t}")
+
+
+# ---- audio ----------------------------------------------------------------
+def read_stem(path):
+    from render_reverb import read_wav, resample
+    x, sr = read_wav(path)
+    return resample(x, sr, SR)
+
+
+def write_wav(path, L, R):
+    send_probe.write_wav(path, L, R)
+
+
+# ---- the run --------------------------------------------------------------
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--image", default="out/mainos_bus.bin", help="a BUILT image (make bus REMIX=...)")
+    ap.add_argument("--remix", default=os.environ.get("REMIX", "bamsep26"),
+                    help="which remix the image is (resolves ids to modules)")
+    ap.add_argument("--tracks", default="", help="T1=D,T2=S,... (letter or module KEY; 'a+b' = FX1+FX2)")
+    ap.add_argument("--project", help="project dir: take ids AND knobs from a part")
+    ap.add_argument("--bank", type=int, default=1)
+    ap.add_argument("--part", type=int, default=1)
+    ap.add_argument("--set", action="append", default=[], help="T2:-VRB=100 knob override")
+    ap.add_argument("--stems", help="dir of T1.wav..T8.wav (a missing one is silence)")
+    ap.add_argument("--stem", action="append", default=[], help="T3=file.wav")
+    ap.add_argument("--seconds", type=float, help="length (default: longest stem)")
+    ap.add_argument("--tail", type=float, default=2.0, help="seconds after the stems end")
+    ap.add_argument("--amp", type=float, default=0.5, help="stem scale into the DSP (0.5 = -6 dBFS)")
+    ap.add_argument("--tempo", type=float, help="publish tempo24 / clocks as the ColdFire cave does")
+    ap.add_argument("--skew", type=int, help="interleave the cores, core 0 N instructions ahead")
+    ap.add_argument("--out", default="out/rig")
+    ap.add_argument("--keep", action="store_true", help="keep the raw files")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    a = ap.parse_args()
+
+    image = pathlib.Path(a.image)
+    if not image.is_file():
+        die(f"{image} does not exist -- `make bus REMIX={a.remix}` first")
+    outdir = pathlib.Path(a.out)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    # the tracks
+    if a.project:
+        tracks = part_tracks(a.project, a.bank, a.part, a.remix)
+    elif a.tracks:
+        tracks = parse_tracks(a.tracks, a.remix)
+    else:
+        die("give --tracks or --project")
+    apply_sets(tracks, a.set)
+
+    # both payloads
+    mems = {}
+    for core, tag in ((0, "A"), (1, "B")):
+        mems[core] = send_probe.dump_mem(image, ROOT / f"out/dsp/mem_{a.remix}_{tag}.mem", tag)
+    send_id = send_probe.SERVER_ID["S"]
+    send_ep = {c: send_probe.entry_points(mems[c], send_id) for c in (0, 1)}
+
+    # instances, in dispatch order: core 0 (tracks 5-8) then core 1 (1-4),
+    # each track FX1 then FX2 on ONE audio buffer
+    inst = []            # dicts
+    for t in [5, 6, 7, 8, 1, 2, 3, 4]:
+        for s in tracks.get(t, []):
+            core = CORE_OF[t]
+            fid = s.module.menu.fx2_id
+            ep = send_probe.entry_points(mems[core], fid)
+            aliased = (s.module.key != "SEND") and ep == send_ep[core]
+            if aliased:
+                print(f"  T{t} FX{s.fx} {s.module.key}: not in payload {'AB'[core]} -- "
+                      f"this core dispatches it to SEND (the alias), as the unit does")
+            pos = POS_OF[t]
+            inst.append(dict(track=t, fx=s.fx, key=s.module.key, core=core,
+                             alloc=2 * pos + (s.fx - 1), r7=1 + 2 * pos + (s.fx - 1),
+                             init=ep[0], proc=ep[1], values=s.values,
+                             aliased=aliased, stock=s.module.is_stock))
+    if not inst:
+        die("no effect on any track")
+
+    # stems
+    stems = {}
+    if a.stems:
+        d = pathlib.Path(a.stems).expanduser()
+        for t in range(1, NTRACKS + 1):
+            for cand in (d / f"T{t}.wav", d / f"t{t}.wav", d / f"track{t}.wav"):
+                if cand.is_file():
+                    stems[t] = read_stem(cand)
+                    break
+    for spec in a.stem:
+        tn, f = spec.split("=", 1)
+        stems[int(tn.upper().lstrip("T"))] = read_stem(pathlib.Path(f).expanduser())
+    longest = max((len(x) for x in stems.values()), default=0)
+    n_src = int(a.seconds * SR) if a.seconds else longest
+    if n_src == 0:
+        die("no stems and no --seconds: nothing to render")
+    pad = send_probe.WARMUP_BLOCKS * FRAMES        # the engines stay dry for 256 calls
+    total = pad + n_src + int(a.tail * SR)
+    blocks = -(-total // FRAMES)
+    n = blocks * FRAMES
+
+    tag = os.getpid()
+    raws = {}
+    for t, x in stems.items():
+        p = ROOT / f"out/dsp/_rig_in_T{t}_{tag}.raw"
+        with open(p, "wb") as f:
+            for i in range(n):
+                j = i - pad
+                v = a.amp * x[j] if 0 <= j < min(len(x), n_src) else 0.0
+                f.write(struct.pack("<i", max(-8388608, min(8388607, int(v * 8388607)))))
+        raws[t] = p
+    silent = ROOT / f"out/dsp/_rig_silence_{tag}.raw"
+    silent.write_bytes(b"\0" * (4 * n))
+
+    out = ROOT / f"out/dsp/_rig_out_{tag}.raw"
+    cmd = [str(send_probe.HOST), "-mem", str(mems[0]), "-memB", str(mems[1]),
+           "-init", ",".join(f"{i['init']:x}" for i in inst),
+           "-proc", ",".join(f"{i['proc']:x}" for i in inst),
+           "-inst", str(len(inst)),
+           "-core", ",".join(str(i["core"]) for i in inst),
+           "-alloc", ",".join(str(i["alloc"]) for i in inst),
+           "-r7", ",".join(str(i["r7"]) for i in inst),
+           "-audioidx", ",".join(str(i["track"] - 1) for i in inst),
+           "-audio", f"{AUDIO_BASE:x}",
+           "-in", ",".join(str(raws.get(i["track"], silent)) for i in inst),
+           "-frames", str(FRAMES), "-blocks", str(blocks),
+           "-out", str(out), "-meter", str(outdir / "meter.txt")]
+    for i in inst:
+        cmd += ["-params", ",".join(map(str, i["values"]))]
+    if a.tempo:
+        cmd += ["-tempo", str(a.tempo)]
+    if a.skew is not None:
+        cmd += ["-skew", str(a.skew)]
+    print("tracks:")
+    for i in inst:
+        print(f"  T{i['track']} FX{i['fx']} {i['key']:14s} core {i['core']} "
+              f"alloc {i['alloc']} r7 {i['r7']} init P:0x{i['init']:05x} "
+              f"params {' '.join(map(str, i['values']))}"
+              f"{'   <- SEND alias' if i['aliased'] else ''}")
+    print(f"{blocks} blocks x {FRAMES} frames ({n / SR:.1f} s incl. {pad / SR:.1f} s warm-up), "
+          f"stems on {sorted(stems) or 'none'}")
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    if a.verbose:
+        print(r.stdout)
+    if r.returncode != 0:
+        die(f"dsp_host failed:\n{r.stdout[-3000:]}{r.stderr[-2000:]}")
+    for line in r.stdout.splitlines():
+        if "meter:" in line or "HANG" in line or "!!" in line:
+            print(line)
+
+    # per-track outputs: the LAST instance on a track's buffer captured it
+    last = {}
+    for k, i in enumerate(inst):
+        last[i["track"]] = k
+    mixL = [0.0] * (n - pad)
+    mixR = [0.0] * (n - pad)
+    for t in range(1, NTRACKS + 1):
+        if t in last:
+            k = last[t]
+            p = out if k == 0 else pathlib.Path(f"{out}.i{k}")
+            arr = array.array("i"); arr.frombytes(p.read_bytes())
+            L, R = list(arr[0::2])[pad:], list(arr[1::2])[pad:]
+        elif t in stems:                       # no effect at all: the stem passes through
+            x = stems[t]
+            L = [int(a.amp * (x[j] if j < min(len(x), n_src) else 0.0) * 8388607) for j in range(n - pad)]
+            R = list(L)
+        else:
+            continue
+        write_wav(outdir / f"T{t}.wav", L, R)
+        peak = max((abs(v) for v in L + R), default=0)
+        print(f"  T{t}.wav  peak {20 * math.log10(max(peak, 1) / 8388608):6.1f} dBFS")
+        for j in range(len(L)):
+            mixL[j] += L[j]; mixR[j] += R[j]
+    mixL = [v * 0.5 for v in mixL]; mixR = [v * 0.5 for v in mixR]
+    write_wav(outdir / "mix.wav", mixL, mixR)
+    peak = max((abs(v) for v in mixL + mixR), default=0)
+    clip = sum(1 for v in mixL + mixR if abs(v) >= 8388607)
+    print(f"  mix.wav  peak {20 * math.log10(max(peak, 1) / 8388608):6.1f} dBFS"
+          f"{f'  !! {clip} clipped samples' if clip else ''}   (unity sum, -6 dB; no AMP/pan model)")
+    print(f"-> {outdir}")
+    if not a.keep:
+        for p in [out, silent, *raws.values()] + [pathlib.Path(f"{out}.i{k}") for k in range(1, len(inst))]:
+            p.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/send_probe.py
+++ b/tools/send_probe.py
@@ -152,11 +152,14 @@ def die(msg):
 
 
 # ---- payload dump --------------------------------------------------------
-def dump_mem(image, mem):
+def dump_mem(image, mem, payload="A"):
+    """Dump one payload of a built image for dsp_host. "A" is core 0 (tracks
+    5-8), "B" core 1 (tracks 1-4); dsp_host boots either since 7 Sep 2026."""
     sys.path.insert(0, str(ROOT / "tools"))
     import dsp_modmap
+    mem = pathlib.Path(mem)
     mem.parent.mkdir(parents=True, exist_ok=True)
-    dsp_modmap.dumpmem(pathlib.Path(image).read_bytes(), ["A", str(mem)])
+    dsp_modmap.dumpmem(pathlib.Path(image).read_bytes(), [payload, str(mem)])
     return mem
 
 

--- a/tools/verify_bus.py
+++ b/tools/verify_bus.py
@@ -8,10 +8,11 @@ the three copies of the housekeeping block that must stay identical across
 modules/send/send_client.asm, modules/busverb/reverb_server.asm and modules/busdelay/delay_server.asm.
 
 WHY THIS EXISTS. The bus is the one piece of this project whose defining
-property cannot be measured locally at all: dsp_host is single-core, so it is
-always trivially in lockstep and can never show a cross-core race (CLAUDE.md's
-"a measurement can be structurally blind" entry -- this is the instance that
-cost months). What CAN be checked locally is the other half: that a change to
+property cannot be measured locally at all: dsp_host runs the cores in
+lockstep (or under a guessed -skew interleave since 7 Sep 2026 -- a fuzz, not
+the hardware's timing) and so can never show the cross-core race ABSENT
+(CLAUDE.md's "a measurement can be structurally blind" entry -- this is the
+instance that cost months). tools/verify_twocore.py is the two-core gate. What CAN be checked locally is the other half: that a change to
 the bus layout does not alter what the bus DOES. A single core writes the
 current buffer and reads the previous one whatever the rotation length is, so
 going from two buffers to three is invisible here -- and that invisibility is
@@ -360,8 +361,8 @@ def main():
               "those\n  renders is the reference's, just later.")
     print(f"\n  all {len(CASES)} cases bit-identical to the reference.")
     print("  ⚠️  This proves the bus still DOES the same thing. It does NOT\n"
-          "     prove anything about the cross-core race -- dsp_host is\n"
-          "     single-core and is always trivially in lockstep.")
+          "     prove anything about the cross-core race -- this gate runs\n"
+          "     one core, and even two emulated cores are never the chip's timing.")
     return 0
 
 

--- a/tools/verify_twocore.py
+++ b/tools/verify_twocore.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Gate for the two-core harness and for PAYLOAD B's placement.
+
+Until 7 Sep 2026 payload B -- the shipping image's half that carries BusDelay
+and serves tracks 1-4 -- had never run anywhere but on the unit. dsp_host now
+boots both payloads with the shared window Y/X:0x30000-0x3FFFF really shared,
+and this gate pins two things at once:
+
+  1. THE HARNESS: a render with the servers on their REAL cores (SEND and
+     BusDelay on payload B, BusVerb on payload A, the delay's wet crossing the
+     core boundary) must be BIT-IDENTICAL to the same layout on one core
+     through the DEV hatch. The bus arithmetic is core-agnostic under
+     lock-step, so any difference is a harness defect (a window not shared, a
+     context address wrong, a buffer misplaced).
+
+  2. THE IMAGE: payload B's copy of the delay is assembled with its own base
+     literal substituted ($30000 -> $38000, docs/BUS.md) and placed by the
+     SPEC build. Identity with the DEV copy proves that substitution and
+     that placement produce the same audio, which until now was checked
+     statically only.
+
+Plus the fuzz: the same two-core layouts under several -skew interleavings
+must still match. That is NOT a proof of the cross-core race fix (the
+interleave is a guess at the hardware's timing, and the four-buffer rotation
+is designed to survive any single-block skew), but a mismatch there is a
+real defect, and no local test could show one before.
+
+    make verify-twocore          # ~1 min; part of `make check`
+
+Both builds are of the `bus` remix: SPEC (the shipping shape) and DEV (the
+hatch). The shipping artifact is snapshotted and restored, the way
+verify_busscreen does, so `make check`'s remix is what is left on disk.
+"""
+import filecmp
+import os
+import pathlib
+import shutil
+import struct
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+import send_probe  # noqa: E402
+
+OUT = ROOT / "out/dsp"
+SCRATCH = OUT / "_twocore"
+IMAGE = ROOT / "out/mainos_bus.bin"
+DEV_MEM = OUT / "mem_dev_A.mem"
+BLOCKS = 700
+SKEWS = (1, 37, 333, -250)
+
+R = [64, 30, 100, 0, 127, 0, 2, 0, 64, 0, 0, 1]          # manifest defaults
+D = [40, 60, 100, 127, 127, 64, 0, 48, 64, 1, 0, 0]      # -VRB 127: wet on into the reverb
+S_DEL = [127, 0] + [0] * 10
+S_VRB = [0, 127] + [0] * 10
+
+# layout: list of (letter, core, params); instance order is dispatch order
+CASES = {
+    "RS   send on B -> reverb on A":            [("R", 0, R), ("S", 1, S_VRB)],
+    "DS   send on B -> delay on B":             [("R", 0, R), ("D", 1, D), ("S", 1, S_DEL)],
+    "RDS  delay on B -> reverb on A (series)":  [("R", 0, R), ("D", 1, D), ("S", 1, S_DEL)],
+    "SSSR two senders per core":                [("R", 0, R), ("S", 0, S_VRB), ("S", 1, S_VRB), ("S", 1, S_VRB)],
+}
+# which instance's stream each case compares (the server being measured)
+PICK = {"RS": 0, "DS": 1, "RDS": 0, "SSSR": 0}
+
+
+def build(env, log):
+    r = subprocess.run([sys.executable, "tools/build_bus.py"], cwd=ROOT,
+                       env={**os.environ, "REMIX": "bus", **env}, capture_output=True, text=True)
+    log.write_text(r.stdout + r.stderr)
+    if r.returncode != 0:
+        sys.exit(f"build failed ({env}): see {log}")
+
+
+def impulse(path, blocks):
+    pad = send_probe.WARMUP_BLOCKS * send_probe.FRAMES
+    with open(path, "wb") as f:
+        for i in range(blocks * send_probe.FRAMES):
+            f.write(struct.pack("<i", 0x400000 if i == pad else 0))
+
+
+def run(mems, layout, out, skew=None):
+    """mems: {core: path}. Instances get per-core positions."""
+    ep = {}
+    for c, m in mems.items():
+        ep[c] = {L: send_probe.entry_points(m, send_probe.SERVER_ID[L]) for L in "RDS"}
+        if ep[c]["D"] == ep[c]["S"] and any(L == "D" and core == c for L, core, _ in layout):
+            sys.exit(f"payload for core {c} ({m.name}) has no real delay -- wrong build")
+    pos = {}
+    cmd = [str(send_probe.HOST), "-mem", str(mems[0])]
+    if 1 in mems:
+        cmd += ["-memB", str(mems[1])]
+    cores, allocs, r7s, inits, procs, inmask = [], [], [], [], [], 0
+    for k, (L, c, _) in enumerate(layout):
+        p = pos.get(c, 0); pos[c] = p + 1
+        cores.append(str(c)); allocs.append(str(1 + 2 * p)); r7s.append(str(2 + 2 * p))
+        inits.append(f"{ep[c][L][0]:x}"); procs.append(f"{ep[c][L][1]:x}")
+        if L == "S":
+            inmask |= 1 << k
+    cmd += ["-init", ",".join(inits), "-proc", ",".join(procs), "-inst", str(len(layout)),
+            "-core", ",".join(cores), "-alloc", ",".join(allocs), "-r7", ",".join(r7s),
+            "-inmask", str(inmask), "-frames", str(send_probe.FRAMES), "-blocks", str(BLOCKS),
+            "-in", str(SCRATCH / "imp.raw"), "-out", str(out)]
+    for _, _, pv in layout:
+        cmd += ["-params", ",".join(map(str, pv))]
+    if skew is not None:
+        cmd += ["-skew", str(skew)]
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    if r.returncode != 0:
+        sys.exit(f"dsp_host failed:\n{r.stdout[-2000:]}{r.stderr[-1000:]}")
+    return r.stdout
+
+
+def stream(out, k):
+    return out if k == 0 else pathlib.Path(f"{out}.i{k}")
+
+
+def main():
+    SCRATCH.mkdir(parents=True, exist_ok=True)
+    snap = SCRATCH / "mainos_bus.snapshot.bin"
+    had = IMAGE.is_file()
+    if had:
+        shutil.copy2(IMAGE, snap)
+    try:
+        build({"XBUS": "1", "SPEC": "1"}, SCRATCH / "build_spec.log")
+        specA = send_probe.dump_mem(IMAGE, SCRATCH / "spec_A.mem", "A")
+        specB = send_probe.dump_mem(IMAGE, SCRATCH / "spec_B.mem", "B")
+        build({"XBUS": "1", "DEV": "1"}, SCRATCH / "build_dev.log")
+        if not DEV_MEM.is_file():
+            sys.exit(f"DEV build left no {DEV_MEM}")
+    finally:
+        if had:
+            shutil.copy2(snap, IMAGE)
+    impulse(SCRATCH / "imp.raw", BLOCKS)
+
+    fails = 0
+    print(f"two-core gate: {len(CASES)} layouts, SPEC two-core vs DEV one-core, then skews {SKEWS}")
+    for name, layout in CASES.items():
+        key = name.split()[0]
+        k = PICK[key]
+        two = run({0: specA, 1: specB}, layout, SCRATCH / f"{key}_two.raw")
+        one = run({0: DEV_MEM}, [(L, 0, pv) for L, _, pv in layout], SCRATCH / f"{key}_one.raw")
+        a, b = stream(SCRATCH / f"{key}_two.raw", k), stream(SCRATCH / f"{key}_one.raw", k)
+        nz = [l for l in two.splitlines() if f"instance {k}:" in l and "non-zero" in l]
+        silent = nz and nz[0].split()[2] == "0"
+        same = filecmp.cmp(a, b, shallow=False)
+        ok = same and not silent
+        fails += not ok
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:42s} "
+              f"{'silent!' if silent else ('identical' if same else 'DIFFERS')}")
+        if not same and not silent:
+            continue
+        for sk in SKEWS:
+            run({0: specA, 1: specB}, layout, SCRATCH / f"{key}_sk.raw", skew=sk)
+            s = filecmp.cmp(stream(SCRATCH / f"{key}_sk.raw", k), a, shallow=False)
+            fails += not s
+            print(f"       {'ok  ' if s else 'FAIL'} skew {sk:5d} {'identical' if s else 'DIFFERS'}")
+    if fails:
+        sys.exit(f"two-core gate: {fails} FAILURE(S)")
+    print("two-core gate: every layout bit-identical across cores and under every skew.")
+    print("  ⚠️  Identity under skew is not proof of the race fix -- the interleave is a")
+    print("     guess at the hardware's timing. A mismatch here would be a real defect.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Tier 1 of the emulator uplift (7 Sep 2026): the harness boots payload A **and** payload B as two DSPs in one process with the shared window `0x30000–0x3FFFF` really shared, so the shipping image's BusDelay (payload B, tracks 1–4) runs locally for the first time and everything that crosses the core boundary renders on real cores.

- `tools/dsp_host`: `-memB`, `-core`, `-audioidx` (FX1→FX2 chain on one buffer), per-instance `-in`, `-skew` (instruction-level interleave), `-meter` (instructions per block per core). Payload B's frame-context routine is found by opcode pattern (`P:0x17a..0x1a3`, exit `0x333`; A's `0x372..0x39e`, `0x53e`) — measured, not assumed. Lock-step by default: `make verify-bus` 19/19 across the rewrite.
- `tools/dsp56300.patch`: the vendored emulator's `Memory` gains a shared window.
- `tools/rig_render.py` / `make render-rig`: all eight tracks on both cores, ids + knobs from a project part or by name, stems in, per-track + mix wavs + meter out. ~real time.
- `tools/verify_twocore.py` (in `make check`): SEND + BusDelay on the real payload B feeding BusVerb on A render **bit-identical** to the DEV hatch across the send hop, the delay hop, the series hop and two-senders-per-core, and under four skews. Payload B's `$38000` placement had only ever been checked statically.

Not the chip's timing (identity under skew proves nothing; a mismatch is a defect), not the cycle cliff, not the ColdFire. Docs updated wherever "single-core" / "cannot boot payload B" was recorded.

`make check` green (291 + the new gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)