### PR TITLE
O5: the port grows the memory the oracle grows, and the gate compares the serial stream

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -169,7 +169,18 @@ first switch boot → main, the M6a gate reached at **204.88 ms** against route
 A's 204.95. `ctest` is **6 tests, all passing** (the new `rtos` one is route
 A's M6a gate, self-contained).
 
-**The oracle diff passes 8 of 8 fields** (`tools/ot_emu/oracle.py`).
+**The oracle diff passes** (`tools/ot_emu/oracle.py`).
+
+> ❌ **RETRACTED 8 Sep 2026: "8 of 8 fields".** The diff's summary counted
+> every field in the golden, including three it has never compared —
+> `gate_ms`, `pit0_fired` and (later) `serial_sent`, all of which track the
+> `ips` knob. O4 actually agreed on **6 compared fields**: `handoff_pc`,
+> `auto_pokes`, `created`, `ran`, `first_switch`, `dispatches`. The claim was
+> inflated by the script, not by the port — nothing about O4's result changes,
+> only what it is honest to say about it. `oracle.py` now counts only what it
+> compared and prints a `REPORTED` line for the rest. Same defect as a watch
+> that prints nothing: a gate that takes credit for fields it did not check
+> (RTOS_FORK §10.3b).
 
 ### The one deliberate divergence from route A
 
@@ -238,6 +249,100 @@ tick). So that is the strict criterion, along with the created fields, the set
 that ran, the first switch and each task's first-run time within one PIT
 period; the resumed PCs and the preemption count are **reported as notes**.
 The gate is still sharp: at ips 4100 it fails on first-run times.
+
+## Milestone O5 — the rest of the memory, and what the oracle really does ✅ (8 Sep 2026)
+
+O5 was written as "the remaining peripherals" and its list was nearly empty:
+the UARTs and the DSPI had already moved into O4, leaving two memory spans
+route A maps in `install` and a serial byte count to compare. Both were done
+in minutes, **and the gate passed on the first run** — which, by the standing
+rule that a gate which has never failed proves nothing, is where the milestone
+actually started.
+
+### The two maps, translated
+
+`Rtos::install` now adds route A's own two spans, with its reasons:
+`0x00010000+0x1f0000` so the test-mode magic word at `0x1ffffe` reads **zero**
+(`0x4003232c` takes `0xdcba` as a test-mode flash), and `0x10100000+0x1000`
+for the settings reset's off-by-four past the SRAM window. ✅ Both are visible
+in the port's own access log: exactly **one read at `0x1ffffe`** (pc
+`0x4003233e`) and exactly **four byte-writes at `0x10100000`**, which is the
+off-by-four reproduced rather than assumed. Neither changed the gate.
+
+### ⚠️ The finding: route A does not fault on unmapped memory, and this port was not the same machine
+
+The port answers **all-ones** for an address in no region and drops the write;
+Unicorn raises `UC_ERR_READ_UNMAPPED`. That difference was assumed to be
+harmless because route A "always faults". It does not. `_prime_menu`
+(`emu_bringup`) installs an unmapped-access hook that **maps a zero page and
+returns True** — a workaround for a stale formatter pointer in the menu
+render — and it stays installed for the rest of the run. So in the golden
+configuration route A *grows*:
+
+| | measured |
+|---|---|
+| regions after the boot | 9 |
+| regions at the M6a gate | 15 |
+| grown by `install`'s two explicit maps | `0x10000-0x1fffff`, `0x10100000-0x10100fff` |
+| grown by the auto-map hook | `0x10000000-0x100affff`, `0x100c0000-0x100fffff`, `0x42000000-0x45ffffff`, `0x48100000-0x4fffffff` |
+
+Those four are, page for page, the four spans this port was answering all-ones
+for — **20,348,069 accesses** (14,073 read, 20,333,996 written). Their two
+largest sources are both plain literal loops, disassembled rather than
+inferred:
+
+- `0x400209a4` is a `moveml`-based `bzero`, called on **64 MB at
+  `0x42000000`** — precisely the gap between route A's two SDRAM regions.
+- `0x40002fb4` is `lea 0x4f502c10,%a0` / `movel #705664,%d0` and a 16-byte
+  clear loop: **10.8 MB**, both bounds hard-coded in the image.
+
+✅ Without a project route A really does fault (`unmapped read 0x100fff04 at
+pc 0x4001fa4e`), which is the behaviour its own note in the work order
+describes — but the oracle is the golden configuration, and there it grows. So
+the port now grows too, at route A's granularity (`addr & ~0xfff`, 4 KB): a
+first touch allocates a **zeroed** page and the access proceeds. `19,385`
+pages, 77 MB, on the run to the gate. `setAutoMap(false)` restores the
+all-ones stub, and then the counter is a work list again.
+
+### ⚠️ The serial byte count was an artefact of the missing memory
+
+The count agreed at **4831** before the auto-map change and disagreed
+(**5731** against route A's 4831) after it. The temptation is to read that as
+the change breaking something. It is the opposite: the port's transmit ring
+lived in memory that was being dropped, so the bytes were never counted.
+
+The streams themselves are **identical**: route A's 4831 bytes are an exact
+prefix of the port's 5731, and at ips 4100 the port's stream is byte-for-byte
+route A's whole stream. The difference is one ~900-byte ring drain landing
+either side of the gate, and it tracks the clock knob — the same shape as O4's
+resumed PCs:
+
+| ips | 3900 | 3990 | 4100 | 4200 | 4300 |
+|---|---|---|---|---|---|
+| bytes sent | 5731 | 5731 | 4831 | 4831 | 4831 |
+
+❌ **Retracted the same day it was written:** an earlier sweep in this session
+found 4831 at every `ips` and concluded the count was clock-independent. That
+sweep was run on the all-ones machine, where the ring writes were being
+discarded — it measured the absence of the memory, not a property of the
+firmware. **A knob sweep on an instrument that cannot see the thing is not
+evidence**, which is the `send_probe` THD lesson in a new costume.
+
+So the gate compares the **bytes over the length both runs reached** — one
+must be a prefix of the other — and reports the totals. That is 4831 bytes of
+content instead of one integer, and it is clock-independent by construction.
+`test_rtos` checks the same thing self-contained, as an FNV-1a over the first
+4831 bytes (`0x208868fc`).
+
+### The negative control
+
+`test_rtos` boots a second machine with `Rtos::Quirks::clearTransmitInterrupt`
+false — the one thing in `install` that changes which serial writes happen —
+and **requires the count to move**. It goes 4831 → 0. Without that, the serial
+comparison would be decoration.
+
+**Gate:** `ctest` 6/6; the oracle diff reports **8 compared fields agree, 0
+disagreements**; `make check` green.
 
 ## What is NOT here yet
 

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -31,7 +31,13 @@ start the next one, and it does not loosen the gate.
 5. **Git:** branch, PR, merge. Never commit to main (O3 was committed to main
    by mistake and had to be moved; do not repeat it).
 6. `ctest` in `out/emu` must stay green. `make check` must stay green.
-7. **Ask nothing of the user mid-milestone.** Everything a milestone needs is
+7. **Before trusting an agreement, check the two machines are the same
+   machine.** O5's gate passed on its first run and the agreement was an
+   artefact: the port answered all-ones where the oracle answered zero, and
+   the bytes that would have disagreed were being dropped on the floor. A
+   knob sweep run on an instrument that cannot see the thing measures the
+   instrument (`CLAUDE.md`, the `send_probe` THD entry).
+8. **Ask nothing of the user mid-milestone.** Everything a milestone needs is
    in this file, `COLDFIRE_PORT.md`, `RTOS_FORK.md` and the route A source.
    If it is genuinely not, that is a BLOCKED PR, not a question.
 
@@ -63,7 +69,8 @@ route A fact, not the port's problem; the golden command above already does it.
 | O1 | boots to the RTOS handoff | reaches `trap #0` | ✅ same PC `0x40000e46`, same two auto-pokes |
 | O2 | the EMAC (fractional, `msac`, A-line dispatch) | `ctest` emac | ✅ hardware's three cases |
 | O3 | PIT + INTC models | `ctest` periph, 14 rules | (wired in by O4) |
-| O4 | the run loop: the kernel runs | `ctest` rtos + the oracle diff | ✅ 8/8 fields; 10 created, 11 ran, 204.88 ms vs 204.95 |
+| O4 | the run loop: the kernel runs | `ctest` rtos + the oracle diff | ✅ 6 compared fields (❌ was written "8/8": the diff counted 2 it never compared); 10 created, 11 ran, 204.88 ms vs 204.95 |
+| O5 | the rest of the memory; the serial stream | `ctest` rtos + the oracle diff | ✅ 8 compared fields; route A's 4831 serial bytes matched byte for byte |
 
 ## Queue
 
@@ -124,17 +131,29 @@ and written into this entry with the two emulators' values side by side.
 
 </details>
 
-### O5 — the remaining peripherals *(Opus, mechanical)*
+### ~~O5 — the remaining peripherals~~ ✅ DONE (8 Sep 2026)
 
-⚠️ **`Uart` and `Dspi` are already done** (O4 needed them). What is left:
-the serial-link handling in `install`, the test-mode word at `0x1ffffe`
-(`0x4003232c` expects `0xdcba`; zero = normal), the settings-reset loop past
-the 1 MB SRAM window (`0x4001f298`). Each is a class in `periph.{h,cpp}`
-with its rules tested in `test_periph.cpp` **before** it is wired in.
+See `COLDFIRE_PORT.md`. Three things O6 and O7 must know:
 
-**Gate:** the O4 oracle diff still passes, and `ot_emu` reports the same
-serial byte count route A does (`report()`: "serial sent: 4831 B") --
-`Rtos::serialSent()` already exposes it, and it is NOT yet compared.
+1. **Route A does NOT fault on unmapped memory in the golden configuration.**
+   `_prime_menu` installs a hook that maps a zero page and returns True, and
+   it stays installed; route A's region list goes 9 → 15 by the M6a gate. The
+   port now grows the same way (`Machine::setAutoMap`, 4 KB pages, zeroed).
+   Before concluding anything from a difference, check whether the two
+   machines answer an unmapped address the same way — for months they did not.
+2. **The serial count is a clock artefact; the serial STREAM is not.** The
+   ring drains in bursts (5731 bytes at ips 3900/3990, 4831 at 4100 and up),
+   and every one of those streams shares route A's 4831 as an exact prefix.
+   The gate compares bytes over the common length.
+3. **`oracle.py` used to count fields it never compared.** It now prints a
+   `REPORTED` line for `gate_ms`, `pit0_fired` and `serial_sent`. When a
+   milestone adds a field, compare it or expect to see it listed there.
+
+The port still auto-maps **20.3 M accesses** on the way to the gate, almost
+all of them a 64 MB clear at `0x42000000` and a 10.8 MB clear at `0x4f502c10`.
+That is not a defect — route A covers the same spans — but O7's card is what
+would make the two machines allocate from the same place, and it is worth
+re-checking the span list once the project loads.
 
 ### O6 — the eDMA and the frame clock *(Opus, but read §8.1 first)*
 
@@ -184,5 +203,5 @@ One session per milestone, in a terminal left open:
 /loop Take the next milestone in docs/COLDFIRE_WORKORDER.md that is not done and not BLOCKED. Work on a branch named for it. Follow the standing rules. Open a PR when its gate passes, or a draft PR titled BLOCKED with the measurement. Then stop.
 ```
 
-Use **Opus** for O4–O7. Switch to Fable for O8 and for any BLOCKED PR.
+Use **Opus** for O6 and O7. Switch to Fable for O8 and for any BLOCKED PR.
 Nothing here needs a flash, the card, or the user.

--- a/tools/emu_rtos.py
+++ b/tools/emu_rtos.py
@@ -1598,11 +1598,26 @@ def attach(image=None, card_image=None, log=None, **kw):
     if r.trap != (32, HANDOFF):
         raise RtosFault(f"handoff trap is {r.trap}, expected (32, {HANDOFF:#x})")
     r.rtos_boot_writes = boot_writes
+    # The region set the BOOT ends with, captured rather than written down.
+    # ⚠️ It grows on its own from here: `_prime_menu` (emu_bringup) installs
+    # an unmapped-access hook that maps a zero page and returns True -- a
+    # workaround for a stale formatter pointer in the menu render -- and it
+    # stays installed, so route A does not fault on unmapped memory on any
+    # path that has primed the menu. Measured 8 Sep 2026: the card attach and
+    # main's own init grow FOUR spans this way before the M6a gate, and they
+    # are exactly the four the C++ port was answering all-ones for
+    # (COLDFIRE_PORT.md, O5).
+    _boot_regions = {(b, e) for b, e, _ in r.uc.mem_regions()}
     rt = Rtos(r, **kw)
     if card_image is not None:
         s = ec.attach(r, card_image, log, cold_hooks=False)
         rt.attach_card(s.card)
     rt.install()
+    # The region set the run STARTS from, captured rather than written down:
+    # an unmapped access auto-maps a zero page once `_prime_menu` has run, so
+    # the list grows, and the growth is the interesting part (see the report
+    # at the end of the until-gate path).
+    rt._base_regions = _boot_regions
     return r, rt
 
 
@@ -1667,6 +1682,8 @@ def _cli():
     ap.add_argument("--step-quantum", type=int, default=32)
     ap.add_argument("--no-tick", action="store_true", help="PIT0 never asserts (step-1 checkpoint)")
     ap.add_argument("--until-gate", action="store_true", help="stop as soon as the M6a gate passes")
+    ap.add_argument("--serial-out", default="",
+                    help="write the bytes each UART transmitted to FILE.a / FILE.b")
     ap.add_argument("--golden", default="",
                     help="write the M6a facts (created tasks, which ran, the first switch, the first "
                          "dispatches, the handoff PC and the boot's auto-pokes) as JSON: THE ORACLE the "
@@ -1976,7 +1993,34 @@ def _cli():
     print("M6a gate   :", "PASS" if ok else "FAIL")
     for p in problems:
         print("   -", p)
+    # ⚠️ --watch-pc / --watch-calls / --watch-mem printed NOTHING on this
+    # path: `_watch_report` was only called from the M6c branch, so a watched
+    # address that never fired and one that fired constantly looked identical
+    # here -- silence. That is the same silent-instrument trap section 10.3b
+    # records for --trace, surviving in a second branch; found 8 Sep 2026
+    # while asking whether route A ever executes the two large clear loops the
+    # C++ port runs (COLDFIRE_PORT.md, O5). Nothing concluded from a silent
+    # watch on this path before today is worth anything.
+    _watch_report()
+    # ⚠️ HOW MANY REGIONS ARE MAPPED, and it is not a constant. `_prime_menu`
+    # (emu_bringup) installs an unmapped-access hook that MAPS A ZERO PAGE and
+    # returns True -- a menu-render workaround for a stale formatter pointer --
+    # and it stays installed for the rest of the run. So on any path that has
+    # primed the menu, route A does NOT fault on unmapped memory: it silently
+    # grows a zero page. Printed because the C++ port answers ALL-ONES and
+    # drops the write instead, which is a different machine (COLDFIRE_PORT.md,
+    # O5, 8 Sep 2026).
+    _now = {(b, e) for b, e, _ in rt.uc.mem_regions()}
+    _grew = sorted(_now - getattr(rt, "_base_regions", _now))
+    print(f"regions    : {len(_now)} mapped at the stop, {len(_grew)} GREW after the boot"
+          + (": " + ", ".join(f"{b:#x}-{e:#x}" for b, e in _grew) if _grew else ""))
+    if a.serial_out:
+        for suffix, u in (("a", rt.uart64), ("b", rt.uart68)):
+            pathlib.Path(a.serial_out + "." + suffix).write_bytes(bytes(u.tx))
+        print(f"serial out : {a.serial_out}.a ({len(rt.uart64.tx)} B), "
+              f"{a.serial_out}.b ({len(rt.uart68.tx)} B)")
     if a.golden:
+        import base64
         import json
         gold = dict(
             handoff_pc=HANDOFF,
@@ -1988,6 +2032,19 @@ def _cli():
             dispatches=[dict(sample=round(s_, 1), tcb=t, pc=pc) for s_, t, pc in rt.dispatches[:200]],
             gate_ms=round(rt.sample / SAMPLE_HZ * 1000, 2),
             pit0_fired=rt.pit0.fired,
+            # THE SERIAL STREAM, not its length. ⚠️ The COUNT is a clock
+            # artefact and the bytes are not: the transmit ring is drained in
+            # bursts, so whether the last ~900-byte drain lands before or
+            # after the gate depends on the instruction budget per sample.
+            # Measured 8 Sep 2026 on the C++ port, same image, same
+            # everything else: ips 3900 and 3990 stop with 5731 bytes sent,
+            # ips 4100, 4200 and 4300 with 4831 -- and every one of those
+            # streams has this one as an exact prefix. So the oracle compares
+            # the BYTES over the length both reached, which is a real property
+            # of the code path, and reports the length difference.
+            serial_sent=[len(rt.uart64.tx), len(rt.uart68.tx)],
+            serial_a=base64.b64encode(bytes(rt.uart64.tx)).decode(),
+            serial_b=base64.b64encode(bytes(rt.uart68.tx)).decode(),
         )
         pathlib.Path(a.golden).parent.mkdir(parents=True, exist_ok=True)
         pathlib.Path(a.golden).write_text(json.dumps(gold, indent=1))

--- a/tools/ot_emu/machine.cpp
+++ b/tools/ot_emu/machine.cpp
@@ -82,6 +82,66 @@ namespace ot
 		return nullptr;
 	}
 
+	void Machine::mapRegion(const uint32_t _base, const uint32_t _size)
+	{
+		// Route A's `except UcError: pass`: a span that is already there is
+		// left alone rather than remapped, so the boot map always wins.
+		for(const auto& r : m_regions)
+			if(_base >= r.base && _base - r.base < r.data.size())
+				return;
+		Region reg;
+		reg.base = _base;
+		reg.data.assign(_size, 0);
+		// A real map WINS over pages this machine grew on its own: carry the
+		// bytes across and drop them, so a later access cannot see stale ones.
+		for(uint32_t a = _base; a < _base + _size; ++a)
+			if(const uint8_t* const b = autoByte(a, false))
+				reg.data[a - _base] = *b;
+		for(uint32_t p = _base >> g_autoPageBits; p <= (_base + _size - 1) >> g_autoPageBits; ++p)
+			m_autoPages.erase(p);
+		m_lastAutoPage = ~0u;
+		m_lastAutoData = nullptr;
+		m_regions.push_back(std::move(reg));
+	}
+
+	// One byte of auto-mapped memory, allocating its page on first touch.
+	// The one-entry cache matters: the loops that need this are `bzero` and
+	// `memcpy` walking tens of megabytes in order, so the page almost never
+	// changes between accesses.
+	uint8_t* Machine::autoByte(const uint32_t _addr, const bool _create)
+	{
+		const uint32_t page = _addr >> g_autoPageBits;
+		if(page != m_lastAutoPage || !m_lastAutoData)
+		{
+			auto it = m_autoPages.find(page);
+			if(it == m_autoPages.end())
+			{
+				if(!_create)
+					return nullptr;
+				it = m_autoPages.emplace(page, std::vector<uint8_t>(g_autoPageSize, 0)).first;
+			}
+			m_lastAutoPage = page;
+			m_lastAutoData = &it->second;
+		}
+		return m_lastAutoData->data() + (_addr & (g_autoPageSize - 1));
+	}
+
+	void Machine::noteUnmapped(const char _kind, const uint32_t _addr, const uint8_t _size,
+		const uint32_t _val)
+	{
+		++m_unmappedCount;
+		const auto p = pc();
+		if(_kind == 'r')
+		{
+			++m_unmappedReads;
+			++m_unmappedReadPcs[p];
+		}
+		++m_unmappedPages[_addr >> 16];
+		++m_unmappedPcs[p];
+		if(m_unmapped.size() < 4096)
+			m_unmapped.push_back({_kind, p, _addr, _size, _val});
+	}
+
 	bool Machine::isPeripheral(const uint32_t _addr) const
 	{
 		for(const auto& p : g_periph)
@@ -166,6 +226,9 @@ namespace ot
 			return static_cast<uint8_t>(peripheralRead(_addr, 1));
 		if(auto* const r = find(_addr, 1))
 			return r->data[_addr - r->base];
+		noteUnmapped('r', _addr, 1, 0xff);
+		if(m_autoMap)
+			return *autoByte(_addr, true);
 		return 0xff;
 	}
 
@@ -178,6 +241,9 @@ namespace ot
 			const auto o = _addr - r->base;
 			return static_cast<uint16_t>((r->data[o] << 8) | r->data[o + 1]);
 		}
+		noteUnmapped('r', _addr, 2, 0xffff);
+		if(m_autoMap)
+			return static_cast<uint16_t>((*autoByte(_addr, true) << 8) | *autoByte(_addr + 1, true));
 		return 0xffff;
 	}
 
@@ -188,6 +254,12 @@ namespace ot
 			return peripheralWrite(_addr, 1, _val);
 		if(auto* const r = find(_addr, 1))
 			r->data[_addr - r->base] = _val;
+		else
+		{
+			noteUnmapped('w', _addr, 1, _val);
+			if(m_autoMap)
+				*autoByte(_addr, true) = _val;
+		}
 	}
 
 	void Machine::write16(const uint32_t _addr, const uint16_t _val)
@@ -200,6 +272,15 @@ namespace ot
 			const auto o = _addr - r->base;
 			r->data[o]     = static_cast<uint8_t>(_val >> 8);
 			r->data[o + 1] = static_cast<uint8_t>(_val);
+		}
+		else
+		{
+			noteUnmapped('w', _addr, 2, _val);
+			if(m_autoMap)
+			{
+				*autoByte(_addr, true)     = static_cast<uint8_t>(_val >> 8);
+				*autoByte(_addr + 1, true) = static_cast<uint8_t>(_val);
+			}
 		}
 	}
 
@@ -218,6 +299,12 @@ namespace ot
 			return (static_cast<uint32_t>(r->data[o]) << 24) | (static_cast<uint32_t>(r->data[o + 1]) << 16)
 				 | (static_cast<uint32_t>(r->data[o + 2]) << 8) | r->data[o + 3];
 		}
+		noteUnmapped('r', _addr, 4, 0xffffffff);
+		if(m_autoMap)
+			return (static_cast<uint32_t>(*autoByte(_addr, true)) << 24)
+				 | (static_cast<uint32_t>(*autoByte(_addr + 1, true)) << 16)
+				 | (static_cast<uint32_t>(*autoByte(_addr + 2, true)) << 8)
+				 | *autoByte(_addr + 3, true);
 		return 0xffffffff;
 	}
 
@@ -233,6 +320,17 @@ namespace ot
 			r->data[o + 1] = static_cast<uint8_t>(_val >> 16);
 			r->data[o + 2] = static_cast<uint8_t>(_val >> 8);
 			r->data[o + 3] = static_cast<uint8_t>(_val);
+		}
+		else
+		{
+			noteUnmapped('w', _addr, 4, _val);
+			if(m_autoMap)
+			{
+				*autoByte(_addr, true)     = static_cast<uint8_t>(_val >> 24);
+				*autoByte(_addr + 1, true) = static_cast<uint8_t>(_val >> 16);
+				*autoByte(_addr + 2, true) = static_cast<uint8_t>(_val >> 8);
+				*autoByte(_addr + 3, true) = static_cast<uint8_t>(_val);
+			}
 		}
 	}
 

--- a/tools/ot_emu/machine.h
+++ b/tools/ot_emu/machine.h
@@ -162,6 +162,61 @@ namespace ot
 		uint32_t peek32(uint32_t _addr);
 		void     poke32(uint32_t _addr, uint32_t _val);
 
+		// Map a span of plain memory after construction. Route A's `install`
+		// adds two of these over the boot map (`Rtos::install`), and an
+		// overlap with something already mapped is IGNORED, not an error --
+		// route A wraps each `mem_map` in a bare `except UcError: pass`.
+		void mapRegion(uint32_t _base, uint32_t _size);
+
+		// ⚠️ THIS MACHINE NEVER FAULTS ON UNMAPPED MEMORY AND ROUTE A ALWAYS
+		// DOES, so the two emulators are least comparable exactly where a
+		// model is missing. Unicorn raises UC_ERR_READ_UNMAPPED, which is why
+		// route A's own note says it "faults reading 0x100fff04 in main's
+		// settings path" without a card attached; here the same read answers
+		// all-ones and the firmware carries on down a path nobody chose. So
+		// every access outside every region and every peripheral window is
+		// COUNTED and the first few thousand are kept, because a silent
+		// all-ones is the port's version of route A's crash and it has to be
+		// visible to be compared at all.
+		// ✅ WHAT ROUTE A ACTUALLY DOES, measured 8 Sep 2026 and NOT what its
+		// source reads like: `_prime_menu` (emu_bringup) installs an
+		// unmapped-access hook that maps a zero page and returns True -- a
+		// workaround for a stale formatter pointer in the menu render -- and
+		// it stays installed for the rest of the run. So in the golden
+		// configuration route A does not fault on unmapped memory at all: it
+		// GROWS. Its region list goes from 11 after `install` to 15 by the
+		// M6a gate, and the four it adds are
+		//     0x10000000-0x100affff  0x100c0000-0x100fffff
+		//     0x42000000-0x45ffffff  0x48100000-0x4fffffff
+		// which are, page for page, the four spans this port was answering
+		// all-ones for (20,348,069 accesses: a 64 MB clear at 0x42000000 from
+		// the bzero at 0x400209a4, a 10.8 MB clear at 0x4f502c10 from the
+		// literal loop at 0x40002fb4, and main's settings window). So the
+		// port grows the same way, at route A's own 4 KB granularity: a first
+		// touch allocates a ZEROED page and the access proceeds.
+		//
+		// ⚠️ Without a project route A DOES fault (measured: "unmapped read
+		// 0x100fff04 at pc 0x4001fa4e"), because nothing primed the menu. The
+		// oracle is the golden configuration, so growing is the faithful
+		// behaviour; `setAutoMap(false)` restores the all-ones stub for
+		// diagnosis, and then this counter is the work list again.
+		void setAutoMap(bool _on) { m_autoMap = _on; }
+		uint64_t autoMappedPages() const { return m_autoPages.size(); }
+
+		struct Unmapped { char kind; uint32_t pc, addr; uint8_t size; uint32_t val; };
+		const std::vector<Unmapped>& unmapped() const { return m_unmapped; }
+		uint64_t unmappedCount() const { return m_unmappedCount; }
+		// A dropped WRITE and an all-ones READ are different problems: the
+		// write is lost only if something reads it back, the read is a value
+		// the firmware acts on. Counted apart for that reason.
+		uint64_t unmappedReads() const { return m_unmappedReads; }
+		uint64_t unmappedWrites() const { return m_unmappedCount - m_unmappedReads; }
+		// The detail log is capped; these two are not. A page is 64 KB.
+		const std::unordered_map<uint32_t, uint64_t>& unmappedPages() const { return m_unmappedPages; }
+		const std::unordered_map<uint32_t, uint64_t>& unmappedPcs() const { return m_unmappedPcs; }
+		// Reads only: the accesses that feed the firmware a value it acts on.
+		const std::unordered_map<uint32_t, uint64_t>& unmappedReadPcs() const { return m_unmappedReadPcs; }
+
 		// Every distinct peripheral address the run touched, in first-touch
 		// order: route A logs the same thing (`BootResult.boot_map`), so the
 		// two boots can be compared without a full instruction trace.
@@ -194,6 +249,19 @@ namespace ot
 		PeriphWrite m_periphWriteFn;
 		std::vector<PeriphWriteRec> m_periphWrites;
 		std::vector<Access> m_periphLog;
+		void noteUnmapped(char _kind, uint32_t _addr, uint8_t _size, uint32_t _val);
+		std::vector<Unmapped> m_unmapped;
+		uint64_t m_unmappedCount = 0, m_unmappedReads = 0;
+		std::unordered_map<uint32_t, uint64_t> m_unmappedPages, m_unmappedPcs, m_unmappedReadPcs;
+
+		// Route A's granularity: `mem_map(addr & ~0xFFF, 0x1000)`.
+		static constexpr uint32_t g_autoPageBits = 12;
+		static constexpr uint32_t g_autoPageSize = 1u << g_autoPageBits;
+		bool m_autoMap = true;
+		std::unordered_map<uint32_t, std::vector<uint8_t>> m_autoPages;
+		uint32_t m_lastAutoPage = ~0u;			// a one-entry cache: these loops are sequential
+		std::vector<uint8_t>* m_lastAutoData = nullptr;
+		uint8_t* autoByte(uint32_t _addr, bool _create);
 		std::function<void(Machine&, uint32_t)> m_step;
 		uint64_t m_instructions = 0;
 		uint64_t m_v4e = 0;			// instructions the V4e layer supplied

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -11,6 +11,7 @@
 // vendored Musashi is ColdFire V2 and this firmware is V4e. That report is
 // the work list for the ISA half of the port, one opcode at a time.
 #include <cstdio>
+#include <map>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -41,6 +42,7 @@ int main(int _argc, char** _argv)
 	bool showPeripherals = false;
 	bool profile = false;
 	std::string golden;
+	std::string serialOut;
 	double runMs = 1000.0;
 	double ips = 3990.0;
 
@@ -52,6 +54,7 @@ int main(int _argc, char** _argv)
 		else if(a == "--periph")				showPeripherals = true;
 		else if(a == "--profile")				profile = true;
 		else if(a == "--golden" && i + 1 < _argc)	golden = _argv[++i];
+		else if(a == "--serial-out" && i + 1 < _argc)	serialOut = _argv[++i];
 		else if(a == "--ms" && i + 1 < _argc)	runMs = std::atof(_argv[++i]);
 		else if(a == "--ips" && i + 1 < _argc)	ips = std::atof(_argv[++i]);
 		else
@@ -115,10 +118,103 @@ int main(int _argc, char** _argv)
 		std::printf("M6a gate   : %s\n", ok ? "PASS" : "FAIL");
 		for(const auto& p : problems)
 			std::printf("   - %s\n", p.c_str());
+		if(!serialOut.empty())
+		{
+			for(const auto& [suffix, tx] : {std::make_pair("a", &rtos.serialTxA()),
+				std::make_pair("b", &rtos.serialTxB())})
+			{
+				std::ofstream o(serialOut + "." + suffix, std::ios::binary);
+				o.write(reinterpret_cast<const char*>(tx->data()), static_cast<std::streamsize>(tx->size()));
+			}
+			std::printf("serial out : %s.a (%zu B), %s.b (%zu B)\n",
+				serialOut.c_str(), rtos.serialTxA().size(), serialOut.c_str(), rtos.serialTxB().size());
+		}
 		if(!golden.empty())
 		{
 			rtos.writeGoldenJson(golden);
 			std::printf("golden     : %s\n", golden.c_str());
+		}
+	}
+
+	// ⚠️ Unmapped memory: route A FAULTS here and this machine answers
+	// all-ones, so anything in this list is a place the two emulators can
+	// disagree without either of them saying so. Grouped by address, with the
+	// PC of the first touch, because the address is the work item.
+	if(m.unmappedCount())
+	{
+		std::map<uint32_t, std::pair<uint64_t, ot::Machine::Unmapped>> byAddr;
+		for(const auto& u : m.unmapped())
+		{
+			auto it = byAddr.find(u.addr);
+			if(it == byAddr.end())
+				byAddr.emplace(u.addr, std::make_pair(uint64_t(1), u));
+			else
+				++it->second.first;
+		}
+		std::printf("auto-mapped: %llu access(es) outside every declared region and window "
+			"(%llu read, %llu written), %zu distinct address(es)%s\n",
+			static_cast<unsigned long long>(m.unmappedCount()),
+			static_cast<unsigned long long>(m.unmappedReads()),
+			static_cast<unsigned long long>(m.unmappedWrites()), byAddr.size(),
+			m.unmapped().size() < m.unmappedCount() ? " (log capped at 4096)" : "");
+		std::printf("             %llu zero page(s) grown, %llu KB -- route A grows the same "
+			"four spans (COLDFIRE_PORT.md O5)\n",
+			static_cast<unsigned long long>(m.autoMappedPages()),
+			static_cast<unsigned long long>(m.autoMappedPages() * 4));
+		// By 64 KB page and by the PC doing it -- uncapped, so a loop that
+		// runs millions of times is one line rather than a truncated list.
+		// Contiguous 64 KB pages are COALESCED into one span: the interesting
+		// number is how far a runaway clear reached, and 700 page lines hide it.
+		std::map<uint32_t, uint64_t> pages(m.unmappedPages().begin(), m.unmappedPages().end());
+		std::printf("             spans:");
+		uint32_t runFirst = 0, runLast = 0;
+		uint64_t runCount = 0;
+		bool inRun = false;
+		const auto flush = [&]()
+		{
+			if(!inRun)
+				return;
+			std::printf(" %#010x-%#010x x%llu", runFirst << 16, ((runLast + 1) << 16) - 1,
+				static_cast<unsigned long long>(runCount));
+		};
+		for(const auto& [page, count] : pages)
+		{
+			if(inRun && page == runLast + 1)
+			{
+				runLast = page;
+				runCount += count;
+				continue;
+			}
+			flush();
+			runFirst = runLast = page;
+			runCount = count;
+			inRun = true;
+		}
+		flush();
+		std::printf("\n");
+		std::vector<std::pair<uint32_t, uint64_t>> pcs(m.unmappedPcs().begin(), m.unmappedPcs().end());
+		std::sort(pcs.begin(), pcs.end(), [](const auto& _a, const auto& _b) { return _a.second > _b.second; });
+		std::printf("             pcs:");
+		for(size_t i = 0; i < pcs.size() && i < 6; ++i)
+			std::printf(" %#010x x%llu", pcs[i].first, static_cast<unsigned long long>(pcs[i].second));
+		std::printf("%s\n", pcs.size() > 6 ? " ..." : "");
+		std::vector<std::pair<uint32_t, uint64_t>> rpcs(m.unmappedReadPcs().begin(), m.unmappedReadPcs().end());
+		std::sort(rpcs.begin(), rpcs.end(), [](const auto& _a, const auto& _b) { return _a.second > _b.second; });
+		std::printf("             read pcs:");
+		for(size_t i = 0; i < rpcs.size() && i < 6; ++i)
+			std::printf(" %#010x x%llu", rpcs[i].first, static_cast<unsigned long long>(rpcs[i].second));
+		std::printf("%s\n", rpcs.size() > 6 ? " ..." : "");
+		size_t n = 0;
+		for(const auto& [addr, e] : byAddr)
+		{
+			if(n++ == 8)
+			{
+				std::printf("   ... %zu more logged\n", byAddr.size() - 8);
+				break;
+			}
+			std::printf("   %c%u %#010x  x%llu  first at pc %#010x -> %#x\n",
+				e.second.kind, e.second.size, addr, static_cast<unsigned long long>(e.first),
+				e.second.pc, e.second.val);
 		}
 	}
 

--- a/tools/ot_emu/oracle.py
+++ b/tools/ot_emu/oracle.py
@@ -43,6 +43,10 @@ What it checks, in the order a port reaches them:
                  and an unequal one is not evidence of anything. What a real
                  divergence looks like instead: a different TASK, a different
                  ORDER, or a time more than a period out -- all still fatal.
+  serial_a/_b    the BYTES each UART transmitted, compared over the length
+                 both reached: one must be a prefix of the other. The total
+                 is reported, never compared -- it tracks the ips knob
+                 because the transmit ring drains in bursts (milestone O5)
   gate_ms        when the gate passed
 
 A field the port has not produced yet is reported as MISSING, not as a
@@ -64,11 +68,13 @@ def main():
         sys.exit(__doc__)
     a, b = load(sys.argv[1]), load(sys.argv[2])
     problems, missing, notes = [], [], []
+    compared = []
 
     def field(name):
         if name not in b:
             missing.append(name)
             return None
+        compared.append(name)
         return b[name]
 
     if (v := field("handoff_pc")) is not None and v != a["handoff_pc"]:
@@ -101,6 +107,40 @@ def main():
 
     if (v := field("first_switch")) is not None and v != a["first_switch"]:
         problems.append(f"first_switch: oracle {[hex(x) for x in a['first_switch']]}, port {[hex(x) for x in v]}")
+
+    if field("serial_a") is not None and field("serial_b") is not None:
+        # THE SERIAL STREAM. What is compared is the BYTES over the length
+        # both emulators reached -- one must be a prefix of the other -- and
+        # NOT the total, which is a clock artefact.
+        #
+        # ⚠️ Measured 8 Sep 2026, and it is the reason this is written the
+        # awkward way. The firmware drains its transmit ring in bursts, so
+        # whether the last ~900-byte drain lands before or after the M6a gate
+        # depends on the instruction budget per sample. Same image, same
+        # everything else:
+        #
+        #     ips 3900  5731 B     ips 4100  4831 B
+        #     ips 3990  5731 B     ips 4200  4831 B
+        #     route A   4831 B     ips 4300  4831 B
+        #
+        # and at ips 4100 the port's 4831 bytes are byte-for-byte route A's,
+        # while at 3990 route A's 4831 are an exact prefix of the port's 5731.
+        # So an equal COUNT would be a coincidence of clock accounting, and an
+        # unequal one is not evidence of anything -- but a byte that differs
+        # inside the common prefix is a different code path, and fatal.
+        import base64
+        for name in ("serial_a", "serial_b"):
+            oa = base64.b64decode(a[name])
+            ob = base64.b64decode(b[name])
+            n = min(len(oa), len(ob))
+            if oa[:n] != ob[:n]:
+                first = next(i for i in range(n) if oa[i] != ob[i])
+                problems.append(f"{name}: the streams differ at byte {first} of {n} "
+                                f"(oracle {oa[first]:#04x}, port {ob[first]:#04x})")
+            elif len(oa) != len(ob):
+                notes.append(f"{name}: {len(oa)} bytes in the oracle, {len(ob)} in the port, "
+                             f"identical over the first {n} -- the ring drains in bursts and "
+                             f"the last one tracks the ips knob")
 
     if (v := field("dispatches")) is not None:
         # THE STRICT PART: the order in which each task FIRST runs, and when.
@@ -148,17 +188,29 @@ def main():
                 notes.append(f"dispatches[{i}]: same task at the same time, resumed at "
                              f"{da['pc']:#x} (oracle) vs {db['pc']:#x} (port)")
 
+    # ⚠️ COUNT ONLY WHAT WAS ACTUALLY COMPARED. The summary used to say
+    # "N field(s) agree" where N was every field in the golden, which quietly
+    # took credit for `gate_ms`, `pit0_fired` and `serial_sent` -- none of
+    # which this script has ever compared, because all three track the ips
+    # knob. A gate that reports fields it did not check is the same defect as
+    # a watch that prints nothing (RTOS_FORK section 10.3b). Fixed 8 Sep 2026.
+    reported = [k for k in a if k not in compared and k not in missing]
     for n in notes:
         print(f"NOTE     {n}")
     for m in missing:
         print(f"MISSING  {m} (the port does not produce it yet)")
     for p in problems:
         print(f"DIFFERS  {p}")
-    checked = len(a) - len(missing)
+    if reported:
+        print("REPORTED " + ", ".join(sorted(reported)) + " -- present in both, NOT compared "
+              "(these track the instruction-budget knob; see the header)")
     if problems:
-        print(f"oracle: {len(problems)} disagreement(s) over {checked} field(s) -- a finding, go and measure")
+        print(f"oracle: {len(problems)} disagreement(s) over {len(compared)} compared field(s) "
+              f"-- a finding, go and measure")
         return 1
-    print(f"oracle: {checked} field(s) agree" + (f", {len(missing)} not yet produced" if missing else "")
+    print(f"oracle: {len(compared)} compared field(s) agree"
+          + (f", {len(reported)} reported only" if reported else "")
+          + (f", {len(missing)} not yet produced" if missing else "")
           + (f", {len(notes)} note(s)" if notes else ""))
     return 0
 

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -1,5 +1,7 @@
 #include "rtos.h"
 
+#include <utility>
+
 #include <algorithm>
 #include <cstdio>
 #include <fstream>
@@ -114,6 +116,23 @@ namespace ot
 			return;
 		}
 
+		// Two spans the BOOT does not map and main's init needs, added here
+		// because route A adds them here (`install`), with its reasons:
+		//
+		//   * Main's init reads a magic word at 0x1ffffe (0x4003232c: equal to
+		//     0xdcba means a test-mode flash) and the boot maps only the first
+		//     64 KB. Zero = no magic. ⚠️ THE PORT WAS ANSWERING ALL-ONES HERE
+		//     and route A answers zero -- both fail the 0xdcba test, so the
+		//     behaviour matched by luck rather than by model, and a machine
+		//     that never faults on unmapped memory gets no warning about that.
+		//   * The settings reset (0x4001f298) clears up to 0x10100004, four
+		//     bytes past the SRAM window -- a firmware off-by-four that
+		//     hardware absorbs. ✅ Reproduced here: the port's own unmapped
+		//     log shows exactly four byte-accesses at 0x10100000.
+		for(const auto& [base, size] : {std::pair<uint32_t, uint32_t>{0x00010000, 0x001f0000},
+			std::pair<uint32_t, uint32_t>{0x10100000, 0x1000}})
+			m_machine.mapRegion(base, size);
+
 		// SEED the models by replaying what the boot wrote into the all-ones
 		// stub before they existed. Route A's rule, including its exclusion:
 		//
@@ -130,8 +149,9 @@ namespace ot
 			peripheralWrite(w.addr, w.size, val, true);
 		}
 		m_seeded = m_machine.peripheralWrites().size();
-		for(auto* u : {&m_uart64, &m_uart68})
-			u->clearTransmitInterrupt();
+		if(m_quirks.clearTransmitInterrupt)
+			for(auto* u : {&m_uart64, &m_uart68})
+				u->clearTransmitInterrupt();
 
 		m_machine.setPeripheralHandlers(
 			[this](uint32_t a, uint8_t s, uint32_t& o) { return peripheralRead(a, s, o); },
@@ -383,6 +403,29 @@ namespace ot
 		return problems.empty();
 	}
 
+	namespace
+	{
+		std::string base64(const std::vector<uint8_t>& _in)
+		{
+			static const char* const g_alphabet =
+				"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+			std::string out;
+			out.reserve((_in.size() + 2) / 3 * 4);
+			for(size_t i = 0; i < _in.size(); i += 3)
+			{
+				const uint32_t a = _in[i];
+				const uint32_t b = i + 1 < _in.size() ? _in[i + 1] : 0;
+				const uint32_t c = i + 2 < _in.size() ? _in[i + 2] : 0;
+				const uint32_t v = (a << 16) | (b << 8) | c;
+				out += g_alphabet[(v >> 18) & 63];
+				out += g_alphabet[(v >> 12) & 63];
+				out += i + 1 < _in.size() ? g_alphabet[(v >> 6) & 63] : '=';
+				out += i + 2 < _in.size() ? g_alphabet[v & 63] : '=';
+			}
+			return out;
+		}
+	}
+
 	void Rtos::writeGoldenJson(const std::string& _path) const
 	{
 		std::ofstream f(_path);
@@ -432,6 +475,13 @@ namespace ot
 		f << (first ? "" : "\n ") << "],\n";
 
 		f << " \"gate_ms\": " << ms() << ",\n";
-		f << " \"pit0_fired\": " << pit0Fired() << "\n}\n";
+		f << " \"pit0_fired\": " << pit0Fired() << ",\n";
+		// THE SERIAL STREAM, not its length -- see route A's golden writer and
+		// the O5 section of COLDFIRE_PORT.md. ⚠️ The COUNT tracks the `ips`
+		// knob (5731 at 3900/3990, 4831 at 4100/4200/4300) because the
+		// transmit ring drains in bursts; the BYTES do not.
+		f << " \"serial_sent\": [" << serialA() << ", " << serialB() << "],\n";
+		f << " \"serial_a\": \"" << base64(serialTxA()) << "\",\n";
+		f << " \"serial_b\": \"" << base64(serialTxB()) << "\"\n}\n";
 	}
 }

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -64,6 +64,16 @@ namespace ot
 	public:
 		explicit Rtos(Machine& _m, double _ips = 3990.0, double _pitClockHz = 264e6);
 
+		// A DELIBERATE DEPARTURE FROM ROUTE A, for the negative control only.
+		// The gate compares the serial byte count, and a gate that has never
+		// failed proves nothing (the standing rule, and why
+		// `tools/verify_bus.py` carries a selftest). `test_rtos` runs the
+		// machine a second time with `clearTransmitInterrupt` false and
+		// requires the count to CHANGE, which is what makes the comparison
+		// evidence rather than decoration. Nothing but the test sets it.
+		struct Quirks { bool clearTransmitInterrupt = true; };
+		void setQuirks(const Quirks& _q) { m_quirks = _q; }
+
 		// Install the models over the peripheral window and SEED them by
 		// replaying every write the boot made into the stub. Route A's
 		// `install()`; it must be called after the boot and before `run`.
@@ -87,6 +97,10 @@ namespace ot
 		uint64_t forces() const { return m_forces; }
 		size_t seeded() const { return m_seeded; }
 		size_t serialSent() const { return m_uart64.tx().size() + m_uart68.tx().size(); }
+		const std::vector<uint8_t>& serialTxA() const { return m_uart64.tx(); }
+		const std::vector<uint8_t>& serialTxB() const { return m_uart68.tx(); }
+		size_t serialA() const { return m_uart64.tx().size(); }
+		size_t serialB() const { return m_uart68.tx().size(); }
 		const std::string& why() const { return m_why; }
 
 		// Route A's `gate_m6a`: every expected task created with its fields,
@@ -120,6 +134,7 @@ namespace ot
 		uint64_t m_idleSkips = 0, m_forces = 0;
 		size_t m_seeded = 0;
 		std::string m_why;
+		Quirks m_quirks;
 		bool m_installed = false;
 		bool m_gateDirty = true;
 		uint32_t m_injectedLevel = 0, m_injectedVector = 0;   // the line currently offered

--- a/tools/ot_emu/test_rtos.cpp
+++ b/tools/ot_emu/test_rtos.cpp
@@ -71,6 +71,58 @@ int main(int _argc, char** _argv)
 	check("the gate is reached at about 205 ms",
 		rtos.ms() > 150.0 && rtos.ms() < 260.0, std::to_string(rtos.ms()) + " ms");
 
+	// ---- what the port SENT, and the negative control -------------------
+	// ✅ Route A transmits 4831 bytes on UART@fc064000 and none on the second
+	// by the M6a gate, and the port's first 4831 are byte-for-byte the same
+	// (measured 8 Sep 2026; at ips 4100 the whole stream is identical).
+	//
+	// ⚠️ The COUNT is NOT checked, because it is a clock artefact: the ring
+	// drains in bursts, so the last ~900-byte drain lands before or after the
+	// gate depending on the instruction budget -- 5731 bytes at ips 3900 and
+	// 3990, 4831 at 4100, 4200 and 4300, every one of them sharing this
+	// prefix. What is checked is the CONTENT of the bytes both runs reached.
+	{
+		uint32_t fnv = 0x811c9dc5u;
+		for(size_t i = 0; i < 4831 && i < rtos.serialTxA().size(); ++i)
+			fnv = (fnv ^ rtos.serialTxA()[i]) * 0x01000193u;
+		check("the first 4831 serial bytes are route A's, byte for byte",
+			rtos.serialTxA().size() >= 4831 && fnv == 0x208868fcu && rtos.serialB() == 0,
+			std::to_string(rtos.serialTxA().size()) + " B, fnv1a " + std::to_string(fnv));
+	}
+
+	// THE NEGATIVE CONTROL, because a gate that has never failed proves
+	// nothing. Boot a second machine and install WITHOUT route A's
+	// transmit-interrupt fix-up -- the one thing in `install` that changes
+	// which serial writes happen -- and require the count to move. If this
+	// ever passes with an equal count, the comparison above is measuring
+	// nothing and should not be trusted.
+	{
+		ot::Machine m2(img);
+		if(m2.run(50'000'000) == ot::Machine::Stop::Handoff)
+		{
+			ot::Rtos r2(m2);
+			ot::Rtos::Quirks q;
+			q.clearTransmitInterrupt = false;
+			r2.setQuirks(q);
+			r2.install();
+			r2.run(1000.0);
+			check("the serial count RESPONDS to a code-path change (negative control)",
+				r2.serialA() != rtos.serialA() || r2.serialB() != rtos.serialB(),
+				"without the transmit fix-up: " + std::to_string(r2.serialA()) + " + "
+					+ std::to_string(r2.serialB()));
+		}
+		else
+			check("the negative control booted", false, m2.why());
+	}
+
+	// ✅ Route A GROWS four regions during the golden run (its `_prime_menu`
+	// hook maps a zero page on any unmapped access), and this machine grows
+	// the same spans. Reported, not asserted: the page count is a
+	// consequence of how far the run got.
+	std::printf("  [note] %llu access(es) auto-mapped, %llu zero page(s) grown\n",
+		static_cast<unsigned long long>(m.unmappedCount()),
+		static_cast<unsigned long long>(m.autoMappedPages()));
+
 	std::printf("%s\n", g_failures ? "RTOS GATE FAILED" : "rtos gate passed.");
 	return g_failures ? 1 : 0;
 }


### PR DESCRIPTION
Milestone O5 from `docs/COLDFIRE_WORKORDER.md`.

Its written scope was nearly empty (the UARTs and DSPI moved into O4), so it was two memory maps and a byte count — and **the gate passed on the first run, with no O5 code at all**. By the standing rule that a gate which has never failed proves nothing, that is where the work started.

## What was translated

Route A's two `install` maps, with its comments. Both are confirmed in the port's own access log rather than assumed: exactly **one read at `0x1ffffe`** (the test-mode magic, which must read zero and was reading all-ones) and exactly **four byte-writes at `0x10100000`** (the settings reset's off-by-four past the SRAM window).

## ⚠️ The finding

**Route A does not fault on unmapped memory in the golden configuration.** `_prime_menu` installs a hook that maps a zero page and returns `True`, and it stays installed. Route A's region list goes **9 → 15** by the M6a gate, and the four it grows on its own are, page for page, the four spans this port was answering all-ones for — **20,348,069 accesses**. The two largest sources are literal loops, disassembled not inferred: a `moveml` bzero over **64 MB at `0x42000000`**, and `lea 0x4f502c10,%a0` / `movel #705664,%d0` clearing **10.8 MB**, both bounds hard-coded in the image.

So the port grows the same way (`Machine::setAutoMap`, 4 KB pages, zeroed). Without a project route A really does fault, as its own note says; but the oracle is the golden configuration.

## ⚠️ The serial count was an artefact of the missing memory

It agreed at **4831** while the transmit ring's writes were being dropped, and disagreed (**5731**) once they were not. The streams are identical — route A's 4831 bytes are an exact prefix of the port's, and at ips 4100 the port's whole stream is byte-for-byte route A's. The gap is one ~900-byte ring drain landing either side of the gate, and it tracks the clock knob:

| ips | 3900 | 3990 | 4100 | 4200 | 4300 |
|---|---|---|---|---|---|
| bytes | 5731 | 5731 | 4831 | 4831 | 4831 |

So the gate compares the **bytes over the common length** (4831 bytes of content) instead of one integer. ❌ An earlier sweep in this session found the count clock-independent and is retracted — it ran on the all-ones machine and measured the missing memory.

## Two instrument defects fixed on the way

- `oracle.py` reported every field in the golden as agreeing, including three it has never compared. It now counts only what it compared. **This retracts O4's "8 of 8 fields" to 6 compared** — nothing about O4's result changes, only what is honest to say about it.
- `--watch-pc` printed **nothing** on the `--until-gate` path (`_watch_report` was only called from the M6c branch). That silence nearly ended this investigation at "route A never runs those loops".

## Gate

- `ctest` **6/6**, including a negative control that requires the serial comparison to respond to a code-path change (4831 → 0).
- Oracle diff: **8 compared fields agree, 0 disagreements.**
- `make check` green.