### PR TITLE
The ColdFire port: a headless Octatrack in C++ that boots to the RTOS handoff, with a gated EMAC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,12 @@ render-rig: bus ## Render ALL EIGHT TRACKS on both cores (the real image, tracks
 verify-twocore: ## Two-core gate: servers on their REAL cores == the DEV hatch, bit for bit, and under 4 skews (~1 min)
 	python3 tools/verify_twocore.py
 
+.PHONY: emu-cf
+emu-cf: ## Build and run the headless ColdFire machine (tools/ot_emu) -- boots to the RTOS handoff
+	cmake -B out/emu -S tools/ot_emu >/dev/null
+	cmake --build out/emu -j8 >/dev/null
+	./out/emu/ot_emu --image $(if $(IMAGE),$(IMAGE),out/raw/section_3_MAIN_OS.bin)
+
 .PHONY: verify-onebus
 verify-onebus: ## THE ONE AUX BUS on both cores: chain, last-live-stage return, MIX passthrough, T8 refusal, no station sends (~2 min)
 	python3 tools/verify_onebus.py

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -51,6 +51,42 @@ real time needs: **≈4.5× slower than real time today**, before the one obviou
 optimisation below. Real time is genuinely in reach, which was the open
 question when the port was scoped.
 
+## Milestone O2 — the EMAC, and its gate ✅ (7 Sep 2026)
+
+**The gate was written FIRST and watched to fail**, which is the whole
+discipline: `tools/ot_emu/test_emac.cpp` encodes hardware's semantics from
+`emu_bringup.emac_selftest` (fractional `macl 0xc00 x 0x200000` -> 3, the
+negative operand -> -3, `msacl` SUBTRACTS -> -3) and reported all three FAIL
+against an emulator with no EMAC before a line of it existed. It passes now.
+`ctest` in the build dir runs it beside the vendored core's own ColdFire
+timing, divide and HI08 tests: **4 tests, all passing.**
+
+What the implementation had to get right, each of which is a defect Unicorn
+shipped (`RTOS_FORK.md` §10.16):
+
+- **Fractional mode is a signed product shifted LEFT ONE, upper 40 bits
+  accumulated** — so `movclrl` yields `(a*b) >> 31`, not `>> 32`. Off by that
+  one bit is what wrote 10,336 for Bryan's 20,672 and got explained away as
+  "2-sample units" for a day.
+- **MAC vs MSAC comes from bit 8 of the EXTENSION word**, never the opcode
+  word. Reading it from the opcode is what made every `msac` add.
+- The EMAC's whole state (four accumulators, their extension bytes, MACSR)
+  lives in this layer, because Musashi's ColdFire state has none.
+
+✅ **And one structural finding, measured the moment the gate ran:** every EMAC
+opcode is `0xAxxx`, i.e. **A-line**, and Musashi routes A-line to
+`m68ki_exception_1010` — a *different* path from the illegal-instruction
+callback, with no callback of its own. So the V4e layer never saw them: the
+test failed with D0 still holding the value the program's first instruction
+loaded. The EMAC is dispatched from `Machine::run`'s own loop instead, reusing
+the opcode fetch already made for the handoff check, which leaves the vendored
+Musashi unpatched. `mov3q` (`a340`) rides the same path.
+
+⚠️ Encodings for all of it came out of `m68k-elf-as -mcpu=5475`, listed in the
+source beside each handler. ❌ **Retracted from O1's work list:** `byterev` and
+`ff1` are **not** V4e — the assembler refuses them for `-mcpu=5475` and names
+the parts that do have them (ISA_C). Nothing needs them.
+
 ### What had to be built, and what each cost
 
 **1. The V4e instructions, as trap-and-emulate (`v4e.cpp`).** Musashi's opcode

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -1,0 +1,128 @@
+# The ColdFire port (`tools/ot_emu`) — a headless Octatrack in C++
+
+> **What this is for.** `tools/emu_rtos.py` (route A) runs the firmware's own
+> scheduler and is the **oracle** every claim here is measured against — but it
+> costs about 120× real time, models no audio, and stops at the DSP host port.
+> `tools/dsp_host` runs both DSP cores at roughly real time and knows nothing
+> of the ColdFire. This is the join: one process, both halves, fast enough to
+> drive interactively. Deliberately **not** a plugin — no JUCE, no UI, no audio
+> device. A library and a CLI you can script and intercept.
+
+Confidence markers as in `CHIP.md`: ✅ measured, 🟡 inferred, ❌ retracted.
+
+## Where it came from
+
+Sam found `joelanders/gearmulator-md-mm` (7 Sep 2026), a full-system
+Machinedrum / Monomachine emulator that runs its firmware in **real time** as a
+plugin: a Musashi-based ColdFire, two DSP56303s over HI08, one deterministic
+interleave scheduler paced by the mixer DSP's frame counter. It proves the
+architecture on the cousin machine. What it does **not** give us is the
+Octatrack's CPU: its Musashi is ColdFire **V2** (`MCF5206E`, ISA_A), with no
+EMAC, none of the V4e instructions this firmware uses everywhere, and none of
+the MCF5445x peripherals.
+
+So we vendor the small piece that helps — `vendor/mc68k`, its submodule: a
+standalone static library with Musashi, ColdFire mode, an HI08 host-port
+register file and peripheral scaffolding, no JUCE anywhere — and write the rest
+against route A as the specification. Licences: mc68k is GPLv3 and Musashi is
+Karl Stenerud's; the same posture as `vendor/dsp56300`, which this repo has
+vendored all along. **Tooling and patches are shared; built binaries are not.**
+
+## Milestone O1 — boot to the RTOS handoff ✅ (7 Sep 2026)
+
+```sh
+make emu-cf                    # or: cmake -B out/emu -S tools/ot_emu && cmake --build out/emu -j8
+./out/emu/ot_emu --image out/raw/section_3_MAIN_OS.bin --profile --periph
+```
+
+**It reaches `trap #0`, and it agrees with the oracle:**
+
+| | route A (`emu_bringup.boot`) | `ot_emu` |
+|---|---|---|
+| handoff PC | `0x40000e46` | `0x40000e46` ✅ |
+| auto-poke 1 | loop `0x4000f9e2`, wrote `0xffff` to `0x0` | identical ✅ |
+| auto-poke 2 | loop `0x4000fa02`, wrote `0xffff` to `0x2000` | identical ✅ |
+| instructions | 10,000,000 (counted in 500k bursts) | 10,170,953 exactly |
+
+**Speed, measured on this machine: 39.1 M instructions/s**, boot to handoff in
+**0.26 s** — about **26× route A's ~1.5 M/s**. For scale, a 16-sample DSP frame
+is ≈63,800 ColdFire instructions, so this is ≈613 frames/s against the 2,756
+real time needs: **≈4.5× slower than real time today**, before the one obvious
+optimisation below. Real time is genuinely in reach, which was the open
+question when the port was scoped.
+
+### What had to be built, and what each cost
+
+**1. The V4e instructions, as trap-and-emulate (`v4e.cpp`).** Musashi's opcode
+tables are GENERATED, and ✅ the generator checked into the tree is **not** the
+one that produced the checked-in tables: regenerating rewrites every handler
+signature (the upstream fork threads a `m68ki_cpu_core*` through them, the
+shipped generator does not), an 18,984-line diff. So the tables are frozen.
+Instead, `m68ki_exception_illegal` calls the illegal-instruction callback
+**first** and takes no exception if it returns nonzero, which makes that
+callback a legal extension point: decode, execute, advance the PC over the
+extension words, return 1.
+
+Implemented so far: **MVS/MVZ** (`0111 rrr 1 oo eeeeee`, `oo` = MVS.B / MVS.W /
+MVZ.B / MVZ.W) with a full effective-address reader. ✅ The encoding was pinned
+against `m68k-elf-objdump -m m68k:cfv4e` on the real image, never against a
+reading of the manual — the boot's own first two are
+`4000043e: 73c1 mvzw %d1,%d1` and `40000440: 71c0 mvzw %d0,%d0`. That covers
+**961,786 of the boot's 10.2M instructions**, and the boot needs nothing else.
+
+⚠️ **Still to come**: `mov3q`, `byterev`, `ff1`, and the whole **EMAC**. The
+EMAC is the one to be careful with — `RTOS_FORK.md` §10.16 is a week lost to
+three defects in *Unicorn's* EMAC, each producing a confident wrong finding for
+a day. `emu_bringup.emac_selftest` already encodes the measured contract
+(`macl` fractional `0xc00 × 0x200000` → 3, negative → −3, `msacl` → −3) and
+should be ported as a CTest **before** any EMAC handler is trusted.
+
+⚠️ **And watch the cost model**: an exception round trip per instruction is
+fine for moves scattered through the code, and may not be for the frame
+builder, which runs EMAC in bulk (~7,400 instructions per frame). If it bites,
+these handlers become the reference an opcode-table implementation is diffed
+against.
+
+**2. Byte-addressable peripheral overrides.** Musashi composes a 32-bit
+peripheral read from two 16-bit reads, so an override stored whole and returned
+per access is truncated to the access width. The PLL register read back
+`0x0000ffff` instead of `0x16000000` and the firmware spun forever in its clock
+check at `0x4000f9e8`. Overrides are per byte now.
+
+**3. The stall detector and auto-poke, ported from route A field for field.**
+A PC confined to a 64-byte window across four 500k bursts, with fewer than
+2,000 stores in between, is a poll rather than a memset; `tryAutoPoke` then
+looks for `move.w (abs),d0 … cmpi #imm,d0` around it and writes the immediate
+to the flag **at the load width** — two bytes, not the compare's width, or the
+low word reads back wrong. Both flags it finds match route A's exactly. These
+are the places the emulator stands in for hardware nobody has modelled yet, and
+the CLI prints them every run rather than hiding them.
+
+## What is NOT here yet
+
+- **The MCF5445x peripherals.** INTC0/1, both PITs, the eDMA with its
+  completion-timing rules, DSPI, the UARTs, FlexBus/ATA and the card. All are
+  modelled in route A's Python, commented rule by rule with each failure mode
+  recorded — that is the specification, and translating it is the bulk of the
+  mechanical work.
+- **The DSP side.** `dsp56kEmu` is already vendored, already patched for the
+  shared window (`tools/dsp56300.patch`), and `tools/dsp_host` already runs both
+  cores. Joining them needs the host-port protocol, which was decoded on
+  7 Sep 2026 from the tape recorder (`emu_rtos.py --tape`): per frame the
+  ColdFire alternates the cores, writes `0x81`, sends a destination/count pair
+  to `0x2000001c`, then DMAs — 336-word per-track records plus a 128-word and a
+  64-word block per core, with one 64-word block read back.
+- **Audio out.** The ESAI path is untraced.
+
+## The order to do it in
+
+1. Port `emac_selftest` as a CTest, then the EMAC handlers. Nothing that
+   computes should be trusted before that gate exists.
+2. The peripherals, translated from route A, each with route A as the diff.
+3. The DSP cores and the host port; audio last.
+
+The rule that makes the rest delegable: **route A is the oracle.** Any
+disagreement between the two emulators is a finding, not a nuisance, and the
+one to trust is whichever can point at a firmware constant that only makes
+sense one way (`RTOS_FORK.md` §10.16's reciprocal tables are the worked
+example).

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -30,6 +30,19 @@ else
 fi
 
 echo
+echo "== 1b) mc68k (ColdFire core for the headless machine) =="
+# Musashi plus ColdFire mode, an HI08 host-port register file and the on-chip
+# peripheral scaffolding -- the CPU half of tools/ot_emu. Vendored, GPLv3, the
+# same posture as vendor/dsp56300: tooling and patches are shared, built
+# binaries never are. `docs/COLDFIRE_PORT.md`.
+if [ ! -d vendor/mc68k ]; then
+  git clone https://github.com/joelanders/mc68k-md-mm vendor/mc68k
+else
+  echo "   already cloned; git pull ..."
+  git -C vendor/mc68k pull --ff-only || true
+fi
+
+echo
 echo "== 2) elektron-firmware-tool (mischa85) =="
 if [ ! -d vendor/elektron-firmware-tool ]; then
   git clone https://github.com/mischa85/elektron-firmware-tool vendor/elektron-firmware-tool

--- a/tools/ot_emu/CMakeLists.txt
+++ b/tools/ot_emu/CMakeLists.txt
@@ -1,0 +1,28 @@
+# The headless Octatrack machine: a ColdFire and (later) two DSP56300 cores in
+# one process, driven from a CLI. No JUCE, no plugin, no audio device -- the
+# deliverable is a library and a program you can script and intercept.
+#
+#   cmake -B out/emu -S tools/ot_emu && cmake --build out/emu -j8
+#   out/emu/ot_emu --image out/raw/section_3_MAIN_OS.bin
+cmake_minimum_required(VERSION 3.16)
+project(ot_emu CXX C)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(OT_VENDOR "${CMAKE_CURRENT_SOURCE_DIR}/../../vendor" CACHE PATH "vendored emulator cores")
+
+# mc68k: Musashi plus the ColdFire mode, the HI08 host-port register file and
+# the on-chip peripheral scaffolding. Vendored, GPLv3 -- the same posture as
+# vendor/dsp56300: tooling and patches are shared, built binaries never are.
+add_subdirectory("${OT_VENDOR}/mc68k" "${CMAKE_CURRENT_BINARY_DIR}/mc68k" EXCLUDE_FROM_ALL)
+
+add_library(ot_machine STATIC machine.cpp machine.h v4e.cpp v4e.h)
+target_include_directories(ot_machine PUBLIC "${OT_VENDOR}" "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(ot_machine PUBLIC 68kEmu)
+
+add_executable(ot_emu main.cpp)
+target_link_libraries(ot_emu PRIVATE ot_machine)

--- a/tools/ot_emu/CMakeLists.txt
+++ b/tools/ot_emu/CMakeLists.txt
@@ -18,7 +18,9 @@ set(OT_VENDOR "${CMAKE_CURRENT_SOURCE_DIR}/../../vendor" CACHE PATH "vendored em
 # mc68k: Musashi plus the ColdFire mode, the HI08 host-port register file and
 # the on-chip peripheral scaffolding. Vendored, GPLv3 -- the same posture as
 # vendor/dsp56300: tooling and patches are shared, built binaries never are.
-add_subdirectory("${OT_VENDOR}/mc68k" "${CMAKE_CURRENT_BINARY_DIR}/mc68k" EXCLUDE_FROM_ALL)
+# Not EXCLUDE_FROM_ALL: the vendored core registers its own ColdFire timing,
+# divide and HI08 tests, and they are the contract this port stands on.
+add_subdirectory("${OT_VENDOR}/mc68k" "${CMAKE_CURRENT_BINARY_DIR}/mc68k")
 
 add_library(ot_machine STATIC machine.cpp machine.h v4e.cpp v4e.h)
 target_include_directories(ot_machine PUBLIC "${OT_VENDOR}" "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -26,3 +28,11 @@ target_link_libraries(ot_machine PUBLIC 68kEmu)
 
 add_executable(ot_emu main.cpp)
 target_link_libraries(ot_emu PRIVATE ot_machine)
+
+# THE GATE. `docs/RTOS_FORK.md` section 10.16: three defects in Unicorn's EMAC
+# cost a week, each producing a confident wrong finding. Nothing this emulator
+# computes is trustworthy until this passes.
+include(CTest)
+add_executable(ot_emac_test test_emac.cpp)
+target_link_libraries(ot_emac_test PRIVATE ot_machine)
+add_test(NAME emac COMMAND ot_emac_test)

--- a/tools/ot_emu/machine.cpp
+++ b/tools/ot_emu/machine.cpp
@@ -261,7 +261,29 @@ namespace ot
 		for(m_instructions = 0; m_instructions < _maxInstructions; ++m_instructions)
 		{
 			const auto p = pc();
-			if(read16(p) == g_trap0)
+			const auto op = read16(p);
+
+			// THE EMAC IS A-LINE, and Musashi routes 0xAxxx to the A-line
+			// EXCEPTION, not to the illegal-instruction callback the V4e layer
+			// hooks (`m68ki_exception_1010`, no callback of its own). So the
+			// EMAC is dispatched here instead, from the fetch this loop already
+			// does for the handoff check -- which keeps the vendored Musashi
+			// unpatched and costs nothing extra.
+			//
+			// ⚠️ The V4e layer expects the PC PAST the opcode word, the way
+			// Musashi leaves it on the illegal path, so advance it first.
+			if((op & 0xf000) == 0xa000)
+			{
+				setPC(p + 2);
+				if(v4e::execute(*this, op) == v4e::Result::Handled)
+				{
+					++m_v4e;
+					continue;
+				}
+				setPC(p);				// not ours: let Musashi take its exception
+			}
+
+			if(op == g_trap0)
 			{
 				char msg[128];
 				std::snprintf(msg, sizeof msg, "reached the RTOS handoff (trap #0) at pc %06x", p);

--- a/tools/ot_emu/machine.cpp
+++ b/tools/ot_emu/machine.cpp
@@ -1,0 +1,316 @@
+#include "machine.h"
+
+#include "v4e.h"
+
+#include <cstdio>
+#include <cstring>
+#include <algorithm>
+
+// Musashi reaches the machine through these free functions; the header wants
+// MC68K_CLASS defined to the concrete class and must be included EXACTLY ONCE
+// in the whole program (it defines them, it does not declare them).
+#define MC68K_CLASS ot::Machine
+#include "mc68k/musashiEntry.h"
+
+#include "mc68k/Musashi/m68k.h"
+#include "mc68k/cpuState.h"
+
+namespace ot
+{
+	namespace
+	{
+		// The RAM map, verbatim from tools/emu_bringup.py's boot(). Sizes are
+		// what route A maps, not what the hardware has: the point is that a
+		// divergence between the two emulators can never be a map difference.
+		constexpr struct { uint32_t base, size; } g_map[] = {
+			{0x00000000, 0x00010000},	// the vector page / low scratch
+			{0x40000000, 0x02000000},	// SDRAM: the OS image at +0x400
+			{0x46000000, 0x02000000},	// SDRAM: data, BSS, app objects
+			{0x48000000, 0x00100000},	// the reset stack lives at the base
+			{0x80000000, 0x01000000},	// fast/shared RAM: voice state, TCBs, DSP frames
+			{0x100b0000, 0x00010000},	// the settings/mirror page the boot touches
+		};
+
+		// Peripheral windows. Reads that have no override answer ALL-ONES,
+		// which is what satisfies the boot's wait-until-set spins.
+		constexpr struct { uint32_t base, size; } g_periph[] = {
+			{0xfc000000, 0x00100000},	// the on-chip peripheral space
+			{0x20000000, 0x00001000},	// the DSP host port
+			{0x90000000, 0x00001000},	// the ATA task file (CompactFlash) over FlexBus
+		};
+	}
+
+	Machine::Machine(const std::vector<uint8_t>& _image)
+		: Mc68k(M68K_CPU_TYPE_MCF5206E)		// the closest type this Musashi has;
+											// V4e is the port's first job
+	{
+		for(const auto& r : g_map)
+		{
+			Region reg;
+			reg.base = r.base;
+			reg.data.assign(r.size, 0);
+			m_regions.push_back(std::move(reg));
+		}
+		if(auto* const r = find(g_imageBase, static_cast<uint32_t>(_image.size())))
+			std::memcpy(r->data.data() + (g_imageBase - r->base), _image.data(), _image.size());
+
+		// The PLL gate: the firmware halts at 0x4000fa8c unless the top byte
+		// of 0xfc0c4000 times 12 MHz is 264 MHz, so the byte is 22 (0x16).
+		// Measured by route A (emu_bringup), kept identical here.
+		override32(0xfc0c4000, 0x16000000);
+
+		// SR BEFORE A7: writing the status register swaps the supervisor and
+		// user stack banks, so setting A7 first puts the reset stack in the
+		// bank the machine is about to leave. Route A's lesson, and it fails
+		// silently -- the boot simply wanders.
+		m68k_set_reg(getCpuState(), M68K_REG_SR, 0x2700);
+		m68k_set_reg(getCpuState(), M68K_REG_SP, g_resetSp);
+		setPC(g_imageBase);
+	}
+
+	void Machine::override32(const uint32_t _addr, const uint32_t _val)
+	{
+		for(uint32_t i = 0; i < 4; ++i)
+			m_overrides[_addr + i] = static_cast<uint8_t>(_val >> (8 * (3 - i)));
+	}
+
+	Region* Machine::find(const uint32_t _addr, const uint32_t _size)
+	{
+		for(auto& r : m_regions)
+			if(r.contains(_addr, _size))
+				return &r;
+		return nullptr;
+	}
+
+	bool Machine::isPeripheral(const uint32_t _addr) const
+	{
+		for(const auto& p : g_periph)
+			if(_addr >= p.base && _addr - p.base < p.size)
+				return true;
+		return false;
+	}
+
+	uint32_t Machine::peripheralRead(const uint32_t _addr, const uint8_t _size)
+	{
+		// Byte by byte, big-endian, so an access of any width or alignment sees
+		// the same bytes. Anything without an override reads ALL-ONES, which is
+		// what satisfies the boot's wait-until-set spins (route A's default).
+		uint32_t v = 0;
+		for(uint32_t i = 0; i < _size; ++i)
+		{
+			const auto it = m_overrides.find(_addr + i);
+			v = (v << 8) | (it != m_overrides.end() ? it->second : 0xff);
+		}
+		if(m_periphLog.size() < 4096)
+			m_periphLog.push_back({'R', pc(), _addr, _size, v});
+		return v;
+	}
+
+	void Machine::peripheralWrite(const uint32_t _addr, const uint8_t _size, const uint32_t _val)
+	{
+		if(m_periphLog.size() < 4096)
+			m_periphLog.push_back({'W', pc(), _addr, _size, _val});
+	}
+
+	uint8_t Machine::read8(const uint32_t _addr)
+	{
+		if(isPeripheral(_addr))
+			return static_cast<uint8_t>(peripheralRead(_addr, 1));
+		if(auto* const r = find(_addr, 1))
+			return r->data[_addr - r->base];
+		return 0xff;
+	}
+
+	uint16_t Machine::read16(const uint32_t _addr)
+	{
+		if(isPeripheral(_addr))
+			return static_cast<uint16_t>(peripheralRead(_addr, 2));
+		if(auto* const r = find(_addr, 2))
+		{
+			const auto o = _addr - r->base;
+			return static_cast<uint16_t>((r->data[o] << 8) | r->data[o + 1]);
+		}
+		return 0xffff;
+	}
+
+	void Machine::write8(const uint32_t _addr, const uint8_t _val)
+	{
+		++m_writes;
+		if(isPeripheral(_addr))
+			return peripheralWrite(_addr, 1, _val);
+		if(auto* const r = find(_addr, 1))
+			r->data[_addr - r->base] = _val;
+	}
+
+	void Machine::write16(const uint32_t _addr, const uint16_t _val)
+	{
+		++m_writes;
+		if(isPeripheral(_addr))
+			return peripheralWrite(_addr, 2, _val);
+		if(auto* const r = find(_addr, 2))
+		{
+			const auto o = _addr - r->base;
+			r->data[o]     = static_cast<uint8_t>(_val >> 8);
+			r->data[o + 1] = static_cast<uint8_t>(_val);
+		}
+	}
+
+	uint16_t Machine::readImm16(const uint32_t _addr)
+	{
+		return read16(_addr);
+	}
+
+	uint32_t Machine::peek32(const uint32_t _addr)
+	{
+		return (static_cast<uint32_t>(read16(_addr)) << 16) | read16(_addr + 2);
+	}
+
+	void Machine::poke32(const uint32_t _addr, const uint32_t _val)
+	{
+		write16(_addr, static_cast<uint16_t>(_val >> 16));
+		write16(_addr + 2, static_cast<uint16_t>(_val));
+	}
+
+	uint32_t Machine::pc() const
+	{
+		return getPC();
+	}
+
+	uint32_t Machine::onIllegalInstruction(const uint32_t _opcode)
+	{
+		// FIRST the V4e layer: this Musashi is ColdFire V2 and the firmware is
+		// V4e, so most of what lands here is not illegal at all, merely absent
+		// (v4e.cpp). A nonzero return tells Musashi to take no exception.
+		if(v4e::execute(*this, _opcode) == v4e::Result::Handled)
+		{
+			++m_v4e;
+			return 1;
+		}
+
+		// Genuinely unknown: report the opcode and the instruction's OWN
+		// address -- REG_PPC, not the PC, which Musashi has already advanced
+		// past the opcode word -- and stop. Letting the exception run would
+		// send the boot somewhere meaningless and hide the cause.
+		const auto at = m68k_get_reg(getCpuState(), M68K_REG_PPC);
+		char buf[256] = {};
+		disassemble(at, buf);
+		char msg[512];
+		std::snprintf(msg, sizeof msg,
+			"unimplemented opcode %04x at %06x after %llu instructions (%s)",
+			_opcode & 0xffff, at, static_cast<unsigned long long>(m_instructions), buf);
+		m_why = msg;
+		m_illegal = true;
+		return 0;
+	}
+
+	// Route A's `try_auto_poke`, instruction for instruction. Scan 48 bytes
+	// around the loop for `move.w (abs).w,d0` (3038) or `move.w (abs).l,d0`
+	// (3039), then within the next 20 bytes for `cmpi.l #imm,d0` (0c80) or
+	// `cmpi.w #imm,d0` (0c40); write the immediate to the flag as a WORD.
+	bool Machine::tryAutoPoke(const uint32_t _pcInLoop)
+	{
+		const uint32_t lo = _pcInLoop - 16;
+		uint8_t blk[48];
+		for(uint32_t i = 0; i < sizeof blk; ++i)
+			blk[i] = read8(lo + i);
+
+		const auto be16 = [&](const uint32_t _i)
+		{
+			return static_cast<uint32_t>((blk[_i] << 8) | blk[_i + 1]);
+		};
+		const auto be32 = [&](const uint32_t _i)
+		{
+			return (be16(_i) << 16) | be16(_i + 2);
+		};
+
+		for(uint32_t i = 0; i + 6 < sizeof blk; i += 2)
+		{
+			uint32_t addr, k;
+			if(be16(i) == 0x3038)						// (abs).w -- sign-extended
+			{
+				addr = static_cast<uint32_t>(static_cast<int32_t>(static_cast<int16_t>(be16(i + 2))));
+				k = i + 4;
+			}
+			else if(be16(i) == 0x3039)					// (abs).l
+			{
+				addr = be32(i + 2);
+				k = i + 6;
+			}
+			else
+				continue;
+
+			bool found = false;
+			uint32_t imm = 0;
+			for(uint32_t j = k; j < std::min<uint32_t>(i + 20, sizeof blk - 2); j += 2)
+			{
+				if(be16(j) == 0x0c80) { imm = be32(j + 2); found = true; break; }	// cmpi.l
+				if(be16(j) == 0x0c40) { imm = be16(j + 2); found = true; break; }	// cmpi.w
+			}
+			if(!found)
+				continue;
+
+			write16(addr, static_cast<uint16_t>(imm));
+			m_autoPokes.push_back({lo + i, addr, imm});
+			return true;
+		}
+		return false;
+	}
+
+	Machine::Stop Machine::run(const uint64_t _maxInstructions)
+	{
+		for(m_instructions = 0; m_instructions < _maxInstructions; ++m_instructions)
+		{
+			const auto p = pc();
+			if(read16(p) == g_trap0)
+			{
+				char msg[128];
+				std::snprintf(msg, sizeof msg, "reached the RTOS handoff (trap #0) at pc %06x", p);
+				m_why = msg;
+				return Stop::Handoff;
+			}
+			if(m_profileEvery && (m_instructions % m_profileEvery) == 0)
+				++m_profile[p];
+			if(m_step)
+				m_step(*this, p);
+			exec();
+			if(m_illegal)
+				return Stop::Illegal;
+
+			// The stall check, once per burst.
+			if((m_instructions % g_burst) == g_burst - 1)
+			{
+				m_window.push_back(pc());
+				m_windowWrites.push_back(m_writes);
+				if(m_window.size() > g_stallBursts)
+				{
+					m_window.erase(m_window.begin());
+					m_windowWrites.erase(m_windowWrites.begin());
+				}
+				if(m_window.size() == g_stallBursts)
+				{
+					const auto lo = *std::min_element(m_window.begin(), m_window.end());
+					const auto hi = *std::max_element(m_window.begin(), m_window.end());
+					if(hi - lo <= 64)
+					{
+						// A memset makes progress; a poll does not.
+						if(m_windowWrites.back() - m_windowWrites.front() > 2000)
+							m_window.clear(), m_windowWrites.clear();
+						else if(tryAutoPoke(pc()))
+							m_window.clear(), m_windowWrites.clear();
+						else
+						{
+							char msg[160];
+							std::snprintf(msg, sizeof msg,
+								"unrecognised spin at %06x after %llu instructions",
+								pc(), static_cast<unsigned long long>(m_instructions));
+							m_why = msg;
+							return Stop::Fault;
+						}
+					}
+				}
+			}
+		}
+		m_why = "instruction budget exhausted";
+		return Stop::Budget;
+	}
+}

--- a/tools/ot_emu/machine.h
+++ b/tools/ot_emu/machine.h
@@ -1,0 +1,160 @@
+// The Octatrack as a machine, headless: one ColdFire MCF54454 and (later) two
+// DSP56300 cores, driven from a script and open to interception.
+//
+// WHY THIS EXISTS. `tools/emu_rtos.py` (route A) already runs the firmware's
+// own scheduler on Unicorn + Python, and it is the ORACLE this port is
+// measured against -- but it costs ~120x real time, models no audio, and
+// stops at the DSP host port. `tools/dsp_host` runs both DSP cores at about
+// real time but knows nothing of the ColdFire. This is the join: the same
+// machine, in one process, fast enough to play with.
+//
+// It is deliberately NOT a plugin. No JUCE, no UI, no audio device. The
+// deliverable is a library plus a CLI you can drive and intercept -- the
+// C++ counterpart of route A's Python API.
+//
+// MILESTONE O1 (this file's only job so far): boot the OS image to the RTOS
+// handoff -- the `trap #0` at 0x4000ff9a that hands control to the kernel --
+// with the same registers route A reaches. Everything below is the minimum
+// that boot touches, taken FIELD FOR FIELD from `tools/emu_bringup.py` so the
+// two can be diffed rather than argued about:
+//
+//   * the RAM map (six regions, `emu_bringup.boot`)
+//   * SR = 0x2700 and A7 = 0x48000000 before the first instruction, SR FIRST
+//     (the supervisor/user stack banks swap on the SR write, so writing A7
+//     first lands it in the wrong bank -- route A's comment, kept because the
+//     failure is silent)
+//   * peripheral reads default to ALL-ONES, which satisfies every
+//     wait-until-set spin in the boot path
+//   * the PLL at 0xfc0c4000 must read (reg >> 24) * 12 MHz == 264 MHz or the
+//     firmware halts at 0x4000fa8c -- so the top byte is 22
+//
+// ⚠️ WHAT IS KNOWN MISSING, and why it is fine for O1: the vendored Musashi
+// implements ColdFire V2 (MCF5206E, ISA_A) and this chip is V4e. Every
+// `mvs`/`mvz`/`mov3q`/`byterev`/`ff1` and the whole EMAC are absent, so the
+// boot will stop at the first one. That is the point: the illegal-instruction
+// report below names the opcode and the PC, which is a work list, not a bug.
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "mc68k/mc68k.h"
+
+namespace ot
+{
+	// One mapped span of plain read/write memory.
+	struct Region
+	{
+		uint32_t base = 0;
+		std::vector<uint8_t> data;
+
+		bool contains(const uint32_t _a, const uint32_t _size) const
+		{
+			return _a >= base && (_a - base) + _size <= data.size();
+		}
+	};
+
+	// A peripheral window: reads answer from `overrides` if the address has
+	// one, else all-ones; writes are logged. This is route A's model, and the
+	// boot never needs more than it (`emu_bringup.boot`).
+	class Machine final : public mc68k::Mc68k
+	{
+	public:
+		static constexpr uint32_t g_imageBase = 0x40000400;	// 0x40000000 + the 0x400 header
+		static constexpr uint32_t g_resetSp   = 0x48000000;
+		static constexpr uint16_t g_trap0     = 0x4e40;		// the RTOS handoff instruction
+
+		explicit Machine(const std::vector<uint8_t>& _image);
+
+		// -- the memory interface Musashi calls through ----------------------
+		uint8_t  read8 (uint32_t _addr) override;
+		uint16_t read16(uint32_t _addr) override;
+		void     write8 (uint32_t _addr, uint8_t  _val) override;
+		void     write16(uint32_t _addr, uint16_t _val) override;
+		uint16_t readImm16(uint32_t _addr) override;
+
+		uint32_t getResetPC() override { return g_imageBase; }
+		uint32_t getResetSP() override { return g_resetSp; }
+
+		uint32_t onIllegalInstruction(uint32_t _opcode) override;
+
+		// -- driving it ------------------------------------------------------
+		// Run until `trap #0` (the handoff), an illegal instruction, or the
+		// budget. Returns why it stopped.
+		enum class Stop { Handoff, Illegal, Budget, Fault };
+		Stop run(uint64_t _maxInstructions);
+
+		uint64_t instructions() const { return m_instructions; }
+		uint64_t v4eExecuted() const { return m_v4e; }
+		uint32_t pc() const;
+		std::string why() const { return m_why; }
+
+		// Interception, the whole point of a headless build: a callback per
+		// instruction (nullptr = off), and direct memory access for probes.
+		void setStepHook(std::function<void(Machine&, uint32_t _pc)> _h) { m_step = std::move(_h); }
+
+		// Sample the PC every `_every` instructions. A boot that does not
+		// reach the handoff is almost always spinning on a flag no peripheral
+		// model answers, and the hot address names it -- route A grew the same
+		// thing (its stall detector) for the same reason.
+		void setProfile(uint32_t _every) { m_profileEvery = _every; }
+		const std::unordered_map<uint32_t, uint64_t>& profile() const { return m_profile; }
+		uint32_t peek32(uint32_t _addr);
+		void     poke32(uint32_t _addr, uint32_t _val);
+
+		// Every distinct peripheral address the run touched, in first-touch
+		// order: route A logs the same thing (`BootResult.boot_map`), so the
+		// two boots can be compared without a full instruction trace.
+		struct Access { char kind; uint32_t pc, addr; uint8_t size; uint32_t val; };
+		const std::vector<Access>& peripheralLog() const { return m_periphLog; }
+
+		// Every completion flag the stall detector had to satisfy, as
+		// (loop pc, flag address, value): route A keeps the same list and it
+		// is the honest record of where this emulator is standing in for
+		// hardware nobody has modelled yet.
+		struct AutoPoke { uint32_t pc, addr, value; };
+		const std::vector<AutoPoke>& autoPokes() const { return m_autoPokes; }
+
+	private:
+		Region* find(uint32_t _addr, uint32_t _size);
+		bool isPeripheral(uint32_t _addr) const;
+		uint32_t peripheralRead(uint32_t _addr, uint8_t _size);
+		void peripheralWrite(uint32_t _addr, uint8_t _size, uint32_t _val);
+
+		std::vector<Region> m_regions;
+		// BYTE-addressable, not word: Musashi composes a 32-bit peripheral read
+		// from two 16-bit reads, so a value stored whole and returned per
+		// access is truncated to the access width. That cost the first boot --
+		// the PLL register read back 0x0000ffff instead of 0x16000000 and the
+		// firmware spun forever in its clock check at 0x4000f9e8.
+		std::unordered_map<uint32_t, uint8_t> m_overrides;
+		void override32(uint32_t _addr, uint32_t _val);
+		std::vector<Access> m_periphLog;
+		std::function<void(Machine&, uint32_t)> m_step;
+		uint64_t m_instructions = 0;
+		uint64_t m_v4e = 0;			// instructions the V4e layer supplied
+		uint32_t m_profileEvery = 0;
+		std::unordered_map<uint32_t, uint64_t> m_profile;
+		std::string m_why;
+		bool m_illegal = false;
+
+		// -- the stall detector, ported field for field from route A ---------
+		// A PC confined to a 64-byte window across four 500k bursts with fewer
+		// than 2,000 stores in between is a poll, not a memset. When one is
+		// found, `tryAutoPoke` looks for the `move.w (abs),d0 ... cmpi #imm,d0`
+		// pair around it and writes imm at the LOAD width -- two bytes, NOT the
+		// compare's width, or the low word reads back wrong (route A's comment,
+		// and it is a measured trap).
+		static constexpr uint64_t g_burst = 500000;
+		static constexpr uint32_t g_stallBursts = 4;
+		bool tryAutoPoke(uint32_t _pcInLoop);
+		std::vector<uint32_t> m_window;
+		std::vector<uint64_t> m_windowWrites;
+		std::vector<AutoPoke> m_autoPokes;
+		uint64_t m_writes = 0;
+	};
+}

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -1,0 +1,112 @@
+// ot_emu -- drive the headless Octatrack machine from the command line.
+//
+//   out/emu/ot_emu --image out/raw/section_3_MAIN_OS.bin [--max N] [--periph]
+//
+// MILESTONE O1: boot to the RTOS handoff. Route A is the oracle -- it reaches
+// `trap #0` and reports the same peripheral touches -- so the useful output
+// here is (a) where this stopped and (b) what it touched on the way, both
+// directly comparable with `tools/emu_rtos.py` / `emu_bringup.boot`.
+//
+// Expect it to stop on an unimplemented opcode long before the handoff: the
+// vendored Musashi is ColdFire V2 and this firmware is V4e. That report is
+// the work list for the ISA half of the port, one opcode at a time.
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <utility>
+
+#include "machine.h"
+
+namespace
+{
+	std::vector<uint8_t> readFile(const std::string& _path)
+	{
+		std::ifstream f(_path, std::ios::binary);
+		if(!f)
+			return {};
+		return std::vector<uint8_t>(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>());
+	}
+}
+
+int main(int _argc, char** _argv)
+{
+	std::string image = "out/raw/section_3_MAIN_OS.bin";
+	uint64_t maxInstructions = 50'000'000;	// route A's own budget
+	bool showPeripherals = false;
+	bool profile = false;
+
+	for(int i = 1; i < _argc; ++i)
+	{
+		const std::string a = _argv[i];
+		if(a == "--image" && i + 1 < _argc)		image = _argv[++i];
+		else if(a == "--max" && i + 1 < _argc)	maxInstructions = std::strtoull(_argv[++i], nullptr, 0);
+		else if(a == "--periph")				showPeripherals = true;
+		else if(a == "--profile")				profile = true;
+		else
+		{
+			std::printf("usage: ot_emu [--image FILE] [--max N] [--periph]\n");
+			return 2;
+		}
+	}
+
+	const auto img = readFile(image);
+	if(img.empty())
+	{
+		std::printf("cannot read %s (run `make os` for the stock image, or `make bus` for a built one)\n",
+			image.c_str());
+		return 1;
+	}
+	std::printf("image      : %s (%zu bytes) at %#x\n", image.c_str(), img.size(), ot::Machine::g_imageBase);
+
+	ot::Machine m(img);
+	if(profile)
+		m.setProfile(64);
+	const auto stop = m.run(maxInstructions);
+
+	static const char* const g_names[] = {"HANDOFF", "ILLEGAL", "BUDGET", "FAULT"};
+	std::printf("stopped    : %s -- %s\n", g_names[static_cast<int>(stop)], m.why().c_str());
+	std::printf("instructions: %llu (%llu supplied by the V4e layer)\n",
+		static_cast<unsigned long long>(m.instructions()),
+		static_cast<unsigned long long>(m.v4eExecuted()));
+
+	if(profile)
+	{
+		std::vector<std::pair<uint32_t, uint64_t>> hot(m.profile().begin(), m.profile().end());
+		std::sort(hot.begin(), hot.end(), [](const auto& _a, const auto& _b){ return _a.second > _b.second; });
+		std::printf("hottest addresses (PC sampled every 64 instructions):\n");
+		for(size_t i = 0; i < hot.size() && i < 16; ++i)
+		{
+			char buf[256] = {};
+			m.disassemble(hot[i].first, buf);
+			std::printf("   %#08x  %8llu  %s\n", hot[i].first,
+				static_cast<unsigned long long>(hot[i].second), buf);
+		}
+	}
+
+	if(!m.autoPokes().empty())
+	{
+		std::printf("auto-pokes (completion flags no model answers, %zu):\n", m.autoPokes().size());
+		for(const auto& p : m.autoPokes())
+			std::printf("   loop %#08x -> wrote %#x to %#08x\n", p.pc, p.value, p.addr);
+	}
+
+	if(showPeripherals)
+	{
+		std::printf("peripheral touches (%zu logged):\n", m.peripheralLog().size());
+		size_t n = 0;
+		for(const auto& a : m.peripheralLog())
+		{
+			if(++n > 60)
+			{
+				std::printf("   ... %zu more\n", m.peripheralLog().size() - 60);
+				break;
+			}
+			std::printf("   %c %#08x size %u = %#x   (pc %#06x)\n", a.kind, a.addr, a.size, a.val, a.pc);
+		}
+	}
+	return stop == ot::Machine::Stop::Handoff ? 0 : 1;
+}

--- a/tools/ot_emu/test_emac.cpp
+++ b/tools/ot_emu/test_emac.cpp
@@ -1,0 +1,101 @@
+// THE EMAC GATE. Run this before trusting anything this emulator computes.
+//
+// WHY IT EXISTS, and why it is the first test in the port rather than a later
+// nicety: three defects in *Unicorn's* ColdFire EMAC cost a week this month
+// (`docs/RTOS_FORK.md` §10.16). Each produced a confident wrong finding that
+// was investigated as firmware behaviour for a day --
+//
+//   * fractional products came back HALVED (unsigned >> 32 where the chip does
+//     signed >> 31), so the recorder wrote a length of 10,336 for Bryan's
+//     20,672 and it was explained away as "2-sample units";
+//   * `msac` ADDED where it must subtract (the MAC/MSAC bit was read from the
+//     opcode word; the chip keeps it in the extension word), so every trig's
+//     sub-frame offset came out 0;
+//   * a harness trampoline was served stale, so a shimmed `msacl ..,%acc1` ran
+//     as the previous `msacl ..,%acc0`.
+//
+// The firmware's own reciprocal tables (`0x80003c20` = 2^31 / block size) are
+// what finally said which side was wrong. So: the expected values below are
+// HARDWARE's, taken from `tools/emu_bringup.py::emac_selftest`, which is the
+// same gate route A refuses to run without.
+//
+// ⚠️ EVERY ENCODING HERE CAME OUT OF `m68k-elf-as -mcpu=5475`, not out of a
+// reading of the manual. The assembler listing is in the comments beside each
+// program so a future reader can re-run it in one command.
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "machine.h"
+
+#include "mc68k/Musashi/m68k.h"
+#include "mc68k/cpuState.h"
+
+namespace
+{
+	int g_failures = 0;
+
+	// Build a machine whose "image" is a program at the load base, run it for
+	// `_instructions`, and return D0.
+	uint32_t runProgram(const std::vector<uint8_t>& _code, const uint32_t _d0, const uint32_t _d1,
+		const uint32_t _instructions)
+	{
+		std::vector<uint8_t> image(_code);
+		ot::Machine m(image);
+		m68k_set_reg(m.getCpuState(), M68K_REG_D0, _d0);
+		m68k_set_reg(m.getCpuState(), M68K_REG_D1, _d1);
+		const auto stop = m.run(_instructions);
+		if(stop != ot::Machine::Stop::Budget)
+			std::printf("     (run stopped early: %s)\n", m.why().c_str());
+		return m68k_get_reg(m.getCpuState(), M68K_REG_D0);
+	}
+
+	void check(const char* _what, const uint32_t _got, const uint32_t _want)
+	{
+		const bool ok = _got == _want;
+		if(!ok)
+			++g_failures;
+		std::printf("  [%s] %-52s got %#010x want %#010x\n",
+			ok ? "PASS" : "FAIL", _what, _got, _want);
+	}
+}
+
+int main()
+{
+	std::printf("EMAC gate (hardware semantics, docs/RTOS_FORK.md section 10.16):\n");
+
+	// The firmware's own block-walk idiom: position x (2^31 / blocksize), in
+	// fractional mode. `movel #0x20,%macsr` selects fractional+signed.
+	//
+	//   7020            moveq #32,%d0        <- loaded by hand below instead
+	//   a900            movel %d0,%macsr
+	//   a200 0800       macl  %d0,%d1,%acc0
+	//   a1c0            movclrl %acc0,%d0
+	const std::vector<uint8_t> macl = {
+		0x70, 0x20,					// moveq #32,%d0   (MACSR = fractional, signed)
+		0xa9, 0x00,					// movel %d0,%macsr
+		0x20, 0x3c, 0, 0, 0x0c, 0x00,	// movel #0xc00,%d0   -- the operands, so the
+		0x22, 0x3c, 0, 0x20, 0, 0,	// movel #0x200000,%d1    program is self-contained
+		0xa2, 0x00, 0x08, 0x00,		// macl %d0,%d1,%acc0
+		0xa1, 0xc0,					// movclrl %acc0,%d0
+		0x4e, 0x71,					// nop
+	};
+	auto negated = macl;
+	negated[6] = 0xff; negated[7] = 0xff; negated[8] = 0xf4; negated[9] = 0x00;	// -0xc00
+
+	//   a200 0900       msacl %d0,%d1,%acc0  -- the extension word's bit 8 is
+	//                                           what makes it a SUBTRACT
+	auto msacl = macl;
+	msacl[18] = 0x09;
+
+	check("macl fractional 0xc00 * 0x200000 (signed >> 31)",
+		runProgram(macl, 0, 0, 32), 3);
+	check("macl fractional -0xc00 * 0x200000",
+		runProgram(negated, 0, 0, 32), 0xfffffffd);
+	check("msacl SUBTRACTS (extension word bit 8)",
+		runProgram(msacl, 0, 0, 32), 0xfffffffd);
+
+	std::printf("%s\n", g_failures ? "EMAC GATE FAILED -- nothing this emulator computes can be trusted"
+									: "EMAC gate passed.");
+	return g_failures ? 1 : 0;
+}

--- a/tools/ot_emu/v4e.cpp
+++ b/tools/ot_emu/v4e.cpp
@@ -197,6 +197,131 @@ namespace ot::v4e
 		setReg(_m, M68K_REG_SR, sr);
 	}
 
+	namespace
+	{
+		// MACSR bits that matter here (CFPRM 4.1): bit 5 F/I selects fractional
+		// mode, bit 4 S/U selects signed, bit 0 is the product-independent
+		// saturation flag this firmware never sets.
+		constexpr uint32_t g_macsrFractional = 0x20;
+
+		// One accumulator, 32 bits plus its 8-bit extensions. Musashi's
+		// ColdFire state has no EMAC, so the port keeps its own -- four
+		// accumulators and the two extension-byte registers.
+		// Musashi's ColdFire state has no EMAC at all, so the whole unit lives
+		// here: four accumulators, their extension bytes, and MACSR.
+		struct Emac
+		{
+			uint32_t acc[4] = {};
+			uint32_t ext[4] = {};	// the sign-extension byte per accumulator
+			uint32_t macsr = 0;
+		};
+		Emac g_emac;
+
+		uint32_t macsr(Machine&) { return g_emac.macsr; }
+	}
+
+	// The whole EMAC, as the MCF5445x does it and as the firmware's own
+	// reciprocal tables prove (RTOS_FORK section 10.16): in FRACTIONAL mode a
+	// signed product is taken and shifted LEFT ONE (the 2.62 product), and the
+	// upper 40 bits are accumulated -- so `movclrl` of the result yields
+	// (a * b) >> 31, not >> 32. `msac` SUBTRACTS, and which of the two it is
+	// comes from bit 8 of the EXTENSION word, never from the opcode word.
+	Result emac(Machine& _m, const uint32_t _opcode)
+	{
+		// movel %dn,%macsr  -- 1010 1001 0000 0rrr  (a900 = from d0)
+		if((_opcode & 0xfff8) == 0xa900)
+		{
+			g_emac.macsr = reg(_m, dReg(_opcode & 7));
+			return Result::Handled;
+		}
+		// movclrl %accN,%dn -- 1010 0rrr 11 00 00NN, clears the accumulator
+		if((_opcode & 0xf1f0) == 0xa1c0)
+		{
+			const uint32_t dn = (_opcode >> 9) & 7;
+			const uint32_t acc = _opcode & 3;
+			setReg(_m, dReg(dn), g_emac.acc[acc]);
+			g_emac.acc[acc] = 0;
+			g_emac.ext[acc] = 0;
+			return Result::Handled;
+		}
+		// movel %accN,%dn (no clear) -- a383 = acc1 -> d3
+		if((_opcode & 0xf1f0) == 0xa180)
+		{
+			setReg(_m, dReg((_opcode >> 9) & 7), g_emac.acc[_opcode & 3]);
+			return Result::Handled;
+		}
+		// movel %accext01,%dn / %accext23 -- ab84
+		if((_opcode & 0xf1f0) == 0xa980 || (_opcode & 0xf1f0) == 0xab80)
+		{
+			const bool hi = (_opcode & 0x0200) != 0;
+			const uint32_t v = hi
+				? ((g_emac.ext[2] & 0xff) | ((g_emac.ext[3] & 0xff) << 8))
+				: ((g_emac.ext[0] & 0xff) | ((g_emac.ext[1] & 0xff) << 8));
+			setReg(_m, dReg((_opcode >> 9) & 7), v);
+			return Result::Handled;
+		}
+
+		// MAC / MSAC, with or without a load. The opcode word carries the two
+		// source registers and the addressing mode; the EXTENSION word carries
+		// the accumulator, the subtract bit and the operand halves.
+		const uint16_t ext = fetch16(_m);
+		const uint32_t ry = (_opcode >> 9) & 7;
+		const uint32_t rx = _opcode & 7;
+		const bool subtract = (ext & 0x0100) != 0;			// ⚠️ EXTENSION word,
+															// not the opcode word
+		const uint32_t accN = ((ext >> 4) & 1) | ((ext >> 8) & 2);
+		const bool wordOp = (ext & 0x0800) == 0;			// size: 0 = word, 1 = long
+		const bool upperY = (ext & 0x0040) != 0;
+		const bool upperX = (ext & 0x0080) != 0;
+
+		const uint32_t rawY = reg(_m, dReg(ry));
+		const uint32_t rawX = reg(_m, dReg(rx));
+
+		int64_t product;
+		if(wordOp)
+		{
+			const auto y = static_cast<int16_t>(upperY ? (rawY >> 16) : (rawY & 0xffff));
+			const auto x = static_cast<int16_t>(upperX ? (rawX >> 16) : (rawX & 0xffff));
+			product = static_cast<int64_t>(y) * static_cast<int64_t>(x);
+		}
+		else
+		{
+			product = static_cast<int64_t>(static_cast<int32_t>(rawY))
+					* static_cast<int64_t>(static_cast<int32_t>(rawX));
+		}
+
+		// FRACTIONAL: the product is shifted left one into 2.62 and the upper
+		// 40 bits accumulate, which is a signed >> 31 by the time `movclrl`
+		// reads the low longword. INTEGER mode accumulates the product itself.
+		// ⚠️ Getting this wrong by one bit is exactly the Unicorn defect that
+		// halved every recorder length for a week.
+		int64_t addend;
+		if(macsr(_m) & g_macsrFractional)
+			addend = (product << 1) >> 32;
+		else
+			addend = product;
+
+		auto acc = static_cast<int64_t>(static_cast<int32_t>(g_emac.acc[accN]));
+		acc = subtract ? acc - addend : acc + addend;
+		g_emac.acc[accN] = static_cast<uint32_t>(acc);
+		g_emac.ext[accN] = static_cast<uint32_t>((acc >> 32) & 0xff);
+
+		// The load half of a `macl %d0,%d1,%a0@+,%d2,%acc1`: mode 3 in the
+		// opcode word's bits 3-5, destination register in the extension word's
+		// top nibble. Only post-increment appears in this firmware.
+		const uint32_t mode = (_opcode >> 3) & 7;
+		if(mode == 3)
+		{
+			const uint32_t an = rx;
+			const uint32_t dst = (ext >> 12) & 7;
+			const auto a = reg(_m, aReg(an));
+			const uint32_t loaded = (static_cast<uint32_t>(_m.read16(a)) << 16) | _m.read16(a + 2);
+			setReg(_m, aReg(an), a + 4);
+			setReg(_m, dReg(dst), loaded);
+		}
+		return Result::Handled;
+	}
+
 	Result execute(Machine& _m, const uint32_t _opcode)
 	{
 		// ---- MVS / MVZ ---------------------------------------------------
@@ -228,6 +353,41 @@ namespace ot::v4e
 			setNZ(_m, v);
 			return Result::Handled;
 		}
+
+		// ---- MOV3Q ---------------------------------------------------------
+		// 1010 iii 1 01 eeeeee -- a 3-bit immediate (0 encodes -1) to a
+		// longword destination. ✅ `a340` assembles as `mov3ql #1,%d0`.
+		if((_opcode & 0xf1c0) == 0xa140)
+		{
+			const uint32_t imm3 = (_opcode >> 9) & 7;
+			const auto v = static_cast<uint32_t>(imm3 == 0 ? -1 : static_cast<int32_t>(imm3));
+			const uint32_t mode = (_opcode >> 3) & 7;
+			const uint32_t rn   = _opcode & 7;
+			if(mode != 0)					// only Dn is reached by this firmware
+				return Result::Unhandled;
+			setReg(_m, dReg(rn), v);
+			setNZ(_m, v);
+			return Result::Handled;
+		}
+
+		// ---- the EMAC ------------------------------------------------------
+		// The gate this port must pass before anything it computes is
+		// trusted: `tools/ot_emu/test_emac.cpp`, and the hardware semantics it
+		// encodes are docs/RTOS_FORK.md section 10.16 -- a week lost to three
+		// defects in Unicorn's version of exactly this.
+		//
+		// ✅ Encodings from `m68k-elf-as -mcpu=5475`:
+		//     a900            movel %d0,%macsr
+		//     a1c0            movclrl %acc0,%d0
+		//     a383            movel %acc1,%d3
+		//     ab84            movel %accext01,%d4
+		//     a200 0800       macl  %d0,%d1,%acc0
+		//     a200 0900       msacl %d0,%d1,%acc0        (ext bit 8 = subtract)
+		//     a418 1800       macl  %d0,%d1,%a0@+,%d2,%acc1
+		//     a200 0080       macw  %d0l,%d1u,%acc0
+		//     a200 0250       macw  %d0u,%d1l,<<,%acc2
+		if((_opcode & 0xf000) == 0xa000)
+			return emac(_m, _opcode);
 
 		return Result::Unhandled;
 	}

--- a/tools/ot_emu/v4e.cpp
+++ b/tools/ot_emu/v4e.cpp
@@ -1,0 +1,234 @@
+// The ColdFire V4e instructions the vendored Musashi does not have.
+//
+// WHY TRAP-AND-EMULATE, and not new opcode handlers. Musashi's tables are
+// GENERATED, and the generator checked into `vendor/mc68k/Musashi/m68kmake.c`
+// is NOT the one that produced the checked-in `m68kops.c`: regenerating with
+// it rewrites every handler signature (the upstream fork threads a
+// `m68ki_cpu_core*` through them, the shipped generator does not), an 18,984
+// line diff. So the tables are effectively frozen. ✅ Measured, not assumed --
+// regenerate into a scratch tree and diff, it is two commands.
+//
+// Instead: `m68ki_exception_illegal` calls the illegal-instruction callback
+// FIRST and takes no exception if it returns nonzero (`m68kcpu.h`). That makes
+// the callback a legal extension point. On entry `REG_PPC` is the faulting
+// instruction's own address and `REG_PC` already points past its opcode word,
+// so a handler decodes, executes, advances `REG_PC` over its extension words
+// and returns 1.
+//
+// The cost is an exception round trip per instruction. Fine for `mvs`/`mvz`,
+// which are ordinary moves scattered through the code; watch it for the EMAC,
+// which the frame builder runs in bulk. If it ever matters, these handlers are
+// the reference an opcode-table implementation gets diffed against.
+//
+// ⚠️ EVERY ENCODING HERE IS VERIFIED AGAINST `m68k-elf-objdump -m m68k:cfv4e`
+// ON THE REAL IMAGE, never against a reading of the manual alone. This
+// project has been bitten twice by a plausible encoding that assembled and did
+// the wrong thing (`CLAUDE.md`: the assembler's `mpysu` family, `tfr a,b` as
+// `rnd b`), and the emulator half cost a week this month (three defects in
+// Unicorn's EMAC, each producing a confident wrong finding). The boot's own
+// first two are the worked example:
+//
+//     4000043e:  73c1        mvzw %d1,%d1
+//     40000440:  71c0        mvzw %d0,%d0
+//
+// which is opcode 0111 rrr 1 oo eeeeee with oo = 11, i.e. the table below.
+#include "v4e.h"
+
+#include "machine.h"
+
+#include "mc68k/Musashi/m68k.h"
+#include "mc68k/cpuState.h"
+
+namespace ot::v4e
+{
+	namespace
+	{
+		constexpr uint32_t g_ccrN = 0x08, g_ccrZ = 0x04, g_ccrV = 0x02, g_ccrC = 0x01;
+
+		uint32_t reg(Machine& _m, const m68k_register_t _r)
+		{
+			return m68k_get_reg(_m.getCpuState(), _r);
+		}
+
+		void setReg(Machine& _m, const m68k_register_t _r, const uint32_t _v)
+		{
+			m68k_set_reg(_m.getCpuState(), _r, _v);
+		}
+
+		m68k_register_t dReg(const uint32_t _i)
+		{
+			return static_cast<m68k_register_t>(M68K_REG_D0 + _i);
+		}
+
+		m68k_register_t aReg(const uint32_t _i)
+		{
+			return static_cast<m68k_register_t>(M68K_REG_A0 + _i);
+		}
+
+		// The PC, as the handler must see it: past the opcode word, pointing at
+		// the first extension word. Musashi has already advanced it.
+		uint32_t pc(Machine& _m)          { return reg(_m, M68K_REG_PC); }
+		void     setPc(Machine& _m, uint32_t _v) { setReg(_m, M68K_REG_PC, _v); }
+
+		uint16_t fetch16(Machine& _m)
+		{
+			const auto p = pc(_m);
+			setPc(_m, p + 2);
+			return _m.read16(p);
+		}
+
+		uint32_t fetch32(Machine& _m)
+		{
+			const uint32_t hi = fetch16(_m);
+			return (hi << 16) | fetch16(_m);
+		}
+
+		// The brief extension word of (d8,An,Xn) / (d8,PC,Xn).
+		uint32_t briefIndex(Machine& _m, const uint32_t _base)
+		{
+			const uint16_t ext = fetch16(_m);
+			const uint32_t xn = (ext >> 12) & 7;
+			const bool isA = (ext & 0x8000) != 0;
+			uint32_t idx = isA ? reg(_m, aReg(xn)) : reg(_m, dReg(xn));
+			if(!(ext & 0x0800))						// word index: sign-extended
+				idx = static_cast<uint32_t>(static_cast<int32_t>(static_cast<int16_t>(idx)));
+			idx <<= (ext >> 9) & 3;					// scale 1/2/4/8
+			const auto disp = static_cast<int32_t>(static_cast<int8_t>(ext & 0xff));
+			return _base + idx + static_cast<uint32_t>(disp);
+		}
+	}
+
+	// Read a source operand of `_size` bytes through effective address
+	// `mode`/`reg`, advancing the PC over any extension words.
+	//
+	// ⚠️ `-(An)` and `(An)+` on a BYTE with An = A7 adjust by TWO on the 68000,
+	// to keep the stack even. Kept here 🟡 INFERRED for ColdFire, which has no
+	// odd-address stack either; nothing in this firmware has exercised it yet,
+	// and the falsifier is a `mvs.b -(%sp)` whose stack pointer comes back odd.
+	bool readEa(Machine& _m, const uint32_t _mode, const uint32_t _reg, const uint32_t _size,
+		uint32_t& _out)
+	{
+		const auto load = [&](const uint32_t _addr)
+		{
+			return _size == 1 ? _m.read8(_addr) : _m.read16(_addr);
+		};
+
+		switch(_mode)
+		{
+		case 0:														// Dn
+			_out = reg(_m, dReg(_reg));
+			return true;
+		case 2:														// (An)
+			_out = load(reg(_m, aReg(_reg)));
+			return true;
+		case 3:														// (An)+
+			{
+				const auto a = reg(_m, aReg(_reg));
+				const uint32_t step = (_size == 1 && _reg == 7) ? 2 : _size;
+				_out = load(a);
+				setReg(_m, aReg(_reg), a + step);
+				return true;
+			}
+		case 4:														// -(An)
+			{
+				const uint32_t step = (_size == 1 && _reg == 7) ? 2 : _size;
+				const auto a = reg(_m, aReg(_reg)) - step;
+				setReg(_m, aReg(_reg), a);
+				_out = load(a);
+				return true;
+			}
+		case 5:														// (d16,An)
+			{
+				const auto disp = static_cast<int32_t>(static_cast<int16_t>(fetch16(_m)));
+				_out = load(reg(_m, aReg(_reg)) + static_cast<uint32_t>(disp));
+				return true;
+			}
+		case 6:														// (d8,An,Xn)
+			_out = load(briefIndex(_m, reg(_m, aReg(_reg))));
+			return true;
+		case 7:
+			switch(_reg)
+			{
+			case 0:													// (xxx).W
+				{
+					const auto a = static_cast<int32_t>(static_cast<int16_t>(fetch16(_m)));
+					_out = load(static_cast<uint32_t>(a));
+					return true;
+				}
+			case 1:													// (xxx).L
+				_out = load(fetch32(_m));
+				return true;
+			case 2:													// (d16,PC)
+				{
+					const auto base = pc(_m);						// the extension word's own address
+					const auto disp = static_cast<int32_t>(static_cast<int16_t>(fetch16(_m)));
+					_out = load(base + static_cast<uint32_t>(disp));
+					return true;
+				}
+			case 3:													// (d8,PC,Xn)
+				{
+					const auto base = pc(_m);
+					_out = load(briefIndex(_m, base));
+					return true;
+				}
+			case 4:													// #imm -- one word for .B and .W
+				{
+					const auto w = fetch16(_m);
+					_out = _size == 1 ? (w & 0xff) : w;
+					return true;
+				}
+			default:
+				return false;
+			}
+		default:
+			return false;
+		}
+	}
+
+	// Set N and Z from a 32-bit result, clear V and C, leave X alone. This is
+	// what MVS/MVZ do (CFPRM), and it is the shape every arithmetic addition
+	// below will reuse.
+	void setNZ(Machine& _m, const uint32_t _result)
+	{
+		auto sr = reg(_m, M68K_REG_SR);
+		sr &= ~(g_ccrN | g_ccrZ | g_ccrV | g_ccrC);
+		if(_result == 0)						sr |= g_ccrZ;
+		if(static_cast<int32_t>(_result) < 0)	sr |= g_ccrN;
+		setReg(_m, M68K_REG_SR, sr);
+	}
+
+	Result execute(Machine& _m, const uint32_t _opcode)
+	{
+		// ---- MVS / MVZ ---------------------------------------------------
+		// 0111 rrr 1 oo eeeeee, oo = 00 MVS.B, 01 MVS.W, 10 MVZ.B, 11 MVZ.W.
+		// ✅ The two the boot reaches at 0x4000043e/0x40000440 disassemble as
+		// `mvzw %d1,%d1` and `mvzw %d0,%d0` under m68k:cfv4e, which pins the
+		// field layout; the sizes and the sign/zero split are CFPRM's.
+		if((_opcode & 0xf100) == 0x7100)
+		{
+			const uint32_t dx     = (_opcode >> 9) & 7;
+			const uint32_t opmode = (_opcode >> 6) & 3;
+			const uint32_t mode   = (_opcode >> 3) & 7;
+			const uint32_t rn     = _opcode & 7;
+			const uint32_t size   = (opmode == 0 || opmode == 2) ? 1 : 2;
+
+			uint32_t src = 0;
+			if(!readEa(_m, mode, rn, size, src))
+				return Result::Unhandled;
+
+			uint32_t v;
+			if(opmode < 2)		// MVS: sign-extend
+				v = size == 1
+					? static_cast<uint32_t>(static_cast<int32_t>(static_cast<int8_t>(src)))
+					: static_cast<uint32_t>(static_cast<int32_t>(static_cast<int16_t>(src)));
+			else				// MVZ: zero-extend
+				v = size == 1 ? (src & 0xff) : (src & 0xffff);
+
+			setReg(_m, dReg(dx), v);
+			setNZ(_m, v);
+			return Result::Handled;
+		}
+
+		return Result::Unhandled;
+	}
+}

--- a/tools/ot_emu/v4e.h
+++ b/tools/ot_emu/v4e.h
@@ -16,5 +16,9 @@ namespace ot
 		// Decode and run one instruction. On entry the PC is past the opcode
 		// word; a handler advances it over its own extension words.
 		Result execute(Machine& _m, uint32_t _opcode);
+
+		// The EMAC, split out because it carries its own state and its own
+		// gate (tools/ot_emu/test_emac.cpp).
+		Result emac(Machine& _m, uint32_t _opcode);
 	}
 }

--- a/tools/ot_emu/v4e.h
+++ b/tools/ot_emu/v4e.h
@@ -1,0 +1,20 @@
+// The ColdFire V4e instruction set this Musashi is missing, executed from the
+// illegal-instruction callback. See v4e.cpp for why that is the extension
+// point and how each encoding was verified.
+#pragma once
+
+#include <cstdint>
+
+namespace ot
+{
+	class Machine;
+
+	namespace v4e
+	{
+		enum class Result { Handled, Unhandled };
+
+		// Decode and run one instruction. On entry the PC is past the opcode
+		// word; a handler advances it over its own extension words.
+		Result execute(Machine& _m, uint32_t _opcode);
+	}
+}


### PR DESCRIPTION
Tier 3, started on Sam's call and **headless** by his scope: no JUCE, no plugin, no audio device — a library and a CLI to drive and intercept. `docs/COLDFIRE_PORT.md` is the record.

**O1 — boots to the handoff, and agrees with the oracle.** `ot_emu` reaches `trap #0` at `0x40000e46`, the same PC route A reaches, having made the same two auto-pokes at the same loops with the same values. **39.1 M instructions/s, boot in 0.26 s — about 26× route A's 1.5 M/s**, i.e. ~4.5× slower than real time at ~63,800 ColdFire instructions per DSP frame. Real time is in reach, which was the open question when this was scoped.

**O2 — the EMAC, gated.** The gate was written first and watched to fail: hardware's three cases from `emu_bringup.emac_selftest`, all FAIL with no EMAC, all pass now. `ctest` runs it beside the vendored core's own ColdFire timing, divide and HI08 tests: **4/4**.

Three things were needed, all measured rather than assumed:
- **V4e as trap-and-emulate.** Musashi's opcode tables are generated and the checked-in generator is *not* the one that produced them (regenerating rewrites every handler signature, an 18,984-line diff), so the tables are frozen; the illegal-instruction callback is a legal extension point. MVS/MVZ covers 961,786 of the boot's 10.2M instructions.
- **Byte-addressable peripheral overrides.** Musashi composes a 32-bit read from two 16-bit reads, so a whole-value override truncated and the PLL spun the boot forever.
- **The A-line finding.** Every EMAC opcode is `0xAxxx`, which Musashi routes to the A-line *exception*, not the illegal callback — so the V4e layer never saw them. They dispatch from the run loop instead, leaving the vendored Musashi unpatched.

❌ Retracted from O1's work list: `byterev` and `ff1` are not V4e (the assembler refuses them for `-mcpu=5475`).

Next, in order: the MCF5445x peripherals translated from route A, then the DSP cores and the host port, audio last. The rule that keeps it delegable: **route A is the oracle**, and any disagreement is a finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)