### PR TITLE
One-aux follow-ups: return pinned to T8 by the dispatch table, fallback SEND in rig_render, levels measured on material

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -16,10 +16,13 @@
 > `tools/verify_onebus.py` (in `make check`) measures every property with
 > the senders and delay on payload B and the reverb and return on payload A.
 > ⚠️ Every project must be `stamp-defaults`'d for the re-slot before play
-> (page 1 of both engines shifted right by one). ⚠️ Open ear item: the
-> repeats-vs-reverb balance at the return is the reverb's MIX alone, and the
-> reverb's wet is ~25 dB under a sustained input where the delay's is not.
-> (The spec artifact is gone; the design is in the memory and in BUS.md.)
+> (page 1 of both engines shifted right by one). The return balance is
+> measured fine on material (repeats and wet within 2 dB on drums and pad;
+> the tone-based "25 dB" alarm is retracted, VOICING R63); renders for the
+> ear are parked in `out/rig/oneaux/`. The rig's cycle floor by the meter:
+> core 0 1,570 instructions/sample, core 1 702 (`docs/HARNESS.md`). The
+> card project is prepared at `out/projects/OCTABAM_ONEAUX` (FLASHPLAN
+> Flash 6). (The spec artifact is gone; the design is in BUS.md.)
 > Sections below that describe two buses are history.
 
 # The plan: end state, resource ledger, and work order

--- a/docs/BUS.md
+++ b/docs/BUS.md
@@ -455,11 +455,13 @@ every track  ──AUX──▶  [aux accumulator]  ──▶  BusDelay  ──c
   level, `RET` (the CRSH knob; RING is inert in BUS mode). It returns the
   **last live stage's** output — the reverb's if the reverb runs, else the
   delay's, else digital silence — and stamps BOTH hosts quiet while it is
-  up. The return is **pinned to dispatch position 3** (`r7 $6700/$6800`):
-  track 8 on core 0, and the mirror slot, track 4, on core 1 — a BUS-mode
-  station anywhere else returns nothing. (Position, not track number: a
-  DSP instance does not know its track; core 1's position 3 is T4 and it
-  cannot be told apart without a per-payload gate.)
+  up. The return is **pinned to track 8**: dispatch position 3 (`r7
+  $6700/$6800`) on payload A only — a BUS-mode station anywhere else,
+  core 1's mirror position (T4) included, returns nothing (gated, both).
+  The core is read off the dispatch table: BusVerb's entry is real on
+  payload A and the SEND alias on B (`X:$21c` vs `X:$21e`); an insert can
+  carry no per-payload literal, since an FX1 module may own no buffers.
+  Consequence: a remix without BusVerb has no return anywhere.
 - **The send is refused on track 8.** `SEND` at core 0's position 3
   contributes nothing and registers nothing whatever its knob says — the
   master loop that silenced the unit on 6 Sep 2026 (`FAILURE_MODES.md`) is
@@ -514,13 +516,17 @@ Falsifiers: a return that flickers (a stamp lost across cores beyond three
 blocks); T8's SEND audible in the return (the pin is wrong); the delay's
 repeats missing from the reverb (the chain buffer's rotation).
 
-**Voicing item, open.** The return's balance between repeats and reverb is
-now the reverb's MIX alone, and the reverb's wet sits ~25 dB under a
-sustained input where the delay's output sits near it (measured in the gate:
-delay-only return −11 dB rms, reverb-only −36 dB for the same tone at two
-senders). At MIX 64 the repeats are −6 dB and the wet is −6 dB relative:
-the reverb all but disappears. Whether the reverb stage wants a fixed
-makeup on its wet (the old +9.5 dB IN makeup, unkeyed) is an ear question.
+**Voicing, measured on material (7 Sep, `out/rig/oneaux/`).** The first
+reading of the return balance — "the reverb's wet sits ~25 dB under the
+repeats" — came from the gate's 438 Hz tone and is ❌ **retracted**: a
+steady sine is the one input a reverb's level says nothing about. On the
+drum loop the return reads −25.1 dB rms with the reverb at MIX 0 (repeats
+through) and −26.8 at MIX 127 (wet only); on the pad −31.4 vs −32.8. The
+two components sit within 2 dB of each other, so **no makeup is needed**
+and MIX 64 lands 3 dB under either alone, as a crossfade of two
+uncorrelated signals should. The sweep renders (reverb MIX 0/32/64/96/127,
+both sources, plus reverb-only, delay-only and dry) are parked in
+`out/rig/oneaux/` for the ear.
 
 ## Menu and slot layout
 

--- a/docs/FLASHPLAN.md
+++ b/docs/FLASHPLAN.md
@@ -319,6 +319,8 @@ python3 tools/ot_project.py stamp-defaults /Volumes/<card>/<set copy> bamsep27
 30–50 on T2–T4/T6–T7, the hosts' `AUX` on T1/T5, T8 = Character SAT=BUS
 RET 127 and NO FX2 (nothing to refuse). T8's old `-VRB 71` (the master loop)
 cannot exist: the station has no send slot and the SEND is refused there.
+**Prepared 7 Sep 2026: `out/projects/OCTABAM_ONEAUX`** (from the 6 Sep
+cleared backup, 16 banks written and read back) — copy it to the card as is.
 
 **Claims, in this order (each failure has its own shape):**
 
@@ -330,7 +332,7 @@ cannot exist: the station has no send slot and the SEND is refused there.
 | iv | MIX | delay MIX 0: the reverb of the DRY sends, no repeats; reverb MIX 64: repeats under the tail | MIX changing level but not blend |
 | v | the refusal | put SEND on T8's FX2 with AUX 127: nothing changes; the same on T4: it sends | T8 audible in the return (the position pin is wrong) |
 | vi | stations silent | a station on any track with its old send bytes (a tag-17 part, unstamped, on a scratch copy) sends nothing | a station's track in the reverb with its AUX at 0 |
-| vii | the return pin | a BUS-mode Character on T7: returns nothing; on T8: returns | a return from T7 |
+| vii | the return pin | a BUS-mode Character on T7 or T4: returns nothing; on T8: returns | a return from T7 or T4 |
 | viii | cross-core stamps | play for minutes: no flicker of the return, no host print creeping back | the return dropping out and back (a stamp lost > 3 blocks) |
 
 **Stop condition:** any of ii–iv failing on the unit after passing

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -253,9 +253,26 @@ budget; the emulator never sees the cliff.
 **`tools/rig_render.py`** drives it track by track: `--tracks T1=D,T2=S,…`
 (or `T3=L+S` for FILTER on FX1 into a SEND on FX2), or `--project DIR
 --bank N --part N` for the ids **and knob bytes** of a real part; stems per
-track; T1–T4 on core 1, T5–T8 on core 0 in dispatch order; out come
+track; T1–T4 on core 1, T5–T8 on core 0 in dispatch order, and an empty
+FX2 slot modelled as the fallback SEND the unit dispatches there (without
+it a layout with nothing at core 0's position 0 had no housekeeper and the
+bus never rotated — a delay-only render was silent, 7 Sep 2026); out come
 `T1.wav…T8.wav`, `mix.wav` (unity sum, −6 dB) and `meter.txt`. About real
 time for eight tracks on two cores. `make render-rig`.
+
+**The rig's floor, metered (7 Sep 2026, `bamsep27`, the RIG table with
+eight stems):** core 0 (Modulation + BusVerb on T5, Spectrum + SEND on T6/T7,
+Character BUS + the fallback SEND on T8) **1,570 instructions/sample** at
+its worst block; core 1 (Character + BusDelay on T1, Spectrum + SEND on
+T2–T4) **702**. ⚠️ Instructions, not cycles — and the 3,120 wall was
+triangulated in `tools/cycle_count.py`'s units (words in the sample loop),
+so the STATIC sum is the comparable floor: for this layout **core 0 = 3,005**
+(BusVerb 1,408 + Modulation 434 + 2 × Spectrum 341 + Character 436 + 3 × SEND
+15) and **core 1 = 2,812** (BusDelay 1,308 + Character + 3 × Spectrum + 3 ×
+SEND). Core 0 sits 115 under the wall before contention — the same class as
+the tag-91 hang at 3,106. The meter reads about half the static count
+(multi-word instructions count once) and is the per-block, init-inclusive
+shape of the load, not a second calibration.
 
 What it still is not: the ColdFire. Knobs are poked into `r6`, AMP/pan and
 the mixer are a unity sum, samples do not play (stems stand in), and the

--- a/docs/VOICING.md
+++ b/docs/VOICING.md
@@ -2110,13 +2110,15 @@ listened to. What the ear will meet, from the numbers:
   bit. A render of the reverb host's OWN material (`render_reverb`, AUX 64)
   prints 6 dB lower than v8 at the same tank drive; the bench baselines in
   this file predate that.
-- **The return's repeats-vs-reverb balance is the reverb's MIX alone.** The
-  reverb's stage output is `in × (1 − MIX) + wet × MIX` where `in` is the
-  delay's output. Measured in `verify_onebus` with a 438 Hz tone at two
-  senders: the delay-only return sits at −11 dB rms, the reverb-only at
-  −36 dB. At MIX 64 both halve, and the reverb all but vanishes under the
-  repeats. **Open**: whether the reverb stage wants a fixed (unkeyed) wet
-  makeup of the +9.5 dB the IN law used to give at full IN, so MIX behaves
-  like a mixer's wet/dry over its whole travel. Decide by ear on the rig
-  (T2 AUX up, reverb MIX swept), not on the tone.
+- **The return's repeats-vs-reverb balance is the reverb's MIX alone**, and
+  it is ✅ fine on material. ❌ The "reverb 25 dB under the repeats" alarm
+  (a 438 Hz tone in the gate: −11 vs −36 dB) is retracted — a steady sine
+  says nothing about a reverb's level. Measured the same evening on the
+  drum loop and the pad through the rig (`out/rig/oneaux/levels.json`):
+  return at reverb MIX 0 (repeats through) −25.1 / −31.4 dB rms, at MIX 127
+  (wet only) −26.8 / −32.8 — within 2 dB, so no makeup; MIX 64 sits 3 dB
+  under either, a crossfade of two uncorrelated signals. The sweep
+  (MIX 0/32/64/96/127, both sources, plus reverb-only, delay-only, dry) is
+  parked in `out/rig/oneaux/` for the ear: what is left to judge is
+  character, not level.
 - **PTCH moved to page 2** (slot 10), MIX took page-1 slot 5 on the delay.

--- a/modules/character/character.asm
+++ b/modules/character/character.asm
@@ -246,8 +246,8 @@ ch_mskz:
         move    #>$20000,x0
         cmp     x0,a
         beq     ch_srr4
-        move    #>$30000,x0
-        cmp     x0,a
+        move    #>$030000,x0            ; 3<<16 (zero-padded: not the base
+        cmp     x0,a                    ; literal the build rewrites)
         beq     ch_srr8
         clr     a                       ; OFF, and anything unexpected
         bra     ch_srrz
@@ -342,12 +342,12 @@ ch_cdone:
         move    #>$20000,x0
         cmp     x0,a
         beq     ch_sfuzz
-        move    #>$30000,x0
+        move    #>$030000,x0            ; 3<<16 = BUS (zero-padded, see above)
         cmp     x0,a
         beq     ch_sbus
         bra     ch_sdone                ; TAPE: the curve alone
 ch_stube:
-        move    #>$300000,x0            ; neg = 0.75: the positive half is
+        move    #>$0300000,x0           ; neg = 0.75: the positive half is
         move    x0,x:(r7+$37)           ; driven harder, so even harmonics
         bra     ch_sdone
 ch_sfuzz:
@@ -370,11 +370,24 @@ ch_sbus:
 ; ONE RETURN (the one-aux rig, 7 Sep 2026): RET (the CRSH knob) is the level
 ; of the LAST LIVE STAGE's output -- the reverb's if it is running, else the
 ; delay's, else nothing -- resolved below from the engines' liveness stamps.
-; The RING knob is inert in BUS mode. And the return is PINNED to dispatch
-; position 3 (r7 $6700/$6800: track 8 on core 0; its mirror is track 4 on
-; core 1): a BUS-mode station anywhere else returns nothing.
+; The RING knob is inert in BUS mode. And the return is PINNED to TRACK 8:
+; dispatch position 3 (r7 $6700/$6800) on payload A only -- a BUS-mode
+; station anywhere else, core 1's position 3 (track 4) included, returns
+; nothing.
         move    x:(r6+$2),x0
         move    x0,x:(r7+$3e)           ; RET level (the CRSH knob)
+; ... on PAYLOAD A ONLY: the mirror position on core 1 is track 4. An insert
+; carries no per-payload literal (an FX1 module may own no buffers, so the
+; build refuses it a base), so the core is read off the DISPATCH TABLE: in
+; the specialized image BusVerb (id 0x07) is real on payload A and ALIASED
+; TO SEND (id 0x09) on payload B -- X:$215+7 == X:$215+9 there. Under the
+; DEV hatch everything is payload A and the test allows. Consequence: a
+; remix WITHOUT BusVerb has no return anywhere (its id aliases on both
+; cores); the rig always carries it on T5.
+        move    x:>$21c,a               ; INIT_TABLE[REVERB SERVER]
+        move    x:>$21e,x0              ; INIT_TABLE[SEND]
+        cmp     x0,a
+        beq     ch_nopos                ; the alias: payload B, never the return
         move    r7,a
         and     #>$ff00,a
         move    #>$6700,x0
@@ -383,8 +396,9 @@ ch_sbus:
         move    #>$6800,x0
         cmp     x0,a
         beq     ch_pos3
+ch_nopos:
         clr     a
-        move    a,x:(r7+$3e)            ; not position 3: no return
+        move    a,x:(r7+$3e)            ; not track 8: no return
 ch_pos3:
 ch_sdone:
 ; WDTH -> mid and side gains. 64 = (1, 1); 0 = (1, 0) mono; 127 = (1, ~2).

--- a/modules/character/manifest.py
+++ b/modules/character/manifest.py
@@ -108,7 +108,9 @@ MODULE = Module(
         asm="modules/character/character.asm",
         priority=13,                  # after the Spectrum station
         bus_role=BusRole.NONE,        # an insert that also WRITES the bus
-        ybase=YBase.NEVER,
+        ybase=YBase.NEVER,                # (an FX1 module may own no buffers;
+                                          # the return's payload test reads the
+                                          # dispatch table instead -- see the source)
         r7_latch_slot=0x69,           # ROTLATCH parks this block's offset here
         gate_label=None,              # no housekeeping: a station never elects
     ),

--- a/tools/rig_render.py
+++ b/tools/rig_render.py
@@ -245,6 +245,17 @@ def main():
 
     # instances, in dispatch order: core 0 (tracks 5-8) then core 1 (1-4),
     # each track FX1 then FX2 on ONE audio buffer
+    # An EMPTY FX2 slot is not empty on the unit: a fresh or unassigned track
+    # dispatches to the fallback, SEND (id 0 aliases to it), which houskeeps
+    # like any bus participant and costs its cycles. Model it, or a layout
+    # with nothing on core 0's position 0 has no housekeeper at all and the
+    # bus never rotates (found 7 Sep 2026: a delay-only render was silent).
+    send_mod = registry.modules().get("SEND")
+    r_ = registry.remix(a.remix)
+    if send_mod is not None and "SEND" in r_.modules:
+        for t in range(1, NTRACKS + 1):
+            if not any(s.fx == 2 for s in tracks.get(t, [])):
+                tracks.setdefault(t, []).append(Slot(send_mod, 2, defaults_of(send_mod)))
     inst = []            # dicts
     for t in [5, 6, 7, 8, 1, 2, 3, 4]:
         for s in tracks.get(t, []):
@@ -345,7 +356,7 @@ def main():
             p = out if k == 0 else pathlib.Path(f"{out}.i{k}")
             arr = array.array("i"); arr.frombytes(p.read_bytes())
             L, R = list(arr[0::2])[pad:], list(arr[1::2])[pad:]
-        elif t in stems:                       # no effect at all: the stem passes through
+        elif t in stems:                       # no instance at all: the stem passes through
             x = stems[t]
             L = [int(a.amp * (x[j] if j < min(len(x), n_src) else 0.0) * 8388607) for j in range(n - pad)]
             R = list(L)

--- a/tools/verify_onebus.py
+++ b/tools/verify_onebus.py
@@ -280,6 +280,18 @@ def main():
     st_4 = run(mems, t4, tag="t4")
     check("a SEND on T4 (core 1 pos 3, the mirror) DOES change it", st_4[2] != ret)
 
+    print("\n== the return is pinned to track 8, and only there ==")
+    r4 = [R(), S6(), D(), S2(), Inst("CHARACTER", 1, 3, fx=1, SAT=3, RET=127)]
+    st_r4 = run(mems, r4, tag="ret4")
+    check("a BUS-mode station on T4 (core 1 pos 3) returns nothing",
+          peak(st_r4[4][0] + st_r4[4][1]) == 0, f"peak {peak(st_r4[4][0] + st_r4[4][1])}")
+    check("... and the hosts keep printing (it stamped nothing)",
+          rms_db(st_r4[0][0]) > -45 and rms_db(st_r4[2][0]) > -45)
+    r7 = [R(), S6(), Inst("CHARACTER", 0, 2, fx=1, SAT=3, RET=127), D(), S2()]
+    st_r7 = run(mems, r7, tag="ret7")
+    check("a BUS-mode station on T7 (core 0 pos 2) returns nothing",
+          peak(st_r7[2][0] + st_r7[2][1]) == 0)
+
     print("\n== the stations have no sends ==")
     # a Spectrum station on T6's FX1 with the OLD send bytes stored (slots 4
     # and 5 at 127, what a pre-rig part holds) beside T6's SEND at AUX 100


### PR DESCRIPTION
Follow-ups to #133, all measured locally.

- **Return pinned to track 8 only**: payload A's position 3; core 1's mirror (T4) now refuses too. The core is read off the dispatch table (BusVerb's entry is the SEND alias on B) because an FX1 module may own no shared-window base. Gated: a BUS-mode station on T4 or T7 returns nothing and stamps nothing.
- **rig_render** models an empty FX2 as the fallback SEND (as the unit does); without it a delay-only layout had no housekeeper and rendered silence.
- **Return balance on material**: repeats and reverb wet within 2 dB at the return on the drum loop and the pad, so no makeup. The tone-based "25 dB" alarm from #133 is retracted (VOICING R63). Sweep renders parked in `out/rig/oneaux/`.
- **Rig cycle floor**: static core 0 = 3,005 of 3,120 (115 under the wall before contention, the tag-91 class), core 1 = 2,812; the meter reads 1,570 / 702 instructions per sample and is not calibrated against the wall.
- **Card project prepared**: `out/projects/OCTABAM_ONEAUX` (rigproj from the 6 Sep cleared backup, 16 banks read back).

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)