### PR TITLE
O6 BLOCKED on O7: the eDMA and the frame clock (model written and unit-gated)

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -344,6 +344,53 @@ comparison would be decoration.
 **Gate:** `ctest` 6/6; the oracle diff reports **8 compared fields agree, 0
 disagreements**; `make check` green.
 
+## Milestone O6 — the eDMA and the frame clock ⛔ BLOCKED on O7 (8 Sep 2026)
+
+The model is written and unit-gated; its **fidelity** gate is M6c, which needs
+a loaded project and a started transport — O7. `COLDFIRE_WORKORDER.md` carries
+the full entry; the two things worth keeping here:
+
+**The three completion rules, and watching the gate fail.** `Edma` was
+implemented first with route A's own *wrong* rule — everything completes at
+once — and the gate failed on exactly the four paced assertions and nothing
+else, which is the symptom route A recorded ("re-raised source 15 before state
+0 could ack it; the ISR spun in state 6"). Fixing `start` to book a paced
+channel at the DSP's next 16-sample boundary turned all 19 green. The other
+two rules (an `SSRT` is bus speed; a memory-to-memory `START` is a copy the
+caller busy-waits for) complete at once, and a linked channel is a burst that
+completes **with** its parent, so ch1 → ch6 → ch7 is one boundary event.
+
+✅ A detail that fell out of writing the test: **ch1's CSR `0x621` has no
+INTMAJOR.** Only ch7 raises a line, and channel 7 is INTC0 source 8 + 7 = 15
+— exactly the source route A names for the end of that chain. The first
+version of the test asserted a line for ch1 and was wrong; the model was
+right.
+
+**The frame latch is cleared on the interrupt ACKNOWLEDGE.** Route A clears
+`frame_pending` as it pushes the frame, because it hand-rolls the push. This
+port lets Musashi dispatch the exception, so offering a line and having it
+taken are different events — the latch is cleared from
+`Machine::readIrqUserVector`, the core's own acknowledge, which is the same
+moment. It is a **latch, not a count**: a masked edge source remembers one
+edge, and counting them delivered ~540 phantom frames back to back in route A.
+
+### What was measured about the block, rather than assumed
+
+- ✅ Route A **cannot run with the frame clock on from boot**: a bare
+  `Rtos(frame=True)` faults on unmapped memory, and priming the auto-map hook
+  leaves its own state unusable. So there is no intermediate oracle
+  comparison for the frame clock — it is M6c or nothing.
+- ✅ The port with `--frame` is identical to frame-off through 100 ms, then
+  wedges: dispatches frozen at 40 from 205 ms through 400 ms while PIT0 keeps
+  firing, **1 frame interrupt taken, 0 eDMA transfers started**. No frame is
+  delivered before main's unmask, so the mask is respected.
+- 🟡 The wedge is *inferred* to be the ISR waiting for a DSP exchange nothing
+  starts (the host port is O8, the chain is kicked from the sequencer path in
+  O7). **Whether the frame model is right in the configuration that matters
+  is not established, and only M6c establishes it.**
+- ✅ No regression with the clock off: the oracle diff is still 8 compared
+  fields, zero disagreements; `ctest` 6/6; `make check` green.
+
 ## What is NOT here yet
 
 - **The rest of the peripherals.** The eDMA with its completion-timing rules

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -155,6 +155,53 @@ That is not a defect — route A covers the same spans — but O7's card is what
 would make the two machines allocate from the same place, and it is worth
 re-checking the span list once the project loads.
 
+### O6 — the eDMA and the frame clock — ⛔ **BLOCKED on O7** (8 Sep 2026)
+
+**The code is written and unit-gated; its FIDELITY gate cannot run.** Do not
+re-do the model — take O7, then come back and run M6c.
+
+`periph.{h,cpp}` now carries `Edma`, translated rule for rule, and
+`rtos.{h,cpp}` carries the frame clock (INTC0 source 1 as a LATCH, eDMA
+sources 8..23, the boundary fed from `tickTimers`, and the latch cleared on
+the CPU's interrupt ACKNOWLEDGE — `Machine::readIrqUserVector`, which is
+where route A clears it). `test_periph` gates 19 assertions: all three
+completion rules, each of route A's wrong versions, the ch1→ch6→ch7 chain as
+one boundary event, CINT/CDNE, replay, and "no INTMAJOR, no line". ✅ The
+gate was watched FAILING first, on route A's own "completes at once" version
+— the four paced assertions, and only those.
+
+**What blocks it.** O6's gate is M6c, which needs a loaded project, a started
+transport, a poked trig and the trig log — that is O7 *plus* the live-call
+machinery (`call_as_main`, `start_transport_live`, `poke_trig`,
+`install_trig_log`). There is no intermediate oracle comparison, and this was
+checked rather than assumed:
+
+- ✅ Route A **cannot be run with the frame clock on from boot at all.** A
+  bare `Rtos(frame=True)` faults on unmapped memory immediately (nothing has
+  primed the auto-map hook), and priming it leaves route A's own `Rtos` state
+  unusable (`self.pc` is None). Its sequencer path turns the frame clock on
+  only *after* the load, which is exactly what the O7 dependency is.
+- ✅ The port with `--frame` from boot is **identical to frame-off through
+  100 ms** (21 dispatches, 0 tasks either way), then wedges between 100 and
+  205 ms: dispatches frozen at 40 from 205 ms through 400 ms while PIT0 keeps
+  firing (41 → 80), **exactly 1 frame interrupt taken, 0 eDMA transfers
+  started, 0 tasks created.** The mask is respected — no frame is delivered
+  before 100 ms.
+- 🟡 **Inferred, not measured:** the wedge is the frame ISR self-masking and
+  waiting for a DSP exchange that never starts, because nothing drives the
+  host port (O8) and the eDMA chain is only kicked from the sequencer path
+  (O7). **Nobody has established that the port's frame model is right in the
+  configuration that matters** — the unit gate covers the rules, M6c covers
+  the fidelity, and only M6c decides.
+
+✅ **No regression:** with the frame clock off (the default, as in route A)
+nothing changed — the oracle diff is still 8 compared fields with zero
+disagreements, `ctest` 6/6, `make check` green.
+
+**To unblock:** land O7, then run M6c and compare against `RTOS_FORK.md` §8.
+
+<details><summary>the original entry</summary>
+
 ### O6 — the eDMA and the frame clock *(Opus, but read §8.1 first)*
 
 **Translates:** `class Edma` — the TCD register file, `SSRT`/`CINT`/`CDNE`,
@@ -170,6 +217,8 @@ tick through `INTFRCH`.
 poked trig) lands **the same byte `0xd3` in `0x46104d15[0]` at frame 344**
 after transport start, with 28 ticks in 400 frames. `RTOS_FORK.md` §8.
 Requires the project load (O7) — so O6 and O7 may be one session.
+
+</details>
 
 ### O7 — the card and the project load *(Opus, large)*
 

--- a/tools/ot_emu/machine.cpp
+++ b/tools/ot_emu/machine.cpp
@@ -334,6 +334,14 @@ namespace ot
 		}
 	}
 
+	uint32_t Machine::readIrqUserVector(const uint8_t _level)
+	{
+		const auto vec = Mc68k::readIrqUserVector(_level);
+		if(m_ack && vec != 0xffffffffu)
+			m_ack(static_cast<uint8_t>(vec), _level);
+		return vec;
+	}
+
 	uint32_t Machine::peek32(const uint32_t _addr)
 	{
 		return read32(_addr);

--- a/tools/ot_emu/machine.h
+++ b/tools/ot_emu/machine.h
@@ -93,6 +93,16 @@ namespace ot
 
 		uint32_t onIllegalInstruction(uint32_t _opcode) override;
 
+		// The interrupt ACKNOWLEDGE: the core calls this when it actually
+		// takes a queued vector, which is the moment route A clears its frame
+		// latch (`_deliver` clears `frame_pending` as it pushes the frame).
+		// Offering a line and having it taken are different events here --
+		// Musashi dispatches the exception itself -- so the latch has to be
+		// cleared from the ack, not from the offer.
+		uint32_t readIrqUserVector(uint8_t _level) override;
+		using AckHook = std::function<void(uint8_t _vector, uint8_t _level)>;
+		void setAckHook(AckHook _h) { m_ack = std::move(_h); }
+
 		// -- driving it ------------------------------------------------------
 		// Run until `trap #0` (the handoff), an illegal instruction, or the
 		// budget. Returns why it stopped. This is the BOOT: it carries the
@@ -263,6 +273,7 @@ namespace ot
 		std::vector<uint8_t>* m_lastAutoData = nullptr;
 		uint8_t* autoByte(uint32_t _addr, bool _create);
 		std::function<void(Machine&, uint32_t)> m_step;
+		AckHook m_ack;
 		uint64_t m_instructions = 0;
 		uint64_t m_v4e = 0;			// instructions the V4e layer supplied
 		uint32_t m_profileEvery = 0;

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -45,6 +45,7 @@ int main(int _argc, char** _argv)
 	std::string serialOut;
 	double runMs = 1000.0;
 	double ips = 3990.0;
+	bool frame = false;			// the DSP frame clock; off by default, as in route A
 
 	for(int i = 1; i < _argc; ++i)
 	{
@@ -57,6 +58,7 @@ int main(int _argc, char** _argv)
 		else if(a == "--serial-out" && i + 1 < _argc)	serialOut = _argv[++i];
 		else if(a == "--ms" && i + 1 < _argc)	runMs = std::atof(_argv[++i]);
 		else if(a == "--ips" && i + 1 < _argc)	ips = std::atof(_argv[++i]);
+		else if(a == "--frame")					frame = true;
 		else
 		{
 			std::printf("usage: ot_emu [--image FILE] [--max N] [--periph] [--profile]\n"
@@ -103,7 +105,7 @@ int main(int _argc, char** _argv)
 	if(stop == ot::Machine::Stop::Handoff)
 	{
 		std::printf("vbr        : %#x (the firmware's own `movec %%a0,%%vbr` at 0x40000db6)\n", m.vbr());
-		ot::Rtos rtos(m, ips);
+		ot::Rtos rtos(m, ips, 264e6, frame);
 		rtos.install();
 		const auto rs = rtos.run(runMs);
 		static const char* const g_rtosNames[] = {"GATE", "TIME", "FAULT", "ILLEGAL"};
@@ -113,6 +115,10 @@ int main(int _argc, char** _argv)
 			rtos.ms(), rtos.created().size(), rtos.dispatches().size(), rtos.ran().size(),
 			static_cast<unsigned long long>(rtos.pit0Fired()),
 			static_cast<unsigned long long>(rtos.idleSkips()), rtos.seeded());
+		std::printf("frame      : %s -- %llu frame interrupt(s) taken, %llu eDMA transfer(s) started\n",
+			frame ? "on" : "off (route A's default: main unmasks source 1 unconditionally)",
+			static_cast<unsigned long long>(rtos.frameCount()),
+			static_cast<unsigned long long>(rtos.edmaStarted()));
 		std::vector<std::string> problems;
 		const bool ok = rtos.gate(&problems);
 		std::printf("M6a gate   : %s\n", ok ? "PASS" : "FAIL");

--- a/tools/ot_emu/periph.cpp
+++ b/tools/ot_emu/periph.cpp
@@ -124,6 +124,132 @@ namespace ot
 			m_regs[_off] = _val;
 	}
 
+	// ---- eDMA --------------------------------------------------------------
+	uint32_t Edma::field(const uint32_t _ch, const uint32_t _off, const uint32_t _n) const
+	{
+		uint32_t v = 0;
+		for(uint32_t i = 0; i < _n; ++i)
+			v = (v << 8) | m_tcd[(_ch & 15) * 32 + _off + i];
+		return v;
+	}
+
+	void Edma::setCsr(const uint32_t _ch, const uint16_t _v)
+	{
+		m_tcd[(_ch & 15) * 32 + 0x1e] = static_cast<uint8_t>(_v >> 8);
+		m_tcd[(_ch & 15) * 32 + 0x1f] = static_cast<uint8_t>(_v);
+	}
+
+	// A host-port channel: either end of the transfer is inside the DSP's
+	// window. Route A checks SADDR and DADDR, and nothing else.
+	bool Edma::paced(const uint32_t _ch) const
+	{
+		for(const uint32_t off : {0u, 0x10u})
+		{
+			const auto a = field(_ch, off, 4);
+			if(a >= g_hostPortLo && a < g_hostPortHi)
+				return true;
+		}
+		return false;
+	}
+
+	void Edma::start(const uint32_t _ch, const bool _paced)
+	{
+		if(m_onTransfer)
+			m_onTransfer(_ch, _paced);
+		setCsr(_ch, static_cast<uint16_t>(csr(_ch) & ~DONE));
+		++m_started;
+		if(_paced)
+			// The DSP delivers its frame on ITS clock, so the completion is
+			// booked for the next 16-sample boundary -- NOT kick + 16, which
+			// gave an 18.5-sample period and dropped every sixth frame, and
+			// NOT at once, which re-raised source 15 before state 0 could ack
+			// it and left the ISR spinning in state 6. `setdefault`: a channel
+			// already booked keeps its EARLIER completion.
+			m_due.emplace(_ch & 15, m_boundary);
+		else
+			complete(_ch);
+	}
+
+	void Edma::complete(const uint32_t _ch)
+	{
+		const auto c = csr(_ch);
+		setCsr(_ch, static_cast<uint16_t>((c & ~START) | DONE));
+		if(c & INTMAJOR)
+			m_irq[_ch & 15] = true;
+		if(c & MAJORELINK)					// the linked channel is a BURST:
+			start((c >> 8) & 0x1f, false);	// it completes with its parent
+	}
+
+	void Edma::advance(const double _now)
+	{
+		for(auto it = m_due.begin(); it != m_due.end();)
+		{
+			if(_now >= it->second)
+			{
+				const auto ch = it->first;
+				it = m_due.erase(it);
+				complete(ch);
+			}
+			else
+				++it;
+		}
+	}
+
+	uint32_t Edma::read(const uint32_t _addr, const uint32_t _size) const
+	{
+		if(_addr >= g_tcd && _addr < g_tcd + m_tcd.size())
+		{
+			const auto off = _addr - g_tcd;
+			uint32_t v = 0;
+			for(uint32_t i = 0; i < _size && off + i < m_tcd.size(); ++i)
+				v = (v << 8) | m_tcd[off + i];
+			return v;
+		}
+		const auto it = m_regs.find(_addr);
+		return it != m_regs.end() ? it->second : 0;
+	}
+
+	void Edma::write(const uint32_t _addr, const uint32_t _size, const uint32_t _val, const bool _replay)
+	{
+		if(_addr >= g_tcd && _addr < g_tcd + m_tcd.size())
+		{
+			const auto off = _addr - g_tcd;
+			for(uint32_t i = 0; i < _size && off + i < m_tcd.size(); ++i)
+				m_tcd[off + i] = static_cast<uint8_t>(_val >> (8 * (_size - 1 - i)));
+			// A write that REACHES the CSR and carries START kicks the
+			// channel -- route A's `off % 32 + size > 0x1e and (val & START)`.
+			if(!_replay && (off % 32) + _size > 0x1e && (_val & START))
+			{
+				const auto ch = static_cast<uint32_t>(off / 32);
+				start(ch, paced(ch));
+			}
+			return;
+		}
+		const auto off = _addr - g_base;
+		if(off == SSRT && _size == 1)
+		{
+			if(!_replay)
+				start(_val & 0x0f, false);	// a control transfer: bus speed
+		}
+		else if(off == CINT && _size == 1)
+		{
+			if(_val & 0x40)
+				m_irq = {};
+			else
+				m_irq[_val & 0x0f] = false;
+		}
+		else if(off == CDNE && _size == 1)
+		{
+			if(_val & 0x40)
+				for(uint32_t c = 0; c < 16; ++c)
+					setCsr(c, static_cast<uint16_t>(csr(c) & ~DONE));
+			else
+				setCsr(_val & 0x0f, static_cast<uint16_t>(csr(_val & 0x0f) & ~DONE));
+		}
+		else
+			m_regs[_addr] = _val;
+	}
+
 	// ---- DSPI --------------------------------------------------------------
 	uint32_t Dspi::read(const uint32_t _off, const uint32_t _size)
 	{

--- a/tools/ot_emu/periph.h
+++ b/tools/ot_emu/periph.h
@@ -134,6 +134,84 @@ namespace ot
 		uint64_t m_pushed = 0;
 	};
 
+	// ---- eDMA --------------------------------------------------------------
+	// The MCF5445x eDMA, as far as the DSP frame exchange and the ColdFire's
+	// per-frame EMAC work use it. Route A's `class Edma`, rule for rule.
+	//
+	// Registers: TCDs at 0xfc045000, 32 bytes per channel (SADDR +0, SOFF +4,
+	// ATTR +6, NBYTES +8, SLAST +0xc, DADDR +0x10, CITER +0x14, DOFF +0x16,
+	// DLAST_SGA +0x18, BITER +0x1c, CSR +0x1e); control bytes at 0xfc04401c
+	// CINT (clear a channel's request; 0x40 = all), +0x1e SSRT (software-start
+	// a channel), +0x1f CDNE (clear DONE). A channel starts by SSRT or by
+	// CSR.START. On completion DONE is set; if CSR.INTMAJOR its INTC0 source
+	// (8 + channel) is asserted until CINT; if CSR.MAJORELINK the channel in
+	// CSR bits 8-12 starts.
+	//
+	// That last rule IS the audio chain the frame handler kicks: ch1 CSR 0x621
+	// links to ch6, ch6's 0x720 links to ch7, ch7's 0x0002 raises source 15,
+	// and the seven-step completion ISR then SSRTs ch1 and ch0 in turn.
+	//
+	// ⚠️ NO DATA MOVES. Audio is out of route A's scope and out of this
+	// model's; COMPLETION TIMING is the one thing that has to be right,
+	// because the exchange is a two-frame pipeline with ~64k instructions of
+	// EMAC work inside it. THREE RULES, and each wrong version produced its
+	// own reproducible symptom in route A (RTOS_FORK.md §8.1):
+	//
+	//   * a CSR.START of a HOST-PORT channel (SADDR or DADDR inside
+	//     0x20000000-0x20000fff) is the frame's audio stream, and the chain it
+	//     links completes at the DSP's NEXT 16-SAMPLE BOUNDARY, as a whole.
+	//     ❌ "kick + 16" gave an 18.5-sample period and dropped every sixth
+	//     frame. ❌ "at once" re-raised source 15 before state 0 could ack it
+	//     and the ISR spun in state 6.
+	//   * an SSRT is one of the ISR's 256-byte control transfers over the same
+	//     host port: bus speed, completes AT ONCE.
+	//   * a CSR.START of a MEMORY-TO-MEMORY channel is a copy the caller
+	//     busy-waits for at 0x400035a8: AT ONCE. ❌ Holding it for a frame
+	//     spun forever.
+	//
+	// A linked channel completes WITH its parent (a burst), which is why the
+	// chain is one event and not three.
+	class Edma
+	{
+	public:
+		static constexpr uint32_t g_base = 0xfc044000, g_tcd = 0xfc045000;
+		enum : uint32_t { CINT = 0x1c, SSRT = 0x1e, CDNE = 0x1f };
+		enum : uint16_t { START = 0x0001, INTMAJOR = 0x0002, MAJORELINK = 0x0020, DONE = 0x0080 };
+		static constexpr uint32_t g_hostPortLo = 0x20000000, g_hostPortHi = 0x20001000;
+
+		bool irq(uint32_t _ch) const { return m_irq[_ch & 15]; }
+		uint64_t started() const { return m_started; }
+		size_t outstanding() const { return m_due.size(); }
+
+		// The DSP's next frame boundary; `Rtos::tickTimers` keeps it current.
+		void setBoundary(double _b) { m_boundary = _b; }
+		void advance(double _now);
+
+		uint32_t read(uint32_t _addr, uint32_t _size) const;
+		void write(uint32_t _addr, uint32_t _size, uint32_t _val, bool _replay);
+
+		// The TAPE hook: (channel, paced). Route A's `on_transfer`.
+		void setTransferHook(std::function<void(uint32_t, bool)> _fn) { m_onTransfer = std::move(_fn); }
+
+		uint32_t tcdField(uint32_t _ch, uint32_t _off, uint32_t _n) const { return field(_ch, _off, _n); }
+
+	private:
+		uint32_t field(uint32_t _ch, uint32_t _off, uint32_t _n) const;
+		uint16_t csr(uint32_t _ch) const { return static_cast<uint16_t>(field(_ch, 0x1e, 2)); }
+		void setCsr(uint32_t _ch, uint16_t _v);
+		bool paced(uint32_t _ch) const;
+		void start(uint32_t _ch, bool _paced);
+		void complete(uint32_t _ch);
+
+		std::array<uint8_t, 16 * 32> m_tcd = {};
+		std::unordered_map<uint32_t, uint32_t> m_regs;
+		std::array<bool, 16> m_irq = {};
+		std::unordered_map<uint32_t, double> m_due;		// channel -> sample it completes at
+		double m_boundary = g_framePeriod;
+		uint64_t m_started = 0;
+		std::function<void(uint32_t, bool)> m_onTransfer;
+	};
+
 	// ---- INTC --------------------------------------------------------------
 	// MCF54455RM rev 5 chapter 17. IPRH/L +0x00/+0x04 (read back what is
 	// asserted), IMRH/L +0x08/+0x0c, INTFRCH/L +0x10/+0x14, SIMR/CIMR bytes at

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -41,7 +41,7 @@ namespace ot
 		}
 	}
 
-	Rtos::Rtos(Machine& _m, const double _ips, const double _pitClockHz)
+	Rtos::Rtos(Machine& _m, const double _ips, const double _pitClockHz, const bool _frame)
 		: m_machine(_m)
 		, m_ips(_ips)
 		, m_pit0("PIT0", _pitClockHz)
@@ -60,6 +60,13 @@ namespace ot
 		m_intc1.addLine(44, [this] { return m_pit1.irq(); });
 		m_intc0.addLine(27, [this] { return m_uart64.irq(); });
 		m_intc0.addLine(28, [this] { return m_uart68.irq(); });
+		// INTC0 source 1 = the DSP frame clock (vector 0x41), and sources
+		// 8..23 are eDMA channels 0..15 (MCF5445x). 8, 9 and 15 are the ones
+		// the frame exchange raises.
+		m_frame = _frame;
+		m_intc0.addLine(1, [this] { return m_frame && m_framePending; });
+		for(uint32_t ch = 0; ch < 16; ++ch)
+			m_intc0.addLine(8 + ch, [this, ch] { return m_edma.irq(ch); });
 	}
 
 	uint32_t Rtos::curTcb()
@@ -74,6 +81,7 @@ namespace ot
 		if(_addr >= g_pit0 && _addr < g_pit0 + 0x10)    { _out = m_pit0.read(_addr - g_pit0, _size, m_sample); return true; }
 		if(_addr >= g_pit1 && _addr < g_pit1 + 0x10)    { _out = m_pit1.read(_addr - g_pit1, _size, m_sample); return true; }
 		if(_addr >= g_dspi && _addr < g_dspi + 0x100)   { _out = m_dspi.read(_addr - g_dspi, _size); return true; }
+		if(_addr >= Edma::g_base && _addr < Edma::g_tcd + 16 * 32) { _out = m_edma.read(_addr, _size); return true; }
 		for(auto* u : {&m_uart64, &m_uart68})
 			if(_addr >= u->base() && _addr < u->base() + 0x20)
 			{
@@ -90,6 +98,7 @@ namespace ot
 		else if(_addr >= g_pit0 && _addr < g_pit0 + 0x10) m_pit0.write(_addr - g_pit0, _size, _val, m_sample);
 		else if(_addr >= g_pit1 && _addr < g_pit1 + 0x10) m_pit1.write(_addr - g_pit1, _size, _val, m_sample);
 		else if(_addr >= g_dspi && _addr < g_dspi + 0x100) m_dspi.write(_addr - g_dspi, _size, _val, _replay);
+		else if(_addr >= Edma::g_base && _addr < Edma::g_tcd + 16 * 32) m_edma.write(_addr, _size, _val, _replay);
 		else
 		{
 			for(auto* u : {&m_uart64, &m_uart68})
@@ -161,6 +170,17 @@ namespace ot
 		// the instruction that made it. This loop steps one instruction at a
 		// time and re-evaluates interrupts after every one, so the hook only
 		// has to count them -- route A needed it to break its burst.
+		// The frame latch is cleared when the CPU TAKES vector 0x41 (INTC0
+		// base 64 + source 1), which is where route A clears it.
+		m_machine.setAckHook([this](const uint8_t _vec, uint8_t)
+		{
+			if(_vec == m_intc0.vectorBase() + 1)
+			{
+				m_framePending = false;
+				++m_frameCount;
+			}
+		});
+
 		m_intc0.setForceHook([this](uint64_t) { ++m_forces; });
 		m_intc1.setForceHook([this](uint64_t) { ++m_forces; });
 		m_installed = true;
@@ -170,6 +190,17 @@ namespace ot
 	{
 		m_pit0.advance(m_sample);
 		m_pit1.advance(m_sample);
+		if(m_frame)
+			while(m_sample >= m_nextFrame)
+			{
+				m_framePending = true;			// a latch, not a count: a masked
+				m_nextFrame += g_framePeriod;	// edge source remembers ONE edge
+			}
+		// The eDMA is told the boundary even when the frame clock is off:
+		// its paced completions are the DSP's clock, not the interrupt's, and
+		// the TCD state is real in every run.
+		m_edma.setBoundary(m_nextFrame);
+		m_edma.advance(m_sample);
 	}
 
 	bool Rtos::anyPending() const
@@ -180,8 +211,8 @@ namespace ot
 
 	bool Rtos::nextExpiry(double& _out) const
 	{
-		bool any = false;
-		double best = 0;
+		bool any = m_frame;
+		double best = m_nextFrame;
 		for(const auto* p : {&m_pit0, &m_pit1})
 		{
 			double e;

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -62,7 +62,16 @@ namespace ot
 	class Rtos
 	{
 	public:
-		explicit Rtos(Machine& _m, double _ips = 3990.0, double _pitClockHz = 264e6);
+		// ⚠️ `_frame` is OFF by default, as it is in route A, and the reason
+		// is not caution: main's own boot tail unmasks INTC0 source 1
+		// unconditionally (0x4001fc2e), so once the clock is modelled it
+		// fires every 16 samples in EVERY run whether or not anything needs
+		// the sequencer -- about 16x more dispatches, since PIT0's 220-sample
+		// period is the coarsest timer otherwise. M6a's gate and the O5
+		// serial comparison were both established without it. The register
+		// state is real either way; only the model's assertion is gated.
+		explicit Rtos(Machine& _m, double _ips = 3990.0, double _pitClockHz = 264e6,
+			bool _frame = false);
 
 		// A DELIBERATE DEPARTURE FROM ROUTE A, for the negative control only.
 		// The gate compares the serial byte count, and a gate that has never
@@ -93,6 +102,9 @@ namespace ot
 		double sample() const { return m_sample; }
 		double ms() const { return m_sample / g_sampleHz * 1000.0; }
 		uint64_t pit0Fired() const { return m_pit0.fired(); }
+		uint64_t frameCount() const { return m_frameCount; }
+		uint64_t edmaStarted() const { return m_edma.started(); }
+		Edma& edma() { return m_edma; }
 		uint64_t idleSkips() const { return m_idleSkips; }
 		uint64_t forces() const { return m_forces; }
 		size_t seeded() const { return m_seeded; }
@@ -124,6 +136,7 @@ namespace ot
 		double m_sample = 0.0;
 
 		Pit m_pit0, m_pit1;
+		Edma m_edma;
 		Intc m_intc0, m_intc1;
 		Uart m_uart64{"UART@fc064000", g_uartA}, m_uart68{"UART@fc068000", g_uartB};
 		Dspi m_dspi;
@@ -132,6 +145,17 @@ namespace ot
 		std::vector<Dispatch> m_dispatches;
 		std::pair<uint32_t, uint32_t> m_firstSwitch{0, 0};
 		uint64_t m_idleSkips = 0, m_forces = 0;
+		// ⚠️ A LATCH, NOT A COUNT. While the source is masked -- through the
+		// boot, and through the handler's own self-mask for the whole DSP
+		// exchange -- a real edge source remembers ONE edge, not how many it
+		// missed. Route A counted them once and delivered ~540 phantom frames
+		// back to back the moment main unmasked (measured 6 Sep 2026). The
+		// handler re-arms itself only through the eDMA exchange; the ISR's
+		// `rte` is not the ack.
+		bool m_frame = false;
+		bool m_framePending = false;
+		double m_nextFrame = g_framePeriod;
+		uint64_t m_frameCount = 0;
 		size_t m_seeded = 0;
 		std::string m_why;
 		Quirks m_quirks;

--- a/tools/ot_emu/test_periph.cpp
+++ b/tools/ot_emu/test_periph.cpp
@@ -125,6 +125,128 @@ int main()
 		checkEq("IPRL reads back the asserted sources", pri.read(0x04, 4), (1u << 3) | (1u << 4));
 	}
 
+	// ---- eDMA ------------------------------------------------------------
+	// The three completion rules. Each wrong version below is one route A
+	// actually shipped, with the symptom it produced (RTOS_FORK.md §8.1), so
+	// these are negative controls and not decoration.
+	{
+		const uint32_t tcd = ot::Edma::g_tcd;
+		const auto csrAddr = [tcd](uint32_t ch) { return tcd + ch * 32 + 0x1e; };
+		const auto saddr   = [tcd](uint32_t ch) { return tcd + ch * 32 + 0x00; };
+		const auto daddr   = [tcd](uint32_t ch) { return tcd + ch * 32 + 0x10; };
+
+		// RULE 1: a CSR.START of a HOST-PORT channel completes at the DSP's
+		// NEXT 16-sample boundary, not instantly and not at kick + 16.
+		{
+			ot::Edma e;
+			e.write(daddr(1), 4, 0x2000001c, false);		// ch1: host port -> RAM
+			e.setBoundary(16.0);
+			e.write(csrAddr(1), 2, ot::Edma::START | ot::Edma::INTMAJOR, false);
+			check("a host-port START does NOT complete at once",
+				!(e.read(csrAddr(1), 2) & ot::Edma::DONE) && !e.irq(1));
+			e.advance(5.0);
+			check("... nor part-way through the frame", !e.irq(1));
+			// ❌ "kick + 16": kicked at 5, that version completed at 21 and
+			// the period came out 18.5 samples, dropping every sixth frame.
+			e.advance(15.9);
+			check("... nor at kick + 16 (that gave an 18.5-sample period)", !e.irq(1));
+			e.advance(16.0);
+			check("... it completes AT the boundary", e.irq(1));
+			checkEq("... and DONE is set", e.read(csrAddr(1), 2) & ot::Edma::DONE, ot::Edma::DONE);
+		}
+
+		// RULE 2: an SSRT is a control transfer over the same host port and
+		// completes AT ONCE, even though the channel looks paced.
+		{
+			ot::Edma e;
+			e.write(saddr(0), 4, 0x2000001c, false);
+			e.write(csrAddr(0), 2, ot::Edma::INTMAJOR, false);	// no START bit
+			e.setBoundary(16.0);
+			e.write(ot::Edma::g_base + ot::Edma::SSRT, 1, 0, false);
+			check("an SSRT completes at once, host port or not", e.irq(0));
+		}
+
+		// RULE 3: a memory-to-memory START completes at once -- the caller
+		// busy-waits on it at 0x400035a8 and holding it for a frame spun
+		// forever.
+		{
+			ot::Edma e;
+			e.write(saddr(2), 4, 0x4f502c10, false);			// the delay ring
+			e.write(daddr(2), 4, 0x46000000, false);
+			e.setBoundary(16.0);
+			e.write(csrAddr(2), 2, ot::Edma::START | ot::Edma::INTMAJOR, false);
+			check("a memory-to-memory START completes at once", e.irq(2));
+		}
+
+		// THE CHAIN, which is the audio path: ch1 (0x621) links to ch6, ch6
+		// (0x720) links to ch7, ch7 (0x0002) raises source 15. It is ONE
+		// event at the boundary, not three -- a linked channel is a burst and
+		// completes with its parent.
+		{
+			ot::Edma e;
+			e.write(daddr(1), 4, 0x2000001c, false);
+			e.write(csrAddr(6), 2, 0x0720, false);				// link to ch7
+			e.write(csrAddr(7), 2, 0x0002, false);				// INTMAJOR, no link
+			e.setBoundary(16.0);
+			e.write(csrAddr(1), 2, 0x0621, false);				// START|MAJORELINK|link ch6
+			check("the chain has not fired before the boundary", !e.irq(7));
+			e.advance(16.0);
+			// ✅ Only ch7 raises a line: 0x621 and 0x720 have no INTMAJOR, and
+			// channel 7 is INTC0 source 8 + 7 = 15, which is exactly the
+			// source route A names for the end of this chain.
+			check("ch1 -> ch6 -> ch7 complete together, and only ch7 raises a line",
+				e.irq(7) && !e.irq(1) && !e.irq(6));
+			checkEq("the whole chain is one boundary event, 3 starts", e.started(), 3);
+		}
+
+		// CINT and CDNE, the acks.
+		{
+			ot::Edma e;
+			e.write(saddr(3), 4, 0x46000000, false);
+			e.write(daddr(3), 4, 0x46100000, false);
+			e.write(csrAddr(3), 2, ot::Edma::START | ot::Edma::INTMAJOR, false);
+			check("INTMAJOR holds the line until CINT", e.irq(3));
+			e.write(ot::Edma::g_base + ot::Edma::CINT, 1, 3, false);
+			check("CINT drops it", !e.irq(3));
+			checkEq("DONE survives CINT", e.read(csrAddr(3), 2) & ot::Edma::DONE, ot::Edma::DONE);
+			e.write(ot::Edma::g_base + ot::Edma::CDNE, 1, 3, false);
+			checkEq("CDNE clears DONE", e.read(csrAddr(3), 2) & ot::Edma::DONE, 0);
+		}
+		{
+			ot::Edma e;
+			for(uint32_t ch : {4u, 5u})
+			{
+				e.write(saddr(ch), 4, 0x46000000, false);
+				e.write(csrAddr(ch), 2, ot::Edma::START | ot::Edma::INTMAJOR, false);
+			}
+			check("two lines up", e.irq(4) && e.irq(5));
+			e.write(ot::Edma::g_base + ot::Edma::CINT, 1, 0x40, false);
+			check("CINT 0x40 clears them all", !e.irq(4) && !e.irq(5));
+		}
+
+		// A REPLAYED write is the boot's, not the firmware's: it must set the
+		// register state and start NOTHING. Same rule the UART and the PIT
+		// carry, and the reason `install` can seed from the boot's log.
+		{
+			ot::Edma e;
+			e.write(saddr(8), 4, 0x46000000, true);
+			e.write(csrAddr(8), 2, ot::Edma::START | ot::Edma::INTMAJOR, true);
+			check("a replayed START does not run the channel", !e.irq(8));
+			checkEq("... but the CSR is stored", e.read(csrAddr(8), 2) & ot::Edma::START, ot::Edma::START);
+		}
+
+		// A channel whose TCD does not ask for an interrupt must not raise
+		// one: ch0 and ch1 carry INTMAJOR from the boot, and route A's note
+		// is that nothing in the model asserts a source the TCD did not ask
+		// for.
+		{
+			ot::Edma e;
+			e.write(saddr(9), 4, 0x46000000, false);
+			e.write(csrAddr(9), 2, ot::Edma::START, false);		// no INTMAJOR
+			check("no INTMAJOR, no line", !e.irq(9));
+		}
+	}
+
 	std::printf("%s\n", g_failures ? "PERIPHERAL GATE FAILED" : "peripheral gate passed.");
 	return g_failures ? 1 : 0;
 }


### PR DESCRIPTION
Milestone O6 from `docs/COLDFIRE_WORKORDER.md`. **The model is written and unit-gated; its fidelity gate cannot run.** Draft, per the standing rule: the gate is not loosened, and the measurement is written into the milestone entry.

## What is done

`Edma` in `periph.{h,cpp}`, translated rule for rule, and the frame clock in `rtos.{h,cpp}` — INTC0 source 1 as a **latch** (not a count: counting delivered ~540 phantom frames back to back in route A), eDMA sources 8..23, the DSP boundary fed from `tickTimers`, and the latch cleared on the CPU's interrupt **acknowledge**. Route A clears it as it pushes the frame by hand; this port lets Musashi dispatch the exception, so offering a line and having it taken are different events, and the clear belongs in `Machine::readIrqUserVector` — the same moment.

**The gate was watched failing first.** `Edma` was written with route A's own wrong rule (everything completes at once) and the gate failed on exactly the four paced assertions and nothing else — the symptom route A recorded: *"re-raised source 15 before state 0 could ack it and the ISR spun in state 6."* Booking a paced channel at the DSP's next 16-sample boundary turned all 19 green.

✅ A detail that fell out of writing the test: **ch1's CSR `0x621` has no INTMAJOR.** Only ch7 raises a line, and channel 7 is INTC0 source 8+7 = **15** — exactly the source route A names for the end of that chain. My first test asserted a line for ch1 and was wrong; the model was right.

## Why it is blocked

O6's gate is M6c, which needs a loaded project, a started transport, a poked trig and the trig log — that is **O7 plus the live-call machinery**. I checked rather than assumed that no intermediate oracle comparison exists:

- ✅ Route A **cannot be run with the frame clock on from boot at all.** A bare `Rtos(frame=True)` faults on unmapped memory immediately; priming the auto-map hook leaves route A's own state unusable (`self.pc` is None). Its sequencer path enables the clock only *after* the load — which is the O7 dependency itself.
- ✅ The port with `--frame` is **identical to frame-off through 100 ms** (21 dispatches, 0 tasks either way), then wedges between 100 and 205 ms: dispatches frozen at 40 from 205 ms through 400 ms while PIT0 keeps firing (41 → 80), **exactly 1 frame interrupt taken, 0 eDMA transfers started, 0 tasks created.** No frame is delivered before main's unmask, so the mask is respected.
- 🟡 **Inferred, not measured:** the wedge is the ISR self-masking and waiting for a DSP exchange that never starts (the host port is O8; the chain is kicked from the sequencer path in O7). **Nobody has established that the frame model is right in the configuration that matters** — the unit gate covers the rules, and only M6c covers the fidelity.

## No regression

With the clock off (the default, as in route A): oracle diff **8 compared fields, zero disagreements**; `ctest` **6/6**; `make check` green.

**To unblock:** land O7, then run M6c against `RTOS_FORK.md` §8. Do not re-do the model.