### PR TITLE
O7: the card and the project load — mount succeeds, load stalls at 1,407 of 6,189 commands

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -393,7 +393,65 @@ error anywhere. Route A carries it in `EXTRA_OVERRIDES` from the boot.
 retraction in the O5 section above. With them, the auto-mapped access count
 falls from 20,348,051 to **4**.
 
-**⛔ Where it stops, measured.** With the card attached and the host-status
+### ⚠️ THE MOUNT'S REAL DEFECT: INTRQ IS NOT INSTANTANEOUS, AND THE FIRMWARE DEPENDS ON THAT
+
+✅ **Measured 8 Sep 2026, and it is the finding of the milestone.** The port
+asserted INTRQ on the same instruction that wrote the ATA command. A PC ring
+armed at the first command shows what that costs, in order:
+
+```
+0x40015a50   the driver writes the command
+0x40015308   the ISR runs ON THE VERY NEXT INSTRUCTION
+   ...       256 words streamed, byte-for-byte route A's
+0x40000968   the ISR SIGNALS the event
+0x40015a58   only now does the caller execute its next instruction
+0x40000818   ... and call the RTOS event WAIT
+0x40000550   the scheduler: nothing to run but main
+0x4001fc9c   main's spin, forever
+```
+
+The signal arrives **before the waiter waits**, so the wait blocks on an event
+that already happened. ⚠️ **Route A survives this only by accident of
+granularity** — it delivers interrupts at burst boundaries, which happens to
+give the caller time to reach the wait. A real CF card takes tens of
+microseconds to fetch a sector, so a completion LATENCY is the physical
+behaviour and instantaneous assertion is the artefact. `Rtos::m_ataLatency`
+(1 sample, ~23 µs) books the assertion forward; `tickTimers` fires it.
+
+This is the "a lock-step emulator cannot show you a race" lesson inverted: the
+port's finer granularity **exposed** a race route A's coarse bursts hide.
+
+### ✅ `mvz` takes an ADDRESS REGISTER source, and the storage stack needs it
+
+With the latency in, the mount died at `unimplemented opcode 71c8 at
+0x40017c10`. That disassembles under `m68k:cfv4e` as **`mvzw %a0,%d0`** (and
+another at `0x40017c2c`): the V4e layer's effective-address reader handled
+`Dn` but not `An` direct. Same family as O4's `ff1` — the image is the
+evidence, not the toolchain.
+
+### Where it stops NOW
+
+With the latency, the `An` source, route A's own park condition (the PC alone —
+requiring nothing pending as well never comes true once the card is live) and a
+step budget that survives preemption, **the mount succeeds**:
+
+| | port | route A |
+|---|---|---|
+| card ready (`0x460d1cb8`) | **1** | 1 |
+| ATA commands | **1,407** | 6,189 |
+| sectors read | **10,695** | 30,467 |
+| sectors written | **297** | **297** ✅ |
+| `LOAD PROJECT` posted | **yes** | yes |
+
+The written count matches exactly, and one ATA interrupt arrives per sector
+(10,994 for 10,695 sectors). ⛔ The load then **stops** rather than running
+slowly: 30,000 ms of emulated time produces the same 1,407 commands as 6,000.
+It ends with the engine task cycling at **`0x400165dc`**, with `main` and `sys`,
+and the in-flight word (`0x46c8c58a`) clear. That is the next thing to chase.
+
+<details><summary>the earlier stopping point, before the race was found</summary>
+
+**⛔ Where it stopped.** With the card attached and the host-status
 byte modelled, the machine parks at main's spin, the mount request posts, and:
 
 | | |
@@ -405,8 +463,9 @@ byte modelled, the machine parks at main's spin, the mount request posts, and:
 
 So the IDENTIFY completes and its interrupt is delivered and acknowledged, and
 then SYS is **blocked waiting for something that never arrives** — a missing
-wake-up, not a wrong loop. 🟡 That reading is inferred from the profile; the
-specific event has not been identified.
+wake-up, not a wrong loop. (✅ It was the INTRQ race above.)
+
+</details>
 
 **Route A's own numbers for this project, re-measured today:** 6,189 commands,
 30,467 sectors read, 297 written, `saved_bank=1`, `final_bank=0`. ⚠️ Note that

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -269,6 +269,29 @@ in the port's own access log: exactly **one read at `0x1ffffe`** (pc
 `0x4003233e`) and exactly **four byte-writes at `0x10100000`**, which is the
 off-by-four reproduced rather than assumed. Neither changed the gate.
 
+> ❌ **RETRACTED 8 Sep 2026 (O7): the MECHANISM below is wrong.** The four
+> spans are real and the measurement stands, but route A does **not** grow
+> them through `_prime_menu`'s auto-mapping hook. That hook is installed only
+> by the menu RENDER helpers (`menu_children`, `render_menu`, `render_fx2`,
+> `render_playback`, `render_fx1`), **none of which run on the golden path** —
+> so it is never installed there, and route A really does fault on unmapped
+> memory. What actually maps the four spans is `emu_card.attach`, explicitly,
+> with its own comment naming what lives in them (the PCM pool, the sector
+> buffers, the delay rings, the on-chip SRAM around the boot's window). The
+> two O5 added in `install` are route A's too. So the golden run has them
+> because it has a **card**, which is also why route A faults at
+> `0x100fff04` without one: that address is inside the card's own
+> `0x100c0000+0x40000` map.
+>
+> **Why the difference matters, and it is not pedantic:** an explicit map has
+> KNOWN BOUNDS. Route A faults on a wild pointer outside them; this port's
+> auto-map absorbs it silently. O7 adds the four spans explicitly
+> (`Rtos::mapCardMemory`), and with a card attached the auto-mapped count
+> falls from **20,348,051 to 4** — the residual three addresses
+> (`0x04020000`, `0x100a0000`, `0xffff0000`) are boot-time touches outside
+> every map route A has, and so are places the two emulators still differ
+> silently. That is the honest work list the auto-map was hiding.
+
 ### ⚠️ The finding: route A does not fault on unmapped memory, and this port was not the same machine
 
 The port answers **all-ones** for an address in no region and drops the write;
@@ -343,6 +366,57 @@ comparison would be decoration.
 
 **Gate:** `ctest` 6/6; the oracle diff reports **8 compared fields agree, 0
 disagreements**; `make check` green.
+
+## Milestone O7 — the card and the project load ⛔ BLOCKED (8 Sep 2026)
+
+The card model, its memory map and the live-call machinery are in and gated;
+**the mount does not complete**, so the milestone's own gate (6,189 ATA
+commands / 30,467 sectors) is nowhere near. What is measured:
+
+**What works.** `card.{h,cpp}` is route A's `AtaCard` — the task file at
+`0x90000000`, IDENTIFY/READ/WRITE/CFA-TRANSLATE, and the ATA rule that a task
+file count of 0 means 256. ⚠️ **The FAT16 image builder is deliberately not
+ported**: route A builds the image from a directory tree in Python, and that
+is a build-time tool producing bytes, not machine behaviour — this port reads
+the same `.img`, so both emulators are guaranteed to be looking at identical
+media. `Rtos` carries `attachCard` (the INTRQ rules, one interrupt per
+sector, cleared by a read of the STATUS register), `callAsMain`,
+`postMessage`, `requestCardMount`, `setNames` and `loadProjectLive`.
+
+**✅ The ATA host-status byte, without which nothing happens at all.**
+`0xfc0a4039` bit 3 must read CLEAR. An unmodelled peripheral answers all-ones,
+the bit is set, the driver concludes there is no card — and the mount request
+posts, SYS runs the card case, and **zero ATA commands** are issued, with no
+error anywhere. Route A carries it in `EXTRA_OVERRIDES` from the boot.
+
+**✅ The card's four memory maps are what O5 misattributed** — see the
+retraction in the O5 section above. With them, the auto-mapped access count
+falls from 20,348,051 to **4**.
+
+**⛔ Where it stops, measured.** With the card attached and the host-status
+byte modelled, the machine parks at main's spin, the mount request posts, and:
+
+| | |
+|---|---|
+| ATA commands issued | **1** (IDENTIFY) — route A's load issues 6,189 |
+| ATA interrupts taken | **1**, and the line is left deasserted |
+| card-ready (`0x460d1cb8`) | **0** — never set, so `LOAD PROJECT` is never posted |
+| the machine afterwards | **idle**, not spinning: a profile over the mount window is indistinguishable from a boot-only profile |
+
+So the IDENTIFY completes and its interrupt is delivered and acknowledged, and
+then SYS is **blocked waiting for something that never arrives** — a missing
+wake-up, not a wrong loop. 🟡 That reading is inferred from the profile; the
+specific event has not been identified.
+
+**Route A's own numbers for this project, re-measured today:** 6,189 commands,
+30,467 sectors read, 297 written, `saved_bank=1`, `final_bank=0`. ⚠️ Note that
+`PART_PTR` reads `0x400e21e0` **before any load** — it is the bank blob's base,
+so a non-null `PART_PTR` is NOT evidence a project loaded. The work order's
+`0x4017d520` is from a different project; the count pair is the gate that
+travels.
+
+**No regression:** the oracle diff is still 8 compared fields with zero
+disagreements, `ctest` 6/6, `make check` green.
 
 ## What is NOT here yet
 

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -70,7 +70,7 @@ route A fact, not the port's problem; the golden command above already does it.
 | O2 | the EMAC (fractional, `msac`, A-line dispatch) | `ctest` emac | ✅ hardware's three cases |
 | O3 | PIT + INTC models | `ctest` periph, 14 rules | (wired in by O4) |
 | O4 | the run loop: the kernel runs | `ctest` rtos + the oracle diff | ✅ 6 compared fields (❌ was written "8/8": the diff counted 2 it never compared); 10 created, 11 ran, 204.88 ms vs 204.95 |
-| O5 | the rest of the memory; the serial stream | `ctest` rtos + the oracle diff | ✅ 8 compared fields; route A's 4831 serial bytes matched byte for byte |
+| O5 | the rest of the memory; the serial stream | `ctest` rtos + the oracle diff | ✅ 8 compared fields; route A's 4831 serial bytes matched byte for byte (❌ its account of *why* route A has the extra memory was wrong — corrected in O7) |
 
 ## Queue
 
@@ -171,6 +171,47 @@ poked trig) lands **the same byte `0xd3` in `0x46104d15[0]` at frame 344**
 after transport start, with 28 ticks in 400 frames. `RTOS_FORK.md` §8.
 Requires the project load (O7) — so O6 and O7 may be one session.
 
+### O7 — the card and the project load — ⛔ **BLOCKED** (8 Sep 2026)
+
+**Most of it is built and gated; the mount does not complete.** Do not re-do
+the card model — pick up at the missing wake-up.
+
+Built: `card.{h,cpp}` (route A's `AtaCard`, gated in `test_periph`),
+`Rtos::attachCard` (the INTRQ rules), `mapCardMemory`, `callAsMain`,
+`postMessage`, `requestCardMount`, `setNames`, `loadProjectLive`, and
+`--card/--mount/--set/--project` on the CLI. ⚠️ The FAT16 image builder is
+deliberately NOT ported: route A builds the image in Python, the port reads
+the same `.img`, so both look at identical media.
+
+Two findings that are worth more than the code:
+
+1. ✅ **`0xfc0a4039` bit 3 must read CLEAR.** Unmodelled it answers all-ones,
+   the driver decides there is no card, and the mount issues **zero ATA
+   commands with no error anywhere**. Route A keeps it in `EXTRA_OVERRIDES`.
+2. ❌ **O5's "route A grows memory through an auto-mapping hook" is
+   retracted.** `emu_card.attach` maps those four spans EXPLICITLY; the hook
+   is only installed by the menu render helpers, which never run on the
+   golden path. `mapCardMemory` now adds them, and the port's auto-mapped
+   count falls from **20,348,051 to 4**. See `COLDFIRE_PORT.md`.
+
+**Where it stops:** the machine parks at main's spin, the request posts, the
+firmware issues **1 IDENTIFY**, its interrupt **is** taken and acknowledged,
+and then card-ready (`0x460d1cb8`) never becomes non-zero, so `LOAD PROJECT`
+is never posted. A profile over the mount window is indistinguishable from a
+boot-only profile, so the machine is **idle, not spinning**: SYS is blocked on
+a wake-up that never arrives. 🟡 The specific event is not identified.
+
+**Route A's targets, re-measured today on `OCTABAM/ONEAUX`:** 6,189 commands,
+30,467 sectors read, 297 written, `saved_bank=1`, `final_bank=0`. ⚠️
+`PART_PTR` reads `0x400e21e0` **before any load** (it is the bank blob's
+base), so it is NOT on its own evidence of a load; the work order's
+`0x4017d520` below is from a different project.
+
+**No regression:** oracle diff 8 compared fields, zero disagreements; `ctest`
+6/6; `make check` green.
+
+<details><summary>the original entry</summary>
+
 ### O7 — the card and the project load *(Opus, large)*
 
 **Translates:** `tools/emu_card.py` (FAT16 + the ATA task-file model at
@@ -182,6 +223,8 @@ ATA commands / ~30,467 sectors** and writes `PART_PTR = 0x4017d520` from
 `0x40087d44` (`RTOS_FORK.md` §5 M6b). ⚠️ The load ends on bank A in route A
 and on the saved bank on hardware (§7): the port must reproduce **route A**
 first (the oracle), and the discrepancy stays documented as route A's.
+
+</details>
 
 ### O8 — the DSP cores and the host port *(Fable — judgment)*
 

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -194,12 +194,35 @@ Two findings that are worth more than the code:
    golden path. `mapCardMemory` now adds them, and the port's auto-mapped
    count falls from **20,348,051 to 4**. See `COLDFIRE_PORT.md`.
 
-**Where it stops:** the machine parks at main's spin, the request posts, the
-firmware issues **1 IDENTIFY**, its interrupt **is** taken and acknowledged,
-and then card-ready (`0x460d1cb8`) never becomes non-zero, so `LOAD PROJECT`
-is never posted. A profile over the mount window is indistinguishable from a
-boot-only profile, so the machine is **idle, not spinning**: SYS is blocked on
-a wake-up that never arrives. 🟡 The specific event is not identified.
+**THE MOUNT NOW SUCCEEDS** (8 Sep 2026, second session). Four defects, all
+measured:
+
+1. ✅ **INTRQ is not instantaneous, and the firmware depends on that.** The
+   port asserted it on the same instruction as the command write, so the ISR
+   ran, streamed, and SIGNALLED the event before the driver reached the WAIT —
+   which then blocked forever on a signal that had already happened. Route A
+   survives only by accident of granularity (burst-boundary delivery). A real
+   CF card takes tens of microseconds, so `m_ataLatency` (1 sample) is the
+   physical behaviour. **The port's finer granularity EXPOSED a race route A's
+   coarse bursts hide** — the usual lesson inverted.
+2. ✅ **`mvzw %a0,%d0`** at `0x40017c10`: the V4e effective-address reader had
+   no `An` direct. Same family as O4's `ff1`.
+3. The park must test **the PC alone**, as route A does — `!anyPending()` as
+   well never comes true once the card is live.
+4. `callAsMain`'s budget must survive preemption (the step count is dominated
+   by the other tasks running underneath the borrowed call).
+
+**Where it stops now:** card ready = **1**, `LOAD PROJECT` posted, **1,407**
+ATA commands / **10,695** sectors read / **297 written — the written count
+matches route A exactly**, and one ATA interrupt arrives per sector. ⛔ The
+load then STOPS rather than running slowly: 30,000 ms of emulated time gives
+the same 1,407 commands as 6,000. It ends with the **engine task cycling at
+`0x400165dc`** and the in-flight word (`0x46c8c58a`) clear. Route A's targets
+are 6,189 / 30,467 / 297. **That stall is the next thing to chase.**
+
+The instruments that found all of this are in the tree and off by default:
+`--ata-trace`, `--periph-trace`, `--pc-ring N`, `--peek`, and the
+acknowledged-vector log (which vector went to which handler, always on).
 
 **Route A's targets, re-measured today on `OCTABAM/ONEAUX`:** 6,189 commands,
 30,467 sectors read, 297 written, `saved_bank=1`, `final_bank=0`. ⚠️

--- a/tools/ot_emu/CMakeLists.txt
+++ b/tools/ot_emu/CMakeLists.txt
@@ -22,7 +22,7 @@ set(OT_VENDOR "${CMAKE_CURRENT_SOURCE_DIR}/../../vendor" CACHE PATH "vendored em
 # divide and HI08 tests, and they are the contract this port stands on.
 add_subdirectory("${OT_VENDOR}/mc68k" "${CMAKE_CURRENT_BINARY_DIR}/mc68k")
 
-add_library(ot_machine STATIC machine.cpp machine.h v4e.cpp v4e.h periph.cpp periph.h rtos.cpp rtos.h)
+add_library(ot_machine STATIC machine.cpp machine.h v4e.cpp v4e.h periph.cpp periph.h card.cpp card.h rtos.cpp rtos.h)
 target_include_directories(ot_machine PUBLIC "${OT_VENDOR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(ot_machine PUBLIC 68kEmu)
 

--- a/tools/ot_emu/card.cpp
+++ b/tools/ot_emu/card.cpp
@@ -1,0 +1,207 @@
+#include "card.h"
+
+#include <algorithm>
+#include <cstdio>
+
+namespace ot
+{
+	AtaCard::AtaCard(std::vector<uint8_t> _image)
+		: m_img(std::move(_image))
+	{
+		m_nsect = static_cast<uint32_t>(m_img.size() / g_sector);
+	}
+
+	std::vector<uint16_t> AtaCard::identifyWords(const uint32_t _totalSectors)
+	{
+		std::vector<uint16_t> w(256, 0);
+		constexpr uint16_t cyl = 1024, heads = 16, spt = 63;
+		w[0] = 0x848a;								// CF signature
+		w[1] = cyl; w[3] = heads; w[6] = spt;
+		w[7] = static_cast<uint16_t>(_totalSectors >> 16);
+		w[8] = static_cast<uint16_t>(_totalSectors);
+		const auto str = [&w](const size_t _idx, const size_t _n, const char* _text)
+		{
+			std::string b(_text);
+			b.resize(_n * 2, ' ');
+			for(size_t i = 0; i < _n; ++i)
+				w[_idx + i] = static_cast<uint16_t>((static_cast<uint8_t>(b[2 * i]) << 8)
+					| static_cast<uint8_t>(b[2 * i + 1]));
+		};
+		str(10, 10, "OCTABAM0001");
+		str(23, 4, "1.0");
+		str(27, 20, "OCTABAM EMULATED CF");
+		w[47] = 0x8001;
+		w[49] = 0x0200;		// LBA supported, NO DMA (bit 8 clear)
+		w[51] = 0x0200;		// PIO mode 2
+		w[53] = 0x0000;		// words 54-58 / 64-70 not valid -> the PIO path
+		w[54] = cyl; w[55] = heads; w[56] = spt;
+		w[57] = static_cast<uint16_t>(_totalSectors);
+		w[58] = static_cast<uint16_t>(_totalSectors >> 16);
+		w[60] = static_cast<uint16_t>(_totalSectors);
+		w[61] = static_cast<uint16_t>(_totalSectors >> 16);
+		return w;
+	}
+
+	uint32_t AtaCard::lba() const
+	{
+		return m_lba0 | (m_lba1 << 8) | (m_lba2 << 16) | ((m_dev & 0x0f) << 24);
+	}
+
+	// ⚠️ A COUNT OF ZERO MEANS 256, which is the ATA rule -- but only in the
+	// task file. The FIRMWARE's own count byte means SECTORS REMAINING, where
+	// zero means none: reading that one as 256 wiped a whole card (5 Sep 2026).
+	uint32_t AtaCard::count() const
+	{
+		return m_count ? m_count : 256;
+	}
+
+	uint32_t AtaCard::read(const uint32_t _off, uint32_t)
+	{
+		if(_off == R_DATA)
+		{
+			if(m_dpos + 1 < m_data.size())
+			{
+				const uint32_t v = (m_data[m_dpos] << 8) | m_data[m_dpos + 1];
+				m_dpos += 2;
+				if(m_dpos >= m_data.size())
+					m_status &= ~ST_DRQ;
+				return v;
+			}
+			return 0;
+		}
+		if(_off == R_CMD || _off == R_ALT)
+			return m_status;
+		if(_off == R_FEAT)
+			return m_error;
+		switch(_off)
+		{
+		case R_COUNT: return m_count;
+		case R_LBA0:  return m_lba0;
+		case R_LBA1:  return m_lba1;
+		case R_LBA2:  return m_lba2;
+		case R_DEV:   return m_dev;
+		default:      return 0;
+		}
+	}
+
+	void AtaCard::write(const uint32_t _off, uint32_t, const uint32_t _val)
+	{
+		if(_off == R_DATA)
+		{
+			if(m_wremaining)
+			{
+				m_wbuf.push_back(static_cast<uint8_t>(_val >> 8));
+				m_wbuf.push_back(static_cast<uint8_t>(_val));
+				if(m_wbuf.size() >= g_sector)
+				{
+					commitSector(m_wbuf.data());
+					m_wbuf.erase(m_wbuf.begin(), m_wbuf.begin() + g_sector);
+				}
+			}
+			return;
+		}
+		if(_off == R_CMD)
+		{
+			command(static_cast<uint8_t>(_val));
+			return;
+		}
+		switch(_off)
+		{
+		case R_FEAT:  m_feat  = _val & 0xff; break;
+		case R_COUNT: m_count = _val & 0xff; break;
+		case R_LBA0:  m_lba0  = _val & 0xff; break;
+		case R_LBA1:  m_lba1  = _val & 0xff; break;
+		case R_LBA2:  m_lba2  = _val & 0xff; break;
+		case R_DEV:   m_dev   = _val & 0xff; break;
+		default: break;
+		}
+	}
+
+	void AtaCard::command(const uint8_t _c)
+	{
+		m_cmd = _c;
+		m_error = 0;
+		m_status = ST_DRDY | ST_DSC;
+		char name[32];
+		switch(_c)
+		{
+		case 0xec:					// IDENTIFY DEVICE
+		{
+			const auto w = identifyWords(m_nsect);
+			m_data.assign(w.size() * 2, 0);
+			// LITTLE-endian in the buffer, as route A packs it ("<256H"):
+			// the firmware byte-swaps what it reads off the bus.
+			for(size_t i = 0; i < w.size(); ++i)
+			{
+				m_data[2 * i]     = static_cast<uint8_t>(w[i]);
+				m_data[2 * i + 1] = static_cast<uint8_t>(w[i] >> 8);
+			}
+			m_dpos = 0;
+			m_status |= ST_DRQ;
+			m_log.push_back({"IDENTIFY", 0, 0});
+			return;
+		}
+		case 0x20:					// READ SECTORS
+		{
+			const auto l = lba(), n = count();
+			const size_t lo = static_cast<size_t>(l) * g_sector;
+			const size_t hi = lo + static_cast<size_t>(n) * g_sector;
+			m_data.assign(m_img.begin() + std::min(lo, m_img.size()),
+				m_img.begin() + std::min(hi, m_img.size()));
+			m_dpos = 0;
+			m_status |= ST_DRQ;
+			m_reads += n;
+			m_log.push_back({"READ", l, n});
+			return;
+		}
+		case 0x30:					// WRITE SECTORS
+		{
+			const auto l = lba(), n = count();
+			m_wbuf.clear();
+			m_wlba = l;
+			m_wremaining = n;
+			m_status |= ST_DRQ;
+			m_log.push_back({"WRITE", l, n});
+			return;
+		}
+		case 0x87:					// CFA TRANSLATE SECTOR
+			m_data.assign(g_sector, 0);
+			m_dpos = 0;
+			m_status |= ST_DRQ;
+			m_log.push_back({"CFA-TRANSLATE", lba(), 0});
+			return;
+		case 0xe5:					// CHECK POWER MODE
+			m_count = 0xff;
+			m_log.push_back({"CHECK-POWER", 0, 0});
+			return;
+		case 0xe0: case 0xe1: case 0xe2: case 0xe3: case 0xe6:
+		case 0xef: case 0xc0: case 0x03: case 0x91: case 0xc6:
+			std::snprintf(name, sizeof name, "CMD-%02x", _c);
+			m_log.push_back({name, 0, 0});
+			return;
+		default:
+			m_error = 0x04;			// ABRT
+			m_status |= 0x01;
+			std::snprintf(name, sizeof name, "UNSUPPORTED-%02x", _c);
+			m_log.push_back({name, 0, 0});
+			return;
+		}
+	}
+
+	// One sector of a WRITE, in order: the handler streams the first sector
+	// through the data register itself (0x40014c48 after the command), the
+	// interrupt handler streams the rest.
+	void AtaCard::commitSector(const uint8_t* _data)
+	{
+		const size_t off = static_cast<size_t>(m_wlba) * g_sector;
+		if(m_wlba < m_nsect)
+			std::copy(_data, _data + g_sector, m_img.begin() + off);
+		++m_writes;
+		++m_wlba;
+		if(--m_wremaining <= 0)
+		{
+			m_wremaining = 0;
+			m_status &= ~ST_DRQ;
+		}
+	}
+}

--- a/tools/ot_emu/card.h
+++ b/tools/ot_emu/card.h
@@ -1,0 +1,76 @@
+// The CompactFlash card behind the FlexBus task-file window at 0x90000000.
+//
+// Translated from `tools/emu_card.py`'s `AtaCard`, which is the specification.
+// ⚠️ THE FAT16 IMAGE BUILDER IS DELIBERATELY NOT HERE. Route A builds the card
+// image from a directory tree in Python (`emu_card.build_image`), and that is
+// a BUILD-TIME tool producing bytes, not machine behaviour: this port reads
+// the same image file, so the two emulators are guaranteed to be looking at
+// identical media and any difference between them is in the machine. Build one
+// with `emu_rtos.stage_project(...)`.
+//
+// The register map is docs/ARCHITECTURE.md §5: data 0xa0, features/error 0xa4,
+// count 0xa8, LBA 0xac/b0/b4, device 0xb8, command/status 0xbc, alt status
+// 0xd8. IDENTIFY advertises PIO only (word 49 bit 8 clear, word 53 zero), so
+// the driver's variant detection at 0x40015e28 never programs the on-chip DMA
+// channel -- which is why this model never has to.
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace ot
+{
+	class AtaCard
+	{
+	public:
+		static constexpr uint32_t g_base = 0x90000000, g_window = 0x1000;
+		static constexpr uint32_t g_sector = 512;
+		enum : uint32_t
+		{
+			R_DATA = 0xa0, R_FEAT = 0xa4, R_COUNT = 0xa8, R_LBA0 = 0xac,
+			R_LBA1 = 0xb0, R_LBA2 = 0xb4, R_DEV = 0xb8, R_CMD = 0xbc, R_ALT = 0xd8
+		};
+		enum : uint32_t { ST_DRDY = 0x40, ST_DSC = 0x10, ST_DRQ = 0x08 };
+
+		explicit AtaCard(std::vector<uint8_t> _image);
+
+		uint32_t read(uint32_t _off, uint32_t _size);
+		void write(uint32_t _off, uint32_t _size, uint32_t _val);
+
+		// What the run did, in the shape route A's log has it: the gate for
+		// the project load is a COUNT of commands and sectors.
+		struct Entry { std::string what; uint32_t lba = 0, count = 0; };
+		const std::vector<Entry>& log() const { return m_log; }
+		uint64_t sectorsRead() const { return m_reads; }
+		uint64_t sectorsWritten() const { return m_writes; }
+
+		// The INTRQ rules live in `Rtos::attachCard` and need these three.
+		uint32_t status() const { return m_status; }
+		size_t dataPos() const { return m_dpos; }
+		size_t dataSize() const { return m_data.size(); }
+
+		uint32_t totalSectors() const { return m_nsect; }
+		static std::vector<uint16_t> identifyWords(uint32_t _totalSectors);
+
+	private:
+		uint32_t lba() const;
+		uint32_t count() const;
+		void command(uint8_t _c);
+		void commitSector(const uint8_t* _data);
+
+		std::vector<uint8_t> m_img;
+		uint32_t m_nsect = 0;
+		uint32_t m_feat = 0, m_count = 0, m_lba0 = 0, m_lba1 = 0, m_lba2 = 0, m_dev = 0xe0;
+		uint32_t m_status = ST_DRDY | ST_DSC;
+		uint32_t m_error = 0;
+		std::vector<uint8_t> m_data;
+		size_t m_dpos = 0;
+		std::vector<uint8_t> m_wbuf;
+		uint32_t m_wlba = 0;
+		int64_t m_wremaining = 0;
+		uint8_t m_cmd = 0;
+		std::vector<Entry> m_log;
+		uint64_t m_reads = 0, m_writes = 0;
+	};
+}

--- a/tools/ot_emu/machine.cpp
+++ b/tools/ot_emu/machine.cpp
@@ -161,6 +161,8 @@ namespace ot
 			{
 				if(m_periphLog.size() < 4096)
 					m_periphLog.push_back({'R', pc(), _addr, _size, v});
+		if(m_periphTraceOn && m_periphTrace.size() < 300000)
+			m_periphTrace.push_back({'R', pc(), _addr, _size, v});
 				return v;
 			}
 		}
@@ -169,6 +171,8 @@ namespace ot
 			const auto v = it->second();
 			if(m_periphLog.size() < 4096)
 				m_periphLog.push_back({'R', pc(), _addr, _size, v});
+		if(m_periphTraceOn && m_periphTrace.size() < 300000)
+			m_periphTrace.push_back({'R', pc(), _addr, _size, v});
 			return v;
 		}
 		// Byte by byte, big-endian, so an access of any width or alignment sees
@@ -182,6 +186,8 @@ namespace ot
 		}
 		if(m_periphLog.size() < 4096)
 			m_periphLog.push_back({'R', pc(), _addr, _size, v});
+		if(m_periphTraceOn && m_periphTrace.size() < 300000)
+			m_periphTrace.push_back({'R', pc(), _addr, _size, v});
 		return v;
 	}
 
@@ -190,6 +196,8 @@ namespace ot
 		m_periphWrites.push_back({_addr, _size, _val});
 		if(m_periphLog.size() < 4096)
 			m_periphLog.push_back({'W', pc(), _addr, _size, _val});
+		if(m_periphTraceOn && m_periphTrace.size() < 300000)
+			m_periphTrace.push_back({'W', pc(), _addr, _size, _val});
 		if(m_periphWriteFn)
 			m_periphWriteFn(_addr, _size, _val);
 	}

--- a/tools/ot_emu/machine.cpp
+++ b/tools/ot_emu/machine.cpp
@@ -334,6 +334,29 @@ namespace ot
 		}
 	}
 
+	uint32_t Machine::readIrqUserVector(const uint8_t _level)
+	{
+		const auto vec = Mc68k::readIrqUserVector(_level);
+		if(m_ack && vec != 0xffffffffu)
+			m_ack(static_cast<uint8_t>(vec), _level);
+		return vec;
+	}
+
+	uint32_t Machine::getA7() const
+	{
+		return m68k_get_reg(const_cast<void*>(static_cast<const void*>(getCpuState())), M68K_REG_A7);
+	}
+
+	void Machine::setA7(const uint32_t _v)
+	{
+		m68k_set_reg(getCpuState(), M68K_REG_A7, _v);
+	}
+
+	uint32_t Machine::getD0() const
+	{
+		return m68k_get_reg(const_cast<void*>(static_cast<const void*>(getCpuState())), M68K_REG_D0);
+	}
+
 	uint32_t Machine::peek32(const uint32_t _addr)
 	{
 		return read32(_addr);

--- a/tools/ot_emu/machine.h
+++ b/tools/ot_emu/machine.h
@@ -93,6 +93,15 @@ namespace ot
 
 		uint32_t onIllegalInstruction(uint32_t _opcode) override;
 
+		// The interrupt ACKNOWLEDGE: the core calls this when it actually
+		// takes a queued vector. Offering a line and having it taken are
+		// different events here, because Musashi dispatches the exception
+		// itself, so anything that has to happen "when the interrupt is
+		// delivered" hangs off this.
+		uint32_t readIrqUserVector(uint8_t _level) override;
+		using AckHook = std::function<void(uint8_t _vector, uint8_t _level)>;
+		void setAckHook(AckHook _h) { m_ack = std::move(_h); }
+
 		// -- driving it ------------------------------------------------------
 		// Run until `trap #0` (the handoff), an illegal instruction, or the
 		// budget. Returns why it stopped. This is the BOOT: it carries the
@@ -149,6 +158,11 @@ namespace ot
 		// not constants (the DSP host port's ping index toggles 0/1).
 		void setOverrideFn(uint32_t _addr, std::function<uint32_t()> _fn) { m_overrideFns[_addr] = std::move(_fn); }
 
+		// A single peripheral BYTE that must not read all-ones. Route A keeps
+		// these in `EXTRA_OVERRIDES`; the boot needs only the PLL, the card
+		// needs one more (see `Rtos::attachCard`).
+		void setOverride8(uint32_t _addr, uint8_t _val) { m_overrides[_addr] = _val; }
+
 		// Interception, the whole point of a headless build: a callback per
 		// instruction (nullptr = off), and direct memory access for probes.
 		void setStepHook(std::function<void(Machine&, uint32_t _pc)> _h) { m_step = std::move(_h); }
@@ -159,6 +173,12 @@ namespace ot
 		// thing (its stall detector) for the same reason.
 		void setProfile(uint32_t _every) { m_profileEvery = _every; }
 		const std::unordered_map<uint32_t, uint64_t>& profile() const { return m_profile; }
+		// Registers a borrowed call needs: main's stack pointer to push the
+		// frame onto, and D0 for the return value.
+		uint32_t getA7() const;
+		void     setA7(uint32_t _v);
+		uint32_t getD0() const;
+
 		uint32_t peek32(uint32_t _addr);
 		void     poke32(uint32_t _addr, uint32_t _val);
 
@@ -263,6 +283,7 @@ namespace ot
 		std::vector<uint8_t>* m_lastAutoData = nullptr;
 		uint8_t* autoByte(uint32_t _addr, bool _create);
 		std::function<void(Machine&, uint32_t)> m_step;
+		AckHook m_ack;
 		uint64_t m_instructions = 0;
 		uint64_t m_v4e = 0;			// instructions the V4e layer supplied
 		uint32_t m_profileEvery = 0;

--- a/tools/ot_emu/machine.h
+++ b/tools/ot_emu/machine.h
@@ -243,6 +243,11 @@ namespace ot
 		struct Access { char kind; uint32_t pc, addr; uint8_t size; uint32_t val; };
 		const std::vector<Access>& peripheralLog() const { return m_periphLog; }
 
+		// EVERY peripheral access in order, not just first touches, while
+		// switched on: for diffing a window of the run against route A's.
+		void setPeriphTrace(bool _on) { m_periphTraceOn = _on; }
+		const std::vector<Access>& periphTrace() const { return m_periphTrace; }
+
 		// Every completion flag the stall detector had to satisfy, as
 		// (loop pc, flag address, value): route A keeps the same list and it
 		// is the honest record of where this emulator is standing in for
@@ -269,6 +274,8 @@ namespace ot
 		PeriphWrite m_periphWriteFn;
 		std::vector<PeriphWriteRec> m_periphWrites;
 		std::vector<Access> m_periphLog;
+		std::vector<Access> m_periphTrace;
+		bool m_periphTraceOn = false;
 		void noteUnmapped(char _kind, uint32_t _addr, uint8_t _size, uint32_t _val);
 		std::vector<Unmapped> m_unmapped;
 		uint64_t m_unmappedCount = 0, m_unmappedReads = 0;

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -12,6 +12,7 @@
 // the work list for the ISA half of the port, one opcode at a time.
 #include <cstdio>
 #include <map>
+#include <memory>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -42,6 +43,9 @@ int main(int _argc, char** _argv)
 	bool showPeripherals = false;
 	bool profile = false;
 	std::string golden;
+	std::string cardImage;		// a FAT16 card image built by emu_rtos.stage_project
+	bool mount = false;			// post the card-mount request to the SYS task
+	std::string setName = "OCTABAM", projectName = "ONEAUX";
 	std::string serialOut;
 	double runMs = 1000.0;
 	double ips = 3990.0;
@@ -54,6 +58,10 @@ int main(int _argc, char** _argv)
 		else if(a == "--periph")				showPeripherals = true;
 		else if(a == "--profile")				profile = true;
 		else if(a == "--golden" && i + 1 < _argc)	golden = _argv[++i];
+		else if(a == "--card" && i + 1 < _argc)		cardImage = _argv[++i];
+		else if(a == "--mount")						mount = true;
+		else if(a == "--set" && i + 1 < _argc)		setName = _argv[++i];
+		else if(a == "--project" && i + 1 < _argc)	projectName = _argv[++i];
 		else if(a == "--serial-out" && i + 1 < _argc)	serialOut = _argv[++i];
 		else if(a == "--ms" && i + 1 < _argc)	runMs = std::atof(_argv[++i]);
 		else if(a == "--ips" && i + 1 < _argc)	ips = std::atof(_argv[++i]);
@@ -104,6 +112,25 @@ int main(int _argc, char** _argv)
 	{
 		std::printf("vbr        : %#x (the firmware's own `movec %%a0,%%vbr` at 0x40000db6)\n", m.vbr());
 		ot::Rtos rtos(m, ips);
+		// The card is attached BEFORE install, as route A attaches it before
+		// `Rtos.install()`: its four memory maps have to be in place before
+		// anything runs, and the boot's replayed writes must not start a
+		// transfer on a window that is about to change owner.
+		std::unique_ptr<ot::AtaCard> card;
+		if(!cardImage.empty())
+		{
+			std::ifstream cf(cardImage, std::ios::binary);
+			if(!cf)
+			{
+				std::printf("card       : %s could not be opened\n", cardImage.c_str());
+				return 1;
+			}
+			std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(cf)),
+				std::istreambuf_iterator<char>());
+			card = std::make_unique<ot::AtaCard>(std::move(bytes));
+			rtos.attachCard(*card);
+			std::printf("card       : %s, %u sectors\n", cardImage.c_str(), card->totalSectors());
+		}
 		rtos.install();
 		const auto rs = rtos.run(runMs);
 		static const char* const g_rtosNames[] = {"GATE", "TIME", "FAULT", "ILLEGAL"};
@@ -118,6 +145,42 @@ int main(int _argc, char** _argv)
 		std::printf("M6a gate   : %s\n", ok ? "PASS" : "FAIL");
 		for(const auto& p : problems)
 			std::printf("   - %s\n", p.c_str());
+		// THE MOUNT. Reaching the M6a gate is not enough: the card case runs
+		// in the SYS task, so the machine has to be parked at main's spin
+		// before the request can be posted, and then run on so SYS can do it.
+		if(mount && card)
+		{
+			const auto park = rtos.runToMainSpin(2000.0);
+			std::printf("load       : park at main's spin: %s\n",
+				park == ot::Rtos::Stop::Gate ? "yes" : rtos.why().c_str());
+			if(park == ot::Rtos::Stop::Gate)
+			{
+				const auto r = rtos.loadProjectLive(setName, projectName);
+				std::printf("             card ready: %#x, LOAD PROJECT posted: %s, "
+					"PART_PTR: %#x, %.1f ms emulated\n",
+					r.ready, r.posted ? "yes" : "no", r.partPtr, r.ms);
+			}
+			size_t reads = 0, identifies = 0;
+			for(const auto& e : card->log())
+			{
+				if(e.what == "READ")
+					++reads;
+				else if(e.what == "IDENTIFY")
+					++identifies;
+			}
+			std::printf("             ATA interrupts taken: %llu; line still asserted: %s\n",
+				static_cast<unsigned long long>(rtos.ataInterrupts()),
+				rtos.ataLineAsserted() ? "YES" : "no");
+			std::printf("             %zu ATA command(s): %zu IDENTIFY, %zu READ, "
+				"%llu sector(s) read, %llu written\n",
+				card->log().size(), identifies, reads,
+				static_cast<unsigned long long>(card->sectorsRead()),
+				static_cast<unsigned long long>(card->sectorsWritten()));
+			for(size_t i = 0; i < card->log().size() && i < 12; ++i)
+				std::printf("             %-16s lba %-8u count %u\n", card->log()[i].what.c_str(),
+					card->log()[i].lba, card->log()[i].count);
+		}
+
 		if(!serialOut.empty())
 		{
 			for(const auto& [suffix, tx] : {std::make_pair("a", &rtos.serialTxA()),

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -45,6 +45,11 @@ int main(int _argc, char** _argv)
 	std::string golden;
 	std::string cardImage;		// a FAT16 card image built by emu_rtos.stage_project
 	bool mount = false;			// post the card-mount request to the SYS task
+	std::string ataTrace;		// write every task-file access here, for diffing against route A
+	std::string periphTrace;	// every peripheral access over the load, for the same diff
+	std::string peeks;			// comma-separated hex addresses to print after the load
+	uint64_t pcRing = 0;		// instructions to record from the first ATA command
+	double loadMs = 6000.0;		// emulated ms to run after LOAD PROJECT is posted
 	std::string setName = "OCTABAM", projectName = "ONEAUX";
 	std::string serialOut;
 	double runMs = 1000.0;
@@ -60,6 +65,11 @@ int main(int _argc, char** _argv)
 		else if(a == "--golden" && i + 1 < _argc)	golden = _argv[++i];
 		else if(a == "--card" && i + 1 < _argc)		cardImage = _argv[++i];
 		else if(a == "--mount")						mount = true;
+		else if(a == "--ata-trace" && i + 1 < _argc)	ataTrace = _argv[++i];
+		else if(a == "--periph-trace" && i + 1 < _argc)	periphTrace = _argv[++i];
+		else if(a == "--peek" && i + 1 < _argc)		peeks = _argv[++i];
+		else if(a == "--pc-ring" && i + 1 < _argc)	pcRing = std::strtoull(_argv[++i], nullptr, 0);
+		else if(a == "--load-ms" && i + 1 < _argc)	loadMs = std::atof(_argv[++i]);
 		else if(a == "--set" && i + 1 < _argc)		setName = _argv[++i];
 		else if(a == "--project" && i + 1 < _argc)	projectName = _argv[++i];
 		else if(a == "--serial-out" && i + 1 < _argc)	serialOut = _argv[++i];
@@ -129,6 +139,7 @@ int main(int _argc, char** _argv)
 				std::istreambuf_iterator<char>());
 			card = std::make_unique<ot::AtaCard>(std::move(bytes));
 			rtos.attachCard(*card);
+			rtos.setAtaTrace(!ataTrace.empty());
 			std::printf("card       : %s, %u sectors\n", cardImage.c_str(), card->totalSectors());
 		}
 		rtos.install();
@@ -150,15 +161,86 @@ int main(int _argc, char** _argv)
 		// before the request can be posted, and then run on so SYS can do it.
 		if(mount && card)
 		{
-			const auto park = rtos.runToMainSpin(2000.0);
-			std::printf("load       : park at main's spin: %s\n",
-				park == ot::Rtos::Stop::Gate ? "yes" : rtos.why().c_str());
-			if(park == ot::Rtos::Stop::Gate)
 			{
-				const auto r = rtos.loadProjectLive(setName, projectName);
+				if(pcRing)
+					rtos.armPcRing(4096, pcRing);
+				const auto forces0 = rtos.forces();
+				const auto disp0 = rtos.dispatches().size();
+				m.setPeriphTrace(!periphTrace.empty());
+				const auto r = rtos.loadProjectLive(setName, projectName, loadMs);
+				m.setPeriphTrace(false);
 				std::printf("             card ready: %#x, LOAD PROJECT posted: %s, "
-					"PART_PTR: %#x, %.1f ms emulated\n",
-					r.ready, r.posted ? "yes" : "no", r.partPtr, r.ms);
+					"PART_PTR: %#x, %.1f ms emulated%s%s\n",
+					r.ready, r.posted ? "yes" : "no", r.partPtr, r.ms,
+					r.postWhy.empty() ? "" : " | post: ", r.postWhy.c_str());
+				std::printf("             forces %llu, dispatches %zu over the load; now in %s at pc %#x\n",
+					static_cast<unsigned long long>(rtos.forces() - forces0),
+					rtos.dispatches().size() - disp0, ot::taskName(rtos.currentTcb()), m.pc());
+				std::printf("             dispatch tail:\n");
+				const auto& ds = rtos.dispatches();
+				for(size_t i = ds.size() > 14 ? ds.size() - 14 : 0; i < ds.size(); ++i)
+					std::printf("               [%9.1f] %-10s pc=%#x\n", ds[i].sample, ot::taskName(ds[i].tcb), ds[i].pc);
+				{
+					// Vectors by (vector, slot): how many times each was taken,
+					// and the tail in order. A slot holding the kernel's
+					// trampoline 0x40000d74 is an interrupt nobody claimed.
+					std::map<std::pair<uint32_t, uint32_t>, uint64_t> byVec;
+					for(const auto& k : rtos.acks())
+						++byVec[{k.vector, k.slot}];
+					std::printf("             vectors acknowledged (%zu):", rtos.acks().size());
+					for(const auto& [key, cnt] : byVec)
+						std::printf(" v%#x->%#x x%llu", key.first, key.second, static_cast<unsigned long long>(cnt));
+					std::printf("\n             ack tail:\n");
+					const auto& ks = rtos.acks();
+					for(size_t i = ks.size() > 12 ? ks.size() - 12 : 0; i < ks.size(); ++i)
+						std::printf("               [%9.1f] v%#04x lvl %u in %-10s at pc %#x -> slot %#x\n",
+							ks[i].sample, ks[i].vector, ks[i].level, ot::taskName(ks[i].tcb), ks[i].pc, ks[i].slot);
+				}
+				if(pcRing && rtos.pcRingArmed())
+				{
+					const auto& ring = rtos.pcRing();
+					const auto pos = rtos.pcRingPos();
+					std::printf("             pc ring (last %zu of %zu recorded from the first ATA command):\n",
+						std::min(ring.size(), pos), pos);
+					const size_t n = std::min(ring.size(), pos);
+					uint32_t last = 0; uint64_t runlen = 0;
+					for(size_t i = 0; i < n; ++i)
+					{
+						const auto v = ring[(pos - n + i) % ring.size()];
+						if(v == last) { ++runlen; continue; }
+						if(runlen > 1) std::printf(" (x%llu)", static_cast<unsigned long long>(runlen));
+						if(i) std::printf("\n");
+						std::printf("               %#010x", v);
+						last = v; runlen = 1;
+					}
+					if(runlen > 1) std::printf(" (x%llu)", static_cast<unsigned long long>(runlen));
+					std::printf("\n");
+				}
+				if(!peeks.empty())
+				{
+					std::printf("             peek:");
+					size_t p = 0;
+					while(p < peeks.size())
+					{
+						auto q = peeks.find(',', p);
+						if(q == std::string::npos) q = peeks.size();
+						const auto addr = static_cast<uint32_t>(std::strtoul(peeks.substr(p, q - p).c_str(), nullptr, 16));
+						std::printf(" [%#x]=%#x", addr, m.peek32(addr));
+						p = q + 1;
+					}
+					std::printf("\n");
+				}
+				if(!periphTrace.empty())
+				{
+					std::ofstream t(periphTrace);
+					for(const auto& e : m.periphTrace())
+					{
+						char line[64];
+						std::snprintf(line, sizeof line, "%c %08x %u %08x %08x", e.kind == 'R' ? 'R' : 'W', e.addr, e.size, e.val, e.pc);
+						t << line << '\n';
+					}
+					std::printf("             periph trace: %s (%zu accesses)\n", periphTrace.c_str(), m.periphTrace().size());
+				}
 			}
 			size_t reads = 0, identifies = 0;
 			for(const auto& e : card->log())
@@ -176,6 +258,13 @@ int main(int _argc, char** _argv)
 				card->log().size(), identifies, reads,
 				static_cast<unsigned long long>(card->sectorsRead()),
 				static_cast<unsigned long long>(card->sectorsWritten()));
+			if(!ataTrace.empty())
+			{
+				std::ofstream t(ataTrace);
+				for(const auto& l : rtos.ataTrace())
+					t << l << '\n';
+				std::printf("             ATA trace: %s (%zu accesses)\n", ataTrace.c_str(), rtos.ataTrace().size());
+			}
 			for(size_t i = 0; i < card->log().size() && i < 12; ++i)
 				std::printf("             %-16s lba %-8u count %u\n", card->log()[i].what.c_str(),
 					card->log()[i].lba, card->log()[i].count);

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -78,6 +78,12 @@ namespace ot
 		{
 			const auto off = _addr - AtaCard::g_base;
 			_out = m_card->read(off, _size);
+			if(m_ataTraceOn && m_ataTrace.size() < 200000)
+			{
+				char line[64];
+				std::snprintf(line, sizeof line, "R %02x %u %04x %08x", off, _size, _out & 0xffff, m_machine.pc());
+				m_ataTrace.emplace_back(line);
+			}
 			// INTRQ is cleared by a read of the STATUS register (not the
 			// alternate status), and raised again when the next sector is
 			// ready: one interrupt per sector.
@@ -85,7 +91,7 @@ namespace ot
 				m_ataIrq = false;
 			else if(off == AtaCard::R_DATA && m_card->dataPos() % AtaCard::g_sector == 0
 				&& m_card->dataPos() < m_card->dataSize())
-				m_ataIrq = true;
+				m_ataIrqDue = m_sample + m_ataLatency;
 			return true;
 		}
 		for(auto* u : {&m_uart64, &m_uart68})
@@ -107,14 +113,25 @@ namespace ot
 		else if(m_card && _addr >= AtaCard::g_base && _addr < AtaCard::g_base + AtaCard::g_window)
 		{
 			const auto off = _addr - AtaCard::g_base;
+			if(m_ataTraceOn && m_ataTrace.size() < 200000)
+			{
+				char line[64];
+				std::snprintf(line, sizeof line, "W %02x %u %04x %08x", off, _size, _val & 0xffff, m_machine.pc());
+				m_ataTrace.emplace_back(line);
+			}
 			const auto before = m_card->sectorsWritten();
 			m_card->write(off, _size, _val);
 			// A command asserts INTRQ at once -- except a WRITE, which
 			// asserts only once the drive has absorbed a sector.
 			if(off == AtaCard::R_CMD)
-				m_ataIrq = (_val & 0xff) != 0x30;
+			{
+				if((_val & 0xff) != 0x30)
+					m_ataIrqDue = m_sample + m_ataLatency;
+				if(!m_pcRing.empty() && !m_pcRingArmed)
+					m_pcRingArmed = true;
+			}
 			else if(off == AtaCard::R_DATA && m_card->sectorsWritten() > before)
-				m_ataIrq = true;
+				m_ataIrqDue = m_sample + m_ataLatency;
 		}
 		else
 		{
@@ -187,10 +204,13 @@ namespace ot
 		// the instruction that made it. This loop steps one instruction at a
 		// time and re-evaluates interrupts after every one, so the hook only
 		// has to count them -- route A needed it to break its burst.
-		m_machine.setAckHook([this](const uint8_t _vec, uint8_t)
+		m_machine.setAckHook([this](const uint8_t _vec, const uint8_t _level)
 		{
 			if(m_card && _vec == m_intc1.vectorBase() + g_ataSource)
 				++m_ataInterrupts;
+			if(m_acks.size() < 100000)
+				m_acks.push_back({m_sample, _vec, _level, curTcb(), m_machine.pc(),
+					m_machine.peek32(g_vbr + 4u * _vec)});
 		});
 
 		m_intc0.setForceHook([this](uint64_t) { ++m_forces; });
@@ -202,6 +222,11 @@ namespace ot
 	{
 		m_pit0.advance(m_sample);
 		m_pit1.advance(m_sample);
+		if(m_ataIrqDue != 0.0 && m_sample >= m_ataIrqDue)
+		{
+			m_ataIrqDue = 0.0;
+			m_ataIrq = true;
+		}
 	}
 
 	bool Rtos::anyPending() const
@@ -212,8 +237,8 @@ namespace ot
 
 	bool Rtos::nextExpiry(double& _out) const
 	{
-		bool any = false;
-		double best = 0;
+		bool any = m_ataIrqDue != 0.0;
+		double best = m_ataIrqDue;
 		for(const auto* p : {&m_pit0, &m_pit1})
 		{
 			double e;
@@ -362,6 +387,10 @@ namespace ot
 	bool Rtos::stepOnce()
 	{
 		const auto pc = m_machine.pc();
+		// The FIRST N after arming, not the last: the question is what the ISR
+		// does, and by the end everything is parked at main's spin.
+		if(m_pcRingArmed && m_pcRingPos < m_pcRing.size())
+			m_pcRing[m_pcRingPos++] = pc;
 		if(pc == g_create)
 			recordCreate();
 
@@ -402,7 +431,11 @@ namespace ot
 		const double end = m_sample + _ms * g_sampleHz / 1000.0;
 		while(m_sample < end)
 		{
-			if(m_machine.pc() == g_mainSpin && !anyPending())
+			// ⚠️ THE PC ALONE, as route A's `until=lambda r: r.pc == MAIN_SPIN`.
+			// Requiring nothing to be pending as well never comes true once
+			// the card is live: the ATA and serial lines assert constantly,
+			// so the park never returned and the load never started.
+			if(m_machine.pc() == g_mainSpin)
 				return Stop::Gate;
 			if(!stepOnce())
 				return Stop::Illegal;
@@ -531,7 +564,12 @@ namespace ot
 			return out;
 		setNames(_set, _project);
 		uint32_t d0 = 0;
-		out.posted = callAsMain(g_postLoad, {g_projectName}, d0);
+		// A generous budget: with the card live the borrowed call is preempted
+		// constantly, so the step count is dominated by the OTHER tasks
+		// running underneath it, not by the call itself.
+		out.posted = callAsMain(g_postLoad, {g_projectName}, d0, 200000000);
+		if(!out.posted)
+			out.postWhy = m_why;
 		run(_runMs, false);
 		out.partPtr = m_machine.peek32(g_partPtr);
 		out.ms = (m_sample - start) / g_sampleHz * 1000.0;

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -74,6 +74,20 @@ namespace ot
 		if(_addr >= g_pit0 && _addr < g_pit0 + 0x10)    { _out = m_pit0.read(_addr - g_pit0, _size, m_sample); return true; }
 		if(_addr >= g_pit1 && _addr < g_pit1 + 0x10)    { _out = m_pit1.read(_addr - g_pit1, _size, m_sample); return true; }
 		if(_addr >= g_dspi && _addr < g_dspi + 0x100)   { _out = m_dspi.read(_addr - g_dspi, _size); return true; }
+		if(m_card && _addr >= AtaCard::g_base && _addr < AtaCard::g_base + AtaCard::g_window)
+		{
+			const auto off = _addr - AtaCard::g_base;
+			_out = m_card->read(off, _size);
+			// INTRQ is cleared by a read of the STATUS register (not the
+			// alternate status), and raised again when the next sector is
+			// ready: one interrupt per sector.
+			if(off == AtaCard::R_CMD)
+				m_ataIrq = false;
+			else if(off == AtaCard::R_DATA && m_card->dataPos() % AtaCard::g_sector == 0
+				&& m_card->dataPos() < m_card->dataSize())
+				m_ataIrq = true;
+			return true;
+		}
 		for(auto* u : {&m_uart64, &m_uart68})
 			if(_addr >= u->base() && _addr < u->base() + 0x20)
 			{
@@ -90,6 +104,18 @@ namespace ot
 		else if(_addr >= g_pit0 && _addr < g_pit0 + 0x10) m_pit0.write(_addr - g_pit0, _size, _val, m_sample);
 		else if(_addr >= g_pit1 && _addr < g_pit1 + 0x10) m_pit1.write(_addr - g_pit1, _size, _val, m_sample);
 		else if(_addr >= g_dspi && _addr < g_dspi + 0x100) m_dspi.write(_addr - g_dspi, _size, _val, _replay);
+		else if(m_card && _addr >= AtaCard::g_base && _addr < AtaCard::g_base + AtaCard::g_window)
+		{
+			const auto off = _addr - AtaCard::g_base;
+			const auto before = m_card->sectorsWritten();
+			m_card->write(off, _size, _val);
+			// A command asserts INTRQ at once -- except a WRITE, which
+			// asserts only once the drive has absorbed a sector.
+			if(off == AtaCard::R_CMD)
+				m_ataIrq = (_val & 0xff) != 0x30;
+			else if(off == AtaCard::R_DATA && m_card->sectorsWritten() > before)
+				m_ataIrq = true;
+		}
 		else
 		{
 			for(auto* u : {&m_uart64, &m_uart68})
@@ -161,6 +187,12 @@ namespace ot
 		// the instruction that made it. This loop steps one instruction at a
 		// time and re-evaluates interrupts after every one, so the hook only
 		// has to count them -- route A needed it to break its burst.
+		m_machine.setAckHook([this](const uint8_t _vec, uint8_t)
+		{
+			if(m_card && _vec == m_intc1.vectorBase() + g_ataSource)
+				++m_ataInterrupts;
+		});
+
 		m_intc0.setForceHook([this](uint64_t) { ++m_forces; });
 		m_intc1.setForceHook([this](uint64_t) { ++m_forces; });
 		m_installed = true;
@@ -316,41 +348,202 @@ namespace ot
 			}
 			idleRuns = 0;
 
-			if(pc == g_create)
-				recordCreate();
-
-			// The scheduler's `rte` is the moment a task is (re)entered: the
-			// TCB it is entering is already current, and the PC it resumes at
-			// is the one the frame pops. So the record is taken AFTER the
-			// instruction, from the new PC -- route A records exactly the
-			// popped PC, not the address of the rte.
-			const bool atSchedRte = pc == g_schedRte;
-
-			if(!m_machine.step())
-			{
-				m_why = m_machine.why();
+			if(!stepOnce())
 				return Stop::Illegal;
-			}
-			m_sample += 1.0 / m_ips;
-
-			if(atSchedRte)
-			{
-				const auto cur = curTcb();
-				m_dispatches.push_back({m_sample, cur, m_machine.pc()});
-				m_gateDirty = true;
-				if(m_firstSwitch.first && !m_firstSwitch.second)
-					m_firstSwitch.second = cur;
-			}
-			// The first trap #0 is the boot handing over: whatever context it
-			// saves is the "from" half of the first switch.
-			if(!m_firstSwitch.first && pc == g_handoff)
-				m_firstSwitch.first = curTcb();
-
-			tickTimers();
-			deliver();
 		}
 		m_why = "time";
 		return Stop::Time;
+	}
+
+	// One instruction and everything the loop does around it. Factored out so
+	// `callAsMain` runs against the SAME live machine -- the whole point of
+	// borrowing main rather than detouring is that interrupts and the other
+	// tasks keep running underneath the call.
+	bool Rtos::stepOnce()
+	{
+		const auto pc = m_machine.pc();
+		if(pc == g_create)
+			recordCreate();
+
+		// The scheduler's `rte` is the moment a task is (re)entered: the TCB
+		// it is entering is already current, and the PC it resumes at is the
+		// one the frame pops. So the record is taken AFTER the instruction,
+		// from the new PC -- route A records exactly the popped PC, not the
+		// address of the rte.
+		const bool atSchedRte = pc == g_schedRte;
+
+		if(!m_machine.step())
+		{
+			m_why = m_machine.why();
+			return false;
+		}
+		m_sample += 1.0 / m_ips;
+
+		if(atSchedRte)
+		{
+			const auto cur = curTcb();
+			m_dispatches.push_back({m_sample, cur, m_machine.pc()});
+			m_gateDirty = true;
+			if(m_firstSwitch.first && !m_firstSwitch.second)
+				m_firstSwitch.second = cur;
+		}
+		// The first trap #0 is the boot handing over: whatever context it
+		// saves is the "from" half of the first switch.
+		if(!m_firstSwitch.first && pc == g_handoff)
+			m_firstSwitch.first = curTcb();
+
+		tickTimers();
+		deliver();
+		return true;
+	}
+
+	Rtos::Stop Rtos::runToMainSpin(const double _ms)
+	{
+		const double end = m_sample + _ms * g_sampleHz / 1000.0;
+		while(m_sample < end)
+		{
+			if(m_machine.pc() == g_mainSpin && !anyPending())
+				return Stop::Gate;
+			if(!stepOnce())
+				return Stop::Illegal;
+		}
+		m_why = "never reached main's spin";
+		return Stop::Time;
+	}
+
+	void Rtos::mapCardMemory()
+	{
+		// ✅ MEASURED, and it CORRECTS THE O5 RECORD. These four spans are
+		// mapped EXPLICITLY by route A's `emu_card.attach`, with its own
+		// comment: the boot maps 32 MB at 0x40000000, 32 MB at 0x46000000,
+		// 1 MB at 0x48000000 and 64 KB at 0x100b0000, and the storage stack
+		// and the project loader use the REST of the 256 MB -- the PCM pool,
+		// the sector buffers at 0x4ece3000/0x4eceb200, the delay rings at
+		// 0x4f502c10 -- plus the on-chip SRAM around the boot's window, where
+		// the names (0x100f8480) and the object tables
+		// (0x100b14f0..0x100f7f30) live.
+		//
+		// ❌ O5 concluded that route A GROWS these through `_prime_menu`'s
+		// auto-mapping hook. It does not. `_prime_menu` is called only from
+		// the menu RENDER helpers, none of which run on the golden path, so
+		// that hook is never installed there and route A really does fault on
+		// anything outside its maps. The spans O5 identified were right; the
+		// mechanism was wrong, and the difference matters: an explicit map has
+		// KNOWN BOUNDS, so a wild pointer outside them is still a fault in
+		// route A while this port's auto-map would absorb it silently.
+		for(const auto& [base, size] : {std::pair<uint32_t, uint32_t>{0x42000000, 0x04000000},
+			std::pair<uint32_t, uint32_t>{0x48100000, 0x07f00000},
+			std::pair<uint32_t, uint32_t>{0x10000000, 0x000b0000},
+			std::pair<uint32_t, uint32_t>{0x100c0000, 0x00040000}})
+			m_machine.mapRegion(base, size);
+	}
+
+	void Rtos::attachCard(AtaCard& _card)
+	{
+		m_card = &_card;
+		mapCardMemory();
+		// ⚠️ THE ATA HOST STATUS BYTE, and without it nothing happens at all.
+		// 0xfc0a4039 bit 3 must read CLEAR (`movew` into the CCR, then `bpl`);
+		// an unmodelled peripheral answers all-ones, the bit is set, and the
+		// driver concludes there is no card -- the request posts, SYS runs the
+		// card case, and ZERO ATA commands are issued, with no error anywhere.
+		// Measured on the first run of this milestone. Route A carries it in
+		// `EXTRA_OVERRIDES` from the boot; here it belongs with the card.
+		m_machine.setOverride8(0xfc0a4039, 0x00);
+		m_intc1.addLine(g_ataSource, [this] { return m_ataIrq; });
+	}
+
+	bool Rtos::callAsMain(const uint32_t _addr, const std::vector<uint32_t>& _args, uint32_t& _d0,
+		const uint64_t _budget)
+	{
+		if(m_machine.pc() != g_mainSpin)
+		{
+			char msg[160];
+			std::snprintf(msg, sizeof msg, "callAsMain(%#x): pc is %#x, not main's spin %#x",
+				_addr, m_machine.pc(), g_mainSpin);
+			m_why = msg;
+			return false;
+		}
+		// retaddr at [sp], then the args in the order given -- the convention
+		// the firmware's own call sites use (`pea a1; pea a0; jsr addr`).
+		const auto sp = m_machine.getA7() - 4 * static_cast<uint32_t>(1 + _args.size());
+		m_machine.poke32(sp, g_mainSpin);
+		for(size_t i = 0; i < _args.size(); ++i)
+			m_machine.poke32(sp + 4 * static_cast<uint32_t>(i + 1), _args[i]);
+		m_machine.setA7(sp);
+		m_machine.setPC(_addr);
+
+		for(uint64_t n = 0; n < _budget; ++n)
+		{
+			if(m_machine.pc() == g_mainSpin)
+			{
+				_d0 = m_machine.getD0();
+				return true;
+			}
+			if(!stepOnce())
+				return false;
+		}
+		char msg[160];
+		std::snprintf(msg, sizeof msg, "callAsMain(%#x) did not return in %llu steps",
+			_addr, static_cast<unsigned long long>(_budget));
+		m_why = msg;
+		return false;
+	}
+
+	bool Rtos::postMessage(const uint32_t _queue, const uint32_t _msg, uint32_t& _d0)
+	{
+		return callAsMain(g_kernelPost, {_queue, _msg}, _d0);
+	}
+
+	void Rtos::setNames(const std::string& _set, const std::string& _project)
+	{
+		const auto write = [this](uint32_t _addr, const std::string& _s)
+		{
+			for(size_t i = 0; i < _s.size() && i < 0x100; ++i)
+				m_machine.write8(_addr + static_cast<uint32_t>(i), static_cast<uint8_t>(_s[i]));
+			m_machine.write8(_addr + static_cast<uint32_t>(std::min<size_t>(_s.size(), 0x100)), 0);
+		};
+		write(g_setName, _set.empty() || _set[0] == '/' ? _set : "/" + _set);
+		write(g_projectName, _project);
+	}
+
+	Rtos::LoadResult Rtos::loadProjectLive(const std::string& _set, const std::string& _project,
+		const double _runMs, const double _mountMs)
+	{
+		LoadResult out;
+		const double start = m_sample;
+
+		if(runToMainSpin() != Stop::Gate)
+			return out;
+		if(!requestCardMount())
+			return out;
+
+		// Wait for the card to come READY rather than for a fixed time: the
+		// mount runs in the SYS task against real ATA commands completed
+		// through vector 0xb6.
+		const double mountEnd = m_sample + _mountMs * g_sampleHz / 1000.0;
+		while(m_sample < mountEnd && m_machine.peek32(g_cardReady) == 0)
+			if(!stepOnce())
+				return out;
+		out.ready = m_machine.peek32(g_cardReady);
+
+		if(runToMainSpin() != Stop::Gate)
+			return out;
+		setNames(_set, _project);
+		uint32_t d0 = 0;
+		out.posted = callAsMain(g_postLoad, {g_projectName}, d0);
+		run(_runMs, false);
+		out.partPtr = m_machine.peek32(g_partPtr);
+		out.ms = (m_sample - start) / g_sampleHz * 1000.0;
+		return out;
+	}
+
+	bool Rtos::requestCardMount()
+	{
+		// msg[0] = 16 selects the card case; msg[1] must be non-zero.
+		m_machine.poke32(g_sysMsgScratch, 0x10010000);
+		uint32_t d0 = 0;
+		return postMessage(g_sysQueue, g_sysMsgScratch, d0);
 	}
 
 	std::unordered_set<uint32_t> Rtos::ran() const

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -27,6 +27,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "card.h"
 #include "machine.h"
 #include "periph.h"
 
@@ -42,6 +43,18 @@ namespace ot
 	inline constexpr uint32_t g_mainTcb   = 0x46c7ae84;
 	inline constexpr uint32_t g_bootTcb   = 0x46c7ae30;		// the context the first trap saves
 	inline constexpr uint32_t g_handoff   = 0x40000e46;		// the boot's trap #0
+
+	inline constexpr uint32_t g_kernelPost    = 0x40000c3c;	// post(queue, msg): never blocks
+	inline constexpr uint32_t g_sysQueue      = 0x460d17ae;	// the sys task's command queue
+	inline constexpr uint32_t g_sysMsgScratch = 0x46c00000;	// scratch for a hand-built message
+	inline constexpr uint32_t g_ataSource     = 54;			// INTC1 source 54 -> vector 0xb6
+
+	// The project load, from `emu_card.py`'s constants.
+	inline constexpr uint32_t g_cardReady   = 0x460d1cb8;	// := 1 after a successful init+mount
+	inline constexpr uint32_t g_setName     = 0x100f8480;	// current SET folder (0x104 bytes)
+	inline constexpr uint32_t g_projectName = 0x100f8378;	// current PROJECT folder
+	inline constexpr uint32_t g_postLoad    = 0x40023c7c;	// (name*) -> posts engine command 4
+	inline constexpr uint32_t g_partPtr     = 0x46c82456;	// null until a project loads
 
 	inline constexpr uint32_t g_intc0 = 0xfc048000, g_intc1 = 0xfc04c000;
 	inline constexpr uint32_t g_pit0  = 0xfc080000, g_pit1  = 0xfc084000;
@@ -82,6 +95,66 @@ namespace ot
 		enum class Stop { Gate, Time, Fault, Illegal };
 		Stop run(double _ms, bool _untilGate = true);
 
+		// Run until the PC is parked at main's spin -- what `callAsMain`
+		// needs before it can borrow the slot.
+		Stop runToMainSpin(double _ms = 5000.0);
+
+		// ---- the card ------------------------------------------------------
+		// Interpose on the task-file window so the card raises INTRQ the way
+		// ATA does (handler 0x40015304: one sector per interrupt, completion
+		// signalled when the count reaches zero): asserted when a command
+		// completes or a sector is ready, after each sector consumed with
+		// more to come, and after each sector absorbed by a WRITE; cleared by
+		// a read of the STATUS register, not the alternate status.
+		//
+		// ⚠️ This is route A's `cold_hooks=False` path: the kernel's own event
+		// wait really blocks and the ATA interrupt really completes the
+		// command. `emu_card.attach`'s `on_wait`/`on_nowait` shortcuts are
+		// deliberately NOT translated -- they are for the cold detours, not
+		// for a machine running its own RTOS.
+		void attachCard(AtaCard& _card);
+		void mapCardMemory();
+
+		// Borrow main's idle slot to call an OS subroutine the way a UI action
+		// would, with the normal trap-dispatch loop still live underneath, so
+		// any REAL wait inside the call runs correctly against every other
+		// task and interrupt. Convention: retaddr at [sp], args at [sp+4]...
+		//
+		// ⚠️ ONLY for a call that CANNOT genuinely block. Main is priority 0
+		// and never legitimately blocks on hardware, so it is the kernel's de
+		// facto idle backstop and main being non-ready is a state the block
+		// path never expects -- route A proved it the hard way by borrowing
+		// main for a call that waits on a real timer: main blocked, nothing
+		// else was ready either, and the scheduler dispatched a garbage TCB.
+		// A call that CAN block belongs to a real task: post it a message.
+		bool callAsMain(uint32_t _addr, const std::vector<uint32_t>& _args, uint32_t& _d0,
+			uint64_t _budget = 4000000);
+		bool postMessage(uint32_t _queue, uint32_t _msg, uint32_t& _d0);
+
+		// Post to the SYS task's own queue the message its dispatch table
+		// sends to the card case: it checks "card ready" and, if clear, calls
+		// the card init FOR REAL from SYS's context (priority 1, safe to
+		// block). msg[0]=16 selects the case; msg[1] must be non-zero to
+		// reach it (`tstb a2@(1)`, else the handler returns having done
+		// nothing).
+		bool requestCardMount();
+
+		// ⚠️ The SET name is an ABSOLUTE path on the card -- the firmware's
+		// own default is "/PRESETS". Without the leading slash the project
+		// loads (relative to the root) and then every bank is "missing",
+		// because the loader has already changed into the project directory.
+		void setNames(const std::string& _set, const std::string& _project);
+
+		// The whole M6b sequence: park, ask SYS to mount, wait for the card
+		// to come ready, set the names, and post LOAD PROJECT the way the UI
+		// does. ⚠️ Deliberately does NOT call the "does SET/PROJECT exist"
+		// helper: with no card it short-circuits, but once a card IS present
+		// it does real FAT lookups and BLOCKS -- and borrowing main for a
+		// call that blocks is the crash `callAsMain` warns about.
+		struct LoadResult { uint32_t ready = 0, partPtr = 0; bool posted = false; double ms = 0; };
+		LoadResult loadProjectLive(const std::string& _set, const std::string& _project,
+			double _runMs = 6000.0, double _mountMs = 3000.0);
+
 		// -- what the oracle compares ---------------------------------------
 		struct Created { double sample; uint32_t tcb, entry, prio, stack, size, creator; };
 		struct Dispatch { double sample; uint32_t tcb, pc; };
@@ -93,6 +166,8 @@ namespace ot
 		double sample() const { return m_sample; }
 		double ms() const { return m_sample / g_sampleHz * 1000.0; }
 		uint64_t pit0Fired() const { return m_pit0.fired(); }
+		uint64_t ataInterrupts() const { return m_ataInterrupts; }
+		bool ataLineAsserted() const { return m_ataIrq; }
 		uint64_t idleSkips() const { return m_idleSkips; }
 		uint64_t forces() const { return m_forces; }
 		size_t seeded() const { return m_seeded; }
@@ -114,6 +189,9 @@ namespace ot
 		bool peripheralRead(uint32_t _addr, uint8_t _size, uint32_t& _out);
 		void peripheralWrite(uint32_t _addr, uint8_t _size, uint32_t _val, bool _replay);
 		void tickTimers();
+		// One instruction plus everything the run loop does around it, so a
+		// borrowed call runs against the same live machine the loop does.
+		bool stepOnce();
 		bool deliver();
 		bool anyPending() const;
 		bool nextExpiry(double& _out) const;
@@ -127,6 +205,9 @@ namespace ot
 		Intc m_intc0, m_intc1;
 		Uart m_uart64{"UART@fc064000", g_uartA}, m_uart68{"UART@fc068000", g_uartB};
 		Dspi m_dspi;
+		AtaCard* m_card = nullptr;
+		bool m_ataIrq = false;
+		uint64_t m_ataInterrupts = 0;
 
 		std::vector<Created> m_created;
 		std::vector<Dispatch> m_dispatches;

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -151,7 +151,8 @@ namespace ot
 		// helper: with no card it short-circuits, but once a card IS present
 		// it does real FAT lookups and BLOCKS -- and borrowing main for a
 		// call that blocks is the crash `callAsMain` warns about.
-		struct LoadResult { uint32_t ready = 0, partPtr = 0; bool posted = false; double ms = 0; };
+		struct LoadResult { uint32_t ready = 0, partPtr = 0; bool posted = false; double ms = 0;
+			std::string postWhy; };
 		LoadResult loadProjectLive(const std::string& _set, const std::string& _project,
 			double _runMs = 6000.0, double _mountMs = 3000.0);
 
@@ -168,8 +169,25 @@ namespace ot
 		uint64_t pit0Fired() const { return m_pit0.fired(); }
 		uint64_t ataInterrupts() const { return m_ataInterrupts; }
 		bool ataLineAsserted() const { return m_ataIrq; }
+		// Every access to the task-file window, in order, for diffing against
+		// route A's: "R|W off size value pc". The first divergence names the
+		// defect; reasoning about it does not.
+		void setAtaTrace(bool _on) { m_ataTraceOn = _on; }
+		const std::vector<std::string>& ataTrace() const { return m_ataTrace; }
+
 		uint64_t idleSkips() const { return m_idleSkips; }
 		uint64_t forces() const { return m_forces; }
+		uint32_t currentTcb() { return curTcb(); }
+		void setAtaLatency(double _samples) { m_ataLatency = _samples; }
+		void armPcRing(size_t _size, uint64_t _budget) { m_pcRing.assign(_size, 0); m_pcRingBudget = _budget; }
+		const std::vector<uint32_t>& pcRing() const { return m_pcRing; }
+		size_t pcRingPos() const { return m_pcRingPos; }
+		bool pcRingArmed() const { return m_pcRingArmed; }
+		// Every vector the CPU acknowledged: (sample, vector, level, tcb, pc it
+		// interrupted, slot contents). Which handler an interrupt actually
+		// went to is a measurement, not a table lookup.
+		struct Ack { double sample; uint8_t vector, level; uint32_t tcb, pc, slot; };
+		const std::vector<Ack>& acks() const { return m_acks; }
 		size_t seeded() const { return m_seeded; }
 		size_t serialSent() const { return m_uart64.tx().size() + m_uart68.tx().size(); }
 		const std::vector<uint8_t>& serialTxA() const { return m_uart64.tx(); }
@@ -206,8 +224,30 @@ namespace ot
 		Uart m_uart64{"UART@fc064000", g_uartA}, m_uart68{"UART@fc068000", g_uartB};
 		Dspi m_dspi;
 		AtaCard* m_card = nullptr;
+		// ⚠️ INTRQ IS NOT INSTANTANEOUS, and the firmware depends on it. The
+		// driver writes the command and THEN calls the RTOS event wait; a
+		// drive that asserted INTRQ on the same instruction would run the ISR,
+		// signal the event, and finish before the waiter ever waits -- and the
+		// wait then blocks forever on a signal that already happened.
+		// Measured 8 Sep 2026: that is exactly what this port did (1 IDENTIFY,
+		// card-ready never set). Route A survives it only by accident of
+		// granularity -- it delivers interrupts at burst boundaries, which
+		// gives the caller time to reach the wait. A real CF card takes tens
+		// of microseconds to fetch a sector, so the latency below is the
+		// PHYSICAL behaviour and route A's is the artefact.
 		bool m_ataIrq = false;
+		double m_ataIrqDue = 0.0;			// 0 = nothing pending
+		double m_ataLatency = 1.0;			// samples; ~23 us at 44.1 kHz
 		uint64_t m_ataInterrupts = 0;
+		std::vector<std::string> m_ataTrace;
+		bool m_ataTraceOn = false;
+		std::vector<Ack> m_acks;
+		// A PC ring armed by the first ATA command: what the ISR does and
+		// where the machine goes afterwards, which is the whole question.
+		std::vector<uint32_t> m_pcRing;
+		size_t m_pcRingPos = 0;
+		bool m_pcRingArmed = false;
+		uint64_t m_pcRingBudget = 0;
 
 		std::vector<Created> m_created;
 		std::vector<Dispatch> m_dispatches;

--- a/tools/ot_emu/test_periph.cpp
+++ b/tools/ot_emu/test_periph.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cmath>
 
+#include "card.h"
 #include "periph.h"
 
 namespace
@@ -123,6 +124,84 @@ int main()
 
 		// IPR reads back what is asserted, which is what the firmware polls.
 		checkEq("IPRL reads back the asserted sources", pri.read(0x04, 4), (1u << 3) | (1u << 4));
+	}
+
+	// ---- the ATA card ----------------------------------------------------
+	// The task-file model. The image here is synthetic -- a real card image is
+	// built by route A's own Python (`emu_rtos.stage_project`) and read from
+	// disk, so the two emulators are looking at identical media.
+	{
+		std::vector<uint8_t> img(64 * ot::AtaCard::g_sector);
+		for(size_t i = 0; i < img.size(); ++i)
+			img[i] = static_cast<uint8_t>(i * 7 + (i >> 9));
+		ot::AtaCard c(img);
+		const uint32_t b = ot::AtaCard::g_base;	// offsets are window-relative
+		(void)b;
+
+		checkEq("the image is 64 sectors", c.totalSectors(), 64);
+
+		// IDENTIFY: the words the driver's variant detection reads. Word 49
+		// bit 8 CLEAR and word 53 zero are what keep it on the PIO path and
+		// stop it programming the on-chip DMA channel.
+		c.write(ot::AtaCard::R_CMD, 1, 0xec);
+		check("IDENTIFY raises DRQ", (c.status() & ot::AtaCard::ST_DRQ) != 0);
+		{
+			const auto w = ot::AtaCard::identifyWords(64);
+			checkEq("word 0 is the CF signature", w[0], 0x848a);
+			checkEq("word 49: LBA supported, DMA bit CLEAR", w[49] & 0x0100, 0);
+			checkEq("word 53 is zero, so words 54-58/64-70 are 'not valid'", w[53], 0);
+			checkEq("words 60/61 carry the sector count", (w[61] << 16) | w[60], 64);
+		}
+		// The data register streams the buffer and drops DRQ at the end.
+		size_t n = 0;
+		while(c.status() & ot::AtaCard::ST_DRQ)
+		{
+			c.read(ot::AtaCard::R_DATA, 2);
+			if(++n > 512)
+				break;
+		}
+		checkEq("IDENTIFY streams exactly 256 words", n, 256);
+
+		// READ SECTORS: count 0 means 256 in the TASK FILE.
+		c.write(ot::AtaCard::R_LBA0, 1, 2);
+		c.write(ot::AtaCard::R_COUNT, 1, 3);
+		c.write(ot::AtaCard::R_CMD, 1, 0x20);
+		checkEq("READ logs its LBA and count", c.log().back().lba, 2);
+		checkEq("... and its count", c.log().back().count, 3);
+		checkEq("... and the sector tally follows it", c.sectorsRead(), 3);
+		{
+			const auto first = c.read(ot::AtaCard::R_DATA, 2);
+			const size_t o = 2 * ot::AtaCard::g_sector;
+			checkEq("the data register returns the image, big-endian on the bus",
+				first, static_cast<uint32_t>((img[o] << 8) | img[o + 1]));
+		}
+
+		// WRITE SECTORS: one sector streamed through the data register lands
+		// in the image, and DRQ drops when the last one is absorbed.
+		{
+			ot::AtaCard w(img);
+			w.write(ot::AtaCard::R_LBA0, 1, 5);
+			w.write(ot::AtaCard::R_COUNT, 1, 1);
+			w.write(ot::AtaCard::R_CMD, 1, 0x30);
+			check("WRITE raises DRQ", (w.status() & ot::AtaCard::ST_DRQ) != 0);
+			for(size_t i = 0; i < ot::AtaCard::g_sector / 2; ++i)
+				w.write(ot::AtaCard::R_DATA, 2, 0xbeef);
+			checkEq("one sector absorbed", w.sectorsWritten(), 1);
+			check("DRQ drops when the count is exhausted",
+				(w.status() & ot::AtaCard::ST_DRQ) == 0);
+			// and it is readable back
+			w.write(ot::AtaCard::R_LBA0, 1, 5);
+			w.write(ot::AtaCard::R_COUNT, 1, 1);
+			w.write(ot::AtaCard::R_CMD, 1, 0x20);
+			checkEq("the written sector reads back", w.read(ot::AtaCard::R_DATA, 2), 0xbeef);
+		}
+
+		// An unsupported command ABORTs rather than being ignored: the
+		// firmware checks the error register, and a silent success here would
+		// send the storage stack down a path that never happened.
+		c.write(ot::AtaCard::R_CMD, 1, 0x99);
+		check("an unknown command sets ABRT and the error bit",
+			(c.status() & 1) != 0 && c.log().back().what.rfind("UNSUPPORTED", 0) == 0);
 	}
 
 	std::printf("%s\n", g_failures ? "PERIPHERAL GATE FAILED" : "peripheral gate passed.");

--- a/tools/ot_emu/v4e.cpp
+++ b/tools/ot_emu/v4e.cpp
@@ -118,6 +118,14 @@ namespace ot::v4e
 		case 0:														// Dn
 			_out = reg(_m, dReg(_reg));
 			return true;
+		case 1:														// An
+			// ✅ MEASURED, not assumed: the storage stack reaches
+			// `mvzw %a0,%d0` at 0x40017c10 (objdump -m m68k:cfv4e decodes it
+			// exactly so), and another at 0x40017c2c. An address register IS
+			// a legal MVS/MVZ source on this part, and leaving it out stopped
+			// the card mount dead with "unimplemented opcode 71c8".
+			_out = reg(_m, aReg(_reg));
+			return true;
 		case 2:														// (An)
 			_out = load(reg(_m, aReg(_reg)));
 			return true;


### PR DESCRIPTION
Milestone O7. **The mount now succeeds**; the project load runs partway and stalls. Still draft — the milestone's gate (6,189 ATA commands / 30,467 sectors) is not met.

## The finding: INTRQ is not instantaneous, and the firmware depends on that

The port asserted the ATA interrupt on the same instruction that wrote the command. A PC ring armed at the first command shows the cost, in order:

```
0x40015a50   the driver writes the command
0x40015308   the ISR runs ON THE VERY NEXT INSTRUCTION
   ...       256 words streamed, byte-for-byte route A's
0x40000968   the ISR SIGNALS the event
0x40015a58   only now does the caller execute its next instruction
0x40000818   ... and call the RTOS event WAIT
0x40000550   the scheduler: nothing to run but main
0x4001fc9c   main's spin, forever
```

The signal arrives **before the waiter waits**, so the wait blocks on an event that already happened. ⚠️ **Route A survives this only by accident of granularity** — it delivers interrupts at burst boundaries, which happens to give the caller time to reach the wait. A real CF card takes tens of microseconds to fetch a sector, so a completion latency is the physical behaviour and instantaneous assertion is the artefact.

This is the project's "a lock-step emulator cannot show you a race" lesson **inverted**: the port's finer granularity *exposed* a race route A's coarse bursts hide.

## Three more, all measured

- ✅ **`mvzw %a0,%d0`** at `0x40017c10` (and `0x40017c2c`) — the V4e effective-address reader handled `Dn` but not `An` direct. Disassembled, not guessed; same family as O4's `ff1`, where the image is the evidence and not the toolchain.
- The park must test **the PC alone**, as route A's own until-clause does. Requiring nothing pending as well never comes true once the card is live: the ATA and serial lines assert constantly.
- `callAsMain`'s step budget must survive preemption — with the card live the count is dominated by the *other* tasks running underneath the borrowed call.

Plus, from the first session: `0xfc0a4039` bit 3 must read CLEAR (unmodelled it answers all-ones, the driver decides there is no card, and the mount issues **zero** ATA commands with no error anywhere), and ❌ **O5's "route A auto-maps its memory" is retracted** — `emu_card.attach` maps four spans explicitly; with `mapCardMemory` the port's auto-mapped count falls from 20,348,051 to 4.

## Where it stands

| | port | route A |
|---|---|---|
| card ready (`0x460d1cb8`) | **1** | 1 |
| ATA commands | **1,407** | 6,189 |
| sectors read | **10,695** | 30,467 |
| sectors written | **297** | **297** ✅ |
| `LOAD PROJECT` posted | **yes** | yes |

The written count matches exactly and one ATA interrupt arrives per sector (10,994 for 10,695 sectors).

⛔ **Still blocked:** the load *stops* rather than running slowly — 30,000 ms of emulated time produces the same 1,407 commands as 6,000. It ends with the **engine task cycling at `0x400165dc`** and the in-flight word (`0x46c8c58a`) clear. That stall is the next thing to chase.

## Instruments

In the tree, off by default: `--ata-trace`, `--periph-trace`, `--pc-ring N`, `--peek`, and an always-on log of which vector was acknowledged and which handler it dispatched to. The PC ring is what found the race.

**No regression:** oracle diff **8 compared fields, zero disagreements**; `ctest` **6/6**; `make check` green.