### PR TITLE
ColdFire port O3: PIT + INTC gated; the oracle made concrete; the unattended work order

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -179,6 +179,19 @@ in route A first:
   64-word block per core, with one 64-word block read back.
 - **Audio out.** The ESAI path is untraced.
 
+## The oracle, made concrete (7 Sep 2026)
+
+`tools/emu_rtos.py --golden FILE` writes route A's M6a facts as JSON —
+handoff PC, auto-pokes, every created task with its fields, which TCBs ran,
+the first switch, the first 200 dispatches with their sample times, the gate
+time. `out/oracle/m6a.json` is that file for the ONEAUX project: **10 tasks
+created, 11 ran, first switch boot → main, gate at 204.95 ms** ✅.
+`tools/ot_emu/oracle.py A B` diffs two such files field by field with no
+tolerance except one PIT period on dispatch times, and reports a field the
+port does not produce yet as MISSING rather than as a failure, so the port's
+report can grow milestone by milestone. `docs/COLDFIRE_WORKORDER.md` is the
+queue that uses it.
+
 ## The order to do it in
 
 1. Port `emac_selftest` as a CTest, then the EMAC handlers. Nothing that

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -139,8 +139,8 @@ the CLI prints them every run rather than hiding them.
 `periph.{h,cpp}`: the **PIT** and the **INTC**, translated from route A rule
 for rule, with each rule's measurement or failure carried across rather than
 summarised. `tools/ot_emu/test_periph.cpp` checks fourteen of them; `ctest`
-now runs **6 tests, all passing** (emac, periph, and the vendored core's
-three).
+now runs **5 tests, all passing** (emac, periph, and the vendored core's
+timing, divide and HI08 tests).
 
 The rules worth naming, because none is obvious and each was a silent failure
 in route A first:

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -134,13 +134,42 @@ low word reads back wrong. Both flags it finds match route A's exactly. These
 are the places the emulator stands in for hardware nobody has modelled yet, and
 the CLI prints them every run rather than hiding them.
 
+## Milestone O3 — the first peripherals, gated ✅ (7 Sep 2026)
+
+`periph.{h,cpp}`: the **PIT** and the **INTC**, translated from route A rule
+for rule, with each rule's measurement or failure carried across rather than
+summarised. `tools/ot_emu/test_periph.cpp` checks fourteen of them; `ctest`
+now runs **6 tests, all passing** (emac, periph, and the vendored core's
+three).
+
+The rules worth naming, because none is obvious and each was a silent failure
+in route A first:
+
+- **A FORCED interrupt ignores the mask** (MCF54455RM rev 5 §17.2.3). The
+  sequencer tick is source 32, installed with ICR 3 and never unmasked
+  anywhere in the image; masking it left route A running 400 frames with
+  **zero ticks**. ✅ measured there, gated here.
+- **CIMR clears MASKALL along with its source.** 🟡 inferred, and the reason
+  is carried too: nothing in the image ever writes IMRH/IMRL (a literal scan
+  found no site), the firmware unmasks only through CIMR, and the unit
+  plainly takes interrupts.
+- **A source with ICR 0 is never delivered**, whatever else is true.
+- **PIT PIF is write-1-to-clear.** Treat the write as a set and the ISR
+  re-enters forever.
+- **The PIT prescaler input is a KNOB, not a fact** (264 MHz by default; off
+  the 132 MHz bus clock every period is 2× longer). What pins it is the
+  sequencer's own tick count, which is M6c's gate.
+
 ## What is NOT here yet
 
-- **The MCF5445x peripherals.** INTC0/1, both PITs, the eDMA with its
-  completion-timing rules, DSPI, the UARTs, FlexBus/ATA and the card. All are
-  modelled in route A's Python, commented rule by rule with each failure mode
-  recorded — that is the specification, and translating it is the bulk of the
-  mechanical work.
+- **The rest of the peripherals.** The eDMA with its completion-timing rules
+  (three wrong versions in route A, each with its own reproducible symptom),
+  DSPI, the UARTs, FlexBus/ATA and the card. All are modelled in route A's
+  Python, commented rule by rule with each failure mode recorded — that is the
+  specification, and translating it is the bulk of the mechanical work.
+- **The run loop that uses them**: interrupt delivery, the burst scheduler and
+  the handoff dispatch, i.e. route A's `Rtos` class. The models are ready for
+  it; nothing calls them yet.
 - **The DSP side.** `dsp56kEmu` is already vendored, already patched for the
   shared window (`tools/dsp56300.patch`), and `tools/dsp_host` already runs both
   cores. Joining them needs the host-port protocol, which was decoded on

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -1,0 +1,174 @@
+# The ColdFire port — work order for unattended sessions
+
+> **Read `docs/COLDFIRE_PORT.md` first**: what exists, what was measured, and
+> the rule that governs everything here — **route A (`tools/emu_rtos.py`) is
+> the oracle.** A disagreement between the two emulators is a finding, not a
+> nuisance; the one to trust is whichever can point at a firmware constant
+> that only makes sense one way, and until someone has, neither is.
+
+This file is the queue. Each milestone below is **self-contained**: it names
+the route A code it translates, the gate that decides whether it is done, and
+the stop condition. A session takes ONE milestone, on its own branch, and
+opens a PR only when its gate passes. If the gate cannot be made to pass, the
+session writes what it measured into the milestone's entry here, opens the PR
+as a draft titled with the milestone and "BLOCKED", and stops. It does not
+start the next one, and it does not loosen the gate.
+
+## Standing rules (they are not advice)
+
+1. **Write the gate before the code, and watch it fail.** O2 did this for the
+   EMAC and O3 for the peripherals. A gate that has never failed proves
+   nothing (`tools/verify_bus.py`'s selftest exists for exactly this reason).
+2. **Translate, do not redesign.** Route A's Python is the specification,
+   comment for comment, including every ⚠️ and every "inferred". If a rule
+   looks arbitrary, it is arbitrary in the firmware too; carry the comment.
+3. **Encodings come from `m68k-elf-as -mcpu=5475` / `objdump -m m68k:cfv4e`
+   on the real image**, never from a reading of the manual. Paste the
+   listing beside the handler.
+4. **Numbers in docs carry a confidence marker** (✅ measured, 🟡 inferred,
+   ❌ retracted), and a retraction is propagated to every place that repeated
+   the old number.
+5. **Git:** branch, PR, merge. Never commit to main (O3 was committed to main
+   by mistake and had to be moved; do not repeat it).
+6. `ctest` in `out/emu` must stay green. `make check` must stay green.
+7. **Ask nothing of the user mid-milestone.** Everything a milestone needs is
+   in this file, `COLDFIRE_PORT.md`, `RTOS_FORK.md` and the route A source.
+   If it is genuinely not, that is a BLOCKED PR, not a question.
+
+## How to run the oracle
+
+```sh
+# the golden file (regenerate only if route A itself changes):
+.venv/bin/python3 tools/emu_rtos.py --project out/projects/OCTABAM_ONEAUX \
+    --set OCTABAM --name ONEAUX --tree out/_oracle_tree --until-gate --ms 1000 \
+    --golden out/oracle/m6a.json
+# the port's own report, same shape (grows milestone by milestone):
+./out/emu/ot_emu --image out/raw/section_3_MAIN_OS.bin --golden out/oracle/port.json
+# the diff:
+python3 tools/ot_emu/oracle.py out/oracle/m6a.json out/oracle/port.json
+```
+
+`out/oracle/m6a.json` as generated 7 Sep 2026: **10 tasks created, 11 ran,
+first switch `0x46c7ae30 → 0x46c7ae84`, gate at 204.95 ms, 50 dispatches
+recorded.** Those are route A's own measured numbers (`RTOS_FORK.md` §5).
+
+⚠️ Route A needs a project attached to reach the gate (`--project`): without
+a card it faults reading `0x100fff04` in main's settings path. That is a
+route A fact, not the port's problem; the golden command above already does it.
+
+## Done
+
+| | what | gate | agrees with oracle |
+|---|---|---|---|
+| O1 | boots to the RTOS handoff | reaches `trap #0` | ✅ same PC `0x40000e46`, same two auto-pokes |
+| O2 | the EMAC (fractional, `msac`, A-line dispatch) | `ctest` emac | ✅ hardware's three cases |
+| O3 | PIT + INTC models | `ctest` periph, 14 rules | (not yet wired in) |
+
+## Queue
+
+### O4 — the run loop: interrupts delivered, the handoff dispatched *(Opus)*
+
+**Translates:** `Rtos.step`, `_deliver`, `_candidates`, `_masked_pending`,
+`_next_expiry`, `_push`, `_pop`, `_handle_trap` (the intno 32 / 256 halves
+only), `_tick_timers`, and the idle rule at `MAIN_SPIN` — `tools/emu_rtos.py`
+lines ~860–1042. Plus `Rtos.__init__`'s seeding of PIT0 and the INTCs from the
+boot's logged peripheral writes (`install`, "seeded from N boot writes").
+
+**Design, fixed by route A and not up for revision:**
+- Time is counted in **samples**; the instruction budget per sample (`ips`,
+  default 3990) is a knob. A burst runs until the next timer expiry, an
+  INTFRC write (which must end the burst *inside* the instruction — hook the
+  INTC's force callback to stop the run loop), a `trap #0`, or an `rte`.
+- **Interrupt delivery** = push a 4-word frame (`0x4000 | vec<<2`, SR,
+  return PC), set SR to `(sr & ~0x8700) | 0x2000 | level<<8`, jump to
+  `[VBR + 4*vec]`, VBR = `0x40000000`. **SR before A7** (the bank swap).
+- `trap #0` from a task = a blocking primitive: push the frame with return
+  `pc+2` and SR `(sr | 0x2000) & ~0x8000`, jump to `[VBR + 0x80]`. Record
+  `(sample, current TCB, trap pc, caller, object)` from the stack the way
+  `_handle_trap` does (the lock primitive's trap at `0x40000a78` sits under
+  12 bytes of saved registers).
+- `rte` (Musashi will execute it natively — but route A pops by hand because
+  Unicorn would not; **decide by measurement** which is right here: run both
+  ways on the first `rte` and compare the popped PC/SR).
+- Idle: a PC parked at `MAIN_SPIN` (`0x4001fc9c`, `bras .`) with nothing
+  pending advances the sample clock to the next timer expiry.
+- Task bookkeeping for the oracle: hook the create site (`CREATE`) and the
+  scheduler's `rte` (`SCHED_RTE = 0x400005a6`) to record `created` and
+  `dispatches` with the current TCB (`[0x800068fc]`).
+
+**Gate:** `ot_emu --golden` produces `created`, `ran`, `first_switch`,
+`dispatches`, `gate_ms`; `oracle.py` reports **zero disagreements** against
+`out/oracle/m6a.json`. The dispatch order must match exactly; the sample
+times within one PIT period.
+
+**Known hazards, from route A's own history (`RTOS_FORK.md` §3):** reading SR
+at a burst boundary through Unicorn's API corrupted the CCR — Musashi has no
+such defect, but verify by comparing the CCR across a burst boundary with a
+`cmpl/bne` pair split across it. Memory-write hooks on MMIO fire. `call_as_main`
+is unsafe for anything that blocks (main is the only always-ready task).
+
+**Stop condition:** the oracle diff is zero, or a disagreement is reproduced
+and written into this entry with the two emulators' values side by side.
+
+### O5 — the remaining peripherals *(Opus, mechanical)*
+
+**Translates:** `Uart` (0xfc064000 / 0xfc068000; the boot sends 4,831 bytes
+through the first), `Dspi` (loopback: three pushed, three waited), the
+serial-link handling in `install`, the test-mode word at `0x1ffffe`
+(`0x4003232c` expects `0xdcba`; zero = normal), the settings-reset loop past
+the 1 MB SRAM window (`0x4001f298`). Each is a class in `periph.{h,cpp}`
+with its rules tested in `test_periph.cpp` **before** it is wired in.
+
+**Gate:** the O4 oracle diff stays zero, and `ot_emu` reports the same
+serial byte count route A does (`report()`: "serial sent: 4831 B").
+
+### O6 — the eDMA and the frame clock *(Opus, but read §8.1 first)*
+
+**Translates:** `class Edma` — the TCD register file, `SSRT`/`CINT`/`CDNE`,
+`START`/`INTMAJOR`/`MAJORELINK`, and the **three completion rules** whose
+wrong versions each produced a specific reproducible symptom (`RTOS_FORK.md`
+§8.1): a host-port-window transfer completes *at the DSP's next 16-sample
+boundary, as a whole chain*; an `SSRT` completes at once; a memory-to-memory
+`START` completes at once. Plus the frame interrupt (INTC0 source 1, vector
+`0x41`) as a **latched edge** at every 16-sample boundary, and the forced
+tick through `INTFRCH`.
+
+**Gate:** M6c's fidelity gate — `out/_testproj` (or the ONEAUX project with a
+poked trig) lands **the same byte `0xd3` in `0x46104d15[0]` at frame 344**
+after transport start, with 28 ticks in 400 frames. `RTOS_FORK.md` §8.
+Requires the project load (O7) — so O6 and O7 may be one session.
+
+### O7 — the card and the project load *(Opus, large)*
+
+**Translates:** `tools/emu_card.py` (FAT16 + the ATA task-file model at
+`0x90000000`, completing through vector `0xb6`), `Rtos.request_card_mount`,
+`load_project_live`, `select_bank_live`, `seq_select_live`, `stage_project`.
+
+**Gate:** the mount reads real ATA IDENTIFY/READ; the load reaches **6,189
+ATA commands / ~30,467 sectors** and writes `PART_PTR = 0x4017d520` from
+`0x40087d44` (`RTOS_FORK.md` §5 M6b). ⚠️ The load ends on bank A in route A
+and on the saved bank on hardware (§7): the port must reproduce **route A**
+first (the oracle), and the discrepancy stays documented as route A's.
+
+### O8 — the DSP cores and the host port *(Fable — judgment)*
+
+Join `dsp56kEmu` (both cores, the shared-window patch) to the machine
+through the host-port protocol decoded on 7 Sep 2026 (`COLDFIRE_PORT.md`
+"What is NOT here yet"). Gate: `tools/verify_twocore.py`'s layouts render
+identically when driven by the firmware instead of by `dsp_host`'s
+hand-rolled calls. Not to be started unattended.
+
+### O9 — audio out *(Fable)*
+
+The ESAI path, untraced. Not to be started unattended.
+
+## Running it overnight
+
+One session per milestone, in a terminal left open:
+
+```
+/loop Take the next milestone in docs/COLDFIRE_WORKORDER.md that is not done and not BLOCKED. Work on a branch named for it. Follow the standing rules. Open a PR when its gate passes, or a draft PR titled BLOCKED with the measurement. Then stop.
+```
+
+Use **Opus** for O4–O7. Switch to Fable for O8 and for any BLOCKED PR.
+Nothing here needs a flash, the card, or the user.

--- a/tools/emu_rtos.py
+++ b/tools/emu_rtos.py
@@ -1667,6 +1667,10 @@ def _cli():
     ap.add_argument("--step-quantum", type=int, default=32)
     ap.add_argument("--no-tick", action="store_true", help="PIT0 never asserts (step-1 checkpoint)")
     ap.add_argument("--until-gate", action="store_true", help="stop as soon as the M6a gate passes")
+    ap.add_argument("--golden", default="",
+                    help="write the M6a facts (created tasks, which ran, the first switch, the first "
+                         "dispatches, the handoff PC and the boot's auto-pokes) as JSON: THE ORACLE the "
+                         "C++ port (tools/ot_emu) is diffed against, docs/COLDFIRE_PORT.md")
     ap.add_argument("--trace", action="store_true", help="print every dispatch/irq/create")
     ap.add_argument("--starvation", action="store_true", help="print burst-end PCs per task")
     ap.add_argument("--watch-calls", default="", help="comma-separated addresses to log entries to")
@@ -1972,6 +1976,22 @@ def _cli():
     print("M6a gate   :", "PASS" if ok else "FAIL")
     for p in problems:
         print("   -", p)
+    if a.golden:
+        import json
+        gold = dict(
+            handoff_pc=HANDOFF,
+            auto_pokes=[dict(pc=pc, addr=ad, value=v) for pc, ad, v in r.auto_pokes],
+            created=[dict(sample=round(c[0], 1), tcb=c[1], entry=c[2], prio=c[3], stack=c[4],
+                          stack_size=c[5], creator=c[6], name=rt._name(c[1])) for c in rt.created],
+            ran=sorted(rt.ran()),
+            first_switch=rt.first_switch,
+            dispatches=[dict(sample=round(s_, 1), tcb=t, pc=pc) for s_, t, pc in rt.dispatches[:200]],
+            gate_ms=round(rt.sample / SAMPLE_HZ * 1000, 2),
+            pit0_fired=rt.pit0.fired,
+        )
+        pathlib.Path(a.golden).parent.mkdir(parents=True, exist_ok=True)
+        pathlib.Path(a.golden).write_text(json.dumps(gold, indent=1))
+        print(f"golden     : {a.golden} ({len(gold['created'])} tasks, {len(gold['dispatches'])} dispatches)")
     return 0 if ok else 1
 
 

--- a/tools/ot_emu/CMakeLists.txt
+++ b/tools/ot_emu/CMakeLists.txt
@@ -22,7 +22,7 @@ set(OT_VENDOR "${CMAKE_CURRENT_SOURCE_DIR}/../../vendor" CACHE PATH "vendored em
 # divide and HI08 tests, and they are the contract this port stands on.
 add_subdirectory("${OT_VENDOR}/mc68k" "${CMAKE_CURRENT_BINARY_DIR}/mc68k")
 
-add_library(ot_machine STATIC machine.cpp machine.h v4e.cpp v4e.h)
+add_library(ot_machine STATIC machine.cpp machine.h v4e.cpp v4e.h periph.cpp periph.h)
 target_include_directories(ot_machine PUBLIC "${OT_VENDOR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(ot_machine PUBLIC 68kEmu)
 
@@ -36,3 +36,9 @@ include(CTest)
 add_executable(ot_emac_test test_emac.cpp)
 target_link_libraries(ot_emac_test PRIVATE ot_machine)
 add_test(NAME emac COMMAND ot_emac_test)
+
+# The peripheral rules, each one a silent failure in route A before it was
+# found (RTOS_FORK sections 8.2 and 4).
+add_executable(ot_periph_test test_periph.cpp)
+target_link_libraries(ot_periph_test PRIVATE ot_machine)
+add_test(NAME periph COMMAND ot_periph_test)

--- a/tools/ot_emu/oracle.py
+++ b/tools/ot_emu/oracle.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""THE ORACLE DIFF: does the C++ port (tools/ot_emu) reach the same machine
+state route A (tools/emu_rtos.py) reaches?
+
+    .venv/bin/python3 tools/emu_rtos.py --until-gate --ms 1000 --golden out/oracle/m6a.json
+    ./out/emu/ot_emu --image out/raw/section_3_MAIN_OS.bin --golden out/oracle/port.json
+    python3 tools/ot_emu/oracle.py out/oracle/m6a.json out/oracle/port.json
+
+Both files carry the same fields; this compares them field by field and
+prints every disagreement. It is deliberately dumb -- no tolerance, no
+"close enough" -- because a disagreement between the two emulators is a
+FINDING, not a nuisance (docs/COLDFIRE_PORT.md). The one to trust is whichever
+can point at a firmware constant that only makes sense one way; until someone
+has, neither is.
+
+What it checks, in the order a port reaches them:
+  handoff_pc     the boot's trap #0 (milestone O1)
+  auto_pokes     the completion flags no model answers, loop pc + addr + value
+  created        every task the kernel creates: tcb, entry, prio, stack, creator
+  ran            every TCB that was dispatched at least once
+  first_switch   boot -> main
+  dispatches     the first N (sample, tcb, pc) -- ORDER is the whole point of
+                 running the scheduler; the sample times are compared with a
+                 tolerance of one PIT period, since the instruction budget per
+                 sample is a knob in both emulators
+  gate_ms        when the gate passed
+
+A field the port has not produced yet is reported as MISSING, not as a
+failure: the port's JSON grows milestone by milestone.
+"""
+import json
+import sys
+
+PIT_PERIOD_SAMPLES = 220.5
+
+
+def load(p):
+    with open(p) as f:
+        return json.load(f)
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    a, b = load(sys.argv[1]), load(sys.argv[2])
+    problems, missing = [], []
+
+    def field(name):
+        if name not in b:
+            missing.append(name)
+            return None
+        return b[name]
+
+    if (v := field("handoff_pc")) is not None and v != a["handoff_pc"]:
+        problems.append(f"handoff_pc: oracle {a['handoff_pc']:#x}, port {v:#x}")
+
+    if (v := field("auto_pokes")) is not None:
+        ka = [(p["pc"], p["addr"], p["value"]) for p in a["auto_pokes"]]
+        kb = [(p["pc"], p["addr"], p["value"]) for p in v]
+        if ka != kb:
+            problems.append(f"auto_pokes: oracle {[tuple(hex(x) for x in k) for k in ka]}, "
+                            f"port {[tuple(hex(x) for x in k) for k in kb]}")
+
+    if (v := field("created")) is not None:
+        key = lambda c: (c["tcb"], c["entry"], c["prio"], c["stack"], c["stack_size"], c["creator"])
+        sa, sb = sorted(map(key, a["created"])), sorted(map(key, v))
+        for k in sa:
+            if k not in sb:
+                problems.append(f"created: oracle has task tcb={k[0]:#x} entry={k[1]:#x} prio={k[2]} "
+                                f"stack={k[3]:#x}+{k[4]:#x} by {k[5]:#x}; port does not")
+        for k in sb:
+            if k not in sa:
+                problems.append(f"created: port has task tcb={k[0]:#x} entry={k[1]:#x} that the oracle does not")
+
+    if (v := field("ran")) is not None:
+        ra, rb = set(a["ran"]), set(v)
+        for t in sorted(ra - rb):
+            problems.append(f"ran: oracle ran tcb {t:#x}, port never did")
+        for t in sorted(rb - ra):
+            problems.append(f"ran: port ran tcb {t:#x}, oracle never did")
+
+    if (v := field("first_switch")) is not None and v != a["first_switch"]:
+        problems.append(f"first_switch: oracle {[hex(x) for x in a['first_switch']]}, port {[hex(x) for x in v]}")
+
+    if (v := field("dispatches")) is not None:
+        n = min(len(a["dispatches"]), len(v))
+        for i in range(n):
+            da, db = a["dispatches"][i], v[i]
+            if da["tcb"] != db["tcb"] or da["pc"] != db["pc"]:
+                problems.append(f"dispatches[{i}]: oracle tcb {da['tcb']:#x} pc {da['pc']:#x} at "
+                                f"{da['sample']}, port tcb {db['tcb']:#x} pc {db['pc']:#x} at {db['sample']}")
+                break
+            if abs(da["sample"] - db["sample"]) > PIT_PERIOD_SAMPLES:
+                problems.append(f"dispatches[{i}]: same task, but oracle at sample {da['sample']} and "
+                                f"port at {db['sample']} -- more than one PIT period apart")
+                break
+        if len(v) < len(a["dispatches"]):
+            problems.append(f"dispatches: port recorded {len(v)}, oracle {len(a['dispatches'])}")
+
+    for m in missing:
+        print(f"MISSING  {m} (the port does not produce it yet)")
+    for p in problems:
+        print(f"DIFFERS  {p}")
+    checked = len(a) - len(missing)
+    if problems:
+        print(f"oracle: {len(problems)} disagreement(s) over {checked} field(s) -- a finding, go and measure")
+        return 1
+    print(f"oracle: {checked} field(s) agree" + (f", {len(missing)} not yet produced" if missing else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ot_emu/periph.cpp
+++ b/tools/ot_emu/periph.cpp
@@ -1,0 +1,174 @@
+#include "periph.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace ot
+{
+	// ---- PIT ---------------------------------------------------------------
+	double Pit::periodSamples() const
+	{
+		const uint32_t pre = (m_pcsr >> 8) & 0xf;
+		return static_cast<double>(m_pmr + 1) * static_cast<double>(1u << pre) / m_clockHz * g_sampleHz;
+	}
+
+	void Pit::arm(const double _now)
+	{
+		if(m_pcsr & EN)
+		{
+			m_expiry = _now + periodSamples();
+			m_armed = true;
+		}
+		else
+			m_armed = false;
+	}
+
+	uint32_t Pit::read(const uint32_t _off, const uint32_t _size, const double _now) const
+	{
+		if(_off == 0)
+			return m_pcsr;
+		if(_off == 2)
+			return m_pmr;
+		if(_off == 4)
+		{
+			// PCNTR: what is left of the current period, scaled into the
+			// counter's own units. Route A's shape exactly -- the firmware
+			// only ever compares it against zero and against PMR.
+			if(!m_armed)
+				return m_pmr;
+			const double period = std::max(periodSamples(), 1e-9);
+			const double frac = std::max(0.0, m_expiry - _now) / period;
+			return static_cast<uint32_t>(frac * static_cast<double>(m_pmr)) & 0xffff;
+		}
+		return (1u << (8 * _size)) - 1;
+	}
+
+	void Pit::write(const uint32_t _off, uint32_t, const uint32_t _val, const double _now)
+	{
+		if(_off == 0)
+		{
+			// PIF is WRITE-1-TO-CLEAR: the incoming bit clears the flag, it
+			// never sets it.
+			const bool wasEnabled = (m_pcsr & EN) != 0;
+			const bool clearPif = (_val & PIF) != 0;
+			m_pcsr = (_val & ~PIF) | (m_pcsr & PIF);
+			if(clearPif)
+				m_pcsr &= ~PIF;
+			if((m_pcsr & EN) && !wasEnabled)
+				arm(_now);
+			else if(!(m_pcsr & EN))
+				m_armed = false;
+		}
+		else if(_off == 2)
+		{
+			m_pmr = _val & 0xffff;
+			// OVW: overwrite the running count immediately. Without it a new
+			// period only takes effect at the next expiry.
+			if((m_pcsr & OVW) || !m_armed)
+				arm(_now);
+		}
+	}
+
+	uint32_t Pit::advance(const double _now)
+	{
+		uint32_t n = 0;
+		while(m_armed && _now >= m_expiry)
+		{
+			m_pcsr |= PIF;
+			++m_fired;
+			++n;
+			if(m_pcsr & RLD)
+				m_expiry += periodSamples();
+			else
+				m_armed = false;
+		}
+		return n;
+	}
+
+	void Pit::seed(const uint32_t _pcsr, const uint32_t _pmr, const double _now)
+	{
+		m_pcsr = _pcsr;
+		m_pmr = _pmr;
+		arm(_now);
+	}
+
+	// ---- INTC --------------------------------------------------------------
+	uint64_t Intc::asserted() const
+	{
+		uint64_t a = m_intfrc;
+		for(const auto& l : m_lines)
+			if(l.second())
+				a |= 1ull << l.first;
+		return a;
+	}
+
+	std::vector<std::pair<uint32_t, uint32_t>> Intc::pending() const
+	{
+		uint64_t a = asserted() & ~m_imr;
+		if(m_imr & 1)			// MASKALL
+			a = 0;
+		a |= m_intfrc;			// ... but a forced source is delivered anyway
+
+		std::vector<std::pair<uint32_t, uint32_t>> out;
+		for(uint32_t s = 1; s < 64; ++s)
+			if((a >> s) & 1)
+				if(const auto level = m_icr[s])		// ICR 0 is never delivered
+					out.emplace_back(level, s);
+		std::sort(out.begin(), out.end(), std::greater<>());
+		return out;
+	}
+
+	uint32_t Intc::read(const uint32_t _off, const uint32_t _size) const
+	{
+		if(_off < 0x18 && _size == 4)
+		{
+			const auto a = asserted();
+			switch(_off)
+			{
+			case 0x00: return static_cast<uint32_t>(a >> 32);
+			case 0x04: return static_cast<uint32_t>(a);
+			case 0x08: return static_cast<uint32_t>(m_imr >> 32);
+			case 0x0c: return static_cast<uint32_t>(m_imr);
+			case 0x10: return static_cast<uint32_t>(m_intfrc >> 32);
+			case 0x14: return static_cast<uint32_t>(m_intfrc);
+			default:   return 0;
+			}
+		}
+		if(_off >= 0x40 && _off < 0x80 && _size == 1)
+			return m_icr[_off - 0x40];
+		return (1u << (8 * _size)) - 1;
+	}
+
+	void Intc::write(const uint32_t _off, const uint32_t _size, const uint32_t _val)
+	{
+		if(_off == 0x08 && _size == 4)
+			m_imr = (static_cast<uint64_t>(_val) << 32) | (m_imr & 0xffffffffull);
+		else if(_off == 0x0c && _size == 4)
+			m_imr = (m_imr & ~0xffffffffull) | _val;
+		else if((_off == 0x10 || _off == 0x14) && _size == 4)
+		{
+			const auto before = m_intfrc;
+			if(_off == 0x10)
+				m_intfrc = (static_cast<uint64_t>(_val) << 32) | (m_intfrc & 0xffffffffull);
+			else
+				m_intfrc = (m_intfrc & ~0xffffffffull) | _val;
+			// A force is a RESCHEDULE REQUEST: the run loop has to see it
+			// inside the instruction that made it, not at the end of a burst.
+			if((m_intfrc & ~before) && m_onForce)
+				m_onForce(m_intfrc & ~before);
+		}
+		else if(_off == 0x1c && _size == 1)			// SIMR: set mask
+			m_imr = (_val & 0x40) ? ~0ull : (m_imr | (1ull << (_val & 0x3f)));
+		else if(_off == 0x1d && _size == 1)			// CIMR: clear mask
+		{
+			// ...and MASKALL (IMRL bit 0) with it. 🟡 INFERRED, and route A
+			// says why: nothing in the image ever writes IMRH/IMRL (a literal
+			// scan found no site), the firmware unmasks only through CIMR, and
+			// the unit plainly takes interrupts -- so CIMR must clear MASKALL
+			// too or nothing would ever be delivered.
+			m_imr = (_val & 0x40) ? 0ull : (m_imr & ~((1ull << (_val & 0x3f)) | 1ull));
+		}
+		else if(_off >= 0x40 && _off < 0x80 && _size == 1)
+			m_icr[_off - 0x40] = _val & 7;
+	}
+}

--- a/tools/ot_emu/periph.h
+++ b/tools/ot_emu/periph.h
@@ -1,0 +1,107 @@
+// The MCF5445x peripherals the RTOS needs, translated from route A.
+//
+// `tools/emu_rtos.py` is the specification for every rule in here, and each
+// one carries the measurement or the failure that established it. Where route
+// A says "measured", this says measured; where it says "inferred", so does
+// this. Nothing is tightened on the way across -- a rule that reads as
+// arbitrary is arbitrary in the firmware too, and the comment says so.
+//
+// Time is counted in SAMPLES, as route A counts it: the two clocks the
+// firmware cares about are fixed ratios of the sample clock (a DSP frame every
+// 16 samples, PIT0 every 220.5), so samples make the ratios exact and the
+// instruction budget a separate, honest knob.
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace ot
+{
+	inline constexpr double g_sampleHz = 44100.0;
+	inline constexpr double g_framePeriod = 16.0;		// samples per DSP frame interrupt
+
+	// ---- PIT ---------------------------------------------------------------
+	// MCF5445x programmable interval timer. PCSR +0, PMR +2, PCNTR +4.
+	//
+	// ⚠️ The prescaler input is a KNOB, not a fact: route A defaults it to
+	// 264 MHz and notes that off the 132 MHz bus clock every period is 2x
+	// longer. The sequencer's own tick rate is what pins it, and M6c's gate is
+	// what checks it.
+	class Pit
+	{
+	public:
+		enum : uint32_t { EN = 1, RLD = 2, PIF = 4, PIE = 8, OVW = 16 };
+
+		Pit(const char* _name, double _clockHz) : m_name(_name), m_clockHz(_clockHz) {}
+
+		double periodSamples() const;
+		bool irq() const { return (m_pcsr & PIF) && (m_pcsr & PIE); }
+		uint64_t fired() const { return m_fired; }
+
+		uint32_t read(uint32_t _off, uint32_t _size, double _now) const;
+		void write(uint32_t _off, uint32_t _size, uint32_t _val, double _now);
+
+		// Fire every expiry up to `_now`; returns how many fired.
+		uint32_t advance(double _now);
+
+		// The state the boot left behind the generic peripheral stub
+		// (0x400005a8..0x400005f6), replayed rather than guessed.
+		void seed(uint32_t _pcsr, uint32_t _pmr, double _now);
+
+	private:
+		void arm(double _now);
+
+		const char* m_name;
+		double m_clockHz;
+		uint32_t m_pcsr = 0, m_pmr = 0xffff;
+		bool m_armed = false;
+		double m_expiry = 0;
+		uint64_t m_fired = 0;
+	};
+
+	// ---- INTC --------------------------------------------------------------
+	// MCF54455RM rev 5 chapter 17. IPRH/L +0x00/+0x04 (read back what is
+	// asserted), IMRH/L +0x08/+0x0c, INTFRCH/L +0x10/+0x14, SIMR/CIMR bytes at
+	// +0x1c/+0x1d (value = source, 0x40 = all), ICRn at +0x40+n. The vector of
+	// a source is `vectorBase + source`.
+	class Intc
+	{
+	public:
+		Intc(const char* _name, uint32_t _vectorBase) : m_name(_name), m_vectorBase(_vectorBase) {}
+
+		// A source whose assertion is a live wire rather than a register bit
+		// (a timer's IRQ, a DMA completion): asked every time.
+		void addLine(uint32_t _source, std::function<bool()> _fn) { m_lines.emplace_back(_source, std::move(_fn)); }
+		void setForceHook(std::function<void(uint64_t)> _fn) { m_onForce = std::move(_fn); }
+
+		uint64_t asserted() const;
+
+		// (level, source) pairs, asserted and deliverable, highest level first.
+		//
+		// ⚠️ A FORCED request IGNORES THE MASK -- "The assertion of an
+		// interrupt request via the interrupt force register is not affected by
+		// the interrupt mask register" (MCF54455RM rev 5, §17.2.3). The
+		// firmware depends on it: the sequencer tick is source 32, installed
+		// with ICR 3 and never unmasked anywhere in the image, and masking it
+		// leaves the sequencer silent -- route A measured 400 frames and zero
+		// ticks before this rule went in. A source with ICR 0 is still never
+		// delivered.
+		std::vector<std::pair<uint32_t, uint32_t>> pending() const;
+
+		uint32_t vectorBase() const { return m_vectorBase; }
+
+		uint32_t read(uint32_t _off, uint32_t _size) const;
+		void write(uint32_t _off, uint32_t _size, uint32_t _val);
+
+	private:
+		const char* m_name;
+		uint32_t m_vectorBase;
+		uint64_t m_imr = ~0ull;			// bit n = source n masked; bit 0 = mask all
+		uint64_t m_intfrc = 0;
+		std::array<uint8_t, 64> m_icr = {};
+		std::vector<std::pair<uint32_t, std::function<bool()>>> m_lines;
+		std::function<void(uint64_t)> m_onForce;
+	};
+}

--- a/tools/ot_emu/test_periph.cpp
+++ b/tools/ot_emu/test_periph.cpp
@@ -1,0 +1,130 @@
+// The peripheral gate: every rule these models carry, checked against the
+// value route A's own model produces.
+//
+// The rules here are not obvious and several are counter-intuitive; each one
+// below exists because getting it wrong produced a specific, silent failure in
+// route A first (`docs/RTOS_FORK.md` §8.2, §4). Testing them is how a
+// translation stays a translation rather than a rewrite.
+#include <cstdio>
+#include <cmath>
+
+#include "periph.h"
+
+namespace
+{
+	int g_failures = 0;
+
+	void check(const char* _what, const bool _ok, const char* _detail = "")
+	{
+		if(!_ok)
+			++g_failures;
+		std::printf("  [%s] %s%s%s\n", _ok ? "PASS" : "FAIL", _what,
+			*_detail ? "  " : "", _detail);
+	}
+
+	void checkEq(const char* _what, const uint64_t _got, const uint64_t _want)
+	{
+		char d[128];
+		std::snprintf(d, sizeof d, "got %#llx want %#llx",
+			static_cast<unsigned long long>(_got), static_cast<unsigned long long>(_want));
+		check(_what, _got == _want, d);
+	}
+}
+
+int main()
+{
+	std::printf("peripheral gate (models translated from tools/emu_rtos.py):\n");
+
+	// ---- PIT -------------------------------------------------------------
+	{
+		// Route A's PIT0: the kernel's 5 ms tick. At the default 264 MHz
+		// prescaler input the period is 220.5 samples, which is what makes the
+		// sequencer's tick count come out right (M6a's gate: 28 ticks in 400
+		// frames, matching the cold run).
+		ot::Pit pit("PIT0", 264e6);
+		// prescaler 2^11, PMR such that the period is ~220.5 samples:
+		//   (pmr+1) * 2048 / 264e6 * 44100 = 220.5  ->  pmr+1 = 645
+		pit.write(2, 2, 644, 0.0);						// PMR
+		pit.write(0, 2, ot::Pit::EN | ot::Pit::RLD | ot::Pit::PIE | (11u << 8), 0.0);
+		const auto period = pit.periodSamples();
+		char d[128];
+		std::snprintf(d, sizeof d, "period %.2f samples (want ~220.5)", period);
+		check("PIT period comes from (PMR+1) << prescaler", std::fabs(period - 220.5) < 0.5, d);
+
+		check("no expiry before the period is up", pit.advance(period - 1.0) == 0);
+		check("one expiry at the period", pit.advance(period + 0.1) == 1);
+		check("PIF raises the line while PIE is set", pit.irq());
+
+		// PIF is WRITE-1-TO-CLEAR: writing it back clears it, and the line
+		// drops. An emulator that treats the write as "set" leaves the ISR
+		// re-entering forever.
+		pit.write(0, 2, ot::Pit::EN | ot::Pit::RLD | ot::Pit::PIE | ot::Pit::PIF | (11u << 8), period);
+		check("PIF is write-1-to-clear", !pit.irq());
+
+		// RLD: the timer reloads, so a long jump forward fires once per period
+		// rather than once in total.
+		const auto n = pit.advance(period * 4.5);
+		std::snprintf(d, sizeof d, "fired %u times over 3.5 periods", n);
+		check("RLD reloads (a jump forward fires every period)", n >= 3 && n <= 4, d);
+	}
+
+	// ---- INTC ------------------------------------------------------------
+	{
+		ot::Intc intc("INTC0", 64);
+
+		// A source is only deliverable once its ICR gives it a level: ICR 0 is
+		// never delivered, whatever else is true.
+		bool line = true;
+		intc.addLine(1, [&]{ return line; });
+		intc.write(0x1d, 1, 1);						// CIMR 1: unmask source 1
+		check("a source with ICR 0 is never delivered", intc.pending().empty());
+
+		intc.write(0x40 + 1, 1, 5);					// ICR1 = level 5
+		const auto p = intc.pending();
+		check("unmasked, with a level, it is delivered", p.size() == 1 && p[0].second == 1);
+
+		intc.write(0x1c, 1, 1);						// SIMR 1: mask it again
+		check("masked, it is not", intc.pending().empty());
+
+		// ⚠️ THE RULE THAT COST 400 SILENT FRAMES: a FORCED source ignores the
+		// mask entirely (MCF54455RM §17.2.3). The sequencer tick is source 32,
+		// ICR 3, and nothing in the image ever unmasks it -- masking it here
+		// leaves the sequencer dead.
+		intc.write(0x40 + 32, 1, 3);				// ICR32 = level 3
+		intc.write(0x1c, 1, 32);					// and MASK source 32
+		intc.write(0x10, 4, 1u);					// INTFRCH bit 0 = source 32
+		bool forcedDelivered = false;
+		for(const auto& e : intc.pending())
+			if(e.second == 32)
+				forcedDelivered = true;
+		check("a FORCED source is delivered THROUGH the mask (RM 17.2.3)", forcedDelivered);
+
+		// MASKALL, and CIMR clearing it: inferred in route A, and the reason is
+		// that nothing in the image writes IMRH/IMRL at all.
+		ot::Intc other("INTC1", 128);
+		other.addLine(2, []{ return true; });
+		other.write(0x40 + 2, 1, 4);
+		other.write(0x1c, 1, 0x40);					// SIMR 0x40: mask everything
+		check("SIMR 0x40 masks all", other.pending().empty());
+		other.write(0x1d, 1, 2);					// CIMR 2
+		check("CIMR clears MASKALL with it (inferred)", !other.pending().empty());
+
+		// Highest level first: the run loop delivers the head of this list.
+		ot::Intc pri("INTC0", 64);
+		pri.addLine(3, []{ return true; });
+		pri.addLine(4, []{ return true; });
+		pri.write(0x40 + 3, 1, 2);
+		pri.write(0x40 + 4, 1, 6);
+		pri.write(0x1d, 1, 3);
+		pri.write(0x1d, 1, 4);
+		const auto order = pri.pending();
+		check("pending() is highest level first",
+			order.size() == 2 && order[0].second == 4 && order[1].second == 3);
+
+		// IPR reads back what is asserted, which is what the firmware polls.
+		checkEq("IPRL reads back the asserted sources", pri.read(0x04, 4), (1u << 3) | (1u << 4));
+	}
+
+	std::printf("%s\n", g_failures ? "PERIPHERAL GATE FAILED" : "peripheral gate passed.");
+	return g_failures ? 1 : 0;
+}


### PR DESCRIPTION
- **O3**: PIT and INTC translated from route A rule for rule, 14 checks in `test_periph.cpp` (forced-through-mask, CIMR clears MASKALL, ICR 0 never delivered, PIF write-1-to-clear). `ctest` 5/5.
- **The oracle, concrete**: `emu_rtos.py --golden` exports route A's M6a facts; `out/oracle/m6a.json` = 10 tasks, 11 ran, boot→main, 204.95 ms. `tools/ot_emu/oracle.py` diffs the port's report against it, MISSING for fields not yet produced.
- **`docs/COLDFIRE_WORKORDER.md`**: the queue for unattended sessions — O4 run loop, O5 peripherals, O6 eDMA + frame clock, O7 card + load (Opus), O8 DSP join, O9 audio (Fable). Each with the route A code it translates, its gate and its stop condition, plus the standing rules and the `/loop` prompt.

(These two commits were first made on main by mistake and moved here unpushed; main was reset to origin.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)