### PR TITLE
FAILURE_MODES: the one-aux return never reaches T8 (tag 20, on the unit)

### DIFF
--- a/docs/FAILURE_MODES.md
+++ b/docs/FAILURE_MODES.md
@@ -204,3 +204,39 @@ emulator's own menu and count rows; if it shows six there too, the emulator
 can find where the count really comes from. Flash 4 (tag 79, MENU SHORTCUT)
 used the same patch -- whether its rows appeared was never recorded.
 
+## The one-aux return never reaches T8: the hosts keep printing their own wet 🔴
+
+**Symptom.** With the one-aux rig on the unit, sending `AUX` from a track
+produces wet — but it comes out of **T1 and T5, the engines' own host
+tracks**. Muting T1 and T5 removes all wet. Nothing arrives at T8, the
+pinned return. Turning the return knob down does silence the wet.
+
+**Seen.** ✅ Flash 6, tag 20, 7 Sep 2026, reported from the unit. Claim ii of
+the Flash 6 table ("T2 sends AUX: repeats AND reverb arrive on T8 with
+nothing on T1/T5's own outputs"). Claims i (the re-slot) and iv (MIX) passed
+in the same session.
+
+**Cause.** 🟡 **INFERRED, not measured.** The symptom is the third falsifier
+the claim itself names — *"the hosts still printing (RETV/RETD)"* — i.e. the
+return-live stamp is not reaching the engines, so neither host goes quiet and
+the return publishes nothing. The stamp has to cross cores here: the return
+is a BUS-mode Character pinned to **T8 = payload A / core 0**, while the
+delay host sits on **T1 = payload B / core 1**. Nothing has been measured on
+the unit to distinguish a lost stamp from a return that never publishes.
+
+**⚠️ THE LOCAL GATE IS GREEN ON EXACTLY THIS.** `tools/verify_onebus.py`
+asserts "T5 (reverb host) prints nothing while the return is live" and the
+same for T1, and both pass — the property hardware falsifies is the property
+the gate checks. That is the standing rule in force, not a surprise:
+`dsp_host` boots both payloads but runs them in lock-step, so a cross-core
+timing defect cannot appear locally. **Believe the hardware.**
+
+**Fix.** None yet, and per the Flash 6 stop condition the next step is
+measurement, not code: *"any of ii–iv failing on the unit after passing
+`make verify-onebus` locally is a cross-core timing fact — record the exact
+configuration (which core, which position) before touching code."* What is
+worth having before the next flash: which track the send came from, whether
+a send from a **core 0** track (T6/T7) behaves differently from a **core 1**
+one (T2–T4), and whether the return is dead or merely intermittent (the
+free lever from `docs/XBUS.md` is to change what sits on track 5).
+


### PR DESCRIPTION
Records a hardware failure mode reported from the unit on the Flash 6 flash (tag 20, 7 Sep) that was never written down. `CLAUDE.md`'s rule is explicit: add one the moment it is seen, do not let it live only in a commit message — or, in this case, only in a chat transcript.

**Symptom.** Sending `AUX` from a track produces wet, but it comes out of **T1 and T5, the engines' own host tracks**. Muting T1 and T5 removes all wet. Nothing arrives at T8, the pinned return.

**Cause — inferred, not measured.** This is the third falsifier claim ii names for itself: *"the hosts still printing (RETV/RETD)"*, i.e. the return-live stamp is not reaching the engines, so neither host goes quiet and the return publishes nothing. The stamp crosses cores here — the return is pinned to T8 (payload A / core 0), the delay host sits on T1 (payload B / core 1). Nothing measured on the unit separates a lost stamp from a return that never publishes.

**⚠️ The local gate is green on exactly this.** `verify_onebus.py` asserts "T5 (reverb host) prints nothing while the return is live" and the same for T1, and both pass. The property hardware falsifies is the property the gate checks — `dsp_host` runs both payloads in lock-step, so a cross-core timing defect cannot appear locally. Believe the hardware.

**No fix here, deliberately.** Flash 6's own stop condition says a claim ii–iv failing on the unit after `make verify-onebus` passes locally is a cross-core timing fact, and the exact configuration gets recorded *before* anyone touches code. The entry says what is worth capturing next: whether a send from a core-0 track (T6/T7) differs from a core-1 one (T2–T4), and whether the return is dead or intermittent.

Docs only — no code, no build change.