### PR TITLE
O7: the load stall was a line-A exception -- MOV3Q to memory, and the UART gap that hid the panic

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -413,7 +413,7 @@ edge, and counting them delivered ~540 phantom frames back to back in route A.
   is not established, and only M6c establishes it.**
 - ✅ No regression with the clock off: the oracle diff is still 8 compared
   fields, zero disagreements; `ctest` 6/6; `make check` green.
-## Milestone O7 — the card and the project load ⛔ BLOCKED (8 Sep 2026)
+## Milestone O7 — the card and the project load ✅ (8 Sep 2026; the stall was a fault)
 
 The card model, its memory map and the live-call machinery are in and gated;
 **the mount does not complete**, so the milestone's own gate (6,189 ATA
@@ -522,6 +522,80 @@ travels.
 
 **No regression:** the oracle diff is still 8 compared fields with zero
 disagreements, `ctest` 6/6, `make check` green.
+
+### ✅ THE "STALL" AT 1,407 COMMANDS WAS A LINE-A EXCEPTION, AND THE UART HID IT
+
+Measured 8 Sep 2026, third session. The port ended the load with the engine
+task cycling at `0x400165dc`, 1,407 ATA commands at 6,000 ms and at 30,000 ms,
+and it was written up as a stall to chase. It was not a stall.
+
+**How it was found, in order — each step an instrument, not a theory:**
+
+1. `--cmd-log` dumps every ATA command in route A's own log order, and route
+   A's log was dumped the same way. `diff` said the port's 1,407 were
+   **byte-identical to route A's first 1,407**. So nothing the card did was
+   wrong; whatever stopped the load stopped it *between* commands.
+2. The PC ring was rewritten as a true ring (the last N instructions, not the
+   first N — a stall asks what was running, not what the ISR did). The tail
+   was a three-instruction spin at `0x4003afa0`:
+   `moveb 0xfc064004,%d0 / movew %d0,%ccr / bpls` — **polling bit 3 of the
+   panel UART's status, TXEMP,** which `Uart::read` never set (it reported
+   TXRDY only, as route A's model does).
+3. Setting TXEMP (a model that consumes every byte at once is always both
+   READY and EMPTY; TXRDY-only describes a shift register with a byte stuck
+   in it forever) turned the spin into a **`halt`** at `0x4003b108`, and the
+   load report — which now names how its run ENDED, not just the counts —
+   said `ILLEGAL -- unimplemented opcode 4ac8 at 4003b108`. Halt is the
+   last instruction of a printer. `--serial-out` showed what it had printed:
+
+   ```
+   EXCEPTION
+   SSP:4 VEC:0A
+   FS:0 SR:2004
+   ADDR:4009D8D0
+   ```
+
+   VEC:0A is the line-A exception. The firmware's own panic handler had
+   named the faulting instruction; with TXRDY only it could never finish
+   saying so.
+4. `0x4009d8d0` is `mov3ql #-1,%a0@+` (`a158`), eight in a row clearing a
+   structure. `v4e.cpp`'s MOV3Q handled **Dn only** — "only Dn is reached
+   by this firmware" — and returned Unhandled for everything else, which
+   the A-line dispatch turned into a real exception.
+
+**The fix, attributed separately:** `writeEaLong` + MOV3Q to every
+alterable destination. On its own it takes the load from 1,407 commands to
+**12,373**, and the whole of route A's 6,189-command log is an exact prefix
+of the port's. TXEMP on its own changes nothing about the load; it is the
+change that made the fault *legible*. Both are kept.
+
+**Why route A never saw it:** Unicorn's m68k implements MOV3Q natively, so
+route A has no shim to get wrong, and it never reaches the exception
+printer, so its identical TXEMP gap costs it nothing. "Route A does not have
+it either" was true of both and evidence of neither — same family as the
+`byterev`/`ff1` retraction in O4 (a toolchain that will not assemble an
+opcode is not evidence the part lacks it; the image is).
+
+**Gate:** `test_emac` now holds MOV3Q's memory forms (`#-1,%a0@+`,
+`#1,%a0@+`, and the post-increment), watched failing on the old code.
+`ctest` 6/6; oracle diff 8 compared fields, zero disagreements; the serial
+stream 5,731 bytes identical.
+
+**⚠️ OPEN — the port runs PAST route A's end, and that is a divergence, not
+a budget.** Route A stops at 6,189 commands with `M6b load: PASS` at a
+6,000 ms budget **and at a 12,000 ms budget** (re-measured 8 Sep 2026: same
+6,189 / 30,467 / 297). The port's load runs on to **12,373 commands /
+60,677 sectors / 562 written** and parks in main, the same total at 6,000
+and at 20,000 ms. The extra 6,184 are 5,919 READs and 265 WRITEs over the
+same FAT and bank sectors (2301, 2333, 22889 …) — the shape of a second
+bank parse. 🟡 Inferred, not measured: the port performs a bank (re)load
+that route A's SYS skips — route A ends "saved_bank=1, final_bank=0" with
+SYS applying the engine's reset-time "select bank 0" (RTOS_FORK.md §7), and
+in the port that select may be going to the card. Nothing on hardware says
+which is right. **The next measurement is which task and PC issue command
+6,190 in the port** (`--ata-trace` carries the PC; its 200,000-access cap
+will need raising or arming at a command index), then the same site in
+route A to see why it does not.
 
 ## What is NOT here yet
 

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -71,6 +71,7 @@ route A fact, not the port's problem; the golden command above already does it.
 | O3 | PIT + INTC models | `ctest` periph, 14 rules | (wired in by O4) |
 | O4 | the run loop: the kernel runs | `ctest` rtos + the oracle diff | ✅ 6 compared fields (❌ was written "8/8": the diff counted 2 it never compared); 10 created, 11 ran, 204.88 ms vs 204.95 |
 | O5 | the rest of the memory; the serial stream | `ctest` rtos + the oracle diff | ✅ 8 compared fields; route A's 4831 serial bytes matched byte for byte (❌ its account of *why* route A has the extra memory was wrong — corrected in O7) |
+| O7 | the card, the mount, the project load | route A's ATA command log is a prefix of the port's | ✅ all 6,189 commands identical, 297 written; ⚠️ OPEN: the port runs on to 12,373 and route A stops at 6,189 at ANY budget (`COLDFIRE_PORT.md` O7) |
 
 ## Queue
 
@@ -155,6 +156,35 @@ That is not a defect — route A covers the same spans — but O7's card is what
 would make the two machines allocate from the same place, and it is worth
 re-checking the span list once the project loads.
 
+### O6 — the eDMA and the frame clock — **UNBLOCKED, NEXT** (O7 landed 8 Sep 2026)
+
+**The code is written and unit-gated; its FIDELITY gate can now run.** Do
+not re-do the model. What O6 still needs is the rest of the live-call
+surface, translated from `emu_rtos.py`: `start_transport_live` (line 1312),
+`poke_trig` (1379), `install_trig_log` (1441), and `select_bank_live`
+(1210) — `callAsMain`/`postMessage`/`loadProjectLive` already exist and are
+the pattern. Then: load `OCTABAM/ONEAUX` (or `out/_testproj`), turn the
+frame clock on the way route A's sequencer path does (AFTER the load, not
+from boot — `--frame` from boot wedges, see below), poke a trig, run 400
+frames, and compare byte `0xd3` at `0x46104d15[0]` at frame 344 with 28
+ticks. The oracle is `tools/emu_frames.py --project out/_testproj --frames
+400 --start --internal-clock --poke-trig 2` (RTOS_FORK.md §8). ⚠️ The
+first thing to read on any early stop is the load report's `load run
+ended:` line — O7's "stall" was an ILLEGAL that looked like one.
+
+### O7b — why the port loads twice — *(Opus, measurement first)*
+
+Route A's load ends at 6,189 ATA commands at any budget; the port's runs to
+12,373 with route A's log as an exact prefix. Find which task and PC issue
+command 6,190 (`--ata-trace` carries the PC; raise or re-arm its 200,000-
+access cap), find the same site in route A, and say why one runs it and the
+other does not. 🟡 The hypothesis is SYS's reset-time "select bank 0"
+(RTOS_FORK.md §7) going to the card in the port and not in route A. Not a
+blocker for O6 (the load's first half is identical and the part pointer
+agrees), but it decides which emulator is telling the truth about the load.
+
+<details><summary>the BLOCKED entry it replaces</summary>
+
 ### O6 — the eDMA and the frame clock — ⛔ **BLOCKED on O7** (8 Sep 2026)
 
 **The code is written and unit-gated; its FIDELITY gate cannot run.** Do not
@@ -200,6 +230,8 @@ disagreements, `ctest` 6/6, `make check` green.
 
 **To unblock:** land O7, then run M6c and compare against `RTOS_FORK.md` §8.
 
+</details>
+
 <details><summary>the original entry</summary>
 
 ### O6 — the eDMA and the frame clock *(Opus, but read §8.1 first)*
@@ -219,7 +251,7 @@ after transport start, with 28 ticks in 400 frames. `RTOS_FORK.md` §8.
 Requires the project load (O7) — so O6 and O7 may be one session.
 
 </details>
-### O7 — the card and the project load — ⛔ **BLOCKED** (8 Sep 2026)
+### ~~O7 — the card and the project load~~ ✅ DONE (8 Sep 2026)
 
 **Most of it is built and gated; the mount does not complete.** Do not re-do
 the card model — pick up at the missing wake-up.
@@ -266,7 +298,22 @@ matches route A exactly**, and one ATA interrupt arrives per sector. ⛔ The
 load then STOPS rather than running slowly: 30,000 ms of emulated time gives
 the same 1,407 commands as 6,000. It ends with the **engine task cycling at
 `0x400165dc`** and the in-flight word (`0x46c8c58a`) clear. Route A's targets
-are 6,189 / 30,467 / 297. **That stall is the next thing to chase.**
+are 6,189 / 30,467 / 297. ~~**That stall is the next thing to chase.**~~
+
+**✅ THE STALL WAS A FAULT (8 Sep 2026, third session).** The V4e layer
+refused `mov3ql #-1,%a0@+` at `0x4009d8d0` ("only Dn is reached by this
+firmware" — ❌ retracted), the firmware took a real line-A exception, its
+panic handler printed `EXCEPTION VEC:0A ADDR:4009D8D0` over the panel UART
+and then polled TXEMP forever, which the UART model never set. Fix =
+MOV3Q to every alterable destination (`writeEaLong`); TXEMP is reported
+too, which is what made the fault legible. **Now: 12,373 commands / 60,677
+sectors / 562 written, and route A's whole 6,189-command log is an exact
+prefix.** ⚠️ Route A stops at 6,189 at a 12 s budget too, so the port's
+extra 6,184 commands are an OPEN divergence (a second bank parse, 🟡
+inferred), carried as O7b below. `COLDFIRE_PORT.md` has the instrument-by-instrument account and
+the attribution. Instruments added: `--cmd-log FILE`, a true PC ring, and
+the load report's `load run ended: TIME|FAULT|ILLEGAL` line — **read that
+line before calling anything a stall.**
 
 The instruments that found all of this are in the tree and off by default:
 `--ata-trace`, `--periph-trace`, `--pc-ring N`, `--peek`, and the
@@ -317,5 +364,16 @@ One session per milestone, in a terminal left open:
 /loop Take the next milestone in docs/COLDFIRE_WORKORDER.md that is not done and not BLOCKED. Work on a branch named for it. Follow the standing rules. Open a PR when its gate passes, or a draft PR titled BLOCKED with the measurement. Then stop.
 ```
 
-Use **Opus** for O6 and O7. Switch to Fable for O8 and for any BLOCKED PR.
+**Model routing (8 Sep 2026, after the Fable credit ran out mid-session):**
+- **Opus** for O6's live-call translation, O7b's measurement, and any
+  milestone whose oracle exists — the work is translate-and-diff, and Opus
+  found and fixed O7's fault end to end (cmd-log diff → PC ring → TXEMP →
+  panic text → MOV3Q) without judgment calls.
+- **Fable** only for a BLOCKED PR where the oracle itself is in question
+  (route A cannot do it, or the two disagree and hardware must decide), for
+  O8's DSP join, and for the roundup/merge pass at the end of a run. Do not
+  spend it on translation.
+- Whatever the model: **no claim without the instrument line that produced
+  it**, and "stall" is not a finding until `load run ended:` says TIME.
+
 Nothing here needs a flash, the card, or the user.

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -48,6 +48,7 @@ int main(int _argc, char** _argv)
 	std::string ataTrace;		// write every task-file access here, for diffing against route A
 	std::string periphTrace;	// every peripheral access over the load, for the same diff
 	std::string peeks;			// comma-separated hex addresses to print after the load
+	std::string cmdLog;		// every ATA COMMAND in order, for diffing against route A
 	uint64_t pcRing = 0;		// instructions to record from the first ATA command
 	double loadMs = 6000.0;		// emulated ms to run after LOAD PROJECT is posted
 	std::string setName = "OCTABAM", projectName = "ONEAUX";
@@ -69,6 +70,7 @@ int main(int _argc, char** _argv)
 		else if(a == "--ata-trace" && i + 1 < _argc)	ataTrace = _argv[++i];
 		else if(a == "--periph-trace" && i + 1 < _argc)	periphTrace = _argv[++i];
 		else if(a == "--peek" && i + 1 < _argc)		peeks = _argv[++i];
+		else if(a == "--cmd-log" && i + 1 < _argc)		cmdLog = _argv[++i];
 		else if(a == "--pc-ring" && i + 1 < _argc)	pcRing = std::strtoull(_argv[++i], nullptr, 0);
 		else if(a == "--load-ms" && i + 1 < _argc)	loadMs = std::atof(_argv[++i]);
 		else if(a == "--set" && i + 1 < _argc)		setName = _argv[++i];
@@ -179,6 +181,12 @@ int main(int _argc, char** _argv)
 					"PART_PTR: %#x, %.1f ms emulated%s%s\n",
 					r.ready, r.posted ? "yes" : "no", r.partPtr, r.ms,
 					r.postWhy.empty() ? "" : " | post: ", r.postWhy.c_str());
+				{
+					static const char* const g_loadStop[] = {"GATE", "TIME", "FAULT", "ILLEGAL"};
+					std::printf("             load run ended: %s%s%s\n",
+						g_loadStop[static_cast<int>(r.stop)],
+						r.stopWhy.empty() ? "" : " -- ", r.stopWhy.c_str());
+				}
 				std::printf("             forces %llu, dispatches %zu over the load; now in %s at pc %#x\n",
 					static_cast<unsigned long long>(rtos.forces() - forces0),
 					rtos.dispatches().size() - disp0, ot::taskName(rtos.currentTcb()), m.pc());
@@ -206,7 +214,7 @@ int main(int _argc, char** _argv)
 				{
 					const auto& ring = rtos.pcRing();
 					const auto pos = rtos.pcRingPos();
-					std::printf("             pc ring (last %zu of %zu recorded from the first ATA command):\n",
+					std::printf("             pc ring (last %zu of %zu instructions since the first ATA command):\n",
 						std::min(ring.size(), pos), pos);
 					const size_t n = std::min(ring.size(), pos);
 					uint32_t last = 0; uint64_t runlen = 0;
@@ -270,6 +278,16 @@ int main(int _argc, char** _argv)
 				for(const auto& l : rtos.ataTrace())
 					t << l << '\n';
 				std::printf("             ATA trace: %s (%zu accesses)\n", ataTrace.c_str(), rtos.ataTrace().size());
+			}
+			// The whole command sequence, in route A's own log order, so the
+			// two can be diffed: the FIRST divergence names the defect.
+			if(!cmdLog.empty())
+			{
+				std::ofstream t(cmdLog);
+				for(const auto& e : card->log())
+					t << e.what << ' ' << e.lba << ' ' << e.count << '\n';
+				std::printf("             cmd log: %s (%zu commands)\n",
+					cmdLog.c_str(), card->log().size());
 			}
 			for(size_t i = 0; i < card->log().size() && i < 12; ++i)
 				std::printf("             %-16s lba %-8u count %u\n", card->log()[i].what.c_str(),

--- a/tools/ot_emu/periph.cpp
+++ b/tools/ot_emu/periph.cpp
@@ -95,8 +95,17 @@ namespace ot
 	// ---- UART --------------------------------------------------------------
 	uint32_t Uart::read(const uint32_t _off, const uint32_t _size)
 	{
+		// ⚠️ TXEMP (bit 3) as well as TXRDY (bit 2). This model consumes every
+		// byte written to the transmit buffer immediately, so its transmitter
+		// is always simultaneously READY and EMPTY; reporting TXRDY alone
+		// describes a shift register with a byte stuck in it forever, a state
+		// this model cannot be in. Route A carries the same gap and never
+		// pays for it (see the MOV3Q note in v4e.cpp): the only firmware that
+		// polls TXEMP is the EXCEPTION printer, which route A never reaches.
+		// ✅ Measured 8 Sep 2026: with TXRDY alone the port spun forever at
+		// 0x4003afa0 and the panic it was trying to print was invisible.
 		if(_off == 0x04)
-			return TXRDY | (m_rx.empty() ? 0 : RXRDY);
+			return TXRDY | TXEMP | (m_rx.empty() ? 0 : RXRDY);
 		if(_off == 0x0c)
 		{
 			if(m_rx.empty())

--- a/tools/ot_emu/periph.h
+++ b/tools/ot_emu/periph.h
@@ -80,7 +80,7 @@ namespace ot
 	class Uart
 	{
 	public:
-		enum : uint32_t { RXRDY = 1, TXRDY = 4 };
+		enum : uint32_t { RXRDY = 1, TXRDY = 4, TXEMP = 8 };
 
 		Uart(const char* _name, uint32_t _base) : m_name(_name), m_base(_base) {}
 

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -424,10 +424,15 @@ namespace ot
 	bool Rtos::stepOnce()
 	{
 		const auto pc = m_machine.pc();
-		// The FIRST N after arming, not the last: the question is what the ISR
-		// does, and by the end everything is parked at main's spin.
-		if(m_pcRingArmed && m_pcRingPos < m_pcRing.size())
-			m_pcRing[m_pcRingPos++] = pc;
+		// A TRUE RING: it keeps the LAST N instructions, not the first N.
+		// The first-N version answered "what does the ISR do" (O7's INTRQ
+		// race); a STALL asks the opposite question -- what was running when
+		// the work stopped -- and the printer already reads it as a ring.
+		if(m_pcRingArmed && !m_pcRing.empty())
+		{
+			m_pcRing[m_pcRingPos % m_pcRing.size()] = pc;
+			++m_pcRingPos;
+		}
 		if(pc == g_create)
 			recordCreate();
 
@@ -607,7 +612,9 @@ namespace ot
 		out.posted = callAsMain(g_postLoad, {g_projectName}, d0, 200000000);
 		if(!out.posted)
 			out.postWhy = m_why;
-		run(_runMs, false);
+		out.stop = run(_runMs, false);
+		if(out.stop != Stop::Time)
+			out.stopWhy = m_why;
 		out.partPtr = m_machine.peek32(g_partPtr);
 		out.ms = (m_sample - start) / g_sampleHz * 1000.0;
 		return out;

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -161,7 +161,11 @@ namespace ot
 		// it does real FAT lookups and BLOCKS -- and borrowing main for a
 		// call that blocks is the crash `callAsMain` warns about.
 		struct LoadResult { uint32_t ready = 0, partPtr = 0; bool posted = false; double ms = 0;
-			std::string postWhy; };
+			std::string postWhy;
+			// How the load's own run ENDED. Time is the ordinary case (the
+			// budget ran out); Fault/Illegal say the machine stopped, which
+			// the ATA counts alone cannot distinguish from a stall.
+			Stop stop = Stop::Time; std::string stopWhy; };
 		LoadResult loadProjectLive(const std::string& _set, const std::string& _project,
 			double _runMs = 6000.0, double _mountMs = 3000.0);
 

--- a/tools/ot_emu/test_emac.cpp
+++ b/tools/ot_emu/test_emac.cpp
@@ -95,6 +95,40 @@ int main()
 	check("msacl SUBTRACTS (extension word bit 8)",
 		runProgram(msacl, 0, 0, 32), 0xfffffffd);
 
+	// ---- MOV3Q to MEMORY (the V4e layer, same dispatch path) -------------
+	// ❌ Retracts v4e.cpp's "only Dn is reached by this firmware": the project
+	// load runs eight `mov3ql #-1,%a0@+` at 0x4009d8d0 and the refusal was a
+	// real line-A exception -- the firmware printed `EXCEPTION VEC:0A
+	// ADDR:4009D8D0` and halted, and it looked like a stall at 1,407 of
+	// 6,189 ATA commands (measured 8 Sep 2026). Route A never needed a shim
+	// (Unicorn has MOV3Q natively), so this gate is the only one that holds
+	// the port's version to the same semantics.
+	//
+	//   207c 4000 0500  moveal #0x40000500,%a0
+	//   a158            mov3ql #-1,%a0@+
+	//   a358            mov3ql #1,%a0@+
+	//   then one of: 2039 4000 0500 movel 0x40000500,%d0
+	//                2039 4000 0504 movel 0x40000504,%d0
+	//                2008           movel %a0,%d0
+	std::printf("MOV3Q gate (memory destinations, v4e.cpp):\n");
+	const std::vector<uint8_t> mov3qHead = {
+		0x20, 0x7c, 0x40, 0x00, 0x05, 0x00,	// moveal #0x40000500,%a0 (inside the image, past the code)
+		0xa1, 0x58,							// mov3ql #-1,%a0@+
+		0xa3, 0x58,							// mov3ql #1,%a0@+
+	};
+	auto readFirst = mov3qHead, readSecond = mov3qHead, readA0 = mov3qHead;
+	for(const uint8_t b : {0x20, 0x39, 0x40, 0x00, 0x05, 0x00}) readFirst.push_back(b);
+	for(const uint8_t b : {0x20, 0x39, 0x40, 0x00, 0x05, 0x04}) readSecond.push_back(b);
+	for(const uint8_t b : {0x20, 0x08}) readA0.push_back(b);
+	for(auto* prog : {&readFirst, &readSecond, &readA0})
+	{
+		prog->push_back(0x4e); prog->push_back(0x71);	// nop
+		prog->resize(0x200, 0);							// room for the data at +0x100
+	}
+	check("mov3ql #-1,%a0@+ writes 0xffffffff", runProgram(readFirst, 0, 0, 4), 0xffffffff);
+	check("mov3ql #1,%a0@+ writes 1 at the next long", runProgram(readSecond, 0, 0, 4), 1);
+	check("(An)+ advanced a0 by 8 over the pair", runProgram(readA0, 0, 0, 4), 0x40000508);
+
 	std::printf("%s\n", g_failures ? "EMAC GATE FAILED -- nothing this emulator computes can be trusted"
 									: "EMAC gate passed.");
 	return g_failures ? 1 : 0;

--- a/tools/ot_emu/v4e.cpp
+++ b/tools/ot_emu/v4e.cpp
@@ -105,6 +105,66 @@ namespace ot::v4e
 	// to keep the stack even. Kept here 🟡 INFERRED for ColdFire, which has no
 	// odd-address stack either; nothing in this firmware has exercised it yet,
 	// and the falsifier is a `mvs.b -(%sp)` whose stack pointer comes back odd.
+	// Write a LONGWORD operand through effective address `mode`/`reg`,
+	// advancing the PC over any extension words. The alterable modes only --
+	// PC-relative and immediate are not destinations, and a caller that asks
+	// for one gets false rather than a silent write somewhere.
+	bool writeEaLong(Machine& _m, const uint32_t _mode, const uint32_t _reg, const uint32_t _val)
+	{
+		switch(_mode)
+		{
+		case 0:														// Dn
+			setReg(_m, dReg(_reg), _val);
+			return true;
+		case 1:														// An
+			setReg(_m, aReg(_reg), _val);
+			return true;
+		case 2:														// (An)
+			_m.write32(reg(_m, aReg(_reg)), _val);
+			return true;
+		case 3:														// (An)+
+			{
+				const auto a = reg(_m, aReg(_reg));
+				_m.write32(a, _val);
+				setReg(_m, aReg(_reg), a + 4);
+				return true;
+			}
+		case 4:														// -(An)
+			{
+				const auto a = reg(_m, aReg(_reg)) - 4;
+				setReg(_m, aReg(_reg), a);
+				_m.write32(a, _val);
+				return true;
+			}
+		case 5:														// (d16,An)
+			{
+				const auto disp = static_cast<int32_t>(static_cast<int16_t>(fetch16(_m)));
+				_m.write32(reg(_m, aReg(_reg)) + static_cast<uint32_t>(disp), _val);
+				return true;
+			}
+		case 6:														// (d8,An,Xn)
+			_m.write32(briefIndex(_m, reg(_m, aReg(_reg))), _val);
+			return true;
+		case 7:
+			switch(_reg)
+			{
+			case 0:													// (xxx).W
+				{
+					const auto a = static_cast<int32_t>(static_cast<int16_t>(fetch16(_m)));
+					_m.write32(static_cast<uint32_t>(a), _val);
+					return true;
+				}
+			case 1:													// (xxx).L
+				_m.write32(fetch32(_m), _val);
+				return true;
+			default:
+				return false;
+			}
+		default:
+			return false;
+		}
+	}
+
 	bool readEa(Machine& _m, const uint32_t _mode, const uint32_t _reg, const uint32_t _size,
 		uint32_t& _out)
 	{
@@ -365,16 +425,29 @@ namespace ot::v4e
 		// ---- MOV3Q ---------------------------------------------------------
 		// 1010 iii 1 01 eeeeee -- a 3-bit immediate (0 encodes -1) to a
 		// longword destination. ✅ `a340` assembles as `mov3ql #1,%d0`.
+		//
+		// ❌❌ THIS RETRACTS "only Dn is reached by this firmware". The
+		// project load reaches `mov3q #-1,%a0@+` (`a158`) at 0x4009d8d0, in a
+		// run of eight that clears a structure, and refusing it raised a real
+		// line-A exception: the firmware's own handler printed
+		// `EXCEPTION / VEC:0A / ADDR:4009D8D0` over the panel port and
+		// executed `halt`. Measured 8 Sep 2026. ⚠️ Route A needs no shim for
+		// this -- Unicorn's m68k implements MOV3Q natively -- so the only
+		// machine that can be wrong here is this one, and "route A does not
+		// have it either" is not evidence.
+		//
+		// Semantics are QEMU's `mov3q` (route A's own engine, so the oracle):
+		// the condition codes are set from the 32-bit VALUE for every
+		// destination, An included, and the destination is written LONG.
 		if((_opcode & 0xf1c0) == 0xa140)
 		{
 			const uint32_t imm3 = (_opcode >> 9) & 7;
 			const auto v = static_cast<uint32_t>(imm3 == 0 ? -1 : static_cast<int32_t>(imm3));
 			const uint32_t mode = (_opcode >> 3) & 7;
 			const uint32_t rn   = _opcode & 7;
-			if(mode != 0)					// only Dn is reached by this firmware
-				return Result::Unhandled;
-			setReg(_m, dReg(rn), v);
 			setNZ(_m, v);
+			if(!writeEaLong(_m, mode, rn, v))
+				return Result::Unhandled;
 			return Result::Handled;
 		}
 


### PR DESCRIPTION
## Summary

The 1,407-of-6,189 "stall" was never a stall. The V4e layer handled MOV3Q for Dn only; the firmware runs eight `mov3ql #-1,%a0@+` at `0x4009d8d0`, took a real line-A exception, and its own panic handler printed `EXCEPTION / VEC:0A / ADDR:4009D8D0` over the panel UART — then polled TXEMP forever, which the UART model never set.

**After:** 12,373 ATA commands / 60,677 sectors / 562 written, and **route A's whole 6,189-command log is an exact prefix** of the port's (`diff` over the normalised logs: identical).

## Attribution (measured, each change alone)
- `v4e.cpp` MOV3Q to every alterable destination (`writeEaLong`): **the fix**. Alone: 1,407 → 12,373.
- `periph.cpp` UART reports TXEMP as well as TXRDY: alone changes nothing about the load. It is what made the fault **legible** — the spin became a `halt` with a message. Route A has the same gap and never pays for it (Unicorn has MOV3Q natively, so it never reaches the printer).

## Instruments added (off by default)
- `--cmd-log FILE`: every ATA command in route A's log order, for diffing. The first divergence names the defect; here there was none.
- The PC ring is a true ring (last N instructions, not first N).
- The load report says how its run **ended** (`load run ended: TIME | FAULT | ILLEGAL <opcode>`). **Read that line before calling anything a stall.**

## Gates
- `test_emac` now holds MOV3Q's memory forms; watched failing on the old code.
- `ctest` 6/6, oracle 8 compared fields / 0 disagreements, serial 5,731 B identical, `make check` green.

## ⚠️ Open, carried as O7b in the work order
Route A ends at 6,189 commands at a 6 s **and** a 12 s budget; the port runs on to 12,373 (same at 6 s and 20 s). The extra 6,184 look like a second bank parse (🟡 SYS's reset-time "select bank 0" going to the card in the port only). Next measurement: which task and PC issue command 6,190. Not a blocker for O6.

Also: O6 is UNBLOCKED and is now the queue head; the work order names the four live-call functions to translate and the model routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)