### PR TITLE
O6: the eDMA and the frame clock — the sequencer's trig is byte-identical to route A's

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -367,52 +367,172 @@ comparison would be decoration.
 **Gate:** `ctest` 6/6; the oracle diff reports **8 compared fields agree, 0
 disagreements**; `make check` green.
 
-## Milestone O6 — the eDMA and the frame clock ⛔ BLOCKED on O7 (8 Sep 2026)
+## Milestone O6 — the eDMA and the frame clock ✅ (8 Sep 2026)
 
-The model is written and unit-gated; its **fidelity** gate is M6c, which needs
-a loaded project and a started transport — O7. `COLDFIRE_WORKORDER.md` carries
-the full entry; the two things worth keeping here:
+**The sequencer runs, and its trig is byte-identical to route A's.** With the
+project loaded, the transport started through the real tasks and a trig poked
+on track 1 step 2, 400 frames of the port produce exactly route A's log:
 
-**The three completion rules, and watching the gate fail.** `Edma` was
-implemented first with route A's own *wrong* rule — everything completes at
-once — and the gate failed on exactly the four paced assertions and nothing
-else, which is the symptom route A recorded ("re-raised source 15 before state
-0 could ack it; the ISR spun in state 6"). Fixing `start` to book a paced
-channel at the DSP's next 16-sample boundary turned all 19 green. The other
-two rules (an `SSRT` is bus speed; a memory-to-memory `START` is a copy the
-caller busy-waits for) complete at once, and a linked channel is a burst that
-completes **with** its parent, so ch1 → ch6 → ch7 is one boundary event.
+| | route A (the oracle) | `ot_emu` |
+|---|---|---|
+| frames since the transport start | 400 | 400 ✅ |
+| sequencer ticks (vector `0x60`) | 28 | 28 ✅ |
+| transport-start writes at frame 0 | `0x10` on tracks 0, 1, 2, 4, 7 | the same five, same order ✅ |
+| the trig | frame **344**, track 0, bytes `0x08` then `0x18` | identical ✅ |
+| saved / final / sequencer bank / pattern | 1 / 1 / 1 / 0 | identical ✅ |
+| eDMA transfers started | 16,801 | 16,800 (reported, not compared) |
 
-✅ A detail that fell out of writing the test: **ch1's CSR `0x621` has no
-INTMAJOR.** Only ch7 raises a line, and channel 7 is INTC0 source 8 + 7 = 15
-— exactly the source route A names for the end of that chain. The first
-version of the test asserted a line for ch1 and was wrong; the model was
-right.
+```sh
+scripts/o6_gate.sh                     # stages ONE card image, runs both, diffs
+python3 tools/ot_emu/oracle.py out/oracle/m6c.json out/oracle/port_m6c.json
+# oracle: 5 compared field(s) agree
+```
 
-**The frame latch is cleared on the interrupt ACKNOWLEDGE.** Route A clears
-`frame_pending` as it pushes the frame, because it hand-rolls the push. This
-port lets Musashi dispatch the exception, so offering a line and having it
-taken are different events — the latch is cleared from
-`Machine::readIrqUserVector`, the core's own acknowledge, which is the same
-moment. It is a **latch, not a count**: a masked edge source remembers one
-edge, and counting them delivered ~540 phantom frames back to back in route A.
+❌ **RETRACTED: `RTOS_FORK.md` §8.4's "byte `0xd3`" and its six
+transport-start writes on tracks 0, 1, 1, 2, 4, 7.** Re-measured today, route
+A **and** the cold tool (`emu_frames.py`, the same command §8.4 quotes) both
+give **five** writes of `0x10` at frame 0 (tracks 0, 1, 2, 4, 7) and `0x08`
+then `0x18` at frame 344. Two independent instruments agree, so the current
+numbers are the reference. 🟡 The likely cause is the EMAC fix of 7 Sep
+(§10.16): §8.4 was measured on 6 Sep, before it, and the byte the trig writes
+is computed by an EMAC chain (below). Inferred, not measured — nobody has
+re-run §8.4's exact tree on the stock library to confirm.
 
-### What was measured about the block, rather than assumed
+### The gate, and the shape of it
 
-- ✅ Route A **cannot run with the frame clock on from boot**: a bare
-  `Rtos(frame=True)` faults on unmapped memory, and priming the auto-map hook
-  leaves its own state unusable. So there is no intermediate oracle
-  comparison for the frame clock — it is M6c or nothing.
-- ✅ The port with `--frame` is identical to frame-off through 100 ms, then
-  wedges: dispatches frozen at 40 from 205 ms through 400 ms while PIT0 keeps
-  firing, **1 frame interrupt taken, 0 eDMA transfers started**. No frame is
-  delivered before main's unmask, so the mask is respected.
-- 🟡 The wedge is *inferred* to be the ISR waiting for a DSP exchange nothing
-  starts (the host port is O8, the chain is kicked from the sequencer path in
-  O7). **Whether the frame model is right in the configuration that matters
-  is not established, and only M6c establishes it.**
-- ✅ No regression with the clock off: the oracle diff is still 8 compared
-  fields, zero disagreements; `ctest` 6/6; `make check` green.
+`--sequencer` on both tools walks the same steps, and every one of them is
+route A's, including the two compensations it documents as compensations (the
+bank switch and the sequencer re-select, which stand in for a load-ordering
+defect the unit does not have — RTOS_FORK.md §7/§8.3): park at main's spin,
+mount, load, switch to the file's bank through `sys`, re-issue the load's own
+last step, clear CLOCK RECEIVE, **then** turn the frame clock on, start the
+transport, poke the trig, and run 400 frames. `tools/ot_emu/stage_card.py`
+builds the card image with route A's own `stage_project`, so both emulators
+read byte-identical media — the FAT16 builder is still deliberately not
+ported (O7).
+
+`oracle.py` compares `m6c_trig`, `m6c_trig_words`, `m6c_ticks`, `m6c_frames`
+and `m6c_bank` **strictly**. None of them tracks the `ips` knob the way the
+dispatch PCs and the serial count do: a trig either fires on the frame the
+other emulator fires it on or it does not.
+
+### Five defects, and none of them was in the frame model
+
+The eDMA and the frame latch were written in the previous session and gated
+by `test_periph`'s 19 assertions; that model needed no change. What stood
+between it and the gate was five other things, each measured:
+
+**1. ✅ The DSP host port needs route A's two stand-in replies, and without
+them the frame handler never returns.** `0x20000004` must read `0x0000`: the
+handler writes 140 there at `0x4000ab1e` and then polls
+`movew 0x20000004,%d0 / tstb %d0 / blts` — it waits for bit 7 of the low byte
+to clear, which is the DSP's handshake. An unmodelled window answers all-ones
+and the bit never clears. The port took **exactly one** frame interrupt,
+entered `0x4000aad0`, and burned **352 M instructions** in that
+three-instruction loop: 0 eDMA transfers, 0 ticks, 0 trigs. It reads as "the
+frame model is wrong" and it is a missing peripheral reply. `0x2000001c` (the
+ping index, read one instruction earlier) toggles 0/1. Both are route A's
+`EXTRA_OVERRIDES`, "the DSP host port as M5 faked it", and both are stand-ins
+for the DSP that O8 will put behind the window.
+
+**2. ✅ `Region::contains` overflowed, and a legitimate unmapped write became
+a 4 GB memory smash.** `(_a - base) + _size <= data.size()` in 32-bit
+arithmetic: with the region at `0x00000000`, an access at `0xffffffff` gives
+offset `0xffffffff`, and `0xffffffff + 1 == 0`, so the region claimed the
+address. The frame handler reaches a `moveb %d0,%a0@-` with `a0 = 0` and the
+emulator died inside Musashi with a bare SIGSEGV — **and printed nothing**,
+because stdout redirected to a file is block-buffered. Three runs went into
+that. Fixed, and with it three instruments that make the next one legible:
+
+- `Machine::badWrite` stops the MACHINE, not the process, on a write the
+  region model cannot honour, naming the address and the PC;
+- `setAutoMapLimit` (default 65,536 pages = 256 MB) does the same for a
+  runaway auto-map, naming the busiest unmapped-access PC — route A's own
+  growth on the golden path is ~200 MB, so the ceiling is well clear of
+  anything faithful;
+- `main` sets **line-buffered stdout**. Same family as the panic printer O7
+  could not finish.
+
+**3. ✅ `SATS` (`0x4c80 | Dn`) was unimplemented**, and it is on the M6c path
+only — the per-frame EMAC routine at `0x4000346a`, which the eDMA completion
+handler's state 5 calls. The boot and the whole project load never meet it.
+Semantics measured in route A's engine (six cases in `test_emac`): with V set,
+a result whose sign bit is clear saturates to `0x80000000` and one whose sign
+bit is set to `0x7fffffff`; with V clear the value is untouched.
+⚠️ **Its flags disagree with the CFPRM and the port follows route A**: the
+manual says N and Z are set from the result and V and C cleared, and route A's
+engine updates **N only**. Nothing between the `sats` and the next
+flag-setting instruction reads the CCR at the only site the firmware reaches.
+What would falsify it: a firmware site that branches on Z or V after a SATS.
+
+**4. ✅ `movel #imm,%macsr` (`a93c`) was unimplemented** — the frame handler's
+own, at `0x4000aeda`. It fell into the MAC path, which consumed one extension
+word instead of the immediate's two, and the instruction stream desynchronised
+inside the handler. (That is what produced defect 2's write to `0xffffffff`.)
+
+**5. ✅ THE EMAC HAD FIVE FIELDS WRONG, AND THE OLD GATE COVERED NONE OF THEM.**
+Every case the O2 gate tested used acc0, two data registers, the long form and
+no parallel load — the one combination in which all five are invisible.
+
+- The **accumulator number** was read as ext bit 4 | ext bit 9. It is opcode
+  **bit 7** (low) and ext **bit 4** (high) — and in the load form the low bit
+  is **inverted** (`a498` is acc0, `a418` is acc1; route A's
+  `_emac_load_shim` carries the same `((~op >> 7) & 1)`). The frame builder
+  uses all four accumulators.
+- An **address-register source** was read as the data register of the same
+  number: `macl %a2,%d0` (`a08a`) multiplied d2.
+- The two **operand-half bits** were applied to the wrong operands
+  (`macw %d0u,%d1l` is ext `0x0040`: bit 6 is the FIRST operand's).
+- The **parallel load** handled only `(An)+`. The frame routine at
+  `0x40003738` uses `(An)` and `(d16,An)` as well, and the `(d16,An)` form is
+  **six bytes** — skipping its displacement word desynchronised the stream
+  and invented an opcode two instructions later.
+- ⚠️ **And the one that survived all of those: the accumulator is 48 bits and
+  holds the product at `>>24`, not `>>32`.** The port shifted each product
+  all the way down before accumulating, which is right for one product and
+  off by one LSB for a subtract whose discarded low bits are non-zero:
+  `floor(-floor(q/2^24)/2^8)` is one less than `-floor(q/2^32)`. Route A's
+  model (QEMU's EMAC plus `tools/unicorn_emac_fractional.patch`) accumulates
+  at `>>24` and shifts down by 8 only when the accumulator is READ
+  (`get_macf`). **That single bit was the whole remaining difference in the
+  M6c gate**: the frame handler's `msacl` came out −15 where route A had −16,
+  an `spl` floor two instructions later turned it into 1 instead of 0, and
+  the sequencer's live nibble read `0x09` where route A reads `0x08` — on
+  every write, on every frame. `movclrl` now returns `acc >> 8`, `movel
+  Rn,%accN` writes `(int32)v << 8`, and the accumulate sign-extends from 48
+  bits (`macsatf`), all as route A does.
+
+`test_emac` now carries **23** assertions covering all of it, every one
+watched failing first. ✅ Encodings from `m68k-elf-as -mcpu=5475`, listed
+beside each rule; the accumulator alignment has a paired control (`macl` with
+the same operands, which agrees under either model, so only the `msacl` case
+is evidence).
+
+### How the last bit was found, in order
+
+Worth keeping, because none of it was reasoning:
+
+1. `--watch-mem` on the port (route A's own flag, ported) said the live
+   nibble is written at `0x4000b910` and `0x4000b9bc` in both.
+2. objdump on the image: `0x4000b910` is `moveb %a2@,%a1@(0,%a3:l)` with
+   `a2 = a0 + 62`, and route A's `--watch-pc` said `a0 = 0x80001798 + track`.
+3. So the byte comes from `0x800017d6 + track`, and the only writer of that
+   table is the frame handler's own loop at `0x4000aef6`:
+   `msacl / movclrl %acc0,%d2 / addl #16,%d2 / spl %d3 / andl %d3,%d2 /
+   moveb %d2,%a2@+`.
+4. `--watch-mem` on both emulators for the two inputs: the frame timebase
+   (`0x46104cf0`) is **identical** (`0x16800`, `0x21c00`, `0x2d000` written at
+   `0x4000aec4`) and so are the per-track words at `0x80001904`. Two inputs
+   the same and the output different leaves the arithmetic.
+5. Reading route A's actual model — the patch and QEMU's `macmulf` /
+   `get_macf` — gave the alignment, and the arithmetic predicts the sign of
+   the error before the fix was written.
+
+### No regression
+
+`ctest` 6/6; the M6a oracle diff still reports **8 compared fields agree, 0
+disagreements**; `make check` green.
+
 ## Milestone O7 — the card and the project load ✅ (8 Sep 2026; the stall was a fault)
 
 The card model, its memory map and the live-call machinery are in and gated;

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -71,6 +71,7 @@ route A fact, not the port's problem; the golden command above already does it.
 | O3 | PIT + INTC models | `ctest` periph, 14 rules | (wired in by O4) |
 | O4 | the run loop: the kernel runs | `ctest` rtos + the oracle diff | ✅ 6 compared fields (❌ was written "8/8": the diff counted 2 it never compared); 10 created, 11 ran, 204.88 ms vs 204.95 |
 | O5 | the rest of the memory; the serial stream | `ctest` rtos + the oracle diff | ✅ 8 compared fields; route A's 4831 serial bytes matched byte for byte (❌ its account of *why* route A has the extra memory was wrong — corrected in O7) |
+| O6 | the eDMA and the frame clock; the sequencer | the M6c fidelity gate (`scripts/o6_gate.sh`) | ✅ 5 compared fields: 400 frames, 28 ticks, the trig at frame 344 track 0 bytes `0x08`/`0x18`, and the bank/pattern four -- byte-identical to route A |
 | O7 | the card, the mount, the project load | route A's ATA command log is a prefix of the port's | ✅ all 6,189 commands identical, 297 written; ⚠️ OPEN: the port runs on to 12,373 and route A stops at 6,189 at ANY budget (`COLDFIRE_PORT.md` O7) |
 
 ## Queue
@@ -156,7 +157,42 @@ That is not a defect — route A covers the same spans — but O7's card is what
 would make the two machines allocate from the same place, and it is worth
 re-checking the span list once the project loads.
 
-### O6 — the eDMA and the frame clock — **UNBLOCKED, NEXT** (O7 landed 8 Sep 2026)
+### ~~O6 — the eDMA and the frame clock~~ ✅ DONE (8 Sep 2026)
+
+See `COLDFIRE_PORT.md`. The gate is `scripts/o6_gate.sh` (stage one card image
+with route A's own staging, run both, diff strictly), and it passes: 400
+frames, **28 ticks**, the trig at **frame 344 on track 0**, bytes `0x08` then
+`0x18`, bank/pattern identical.
+
+❌ **This entry's own gate value was stale, and so was `RTOS_FORK.md` §8.4's.**
+The byte is `0x08`/`0x18`, not `0xd3`, and there are FIVE transport-start
+writes (tracks 0, 1, 2, 4, 7), not six. Route A and the cold tool agree on
+today's numbers; 🟡 the EMAC fix of 7 Sep is the likely cause and is inferred,
+not measured.
+
+Four things later milestones should know:
+
+1. **The DSP host port needs route A's two stand-in replies** (`0x20000004`
+   reads `0x0000`, `0x2000001c` toggles). Without them the frame handler
+   spins forever on the DSP's handshake — 352 M instructions, one frame
+   taken, no eDMA, and it reads as a broken frame model.
+2. **A defect in the port's own memory model can present as a crash with no
+   output at all.** `Region::contains` overflowed at `0xffffffff`; the fix
+   came with a bounds guard that stops the MACHINE, an auto-map ceiling, and
+   line-buffered stdout. Read `run ended:` — and now, if it says nothing at
+   all, suspect the buffering before the firmware.
+3. **`SATS` and `movel #imm,%macsr` are on the M6c path and nowhere else**, so
+   O1..O5 and the whole project load ran without ever meeting them.
+4. **The EMAC gate that passed since O2 covered one corner of the unit.** Five
+   fields were wrong — the accumulator number (inverted in the load form), An
+   sources, the operand-half bits, the parallel load's addressing modes, and
+   the accumulator's **48-bit `>>24` alignment**, which is the one that
+   survived everything else and was worth exactly one LSB per subtract. If a
+   port result is off by one, suspect where the truncation happens.
+
+<details><summary>the entry it replaces</summary>
+
+### O6 — the eDMA and the frame clock — UNBLOCKED, NEXT (the original)
 
 **The code is written and unit-gated; its FIDELITY gate can now run.** Do
 not re-do the model. What O6 still needs is the rest of the live-call
@@ -171,6 +207,8 @@ ticks. The oracle is `tools/emu_frames.py --project out/_testproj --frames
 400 --start --internal-clock --poke-trig 2` (RTOS_FORK.md §8). ⚠️ The
 first thing to read on any early stop is the load report's `load run
 ended:` line — O7's "stall" was an ILLEGAL that looked like one.
+
+</details>
 
 ### O7b — why the port loads twice — *(Opus, measurement first)*
 

--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -578,11 +578,22 @@ flag.
 
 ## 8. M6c — the fidelity gate, and the three things that stood between it and route A (Fable review, 6 Sep 2026)
 
+> ❌ **RETRACTED 8 Sep 2026 (milestone O6): the BYTE below is `0x08` then
+> `0x18`, not `0xd3`, and there are FIVE transport-start writes, not six.**
+> Re-measured on the same project with the same commands: route A
+> (`--sequencer`) and the cold tool (`emu_frames.py`) both give five writes of
+> `0x10` at frame 0 (tracks 0, 1, 2, 4, 7) and `0x08` then `0x18` at frame 344
+> on track 0. The FRAME (344), the track and the tick count (28) are unchanged.
+> 🟡 The likely cause is the EMAC fix of 7 Sep (§10.16) — the byte is computed
+> by an EMAC chain in the frame handler — but nobody has re-run this section's
+> exact tree on the stock library, so that attribution is inferred. The C++
+> port reproduces the current numbers exactly (`COLDFIRE_PORT.md`, O6).
+
 `out/_testproj` is a symlink to a project **freshly saved on the unit
 6 Sep 2026** (`OCTABAM_RIG_20260906_cleared`, `~/octa/backups/`): a cold
 run against it (`tools/emu_frames.py --project out/_testproj --frames 400
 --start --internal-clock --poke-trig 2`) lands track 1's live nibble at
-**frame 344, byte `0xd3`** — the frame this document's M5 claim named; the
+**frame 344, byte `0xd3`** (❌ the byte is retracted above) — the frame this document's M5 claim named; the
 byte differs from the `0xb6` written down at the time and the cold number
 measured today is the reference, not the historical one.
 
@@ -727,8 +738,14 @@ own last step, internal clock, transport by the M5 detour, `--poke-trig
 | | cold (M5) | route A (M6c) |
 |---|---|---|
 | ticks in 400 frames | 28 | 28 (frames 1, 16, 30, 45, 59, 73, …) |
-| transport-start writes | `0x10` on tracks 0, 1, 1, 2, 4, 7 | the same six, same order |
-| the trig | track 0, byte **`0xd3`**, 344 frames after the start frame | track 0, byte **`0xd3`**, 344 frames after the start frame |
+| transport-start writes | ❌ `0x10` on tracks 0, 1, 1, 2, 4, 7 | ❌ the same six, same order |
+| the trig | ❌ track 0, byte **`0xd3`**, 344 frames after the start frame | ❌ track 0, byte **`0xd3`**, 344 frames after the start frame |
+
+❌ **The last two rows are RETRACTED (8 Sep 2026) — see the note at the head of
+§8.** Re-measured: FIVE transport-start writes of `0x10` (tracks 0, 1, 2, 4, 7)
+and the trig is bytes **`0x08` then `0x18`** on track 0, still 344 frames after
+the start frame, still 28 ticks. The two tools still agree with each other, and
+the C++ port now agrees with both.
 
 Frame numbering differs by one between the two tools (cold counts the
 first frame after the start as 0, the route-A script counted it as 1; the

--- a/scripts/o6_gate.sh
+++ b/scripts/o6_gate.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# THE O6 FIDELITY GATE: does the C++ port's sequencer land the same trig, on
+# the same frame, after the same number of ticks, as route A's?
+#
+#   scripts/o6_gate.sh [PROJECT] [SET] [NAME]
+#
+# Four steps, and the first two are what make the comparison mean anything:
+#   1. stage ONE card image with route A's own staging, so both emulators read
+#      identical media (tools/ot_emu/stage_card.py);
+#   2. run route A -- the ORACLE -- and write its M6c facts;
+#   3. run the port the same way and write its own;
+#   4. diff them field by field, strictly (tools/ot_emu/oracle.py).
+#
+# ⚠️ Route A's run costs about two minutes and the port's about the same; this
+# is not a per-commit check. `make check` does not run it. Set SKIP_ORACLE=1 to
+# reuse an existing out/oracle/m6c.json when only the port has changed.
+set -euo pipefail
+
+PROJECT=${1:-out/_testproj}
+SET=${2:-OCTABAM}
+NAME=${3:-RIG}
+PY=${PY:-.venv/bin/python3}
+IMAGE=${IMAGE:-out/raw/section_3_MAIN_OS.bin}
+FRAMES=${FRAMES:-400}
+STEP=${STEP:-2}
+MS=${MS:-20000}
+
+mkdir -p out/oracle
+
+echo "== staging the card (route A's own staging, so both read identical media)"
+"$PY" tools/ot_emu/stage_card.py "$PROJECT" "$SET" "$NAME" \
+    --tree out/_o6_tree_port --out out/o6_card.img
+
+if [ "${SKIP_ORACLE:-0}" = 1 ] && [ -f out/oracle/m6c.json ]; then
+    echo "== reusing out/oracle/m6c.json (SKIP_ORACLE=1)"
+else
+    echo "== route A (the oracle)"
+    "$PY" tools/emu_rtos.py --project "$PROJECT" --set "$SET" --name "$NAME" \
+        --tree out/_o6_tree --sequencer --internal-clock --poke-trig "$STEP" \
+        --frames "$FRAMES" --ms "$MS" --golden out/oracle/m6c.json \
+        | grep -v '^   ' | tail -20
+fi
+
+echo "== the port"
+cmake --build out/emu -j8 >/dev/null
+./out/emu/ot_emu --image "$IMAGE" --card out/o6_card.img --set "$SET" --project "$NAME" \
+    --sequencer --internal-clock --poke-trig "$STEP" --frames "$FRAMES" --load-ms "$MS" \
+    --m6c-golden out/oracle/port_m6c.json | tail -30
+
+echo "== the diff"
+python3 tools/ot_emu/oracle.py out/oracle/m6c.json out/oracle/port_m6c.json

--- a/tools/emu_rtos.py
+++ b/tools/emu_rtos.py
@@ -616,6 +616,11 @@ class Rtos:
         self.next_frame = FRAME_PERIOD
         self.frame_pending = False
         self.frame_count = 0
+        # Sequencer ticks: deliveries of vector 0x60 (INTC0 source 32, the
+        # frame handler's own forced interrupt -- §8.2). Counted so the M6c
+        # report can state it instead of leaving it to be inferred from the
+        # trig log; the C++ port counts the same vector's acknowledgements.
+        self.tick_count = 0
         # INTC0 sources: 1 = DSP frame (vector 0x41); 27/28 -> vectors
         # 0x5b/0x5c -> handlers 0x400109bc/0x40010b88 (vector-install scan,
         # 6 Sep 2026); INTC1 source 43 = PIT0.
@@ -983,6 +988,8 @@ class Rtos:
         if name == "INTC0" and src == 1:
             self.frame_pending = False
             self.frame_count += 1
+        if vec == 0x60:
+            self.tick_count += 1
         self._t(f"irq {name} src {src} vec {vec} level {level} -> {self.pc:#x} (was ipl {ipl})")
         return True
 
@@ -1900,6 +1907,7 @@ def _cli():
             # returned, which is what emu_frames.py's cold run calls frame 0:
             # the two reports compare directly (cold: the trig at 344).
             frame0 = rt.frame_count + 1
+            ticks0 = rt.tick_count
             target = frame0 + a.frames
             rt.run(ms=a.frames * FRAME_PERIOD / SAMPLE_HZ * 1000.0 * 5 + 2000,
                    until=lambda x: x.frame_count >= target)
@@ -1918,6 +1926,7 @@ def _cli():
                   f"{_word(rt, REC_ARM):#x}")
         print(f"load       : mounted={mounted} saved_bank={saved_bank} bank={final_bank} "
               f"clock={'internal' if a.internal_clock else 'external (CLOCK RECEIVE as saved)'}")
+        print(f"ticks      : {rt.tick_count - ticks0} sequencer tick(s) (vector 0x60) since transport start")
         print(f"frames run : {rt.frame_count - frame0} since transport start (target {a.frames}; "
               f"{frame0} before it), eDMA transfers {rt.edma.started}")
         if a.tape:
@@ -1947,6 +1956,24 @@ def _cli():
             print(f"arm-phase  : {len(fixes)} trig word(s) had bit 7 cleared (COMPENSATION): "
                   + ", ".join(f"track {t} {w:#x} @ {s_:.0f}" for s_, t, w in fixes[:8]))
         _watch_report()
+        if a.golden:
+            # THE M6c ORACLE, in the shape tools/ot_emu/oracle.py compares:
+            # the trig log with frame numbers relative to the transport start,
+            # the tick count, the frames run, and the four bank/pattern bytes.
+            # Deliberately a SEPARATE file from the M6a golden -- a different
+            # configuration measures a different thing.
+            import json as _json
+            pathlib.Path(a.golden).parent.mkdir(parents=True, exist_ok=True)
+            with open(a.golden, "w") as f:
+                _json.dump({
+                    "m6c_trig": [[fr - frame0, tr, v] for fr, tr, v in rt.live_nibble_log],
+                    "m6c_trig_words": [[fr - frame0, i, v] for fr, i, v in rt.trig_words_log],
+                    "m6c_ticks": rt.tick_count - ticks0,
+                    "m6c_frames": rt.frame_count - frame0,
+                    "m6c_bank": [saved_bank if saved_bank is not None else -1,
+                                 final_bank, seq_bank, seq_pattern],
+                }, f, indent=1)
+            print(f"golden     : {a.golden}")
         label = "M6d run (via-key)" if a.via_key else "M6c run"
         print(f"{label:11s}:", "PASS (ran to target)" if ok else "FAIL (stopped short)")
         return 0 if ok else 1

--- a/tools/ot_emu/machine.cpp
+++ b/tools/ot_emu/machine.cpp
@@ -59,6 +59,28 @@ namespace ot
 		// Measured by route A (emu_bringup), kept identical here.
 		override32(0xfc0c4000, 0x16000000);
 
+		// ✅ THE DSP HOST PORT AS ROUTE A FAKES IT -- and without it the frame
+		// handler never returns. Route A carries exactly two replies in its
+		// EXTRA_OVERRIDES (`emu_rtos.attach`, "the DSP host port as M5 faked
+		// it"), and both are stand-ins for the DSP that milestone O8 will put
+		// behind this window:
+		//
+		//   0x20000004 reads 0x0000. The frame handler at 0x4000ab1a writes
+		//   140 there and then polls `movew 0x20000004,%d0 / tstb %d0 / blts`
+		//   -- it waits for BIT 7 OF THE LOW BYTE TO CLEAR, the DSP's
+		//   handshake. An unmodelled window answers all-ones, the bit never
+		//   clears, and the handler spins there forever. ✅ Measured 8 Sep
+		//   2026 (O6): the port took exactly ONE frame interrupt, entered
+		//   0x4000aad0, and burned 352 M instructions in that three-
+		//   instruction loop -- 0 eDMA transfers, 0 ticks, 0 trigs. It reads
+		//   as "the frame model is wrong"; it is a missing peripheral reply.
+		//
+		//   0x2000001c is the ping index, read one instruction earlier at
+		//   0x4000aafa; route A toggles it 0/1 on every read.
+		m_overrides[0x20000004] = 0x00;
+		m_overrides[0x20000005] = 0x00;
+		setOverrideFn(0x2000001c, [ping = uint32_t(0)]() mutable { return ping ^= 1; });
+
 		// SR BEFORE A7: writing the status register swaps the supervisor and
 		// user stack banks, so setting A7 first puts the reset stack in the
 		// bank the machine is about to leave. Route A's lesson, and it fails
@@ -118,6 +140,29 @@ namespace ot
 			{
 				if(!_create)
 					return nullptr;
+				if(m_autoPages.size() >= m_autoMapLimit)
+				{
+					// Stop the machine rather than the process. `step()`
+					// reports `m_illegal`, so the run ends with a reason and
+					// the whole report -- counts, PCs, spans -- still prints.
+					if(!m_illegal)
+					{
+						uint32_t worst = 0; uint64_t n = 0;
+						for(const auto& [pcv, cnt] : m_unmappedPcs)
+							if(cnt > n) { n = cnt; worst = pcv; }
+						char msg[192];
+						std::snprintf(msg, sizeof msg,
+							"auto-map limit: %llu pages grown (%llu KB); the address is %#x "
+							"and the busiest unmapped-access pc is %#x x%llu",
+							static_cast<unsigned long long>(m_autoPages.size()),
+							static_cast<unsigned long long>(m_autoPages.size() * 4),
+							_addr, worst, static_cast<unsigned long long>(n));
+						m_why = msg;
+						m_illegal = true;
+					}
+					m_autoScrap.assign(g_autoPageSize, 0);
+					return m_autoScrap.data() + (_addr & (g_autoPageSize - 1));
+				}
 				it = m_autoPages.emplace(page, std::vector<uint8_t>(g_autoPageSize, 0)).first;
 			}
 			m_lastAutoPage = page;
@@ -255,24 +300,54 @@ namespace ot
 		return 0xffff;
 	}
 
+	// A write the region model cannot honour. It cannot happen if `find` is
+	// right -- which is the point: without this the emulator DIES inside
+	// Musashi's opcode handler with a bare SIGSEGV and no report at all, and
+	// three runs were spent on that (O6, 8 Sep 2026). Stopping the machine
+	// keeps the PC, the address and the whole report.
+	void Machine::badWrite(const char* _what, const uint32_t _addr, const uint8_t _size)
+	{
+		if(m_illegal)
+			return;
+		char msg[192];
+		std::snprintf(msg, sizeof msg, "%s: %u-byte write to %#x at pc %#x could not be placed",
+			_what, _size, _addr, currentPc());
+		m_why = msg;
+		m_illegal = true;
+	}
+
 	void Machine::write8(const uint32_t _addr, const uint8_t _val)
 	{
 		++m_writes;
+		if(!m_writeWatches.empty())
+			noteWatchedWrite(_addr, 1, _val);
 		if(isPeripheral(_addr))
 			return peripheralWrite(_addr, 1, _val);
 		if(auto* const r = find(_addr, 1))
-			r->data[_addr - r->base] = _val;
+		{
+			const auto o = _addr - r->base;
+			if(o >= r->data.size())
+				return badWrite("region", _addr, 1);
+			r->data[o] = _val;
+		}
 		else
 		{
 			noteUnmapped('w', _addr, 1, _val);
 			if(m_autoMap)
-				*autoByte(_addr, true) = _val;
+			{
+				if(auto* const b = autoByte(_addr, true))
+					*b = _val;
+				else
+					badWrite("auto-map", _addr, 1);
+			}
 		}
 	}
 
 	void Machine::write16(const uint32_t _addr, const uint16_t _val)
 	{
 		++m_writes;
+		if(!m_writeWatches.empty())
+			noteWatchedWrite(_addr, 2, _val);
 		if(isPeripheral(_addr))
 			return peripheralWrite(_addr, 2, _val);
 		if(auto* const r = find(_addr, 2))
@@ -319,6 +394,8 @@ namespace ot
 	void Machine::write32(const uint32_t _addr, const uint32_t _val)
 	{
 		++m_writes;
+		if(!m_writeWatches.empty())
+			noteWatchedWrite(_addr, 4, _val);
 		if(isPeripheral(_addr))
 			return peripheralWrite(_addr, 4, _val);
 		if(auto* const r = find(_addr, 4))
@@ -374,6 +451,23 @@ namespace ot
 	{
 		write16(_addr, static_cast<uint16_t>(_val >> 16));
 		write16(_addr + 2, static_cast<uint16_t>(_val));
+	}
+
+	void Machine::addWriteWatch(const uint32_t _begin, const uint32_t _end, WriteWatch _cb)
+	{
+		m_writeWatches.push_back({_begin, _end, std::move(_cb)});
+	}
+
+	void Machine::noteWatchedWrite(const uint32_t _addr, const uint8_t _size, const uint32_t _val)
+	{
+		for(const auto& w : m_writeWatches)
+			if(_addr + _size > w.begin && _addr <= w.end)
+				w.cb(_addr, _size, _val, currentPc());
+	}
+
+	uint32_t Machine::currentPc() const
+	{
+		return m68k_get_reg(const_cast<void*>(static_cast<const void*>(getCpuState())), M68K_REG_PPC);
 	}
 
 	uint32_t Machine::pc() const

--- a/tools/ot_emu/machine.h
+++ b/tools/ot_emu/machine.h
@@ -54,7 +54,17 @@ namespace ot
 
 		bool contains(const uint32_t _a, const uint32_t _size) const
 		{
-			return _a >= base && (_a - base) + _size <= data.size();
+			// ⚠️ `(_a - base) + _size <= data.size()` OVERFLOWS. With the
+			// region at 0x00000000, an access at 0xffffffff gives offset
+			// 0xffffffff and 0xffffffff + 1 == 0, so the region claimed the
+			// address and the write went 4 GB past its buffer. ✅ Measured
+			// 8 Sep 2026 (O6): the frame handler's `moveb %d0,%a0@-` with a0
+			// = 0 writes 0xffffffff, and the emulator died there with a bare
+			// SIGSEGV inside Musashi. Subtract instead of add.
+			if(_a < base)
+				return false;
+			const auto off = _a - base;
+			return off < data.size() && data.size() - off >= _size;
 		}
 	};
 
@@ -184,6 +194,21 @@ namespace ot
 		uint32_t peek32(uint32_t _addr);
 		void     poke32(uint32_t _addr, uint32_t _val);
 
+		// Route A's `watch_mem`: every write into a small range, with the PC
+		// of the instruction making it. Used by the M6c trig log (the
+		// per-track live nibble at 0x46104d15) and by the load's own watch on
+		// PART_PTR, which is how the engine's BANK= parse is told apart from
+		// every other writer of that word.
+		//
+		// ⚠️ THE PC IS `M68K_REG_PPC`, NOT `pc()`. Musashi's PC is the fetch
+		// pointer -- already past the instruction and its extension words by
+		// the time the write executes -- so a watch that reported `pc()` would
+		// name the NEXT instruction, and route A's site addresses would never
+		// match. PPC is the address of the instruction being executed.
+		using WriteWatch = std::function<void(uint32_t _addr, uint8_t _size, uint32_t _val, uint32_t _pc)>;
+		void addWriteWatch(uint32_t _begin, uint32_t _end, WriteWatch _cb);
+		uint32_t currentPc() const;
+
 		// Map a span of plain memory after construction. Route A's `install`
 		// adds two of these over the boot map (`Rtos::install`), and an
 		// overlap with something already mapped is IGNORED, not an error --
@@ -223,6 +248,17 @@ namespace ot
 		// behaviour; `setAutoMap(false)` restores the all-ones stub for
 		// diagnosis, and then this counter is the work list again.
 		void setAutoMap(bool _on) { m_autoMap = _on; }
+		// ⚠️ A RUNAWAY AUTO-MAP IS A BUG, AND WITHOUT A CEILING IT PRESENTS AS
+		// A CRASH IN THE EMULATOR RATHER THAN AS A FINDING ABOUT THE FIRMWARE.
+		// Measured 8 Sep 2026 (O6): a `moveb %d0,%a0@-` loop walking down
+		// through unmapped memory grew a 4 KB page per 4 KB of address space
+		// until the process died -- SIGSEGV bare, SIGBUS under ASan, no report
+		// printed either way, because the port's own stdout never flushed. The
+		// limit turns that into "stopped: auto-map limit, N pages, top pc X",
+		// which names the loop. Route A's own growth on the golden path is 4
+		// spans / ~200 MB before the card maps them explicitly, so the default
+		// is well clear of anything faithful.
+		void setAutoMapLimit(uint64_t _pages) { m_autoMapLimit = _pages; }
 		uint64_t autoMappedPages() const { return m_autoPages.size(); }
 
 		struct Unmapped { char kind; uint32_t pc, addr; uint8_t size; uint32_t val; };
@@ -279,6 +315,9 @@ namespace ot
 		std::vector<Access> m_periphTrace;
 		bool m_periphTraceOn = false;
 		void noteUnmapped(char _kind, uint32_t _addr, uint8_t _size, uint32_t _val);
+		struct Watch { uint32_t begin, end; WriteWatch cb; };
+		std::vector<Watch> m_writeWatches;
+		void noteWatchedWrite(uint32_t _addr, uint8_t _size, uint32_t _val);
 		std::vector<Unmapped> m_unmapped;
 		uint64_t m_unmappedCount = 0, m_unmappedReads = 0;
 		std::unordered_map<uint32_t, uint64_t> m_unmappedPages, m_unmappedPcs, m_unmappedReadPcs;
@@ -291,6 +330,9 @@ namespace ot
 		uint32_t m_lastAutoPage = ~0u;			// a one-entry cache: these loops are sequential
 		std::vector<uint8_t>* m_lastAutoData = nullptr;
 		uint8_t* autoByte(uint32_t _addr, bool _create);
+		void badWrite(const char* _what, uint32_t _addr, uint8_t _size);
+		uint64_t m_autoMapLimit = 65536;		// 4 KB pages: 256 MB
+		std::vector<uint8_t> m_autoScrap;		// where a write goes once the limit is hit
 		std::function<void(Machine&, uint32_t)> m_step;
 		AckHook m_ack;
 		uint64_t m_instructions = 0;

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -38,6 +38,11 @@ namespace
 
 int main(int _argc, char** _argv)
 {
+	// ⚠️ LINE-BUFFERED, ALWAYS. Redirected to a file, printf is block-buffered,
+	// so a run that dies mid-way writes NOTHING -- the O6 auto-map runaway
+	// crashed three times before anyone saw a line of the report that would
+	// have named it. Same family as the panic printer O7 could not finish.
+	std::setvbuf(stdout, nullptr, _IOLBF, 0);
 	std::string image = "out/raw/section_3_MAIN_OS.bin";
 	uint64_t maxInstructions = 50'000'000;	// route A's own budget
 	bool showPeripherals = false;
@@ -56,6 +61,13 @@ int main(int _argc, char** _argv)
 	double runMs = 1000.0;
 	double ips = 3990.0;
 	bool frame = false;			// the DSP frame clock; off by default, as in route A
+	bool sequencer = false;		// M6c: load, start the transport, run the sequencer for real
+	int frames = 400;			// with --sequencer: DSP frames to run after the transport start
+	int pokeTrig = 0;			// with --sequencer: set a trig on track 1 at this step (1-64)
+	bool internalClock = false;	// with --sequencer: clear CLOCK RECEIVE
+	int bankOverride = -1;		// with --sequencer: switch to this bank (default: the file's saved bank)
+	std::string m6cGolden;		// the M6c facts as JSON, for tools/ot_emu/oracle.py
+	std::string watchMem;		// ADDR,LEN -- log every write into that range (route A's own flag)
 
 	for(int i = 1; i < _argc; ++i)
 	{
@@ -79,6 +91,14 @@ int main(int _argc, char** _argv)
 		else if(a == "--ms" && i + 1 < _argc)	runMs = std::atof(_argv[++i]);
 		else if(a == "--ips" && i + 1 < _argc)	ips = std::atof(_argv[++i]);
 		else if(a == "--frame")					frame = true;
+		else if(a == "--sequencer")				sequencer = true;
+		// --sequencer needs a mounted card and a loaded project: it implies both.
+		else if(a == "--frames" && i + 1 < _argc)	frames = std::atoi(_argv[++i]);
+		else if(a == "--poke-trig" && i + 1 < _argc)	pokeTrig = std::atoi(_argv[++i]);
+		else if(a == "--internal-clock")			internalClock = true;
+		else if(a == "--bank" && i + 1 < _argc)		bankOverride = std::atoi(_argv[++i]);
+		else if(a == "--m6c-golden" && i + 1 < _argc)	m6cGolden = _argv[++i];
+		else if(a == "--watch-mem" && i + 1 < _argc)	watchMem = _argv[++i];
 		else
 		{
 			std::printf("usage: ot_emu [--image FILE] [--max N] [--periph] [--profile]\n"
@@ -86,6 +106,9 @@ int main(int _argc, char** _argv)
 			return 2;
 		}
 	}
+
+	if(sequencer)
+		mount = true;			// M6c needs the card mounted and the project loaded
 
 	const auto img = readFile(image);
 	if(img.empty())
@@ -147,6 +170,15 @@ int main(int _argc, char** _argv)
 			std::printf("card       : %s, %u sectors\n", cardImage.c_str(), card->totalSectors());
 		}
 		rtos.install();
+		if(!watchMem.empty())
+		{
+			const auto comma = watchMem.find(',');
+			const auto wa = static_cast<uint32_t>(std::strtoul(watchMem.c_str(), nullptr, 0));
+			const auto wl = comma == std::string::npos ? 4u
+				: static_cast<uint32_t>(std::strtoul(watchMem.c_str() + comma + 1, nullptr, 0));
+			rtos.watchMem(wa, wl);
+			std::printf("watch-mem  : %#x..%#x\n", wa, wa + wl - 1);
+		}
 		const auto rs = rtos.run(runMs);
 		static const char* const g_rtosNames[] = {"GATE", "TIME", "FAULT", "ILLEGAL"};
 		std::printf("rtos       : %s -- %s\n", g_rtosNames[static_cast<int>(rs)], rtos.why().c_str());
@@ -169,18 +201,29 @@ int main(int _argc, char** _argv)
 		// before the request can be posted, and then run on so SYS can do it.
 		if(mount && card)
 		{
+			ot::Rtos::LoadResult load;
 			{
 				if(pcRing)
 					rtos.armPcRing(4096, pcRing);
 				const auto forces0 = rtos.forces();
 				const auto disp0 = rtos.dispatches().size();
 				m.setPeriphTrace(!periphTrace.empty());
-				const auto r = rtos.loadProjectLive(setName, projectName, loadMs);
+				load = rtos.loadProjectLive(setName, projectName, loadMs);
+				const auto& r = load;
 				m.setPeriphTrace(false);
 				std::printf("             card ready: %#x, LOAD PROJECT posted: %s, "
 					"PART_PTR: %#x, %.1f ms emulated%s%s\n",
 					r.ready, r.posted ? "yes" : "no", r.partPtr, r.ms,
 					r.postWhy.empty() ? "" : " | post: ", r.postWhy.c_str());
+				// ⚠️ PART_PTR reads bank A's blob base BEFORE any load, so it
+				// is not on its own evidence that a project loaded (O7). The
+				// bank the engine PARSED is: it comes from the write the
+				// BANK= parse makes, and it is the number route A reports.
+				std::printf("             saved_bank: %d, final bank: %u%s\n",
+					r.savedBank, r.finalBank,
+					r.savedBank >= 0 && r.finalBank != static_cast<uint32_t>(r.savedBank)
+						? "  (sys applied the engine's own reset-time 'select bank 0' "
+						  "after the BANK= parse -- RTOS_FORK.md section 7)" : "");
 				{
 					static const char* const g_loadStop[] = {"GATE", "TIME", "FAULT", "ILLEGAL"};
 					std::printf("             load run ended: %s%s%s\n",
@@ -292,6 +335,133 @@ int main(int _argc, char** _argv)
 			for(size_t i = 0; i < card->log().size() && i < 12; ++i)
 				std::printf("             %-16s lba %-8u count %u\n", card->log()[i].what.c_str(),
 					card->log()[i].lba, card->log()[i].count);
+
+			// -- M6c: the sequencer, for real (milestone O6) -----------------
+			// Route A's `--sequencer` branch, step for step. The order is
+			// load-bearing and every step of it is compensation or detour that
+			// route A documents: the bank switch and the sequencer re-select
+			// compensate for an emulator ordering defect (the unit comes up on
+			// the saved bank and plays it), and the transport start is the
+			// "M5 detour" RTOS_FORK.md §5 allows for M6c.
+			if(sequencer)
+			{
+				const int bank = bankOverride >= 0 ? bankOverride : load.savedBank;
+				uint32_t finalBank = load.finalBank;
+				if(bank >= 0 && finalBank != static_cast<uint32_t>(bank))
+					finalBank = rtos.selectBankLive(static_cast<uint32_t>(bank));
+				const auto pattern = m.peek32(ot::g_curPattern) >> 24;
+				const auto seq = rtos.seqSelectLive(finalBank, pattern);
+				if(internalClock)
+					std::printf("midi byte  : %#04x -> clock receive cleared\n", rtos.internalClock());
+				// The frame clock and the exact instruction clock come on
+				// HERE, after the boot and the load, exactly as route A turns
+				// them on: on hardware the frame exchange runs from boot, and
+				// nothing the trig test reads depends on it having done so.
+				rtos.setFrame(true);
+				if(!rtos.startTransportLive())
+					std::printf("transport  : FAILED -- %s\n", rtos.why().c_str());
+				if(pokeTrig)
+					std::printf("poke trig  : track 1 step %d -> mask byte 7 = %#04x\n",
+						pokeTrig, rtos.pokeTrig(static_cast<uint32_t>(pokeTrig)));
+				rtos.installTrigLog();
+				// Frame 0 = the first frame delivered after the transport
+				// start returned, which is what the cold tool calls frame 0:
+				// the two reports compare directly.
+				const auto frame0 = rtos.frameCount() + 1;
+				const auto ticks0 = rtos.ticks();
+				const auto ackTail = rtos.acks().size();
+				if(pcRing)
+					rtos.armPcRingNow(pcRing);
+				const auto target = frame0 + static_cast<uint64_t>(frames);
+				const auto rs2 = rtos.runUntil(frames * ot::g_framePeriod / ot::g_sampleHz * 1000.0 * 5 + 2000.0,
+					[&] { return rtos.frameCount() >= target; });
+				static const char* const g_seqStop[] = {"REACHED", "TIME", "FAULT", "ILLEGAL"};
+				std::printf("sequencer  : playing bank %u pattern %u "
+					"(re-selected through the load's own last step)\n", seq.first, seq.second);
+				std::printf("frames run : %llu since transport start (target %d), run ended %s%s%s\n",
+					static_cast<unsigned long long>(rtos.frameCount() - frame0), frames,
+					g_seqStop[static_cast<int>(rs2)],
+					rs2 == ot::Rtos::Stop::Gate ? "" : " -- ", rs2 == ot::Rtos::Stop::Gate ? "" : rtos.why().c_str());
+				// ⚠️ THREE CAUSES, ONE SYMPTOM. A frame that never arrives is a
+				// masked source, a source installed at level 0, or a line that
+				// is not asserting -- and the eDMA count says whether the
+				// handler that did run got as far as kicking its chain.
+				std::printf("             INTC0 src 1 (frame): masked %d, icr %u, asserting %d, latch %d; "
+					"src 32 (tick): icr %u\n",
+					rtos.intc0().masked(1), rtos.intc0().icr(1), rtos.intc0().assertedSource(1),
+					rtos.framePending(), rtos.intc0().icr(32));
+				{
+					std::map<std::pair<uint32_t, uint32_t>, uint64_t> byVec;
+					const auto& ks = rtos.acks();
+					for(size_t i = ackTail; i < ks.size(); ++i)
+						++byVec[{ks[i].vector, ks[i].slot}];
+					std::printf("             vectors acknowledged since the transport start (%zu):",
+						ks.size() - ackTail);
+					for(const auto& [key, cnt] : byVec)
+						std::printf(" v%#x->%#x x%llu", key.first, key.second, static_cast<unsigned long long>(cnt));
+					std::printf("\n");
+					for(size_t i = ks.size() > 8 ? ks.size() - 8 : 0; i < ks.size(); ++i)
+						std::printf("               [%9.1f] v%#04x lvl %u in %-10s at pc %#x -> slot %#x\n",
+							ks[i].sample, ks[i].vector, ks[i].level, ot::taskName(ks[i].tcb), ks[i].pc, ks[i].slot);
+				}
+				std::printf("             ticks %llu, eDMA transfers %llu\n",
+					static_cast<unsigned long long>(rtos.ticks() - ticks0),
+					static_cast<unsigned long long>(rtos.edmaStarted()));
+				if(pcRing && rtos.pcRingArmed())
+				{
+					const auto& ring = rtos.pcRing();
+					const auto pos = rtos.pcRingPos();
+					const size_t n = std::min(ring.size(), pos);
+					std::printf("             pc ring (last %zu of %zu instructions since the transport start):\n",
+						n, pos);
+					uint32_t last = 0; uint64_t runlen = 0;
+					for(size_t i = 0; i < n; ++i)
+					{
+						const auto v = ring[(pos - n + i) % ring.size()];
+						if(v == last) { ++runlen; continue; }
+						if(runlen > 1) std::printf(" (x%llu)", static_cast<unsigned long long>(runlen));
+						if(i) std::printf("\n");
+						std::printf("               %#010x", v);
+						last = v; runlen = 1;
+					}
+					if(runlen > 1) std::printf(" (x%llu)", static_cast<unsigned long long>(runlen));
+					std::printf("\n");
+				}
+				std::printf("FW_LIVE_NIBBLE (%#x) writes (%zu), frames since transport start:\n",
+					ot::g_fwLiveNibble, rtos.liveNibbleLog().size());
+				for(const auto& w : rtos.liveNibbleLog())
+					std::printf("   frame %5lld track %u byte %#04x  nibble %x  flags %#04x  at pc %#x\n",
+						static_cast<long long>(w.frame - frame0), w.index, w.value,
+						w.value & 0xf, w.value & 0xf0, w.pc);
+				std::printf("FW_TRIG_WORDS (%#x) nonzero writes (%zu)\n",
+					ot::g_fwTrigWords, rtos.trigWordsLog().size());
+				if(!m6cGolden.empty())
+				{
+					ot::Rtos::M6c f;
+					f.frame0 = frame0;
+					f.ticks0 = ticks0;
+					f.ticks = rtos.ticks();
+					f.frames = rtos.frameCount() - frame0;
+					f.savedBank = load.savedBank;
+					f.finalBank = finalBank;
+					f.seqBank = seq.first;
+					f.seqPattern = seq.second;
+					rtos.writeM6cJson(m6cGolden, f);
+					std::printf("m6c golden : %s\n", m6cGolden.c_str());
+				}
+			}
+		}
+
+		if(!watchMem.empty())
+		{
+			// ⚠️ PRINT THEM ALL (capped only against a flood). A watch that
+			// hides its hits is the silent-instrument trap route A records
+			// twice over: an address that never fired and one that fired every
+			// frame have to look different.
+			std::printf("watch-mem  : %zu write(s)\n", rtos.memWrites().size());
+			for(const auto& w : rtos.memWrites())
+				std::printf("   [%10.1f] [%#x] <- %#x (%u) at pc %#x in %s\n",
+					w.sample, w.addr, w.val, w.size, w.pc, ot::taskName(w.tcb));
 		}
 
 		if(!serialOut.empty())

--- a/tools/ot_emu/oracle.py
+++ b/tools/ot_emu/oracle.py
@@ -49,8 +49,31 @@ What it checks, in the order a port reaches them:
                  because the transmit ring drains in bursts (milestone O5)
   gate_ms        when the gate passed
 
+And, from the M6c goldens (milestone O6 -- a different configuration, so a
+SEPARATE pair of files, written by `emu_rtos.py --sequencer --golden` and
+`ot_emu --sequencer --m6c-golden`):
+
+    .venv/bin/python3 tools/emu_rtos.py --project out/_testproj --set OCTABAM --name RIG \
+        --sequencer --internal-clock --poke-trig 2 --frames 400 --ms 20000 \
+        --golden out/oracle/m6c.json
+    ./out/emu/ot_emu --image out/raw/section_3_MAIN_OS.bin --card out/o6_card.img \
+        --set OCTABAM --project RIG --sequencer --internal-clock --poke-trig 2 \
+        --frames 400 --load-ms 20000 --m6c-golden out/oracle/port_m6c.json
+    python3 tools/ot_emu/oracle.py out/oracle/m6c.json out/oracle/port_m6c.json
+
+  m6c_trig       every write into the per-track live nibble (0x46104d15), as
+                 (frames since the transport start, track, byte) -- the trig
+                 itself. Compared STRICTLY: unlike the dispatch PCs and the
+                 serial count, none of the M6c fields tracks the ips knob.
+  m6c_trig_words the per-track trig words (0x46104d26); empty in every run so far
+  m6c_ticks      sequencer ticks (vector 0x60) since the transport start
+  m6c_frames     frames delivered since the transport start
+  m6c_bank       [saved bank, final bank, sequencer bank, sequencer pattern]
+
 A field the port has not produced yet is reported as MISSING, not as a
-failure: the port's JSON grows milestone by milestone.
+failure: the port's JSON grows milestone by milestone. A field the ORACLE
+does not carry is skipped entirely -- the two goldens measure different
+configurations and each carries only its own.
 """
 import json
 import sys
@@ -71,6 +94,13 @@ def main():
     compared = []
 
     def field(name):
+        # ⚠️ A FIELD THE ORACLE DOES NOT CARRY IS NOT THIS RUN'S BUSINESS.
+        # The M6a golden and the M6c golden are different configurations
+        # measuring different things, and each carries only its own fields;
+        # without this the M6c diff would report every M6a field as missing
+        # from the port and take credit for none of what it did compare.
+        if name not in a:
+            return None
         if name not in b:
             missing.append(name)
             return None
@@ -187,6 +217,33 @@ def main():
             if da["pc"] != db["pc"]:
                 notes.append(f"dispatches[{i}]: same task at the same time, resumed at "
                              f"{da['pc']:#x} (oracle) vs {db['pc']:#x} (port)")
+
+    # -- M6c, the sequencer's fidelity (milestone O6) ------------------------
+    # Every one of these is compared STRICTLY. Unlike the dispatch PCs and the
+    # serial count, none of them tracks the instruction-budget knob: a trig
+    # either fires on the frame the other emulator fires it on or it does not,
+    # and the tick count is a property of the tempo and the frame period.
+    if (v := field("m6c_trig")) is not None:
+        ta = [tuple(x) for x in a["m6c_trig"]]
+        tb = [tuple(x) for x in v]
+        if ta != tb:
+            problems.append("m6c_trig: the live-nibble log differs\n"
+                            f"    oracle {[(f, t, hex(x)) for f, t, x in ta]}\n"
+                            f"    port   {[(f, t, hex(x)) for f, t, x in tb]}")
+
+    if (v := field("m6c_trig_words")) is not None:
+        if [tuple(x) for x in a["m6c_trig_words"]] != [tuple(x) for x in v]:
+            problems.append(f"m6c_trig_words: oracle {a['m6c_trig_words']}, port {v}")
+
+    if (v := field("m6c_ticks")) is not None and v != a["m6c_ticks"]:
+        problems.append(f"m6c_ticks: oracle {a['m6c_ticks']}, port {v}")
+
+    if (v := field("m6c_frames")) is not None and v != a["m6c_frames"]:
+        problems.append(f"m6c_frames: oracle {a['m6c_frames']} frames since the transport start, port {v}")
+
+    if (v := field("m6c_bank")) is not None and list(v) != list(a["m6c_bank"]):
+        problems.append(f"m6c_bank: [saved, final, seq bank, seq pattern] "
+                        f"oracle {a['m6c_bank']}, port {list(v)}")
 
     # ⚠️ COUNT ONLY WHAT WAS ACTUALLY COMPARED. The summary used to say
     # "N field(s) agree" where N was every field in the golden, which quietly

--- a/tools/ot_emu/periph.h
+++ b/tools/ot_emu/periph.h
@@ -249,6 +249,14 @@ namespace ot
 
 		uint32_t vectorBase() const { return m_vectorBase; }
 
+		// Diagnostics. "The interrupt never arrived" has three different
+		// causes -- the source is masked, it is installed at level 0, or it is
+		// not asserting at all -- and only reading all three tells them apart.
+		// The frame clock cost a whole measurement to that ambiguity.
+		bool masked(uint32_t _source) const { return (m_imr >> _source) & 1; }
+		uint8_t icr(uint32_t _source) const { return m_icr[_source]; }
+		bool assertedSource(uint32_t _source) const { return (asserted() >> _source) & 1; }
+
 		uint32_t read(uint32_t _off, uint32_t _size) const;
 		void write(uint32_t _off, uint32_t _size, uint32_t _val);
 

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -356,6 +356,16 @@ namespace ot
 
 	Rtos::Stop Rtos::run(const double _ms, const bool _untilGate)
 	{
+		return runInternal(_ms, _untilGate, nullptr);
+	}
+
+	Rtos::Stop Rtos::runUntil(const double _ms, const std::function<bool()>& _stop)
+	{
+		return runInternal(_ms, false, &_stop);
+	}
+
+	Rtos::Stop Rtos::runInternal(const double _ms, const bool _untilGate, const std::function<bool()>* _stop)
+	{
 		if(!m_installed)
 		{
 			if(m_why.empty())
@@ -380,6 +390,11 @@ namespace ot
 					m_why = "the M6a gate passed";
 					return Stop::Gate;
 				}
+			}
+			if(_stop && (*_stop)())
+			{
+				m_why = "the caller's condition came true";
+				return Stop::Gate;
 			}
 
 			const auto pc = m_machine.pc();
@@ -605,6 +620,20 @@ namespace ot
 		if(runToMainSpin() != Stop::Gate)
 			return out;
 		setNames(_set, _project);
+		// Route A's own watch: the engine's BANK= parse is the write to
+		// PART_PTR made at 0x40087d44, and it is the ONLY thing that tells
+		// the saved bank apart from every other writer of that word (`sys`'s
+		// select-bank case writes it too, from a different PC).
+		if(!m_partPtrWatched)
+		{
+			m_partPtrWatched = true;
+			m_machine.addWriteWatch(g_partPtr, g_partPtr + 3,
+				[this](uint32_t, uint8_t, const uint32_t _val, const uint32_t _pc)
+				{
+					if(_pc == g_engineBankWrite)
+						m_savedBank = static_cast<int>((_val - g_bankBlob) / g_bankStride);
+				});
+		}
 		uint32_t d0 = 0;
 		// A generous budget: with the card live the borrowed call is preempted
 		// constantly, so the step count is dominated by the OTHER tasks
@@ -616,8 +645,123 @@ namespace ot
 		if(out.stop != Stop::Time)
 			out.stopWhy = m_why;
 		out.partPtr = m_machine.peek32(g_partPtr);
+		out.savedBank = m_savedBank;
+		out.finalBank = m_machine.read8(g_curBank);
 		out.ms = (m_sample - start) / g_sampleHz * 1000.0;
 		return out;
+	}
+
+	// -- M6c: the sequencer under the real scheduler -------------------------
+	void Rtos::setFrame(const bool _on)
+	{
+		m_frame = _on;
+		// Route A's `rt.next_frame = rt.sample + FRAME_PERIOD`: the first
+		// boundary is one period from HERE, not from a clock that has been
+		// running since the boot. Route A also switches to its exact
+		// instruction clock at this point; this port has counted executed
+		// instructions all along, so there is nothing to switch.
+		if(_on)
+			m_nextFrame = m_sample + g_framePeriod;
+	}
+
+	uint8_t Rtos::selectBankLive(const uint32_t _bank, const double _ms)
+	{
+		if(runToMainSpin() != Stop::Gate)
+			return m_machine.read8(g_curBank);
+		// msg[0] = the select-bank opcode, msg[1] = the bank.
+		m_machine.poke32(g_sysMsgScratch,
+			(g_selectBankCase << 24) | ((_bank & 0x0f) << 16));
+		uint32_t d0 = 0;
+		if(!postMessage(g_sysQueue, g_sysMsgScratch, d0))
+			return m_machine.read8(g_curBank);
+		const double end = m_sample + _ms * g_sampleHz / 1000.0;
+		while(m_sample < end && m_machine.read8(g_curBank) != (_bank & 0xff))
+			if(!stepOnce())
+				break;
+		return m_machine.read8(g_curBank);
+	}
+
+	std::pair<uint8_t, uint8_t> Rtos::seqSelectLive(const uint32_t _bank, const uint32_t _pattern)
+	{
+		if(runToMainSpin() == Stop::Gate)
+		{
+			uint32_t d0 = 0;
+			callAsMain(g_fwSeqSelect, {_bank, _pattern}, d0);
+		}
+		return {m_machine.read8(g_fwSeqBank), m_machine.read8(g_fwSeqPattern)};
+	}
+
+	uint8_t Rtos::internalClock()
+	{
+		const auto midi = m_machine.read8(g_fwMidiSettings);
+		m_machine.write8(g_fwMidiSettings, static_cast<uint8_t>(midi & ~1u));
+		return midi;
+	}
+
+	bool Rtos::startTransportLive()
+	{
+		if(runToMainSpin() != Stop::Gate)
+			return false;
+		uint32_t d0 = 0;
+		if(!callAsMain(g_fwTransport, {0}, d0))
+			return false;
+		for(uint32_t t = 0; t < 8; ++t)
+		{
+			if(runToMainSpin() != Stop::Gate)
+				return false;
+			if(!callAsMain(g_fwStartTrack, {t}, d0))
+				return false;
+		}
+		return true;
+	}
+
+	uint8_t Rtos::pokeTrig(const uint32_t _step)
+	{
+		const auto blob = m_machine.peek32(g_partPtr);
+		const auto at = blob + 7 - (_step - 1) / 8;
+		const auto v = static_cast<uint8_t>(m_machine.read8(at) | (1u << ((_step - 1) % 8)));
+		m_machine.write8(at, v);
+		return v;
+	}
+
+	void Rtos::watchMem(const uint32_t _addr, const uint32_t _len)
+	{
+		m_machine.addWriteWatch(_addr, _addr + _len - 1,
+			[this](const uint32_t _a, const uint8_t _size, const uint32_t _val, const uint32_t _pc)
+			{
+				if(m_memWrites.size() < 20000)
+					m_memWrites.push_back({m_sample, curTcb(), _pc, _a, _val, _size});
+			});
+	}
+
+	void Rtos::installTrigLog()
+	{
+		if(m_trigLogInstalled)
+			return;
+		m_trigLogInstalled = true;
+		m_machine.addWriteWatch(g_fwLiveNibble, g_fwLiveNibble + 7,
+			[this](const uint32_t _addr, uint8_t, const uint32_t _val, const uint32_t _pc)
+			{
+				const auto v = _val & 0xff;
+				if(v)
+					m_liveNibble.push_back({m_frameCount, _addr - g_fwLiveNibble, v, _pc});
+			});
+		m_machine.addWriteWatch(g_fwTrigWords, g_fwTrigWords + 15,
+			[this](const uint32_t _addr, uint8_t, const uint32_t _val, const uint32_t _pc)
+			{
+				const auto v = _val & 0xffff;
+				if(v)
+					m_trigWords.push_back({m_frameCount, (_addr - g_fwTrigWords) / 2, v, _pc});
+			});
+	}
+
+	uint64_t Rtos::ticks() const
+	{
+		uint64_t n = 0;
+		for(const auto& a : m_acks)
+			if(a.vector == g_tickVector)
+				++n;
+		return n;
 	}
 
 	bool Rtos::requestCardMount()
@@ -699,6 +843,30 @@ namespace ot
 			}
 			return out;
 		}
+	}
+
+	void Rtos::writeM6cJson(const std::string& _path, const M6c& _m) const
+	{
+		std::ofstream f(_path);
+		f << "{\n";
+		const auto log = [&f](const char* _name, const std::vector<TrigWrite>& _v, const uint64_t _frame0)
+		{
+			f << " \"" << _name << "\": [";
+			bool first = true;
+			for(const auto& w : _v)
+			{
+				f << (first ? "" : ", ") << "[" << static_cast<int64_t>(w.frame - _frame0)
+				  << ", " << w.index << ", " << w.value << "]";
+				first = false;
+			}
+			f << "],\n";
+		};
+		log("m6c_trig", m_liveNibble, _m.frame0);
+		log("m6c_trig_words", m_trigWords, _m.frame0);
+		f << " \"m6c_ticks\": " << (_m.ticks - _m.ticks0) << ",\n";
+		f << " \"m6c_frames\": " << _m.frames << ",\n";
+		f << " \"m6c_bank\": [" << _m.savedBank << ", " << _m.finalBank << ", "
+		  << _m.seqBank << ", " << _m.seqPattern << "]\n}\n";
 	}
 
 	void Rtos::writeGoldenJson(const std::string& _path) const

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -55,6 +56,33 @@ namespace ot
 	inline constexpr uint32_t g_projectName = 0x100f8378;	// current PROJECT folder
 	inline constexpr uint32_t g_postLoad    = 0x40023c7c;	// (name*) -> posts engine command 4
 	inline constexpr uint32_t g_partPtr     = 0x46c82456;	// null until a project loads
+
+	// -- M6c: the sequencer, from route A's own constants ------------------
+	// The bank blobs in RAM: PART_PTR = g_bankBlob + bank * g_bankStride,
+	// i.e. the CURRENT bank's data. 0x400e21e0 is bank A, 0x4017d520 bank B.
+	// ⚠️ PART_PTR reads the bank-A base BEFORE any load, so a non-null
+	// PART_PTR is not on its own evidence that a project loaded (O7).
+	inline constexpr uint32_t g_bankBlob        = 0x400e21e0;
+	inline constexpr uint32_t g_bankStride      = 635712;
+	inline constexpr uint32_t g_curBank         = 0x80000002;
+	inline constexpr uint32_t g_curPattern      = 0x80000004;
+	inline constexpr uint32_t g_engineBankWrite = 0x40087d44;	// LOAD PROJECT writes PART_PTR from BANK= here
+	inline constexpr uint32_t g_selectBankCase  = 21;			// sys table[20]: "select bank msg[1]"
+
+	inline constexpr uint32_t g_fwTransport   = 0x4009b964;	// (arg) transport start/stop; start posts to the UI queue
+	inline constexpr uint32_t g_fwStartTrack  = 0x4009b5c8;	// (track) promote a track to running
+	inline constexpr uint32_t g_fwSeqSelect   = 0x400a1030;	// sequencer select(bank, pattern): LOAD PROJECT's last step
+	inline constexpr uint32_t g_fwSeqBank     = 0x800065bd;	// the sequencer's own playing bank byte
+	inline constexpr uint32_t g_fwSeqPattern  = 0x800065be;	// ... and playing pattern
+	inline constexpr uint32_t g_fwMidiSettings= 0x80000028;	// project MIDI byte: bit 0 = CLOCK RECEIVE
+	inline constexpr uint32_t g_fwLiveNibble  = 0x46104d15;	// per-track byte a fired trig actually changes
+	inline constexpr uint32_t g_fwTrigWords   = 0x46104d26;	// per-track word Bryan named; zero in every run so far
+	// The sequencer tick: the frame handler's countdown expires and FORCES
+	// INTC0 source 32, whose vector is 0x60 -- and the source is never
+	// unmasked, because a forced request is not affected by the mask
+	// (MCF54455RM rev 5 §17.2.3, and RTOS_FORK.md §8.2). Counting the
+	// acknowledgements of that vector is counting ticks.
+	inline constexpr uint8_t  g_tickVector    = 0x60;
 
 	inline constexpr uint32_t g_intc0 = 0xfc048000, g_intc1 = 0xfc04c000;
 	inline constexpr uint32_t g_pit0  = 0xfc080000, g_pit1  = 0xfc084000;
@@ -103,6 +131,10 @@ namespace ot
 
 		enum class Stop { Gate, Time, Fault, Illegal };
 		Stop run(double _ms, bool _untilGate = true);
+		// The same loop -- idle skip included, which is what makes a frame
+		// run cheap -- stopping on a caller's condition instead of the gate.
+		// Returns Stop::Gate when the condition came true.
+		Stop runUntil(double _ms, const std::function<bool()>& _stop);
 
 		// Run until the PC is parked at main's spin -- what `callAsMain`
 		// needs before it can borrow the slot.
@@ -148,6 +180,67 @@ namespace ot
 		// nothing).
 		bool requestCardMount();
 
+		// -- M6c: the sequencer under the real scheduler ---------------------
+		// Turn the DSP frame clock on HERE, after the boot and the load, which
+		// is where route A's `--sequencer` turns it on -- not from boot.
+		// ✅ Route A cannot be run with it on from boot at all (a bare
+		// `Rtos(frame=True)` faults on unmapped memory before anything has
+		// primed its auto-map hook), so the from-boot form has no oracle.
+		void setFrame(bool _on);
+
+		// Switch the working bank through sys's own case -- the very message
+		// the engine's reset posts with bank 0 (RTOS_FORK.md §7): PART_PTR :=
+		// the bank's blob, the blob is copied into SRAM, the bank byte
+		// follows. Returns the bank byte.
+		uint8_t selectBankLive(uint32_t _bank, double _ms = 500.0);
+
+		// The sequencer's own bank/pattern select, the LOAD PROJECT handler's
+		// LAST step. It writes the sequencer's playing bank/pattern -- the
+		// bytes FW_START_TRACK and the step handler index the bank blob by.
+		// ⚠️ Route A needs this re-issued after the load: by the time the
+		// handler reaches its last step, `sys` has applied the engine's own
+		// reset-time "select bank 0" in the handler's real card waits, so the
+		// sequencer is left on bank A with an empty bank's pattern record.
+		// It is COMPENSATION for an emulator ordering defect, not firmware
+		// behaviour -- the unit comes up on the saved bank and plays it -- and
+		// it goes when the load's timing is made faithful.
+		std::pair<uint8_t, uint8_t> seqSelectLive(uint32_t _bank, uint32_t _pattern);
+
+		// Clear the project's CLOCK RECEIVE bit so the sequencer runs on its
+		// own clock. With it set -- as Sam's projects save it, the Rytm is
+		// master -- the frame handler takes the external-clock path and the
+		// countdown never moves: 400 frames, zero ticks, no trig.
+		uint8_t internalClock();
+
+		// Start the sequencer through the real tasks, the "M5 detour" §5
+		// allows for M6c: FW_TRANSPORT(0)'s start case only sets state and
+		// posts to the UI queue, and FW_START_TRACK(t) writes a per-track
+		// state byte directly. Neither has a wait primitive on its path, so
+		// both are safe under callAsMain.
+		bool startTransportLive();
+
+		// Set a trig on track 1 at `step` (1-64) in whichever bank PART_PTR
+		// currently names: byte 7 - (step-1)/8, bit (step-1)%8 -- the layout
+		// `ot_project.set_pattern_trig` writes on disk.
+		uint8_t pokeTrig(uint32_t _step);
+
+		// Watch the per-track live nibble and the trig words, keyed by this
+		// machine's own frame count -- route A's `install_trig_log`.
+		// Route A's `--watch-mem ADDR,LEN`: every write into a range, with the
+		// sample, the task, the PC and the value. The counterpart instrument
+		// to route A's, so a divergence can be diffed line for line instead of
+		// reasoned about.
+		struct MemWrite { double sample; uint32_t tcb, pc, addr, val; uint8_t size; };
+		void watchMem(uint32_t _addr, uint32_t _len);
+		const std::vector<MemWrite>& memWrites() const { return m_memWrites; }
+
+		void installTrigLog();
+		struct TrigWrite { uint64_t frame; uint32_t index, value, pc; };
+		const std::vector<TrigWrite>& liveNibbleLog() const { return m_liveNibble; }
+		const std::vector<TrigWrite>& trigWordsLog() const { return m_trigWords; }
+		// Sequencer ticks: acknowledgements of vector 0x60.
+		uint64_t ticks() const;
+
 		// ⚠️ The SET name is an ABSOLUTE path on the card -- the firmware's
 		// own default is "/PRESETS". Without the leading slash the project
 		// loads (relative to the root) and then every bank is "missing",
@@ -160,7 +253,16 @@ namespace ot
 		// helper: with no card it short-circuits, but once a card IS present
 		// it does real FAT lookups and BLOCKS -- and borrowing main for a
 		// call that blocks is the crash `callAsMain` warns about.
+		// `savedBank` is the bank the engine parsed from the project file's
+		// BANK= key and wrote to PART_PTR (-1 if that write never happened --
+		// the load did not get that far); `finalBank` is the current bank at
+		// the end of the run. ⚠️ THE TWO CAN DIFFER, and that is a real
+		// cross-task ordering rather than a load failure: SYS consumes the
+		// engine reset's queued "select bank 0" whenever the scheduler next
+		// gives it the CPU, and if that is AFTER the BANK= parse it switches
+		// the working bank back to A (RTOS_FORK.md §7).
 		struct LoadResult { uint32_t ready = 0, partPtr = 0; bool posted = false; double ms = 0;
+			int savedBank = -1; uint32_t finalBank = 0;
 			std::string postWhy;
 			// How the load's own run ENDED. Time is the ordinary case (the
 			// budget ran out); Fault/Illegal say the machine stopped, which
@@ -181,6 +283,9 @@ namespace ot
 		double ms() const { return m_sample / g_sampleHz * 1000.0; }
 		uint64_t pit0Fired() const { return m_pit0.fired(); }
 		uint64_t frameCount() const { return m_frameCount; }
+		bool framePending() const { return m_framePending; }
+		const Intc& intc0() const { return m_intc0; }
+		const Intc& intc1() const { return m_intc1; }
 		uint64_t edmaStarted() const { return m_edma.started(); }
 		Edma& edma() { return m_edma; }
 		uint64_t ataInterrupts() const { return m_ataInterrupts; }
@@ -196,6 +301,10 @@ namespace ot
 		uint32_t currentTcb() { return curTcb(); }
 		void setAtaLatency(double _samples) { m_ataLatency = _samples; }
 		void armPcRing(size_t _size, uint64_t _budget) { m_pcRing.assign(_size, 0); m_pcRingBudget = _budget; }
+		// Arm the ring HERE rather than at the first ATA command: the frame
+		// handler runs long after the load, and "what did the one frame we
+		// took actually do" is a different question from "what did the ISR do".
+		void armPcRingNow(size_t _size) { m_pcRing.assign(_size, 0); m_pcRingPos = 0; m_pcRingArmed = true; }
 		const std::vector<uint32_t>& pcRing() const { return m_pcRing; }
 		size_t pcRingPos() const { return m_pcRingPos; }
 		bool pcRingArmed() const { return m_pcRingArmed; }
@@ -218,10 +327,19 @@ namespace ot
 
 		void writeGoldenJson(const std::string& _path) const;
 
+		// The M6c facts, in the same shape route A's `--sequencer --golden`
+		// writes them, for `tools/ot_emu/oracle.py`: the trig log with frame
+		// numbers relative to the transport start, the tick count, the frames
+		// run, and the four bank/pattern bytes.
+		struct M6c { uint64_t frame0 = 0, ticks0 = 0, frames = 0, ticks = 0;
+			int savedBank = -1; uint32_t finalBank = 0, seqBank = 0, seqPattern = 0; };
+		void writeM6cJson(const std::string& _path, const M6c& _m) const;
+
 	private:
 		uint32_t curTcb();
 		bool peripheralRead(uint32_t _addr, uint8_t _size, uint32_t& _out);
 		void peripheralWrite(uint32_t _addr, uint8_t _size, uint32_t _val, bool _replay);
+		Stop runInternal(double _ms, bool _untilGate, const std::function<bool()>* _stop);
 		void tickTimers();
 		// One instruction plus everything the run loop does around it, so a
 		// borrowed call runs against the same live machine the loop does.
@@ -277,6 +395,11 @@ namespace ot
 		// back to back the moment main unmasked (measured 6 Sep 2026). The
 		// handler re-arms itself only through the eDMA exchange; the ISR's
 		// `rte` is not the ack.
+		std::vector<TrigWrite> m_liveNibble, m_trigWords;
+		std::vector<MemWrite> m_memWrites;
+		bool m_trigLogInstalled = false;
+		bool m_partPtrWatched = false;
+		int m_savedBank = -1;
 		bool m_frame = false;
 		bool m_framePending = false;
 		double m_nextFrame = g_framePeriod;

--- a/tools/ot_emu/stage_card.py
+++ b/tools/ot_emu/stage_card.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Build the card image the C++ port reads, with ROUTE A'S OWN STAGING.
+
+    .venv/bin/python3 tools/ot_emu/stage_card.py out/_testproj OCTABAM RIG \
+        --tree out/_o6_tree_port --out out/o6_card.img
+
+⚠️ THE POINT IS THAT BOTH EMULATORS LOOK AT IDENTICAL MEDIA. `emu_rtos.
+stage_project` is the function route A calls, so the tree it copies and the
+FAT16 image it builds are the same bytes either way -- the FAT16 builder is
+deliberately NOT ported to C++ for exactly this reason (COLDFIRE_PORT.md O7).
+Building the image any other way (`emu_card.py --image-only` has its own skip
+list) would make a difference between the two emulators that is the harness's
+and not the firmware's, which is the class of defect standing rule 7 exists
+for.
+"""
+import argparse
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+import emu_rtos  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("project")
+    ap.add_argument("set_name", nargs="?", default="OCTABAM")
+    ap.add_argument("name", nargs="?", default=None)
+    ap.add_argument("--tree", default="out/_o6_tree_port",
+                    help="scratch dir the card is staged in; it is WIPED at start, so a "
+                         "run concurrent with route A's needs its own")
+    ap.add_argument("--image-mb", type=int, default=64)
+    ap.add_argument("--out", default="out/o6_card.img")
+    a = ap.parse_args()
+    img, staged = emu_rtos.stage_project(a.project, a.set_name, a.name,
+                                         tree=a.tree, image_mb=a.image_mb)
+    pathlib.Path(a.out).parent.mkdir(parents=True, exist_ok=True)
+    with open(a.out, "wb") as f:
+        f.write(img)
+    print(f"{a.out}: {len(img)} bytes, SET {a.set_name} PROJECT {staged}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ot_emu/test_emac.cpp
+++ b/tools/ot_emu/test_emac.cpp
@@ -95,6 +95,146 @@ int main()
 	check("msacl SUBTRACTS (extension word bit 8)",
 		runProgram(msacl, 0, 0, 32), 0xfffffffd);
 
+	// ---- THE FOUR FIELDS THE FIRST DECODER GOT WRONG ---------------------
+	// ⚠️ Every case above passes with all four defects in place, because each
+	// uses acc0, two DATA registers, the long form and no parallel load --
+	// the one combination in which none of them shows (found 8 Sep 2026 when
+	// the frame handler's own MAC block stopped the port dead, O6). The
+	// expected values below are ROUTE A's, measured by running the same
+	// opcodes in its engine, except where noted.
+	//
+	//   .venv/bin/python3 -c "... macl %a2,%d1,%acc0 -> acc0 = 3 ..."
+	std::printf("EMAC field gate (the four the first decoder got wrong):\n");
+	{
+		// A run that ends by draining all four accumulators into d4..d7:
+		//   a1c4 a3c5 a5c6 a7c7   movclrl %acc0..3,%d4..%d7
+		const auto runEmac = [](const uint32_t _macsr, const std::vector<uint8_t>& _instr,
+			const std::vector<std::pair<m68k_register_t, uint32_t>>& _regs)
+		{
+			std::vector<uint8_t> image = {0xa9, 0x3c,
+				static_cast<uint8_t>(_macsr >> 24), static_cast<uint8_t>(_macsr >> 16),
+				static_cast<uint8_t>(_macsr >> 8), static_cast<uint8_t>(_macsr)};
+			image.insert(image.end(), _instr.begin(), _instr.end());
+			for(const uint8_t b : {0xa1, 0xc4, 0xa3, 0xc5, 0xa5, 0xc6, 0xa7, 0xc7, 0x4e, 0x71})
+				image.push_back(b);
+			const auto codeLen = image.size();
+			image.resize(0x400, 0);				// room for the load forms' data
+			image[0x201] = 0x11; image[0x202] = 0x22; image[0x203] = 0x33;	// at 0x40000600
+			image[0x209] = 0x44; image[0x20a] = 0x55; image[0x20b] = 0x66;	// at 0x40000608
+			ot::Machine m(image);
+			for(const auto& [r, v] : _regs)
+				m68k_set_reg(m.getCpuState(), r, v);
+			const auto stop = m.run(static_cast<uint64_t>(codeLen));	// one per two bytes is plenty
+			if(stop == ot::Machine::Stop::Illegal)
+				std::printf("     (stopped: %s)\n", m.why().c_str());
+			struct Out { uint32_t acc[4]; uint32_t d[8]; uint32_t a[4]; };
+			Out o{};
+			for(int i = 0; i < 4; ++i)
+				o.acc[i] = static_cast<uint32_t>(m68k_get_reg(m.getCpuState(),
+					static_cast<m68k_register_t>(M68K_REG_D4 + i)));
+			for(int i = 0; i < 8; ++i)
+				o.d[i] = static_cast<uint32_t>(m68k_get_reg(m.getCpuState(),
+					static_cast<m68k_register_t>(M68K_REG_D0 + i)));
+			for(int i = 0; i < 4; ++i)
+				o.a[i] = static_cast<uint32_t>(m68k_get_reg(m.getCpuState(),
+					static_cast<m68k_register_t>(M68K_REG_A0 + i)));
+			return o;
+		};
+
+		// 1. AN ADDRESS REGISTER SOURCE. `a20a 0800 macl %a2,%d1,%acc0`: the
+		//    first decoder multiplied d2. ✅ route A: acc0 = 3.
+		check("macl %a2,%d1 multiplies a2, not d2",
+			runEmac(0x20, {0xa2, 0x0a, 0x08, 0x00},
+				{{M68K_REG_A2, 0xc00}, {M68K_REG_D1, 0x200000}}).acc[0], 3);
+
+		// 2. THE ACCUMULATOR NUMBER. `a280 0810 macl %d0,%d1,%acc3` -- opcode
+		//    bit 7 is the LOW bit and ext bit 4 the HIGH one. ✅ route A: the
+		//    product lands in acc3 and acc0 stays zero.
+		{
+			const auto o = runEmac(0x20, {0xa2, 0x80, 0x08, 0x10},
+				{{M68K_REG_D0, 0xc00}, {M68K_REG_D1, 0x200000}});
+			check("macl ...,%acc3 lands in acc3", o.acc[3], 3);
+			check("... and acc0 is untouched", o.acc[0], 0);
+		}
+
+		// 3. WHICH OPERAND'S HALF. In integer mode (MACSR 0) the product is
+		//    accumulated whole, so 3 x 5 = 15 is readable. ✅ route A:
+		//    `macw %d0u,%d1l` (ext 0x0040) = 15, `%d0l,%d1u` (0x0080) = 0,
+		//    `%d0l,%d1l` (0x0000) = 0, with d0 = 0x00030000 and d1 = 5.
+		const std::vector<std::pair<m68k_register_t, uint32_t>> halves =
+			{{M68K_REG_D0, 0x00030000}, {M68K_REG_D1, 0x00000005}};
+		check("macw %d0u,%d1l -- ext bit 6 is the FIRST operand's half",
+			runEmac(0, {0xa2, 0x00, 0x00, 0x40}, halves).acc[0], 15);
+		check("macw %d0l,%d1u -- and bit 7 the second's",
+			runEmac(0, {0xa2, 0x00, 0x00, 0x80}, halves).acc[0], 0);
+		check("macw %d0l,%d1l", runEmac(0, {0xa2, 0x00, 0x00, 0x00}, halves).acc[0], 0);
+
+		// 4. THE PARALLEL LOAD, in the three modes the frame routine uses.
+		//    ⚠️ Route A cannot run these natively -- Unicorn raises
+		//    illegal-instruction and route A SHIMS them
+		//    (`emu_bringup._emac_load_shim`) -- so the expectations here are
+		//    that shim's semantics, which this decoder is a translation of,
+		//    with values chosen so a wrong field is visible:
+		//    the multiply is 3 x 5 in integer mode and the load is a longword
+		//    from the image at 0x40000600 / 0x40000608.
+		//
+		//    `a490 1800  macl %d0,%d1,%a0@,%d2,%acc0`      -- (An)
+		//    `a498 1800  macl %d0,%d1,%a0@+,%d2,%acc0`     -- (An)+
+		//    `a4a8 1800 0008  macl %d0,%d1,%a0@(8),%d2,%acc0` -- (d16,An), SIX bytes
+		const std::vector<std::pair<m68k_register_t, uint32_t>> loadRegs =
+			{{M68K_REG_D0, 3}, {M68K_REG_D1, 5}, {M68K_REG_A0, 0x40000600}};
+		{
+			const auto o = runEmac(0, {0xa4, 0x90, 0x18, 0x00}, loadRegs);
+			check("macl ...,%a0@,%d2 accumulates 3 x 5", o.acc[0], 15);
+			check("... and loads the longword at (a0) into d2", o.d[2], 0x00112233);
+			check("... leaving a0 alone", o.a[0], 0x40000600);
+		}
+		{
+			const auto o = runEmac(0, {0xa4, 0x98, 0x18, 0x00}, loadRegs);
+			check("macl ...,%a0@+,%d2 loads and advances a0 by 4", o.a[0], 0x40000604);
+			check("... with d2 the longword that was at (a0)", o.d[2], 0x00112233);
+		}
+		{
+			// ⚠️ THE SIX-BYTE FORM. Skipping the displacement word is what
+			// desynchronised the stream and invented an opcode two
+			// instructions later; the `movclrl` tail only runs if the PC came
+			// out right, so acc0 reading 15 IS the length check.
+			const auto o = runEmac(0, {0xa4, 0xa8, 0x18, 0x00, 0x00, 0x08}, loadRegs);
+			check("macl ...,%a0@(8),%d2 accumulates (so the PC advanced 6)", o.acc[0], 15);
+			check("... and loads the longword at (a0)+8", o.d[2], 0x00445566);
+		}
+		// 4b. THE ACCUMULATOR'S ALIGNMENT -- the one the M6c gate caught.
+		//    A product whose low 24 bits are NOT zero, subtracted from a
+		//    cleared accumulator. ✅ route A: `msacl %d0,%d1,%acc0` with
+		//    d0 = 46080 and d1 = 745654 in fractional mode gives -16
+		//    (0xfffffff0); `macl` with the same operands gives 15. A model
+		//    that shifts each product to >>32 BEFORE accumulating gives -15
+		//    for the msac -- one LSB, and it is what made the sequencer's
+		//    live nibble read 0x09 where route A reads 0x08 on every frame.
+		//    ⚠️ The two cases must both be here: the `macl` one agrees under
+		//    either model, so only the `msacl` one is evidence.
+		{
+			const std::vector<std::pair<m68k_register_t, uint32_t>> off =
+				{{M68K_REG_D0, 46080}, {M68K_REG_D1, 745654}};
+			check("msacl fractional 46080 x 745654 -> -16, not -15",
+				runEmac(0x20, {0xa2, 0x00, 0x09, 0x00}, off).acc[0], 0xfffffff0);
+			check("macl with the same operands -> 15 (agrees either way)",
+				runEmac(0x20, {0xa2, 0x00, 0x08, 0x00}, off).acc[0], 15);
+		}
+
+		// 5. `movel #imm,%macsr` (a93c) -- the frame handler's own at
+		//    0x4000aeda. The whole runner depends on it: if it were mis-sized
+		//    every case above would run in the wrong MACSR. Read it back with
+		//    `a980 movel %macsr,%d0`.
+		{
+			std::vector<uint8_t> image = {0xa9, 0x3c, 0, 0, 0, 0x20, 0xa9, 0x80, 0x4e, 0x71};
+			ot::Machine m(image);
+			m.run(4);
+			check("movel #32,%macsr then movel %macsr,%d0",
+				static_cast<uint32_t>(m68k_get_reg(m.getCpuState(), M68K_REG_D0)), 0x20);
+		}
+	}
+
 	// ---- MOV3Q to MEMORY (the V4e layer, same dispatch path) -------------
 	// ❌ Retracts v4e.cpp's "only Dn is reached by this firmware": the project
 	// load runs eight `mov3ql #-1,%a0@+` at 0x4009d8d0 and the refusal was a
@@ -128,6 +268,66 @@ int main()
 	check("mov3ql #-1,%a0@+ writes 0xffffffff", runProgram(readFirst, 0, 0, 4), 0xffffffff);
 	check("mov3ql #1,%a0@+ writes 1 at the next long", runProgram(readSecond, 0, 0, 4), 1);
 	check("(An)+ advanced a0 by 8 over the pair", runProgram(readA0, 0, 0, 4), 0x40000508);
+
+	// ---- SATS (the V4e layer, same dispatch path) ------------------------
+	// ✅ The firmware reaches `satsl %d0` at 0x4000346a, inside the per-frame
+	// EMAC routine the frame handler's state 5 calls -- so it is on the M6c
+	// path and nowhere near the boot, which is why O1..O5 never met it. With
+	// it unimplemented the port stopped there with "unimplemented opcode 4c80"
+	// and delivered ZERO frames (measured 8 Sep 2026, O6).
+	//
+	// ✅ Encoding from `m68k-elf-as -mcpu=5475`: 4c80 / 4c81 / 4c87 for
+	// %d0 / %d1 / %d7 -- `0x4c80 | Dn`.
+	//
+	// ✅ SEMANTICS MEASURED IN ROUTE A'S OWN ENGINE, not read from the manual
+	// (the values below are what Unicorn returns for each case):
+	//     V set,   d0 = 0x00000001 -> 0x80000000
+	//     V set,   d0 = 0x80000001 -> 0x7fffffff
+	//     V clear, d0 = 0x12345678 -> unchanged
+	// i.e. a saturate that only fires on overflow, to the end of the range the
+	// sign bit says the result WRAPPED away from.
+	//
+	// ⚠️ AND ONE MEASURED DISAGREEMENT WITH THE MANUAL, carried rather than
+	// resolved. The CFPRM says SATS sets N and Z from the result and CLEARS V
+	// and C. Route A's engine updates **N only**: a pre-set Z survives a
+	// non-zero result, and V and C are left exactly as they were (measured
+	// 8 Sep 2026, six cases). This port matches ROUTE A, because route A is
+	// the oracle and the two emulators being comparable is the point of the
+	// milestone -- and because at the only site the firmware reaches, the four
+	// instructions after the `sats` are three `movclrl`s and a `movel`, with
+	// no conditional branch between the `sats` and the next instruction that
+	// redefines the flags. WHAT WOULD FALSIFY IT: a firmware site that
+	// branches on Z or V after a SATS. If one turns up, the manual wins and
+	// this is a defect in both emulators.
+	std::printf("SATS gate (v4e.cpp; semantics measured in route A's engine):\n");
+	const std::vector<uint8_t> satsBody = {
+		0x4c, 0x80,					// satsl %d0
+		0x4e, 0x71,					// nop
+	};
+	// The CCR cannot be set by a program here (`move #imm,%sr` is privileged
+	// and route A's own probe could not run it either), so it is written into
+	// the machine's SR before the run, the way D0 is.
+	const auto runSats = [](const uint32_t _sr, const uint32_t _d0)
+	{
+		std::vector<uint8_t> image = {0x4c, 0x80, 0x4e, 0x71};
+		ot::Machine m(image);
+		m68k_set_reg(m.getCpuState(), M68K_REG_SR, _sr);
+		m68k_set_reg(m.getCpuState(), M68K_REG_D0, _d0);
+		m.run(2);
+		return std::make_pair(static_cast<uint32_t>(m68k_get_reg(m.getCpuState(), M68K_REG_D0)),
+			static_cast<uint32_t>(m68k_get_reg(m.getCpuState(), M68K_REG_SR)) & 0x1fu);
+	};
+	{
+		constexpr uint32_t sup = 0x2700, V = 0x02, C = 0x01, Z = 0x04, N = 0x08;
+		check("sats V set, positive-looking -> 0x80000000", runSats(sup | V, 1).first, 0x80000000);
+		check("sats V set, negative-looking -> 0x7fffffff", runSats(sup | V, 0x80000001).first, 0x7fffffff);
+		check("sats V clear leaves the value alone", runSats(sup, 0x12345678).first, 0x12345678);
+		// The flags, exactly as route A's engine leaves them.
+		check("sats sets N from the result", runSats(sup | V, 1).second, N | V);
+		check("sats clears N from the result", runSats(sup | N, 5).second, 0u);
+		check("sats leaves Z, V and C untouched (route A, NOT the CFPRM)",
+			runSats(sup | N | Z | V | C, 1).second, N | Z | V | C);
+	}
 
 	std::printf("%s\n", g_failures ? "EMAC GATE FAILED -- nothing this emulator computes can be trusted"
 									: "EMAC gate passed.");

--- a/tools/ot_emu/v4e.cpp
+++ b/tools/ot_emu/v4e.cpp
@@ -270,22 +270,86 @@ namespace ot::v4e
 		// MACSR bits that matter here (CFPRM 4.1): bit 5 F/I selects fractional
 		// mode, bit 4 S/U selects signed, bit 0 is the product-independent
 		// saturation flag this firmware never sets.
-		constexpr uint32_t g_macsrFractional = 0x20;
+		constexpr uint32_t g_macsrFractional = 0x20;	// F/I
+		constexpr uint32_t g_macsrSigned     = 0x10;	// S/U
 
 		// One accumulator, 32 bits plus its 8-bit extensions. Musashi's
 		// ColdFire state has no EMAC, so the port keeps its own -- four
 		// accumulators and the two extension-byte registers.
 		// Musashi's ColdFire state has no EMAC at all, so the whole unit lives
 		// here: four accumulators, their extension bytes, and MACSR.
+		// ⚠️ THE ACCUMULATOR IS 48 BITS AND HOLDS THE PRODUCT AT >>24, NOT >>32.
+		// The first version kept a 32-bit accumulator and shifted each product
+		// all the way down before adding it, which is right for ONE positive
+		// product and off by one LSB for a SUBTRACT whose discarded low bits
+		// are non-zero: floor(-floor(q/2^24)/2^8) is one less than
+		// -floor(q/2^32). ✅ That is exactly the bit the M6c gate caught
+		// (8 Sep 2026): the frame handler's `msacl` came out -15 where route
+		// A had -16, the `spl` floor two instructions later turned it into
+		// 1 instead of 0, and the sequencer's live nibble read 0x09 instead of
+		// 0x08 on every write. Route A's model (QEMU's m68k EMAC plus
+		// `tools/unicorn_emac_fractional.patch`) accumulates at >>24 and
+		// shifts down by 8 only when the accumulator is READ.
 		struct Emac
 		{
-			uint32_t acc[4] = {};
-			uint32_t ext[4] = {};	// the sign-extension byte per accumulator
+			int64_t acc[4] = {};
 			uint32_t macsr = 0;
+			uint32_t mask = 0;		// the '&' form's address mask register
 		};
 		Emac g_emac;
 
 		uint32_t macsr(Machine&) { return g_emac.macsr; }
+
+		// Reading an accumulator OUT: route A's `get_macf` (fractional: >> 8,
+		// no rounding because MACSR's RT bit is clear in this firmware) and
+		// its integer form (the low longword, no saturation because OMC is
+		// clear too).
+		uint32_t accRead(const uint32_t _n)
+		{
+			if(g_emac.macsr & g_macsrFractional)
+				return static_cast<uint32_t>(g_emac.acc[_n] >> 8);
+			return static_cast<uint32_t>(g_emac.acc[_n]);
+		}
+
+		// ... and writing one IN: route A's `move_mac`.
+		void accWrite(const uint32_t _n, const uint32_t _v)
+		{
+			if(g_emac.macsr & g_macsrFractional)
+				g_emac.acc[_n] = static_cast<int64_t>(static_cast<int32_t>(_v)) << 8;
+			else if(g_emac.macsr & g_macsrSigned)
+				g_emac.acc[_n] = static_cast<int64_t>(static_cast<int32_t>(_v));
+			else
+				g_emac.acc[_n] = static_cast<int64_t>(_v);
+		}
+
+		// The extension registers, exactly as route A's `get_mac_extf` /
+		// `get_mac_exti` / `set_mac_extf` read and write them. Nothing this
+		// firmware does reaches them on the M6c path; they are here so that a
+		// path that DOES cannot quietly get a different answer.
+		uint32_t accExtRead(const uint32_t _lo)
+		{
+			const auto a0 = static_cast<uint64_t>(g_emac.acc[_lo]);
+			const auto a1 = static_cast<uint64_t>(g_emac.acc[_lo + 1]);
+			if(!(g_emac.macsr & g_macsrFractional))
+				return static_cast<uint32_t>(((a0 >> 32) & 0xffff) | ((a1 >> 16) & 0xffff0000));
+			uint32_t v = static_cast<uint32_t>(a0 & 0x00ff);
+			v |= static_cast<uint32_t>((a0 >> 32) & 0xff00);
+			v |= static_cast<uint32_t>((a1 << 16) & 0x00ff0000);
+			v |= static_cast<uint32_t>((a1 >> 16) & 0xff000000);
+			return v;
+		}
+
+		void accExtWrite(const uint32_t _lo, const uint32_t _v)
+		{
+			int64_t res = g_emac.acc[_lo] & 0xffffffff00ll;
+			res |= static_cast<int64_t>(static_cast<int16_t>(_v & 0xff00)) << 32;
+			res |= _v & 0xff;
+			g_emac.acc[_lo] = res;
+			res = g_emac.acc[_lo + 1] & 0xffffffff00ll;
+			res |= static_cast<int64_t>(static_cast<int32_t>(_v & 0xff000000)) << 16;
+			res |= (_v >> 16) & 0xff;
+			g_emac.acc[_lo + 1] = res;
+		}
 	}
 
 	// The whole EMAC, as the MCF5445x does it and as the firmware's own
@@ -294,98 +358,248 @@ namespace ot::v4e
 	// upper 40 bits are accumulated -- so `movclrl` of the result yields
 	// (a * b) >> 31, not >> 32. `msac` SUBTRACTS, and which of the two it is
 	// comes from bit 8 of the EXTENSION word, never from the opcode word.
+	// THE WHOLE EMAC, and every field below came out of `m68k-elf-as
+	// -mcpu=5475` / `objdump -m m68k:cfv4e`, never out of a reading of the
+	// manual (standing rule 3). The listings are quoted beside each rule.
+	//
+	// ⚠️ THE FIRST VERSION OF THIS FUNCTION GOT FOUR FIELDS WRONG AND STILL
+	// PASSED THE EMAC GATE, because every case the gate covered used acc0,
+	// two data registers and no parallel load -- the one combination in which
+	// all four defects are invisible (measured 8 Sep 2026, O6):
+	//   1. the ACCUMULATOR NUMBER was read as ext bit 4 | ext bit 9; it is
+	//      opcode bit 7 (LOW) and ext bit 4 (HIGH) -- and in the LOAD form
+	//      the low bit is INVERTED (route A's `_emac_load_shim` carries the
+	//      same `((~op >> 7) & 1)`, and objdump agrees: acc0 is `a498`,
+	//      acc1 `a418`). The frame builder uses all four accumulators.
+	//   2. an ADDRESS REGISTER source was read as the data register of the
+	//      same number: `macl %a2,%d0` (`a08a`) multiplied d2, not a2.
+	//   3. the two operand-half bits were applied to the wrong operands
+	//      (`macw %d0u,%d1l` is ext 0x0040: bit 6 is the FIRST operand's).
+	//   4. the parallel load handled ONLY (An)+, and the firmware's frame
+	//      routine at 0x40003738 uses (An) and (d16,An) as well -- the
+	//      (d16,An) form is SIX bytes and skipping its displacement word
+	//      desynchronised the instruction stream, which is what actually
+	//      stopped the port (an invented opcode two instructions later).
+	// The gate now covers all four.
 	Result emac(Machine& _m, const uint32_t _opcode)
 	{
-		// movel %dn,%macsr  -- 1010 1001 0000 0rrr  (a900 = from d0)
-		if((_opcode & 0xfff8) == 0xa900)
+		// ---- the register moves: `1010 sss 1 d c eeeeee` -------------------
+		// sss (bits 11-9) names the EMAC register: 0..3 = ACC0..3, 4 = MACSR,
+		// 5 = ACCext01, 6 = MASK, 7 = ACCext23. Bit 8 is 1 for this family and
+		// 0 for every MAC, which is what tells them apart. Bit 7 is the
+		// direction (0 = <ea> into the EMAC register, 1 = out of it), bit 6
+		// clears the accumulator on the way out (`movclr`), and bits 5-0 are
+		// an <ea>: mode 0 = Dn, mode 1 = An, mode 7 reg 4 = #imm.
+		//
+		// ✅ m68k-elf-as -mcpu=5475:
+		//     a900  movel %d0,%macsr        a90c  movel %a4,%macsr
+		//     a93c 0000 0020  movel #32,%macsr     <- the frame handler's own,
+		//                                             at 0x4000aeda
+		//     a980  movel %macsr,%d0        ad81  movel %mask,%d1
+		//     ab84  movel %accext01,%d4     af85  movel %accext23,%d5
+		//     a100  movel %d0,%acc0         a180  movel %acc0,%d0
+		//     a1c0  movclrl %acc0,%d0       a7c7  movclrl %acc3,%d7
+		if(_opcode & 0x0100)
 		{
-			g_emac.macsr = reg(_m, dReg(_opcode & 7));
-			return Result::Handled;
-		}
-		// movclrl %accN,%dn -- 1010 0rrr 11 00 00NN, clears the accumulator
-		if((_opcode & 0xf1f0) == 0xa1c0)
-		{
-			const uint32_t dn = (_opcode >> 9) & 7;
-			const uint32_t acc = _opcode & 3;
-			setReg(_m, dReg(dn), g_emac.acc[acc]);
-			g_emac.acc[acc] = 0;
-			g_emac.ext[acc] = 0;
-			return Result::Handled;
-		}
-		// movel %accN,%dn (no clear) -- a383 = acc1 -> d3
-		if((_opcode & 0xf1f0) == 0xa180)
-		{
-			setReg(_m, dReg((_opcode >> 9) & 7), g_emac.acc[_opcode & 3]);
-			return Result::Handled;
-		}
-		// movel %accext01,%dn / %accext23 -- ab84
-		if((_opcode & 0xf1f0) == 0xa980 || (_opcode & 0xf1f0) == 0xab80)
-		{
-			const bool hi = (_opcode & 0x0200) != 0;
-			const uint32_t v = hi
-				? ((g_emac.ext[2] & 0xff) | ((g_emac.ext[3] & 0xff) << 8))
-				: ((g_emac.ext[0] & 0xff) | ((g_emac.ext[1] & 0xff) << 8));
-			setReg(_m, dReg((_opcode >> 9) & 7), v);
+			const uint32_t which = (_opcode >> 9) & 7;
+			const bool out = (_opcode & 0x0080) != 0;
+			const bool clear = (_opcode & 0x0040) != 0;
+			const uint32_t mode = (_opcode >> 3) & 7;
+			const uint32_t rn = _opcode & 7;
+
+			const auto readEa = [&]() -> uint32_t
+			{
+				if(mode == 0)	return reg(_m, dReg(rn));
+				if(mode == 1)	return reg(_m, aReg(rn));
+				if(mode == 7 && rn == 4)
+				{
+					const uint32_t hi = fetch16(_m);
+					return (hi << 16) | fetch16(_m);
+				}
+				return 0;
+			};
+			if(mode > 1 && !(mode == 7 && rn == 4))
+				return Result::Unhandled;			// no other <ea> is reached; be loud
+
+			if(!out)
+			{
+				const auto v = readEa();
+				switch(which)
+				{
+				case 4: g_emac.macsr = v; break;
+				case 5: accExtWrite(0, v); break;
+				case 6: g_emac.mask = v; break;
+				case 7: accExtWrite(2, v); break;
+				default: accWrite(which, v); break;
+				}
+				return Result::Handled;
+			}
+			uint32_t v = 0;
+			switch(which)
+			{
+			case 4: v = g_emac.macsr; break;
+			case 5: v = accExtRead(0); break;
+			case 6: v = g_emac.mask; break;
+			case 7: v = accExtRead(2); break;
+			default:
+				v = accRead(which);
+				if(clear)
+					g_emac.acc[which] = 0;
+				break;
+			}
+			setReg(_m, mode == 1 ? aReg(rn) : dReg(rn), v);
 			return Result::Handled;
 		}
 
-		// MAC / MSAC, with or without a load. The opcode word carries the two
-		// source registers and the addressing mode; the EXTENSION word carries
-		// the accumulator, the subtract bit and the operand halves.
+		// ---- MAC / MSAC ----------------------------------------------------
+		// The extension word is common to both forms:
+		//     bit 11 size (1 = long), bits 10-9 scale, bit 8 SUBTRACT,
+		//     bit 7 upper half of Rx, bit 6 upper half of Ry, bit 5 the '&'
+		//     mask form, bit 4 the accumulator's HIGH bit.
+		// ✅ `macw %d0u,%d1l,%acc0` is `a200 0040` and `macw %d0l,%d1u,%acc0`
+		// is `a200 0080`, which is what pins bit 6 to the FIRST operand;
+		// `macl %d0,%d1,<<,%acc2` is `a200 0a10`, which pins the scale.
 		const uint16_t ext = fetch16(_m);
-		const uint32_t ry = (_opcode >> 9) & 7;
-		const uint32_t rx = _opcode & 7;
-		const bool subtract = (ext & 0x0100) != 0;			// ⚠️ EXTENSION word,
-															// not the opcode word
-		const uint32_t accN = ((ext >> 4) & 1) | ((ext >> 8) & 2);
-		const bool wordOp = (ext & 0x0800) == 0;			// size: 0 = word, 1 = long
-		const bool upperY = (ext & 0x0040) != 0;
-		const bool upperX = (ext & 0x0080) != 0;
-
-		const uint32_t rawY = reg(_m, dReg(ry));
-		const uint32_t rawX = reg(_m, dReg(rx));
-
-		int64_t product;
-		if(wordOp)
-		{
-			const auto y = static_cast<int16_t>(upperY ? (rawY >> 16) : (rawY & 0xffff));
-			const auto x = static_cast<int16_t>(upperX ? (rawX >> 16) : (rawX & 0xffff));
-			product = static_cast<int64_t>(y) * static_cast<int64_t>(x);
-		}
-		else
-		{
-			product = static_cast<int64_t>(static_cast<int32_t>(rawY))
-					* static_cast<int64_t>(static_cast<int32_t>(rawX));
-		}
-
-		// FRACTIONAL: the product is shifted left one into 2.62 and the upper
-		// 40 bits accumulate, which is a signed >> 31 by the time `movclrl`
-		// reads the low longword. INTEGER mode accumulates the product itself.
-		// ⚠️ Getting this wrong by one bit is exactly the Unicorn defect that
-		// halved every recorder length for a week.
-		int64_t addend;
-		if(macsr(_m) & g_macsrFractional)
-			addend = (product << 1) >> 32;
-		else
-			addend = product;
-
-		auto acc = static_cast<int64_t>(static_cast<int32_t>(g_emac.acc[accN]));
-		acc = subtract ? acc - addend : acc + addend;
-		g_emac.acc[accN] = static_cast<uint32_t>(acc);
-		g_emac.ext[accN] = static_cast<uint32_t>((acc >> 32) & 0xff);
-
-		// The load half of a `macl %d0,%d1,%a0@+,%d2,%acc1`: mode 3 in the
-		// opcode word's bits 3-5, destination register in the extension word's
-		// top nibble. Only post-increment appears in this firmware.
 		const uint32_t mode = (_opcode >> 3) & 7;
-		if(mode == 3)
+		const bool subtract = (ext & 0x0100) != 0;			// ⚠️ EXTENSION word,
+															// never the opcode word
+		const bool wordOp = (ext & 0x0800) == 0;
+		const bool upperRx = (ext & 0x0080) != 0;
+		const bool upperRy = (ext & 0x0040) != 0;
+		if(ext & 0x0020)		// the '&' form ANDs the loaded value with MASK
+			return Result::Unhandled;			// not reached by this firmware; be loud
+		if((ext >> 9) & 3)		// a scale factor (<< or >>) -- likewise
+			return Result::Unhandled;
+
+		uint32_t rx4 = 0, ry4 = 0, accN = 0;
+		bool load = false, rwIsA = false;
+		uint32_t rw = 0, an = 0, ea = 0;
+		if(mode <= 1)
 		{
-			const uint32_t an = rx;
-			const uint32_t dst = (ext >> 12) & 7;
-			const auto a = reg(_m, aReg(an));
-			const uint32_t loaded = (static_cast<uint32_t>(_m.read16(a)) << 16) | _m.read16(a + 2);
-			setReg(_m, aReg(an), a + 4);
-			setReg(_m, dReg(dst), loaded);
+			// ✅ Plain: `a003 0810 macl %d3,%d0,%acc2`, `a08a 0800 macl
+			// %a2,%d0,%acc1`, `a040 0800 macl %d0,%a0,%acc0`. Rx is opcode
+			// bits 11-9 with bit 6 as its A/D flag; Ry is bits 3-0, so the
+			// <ea> mode field being 1 IS Ry's A/D flag.
+			rx4 = ((_opcode >> 9) & 7) | (((_opcode >> 6) & 1) << 3);
+			ry4 = _opcode & 0x0f;
+			accN = ((_opcode >> 7) & 1) | (((ext >> 4) & 1) << 1);
+		}
+		else if(mode >= 2 && mode <= 5)
+		{
+			// ✅ With a parallel load: `a498 1800 macl %d0,%d1,%a0@+,%d2,%acc0`.
+			// Opcode bits 11-9 are Rw (the load's destination) with bit 6 its
+			// A/D flag, bits 5-3/2-0 are the load's <ea>, and BOTH multiply
+			// sources move into the extension word: bits 15-12 = Rx, bits 3-0
+			// = Ry, each 4-bit with 8..15 meaning An.
+			//
+			// ⚠️ THE ACCUMULATOR'S LOW BIT IS INVERTED HERE and this is not a
+			// guess: objdump reads `a498 1800` as acc0 and `a418 1800` as
+			// acc1, and route A's `_emac_load_shim` carries the same
+			// `((~op >> 7) & 1)`. Both readings are binutils', so a chip that
+			// disagreed would put every frame's arithmetic in the wrong
+			// accumulator in BOTH emulators -- what would falsify it is a
+			// hardware capture, which nobody has.
+			load = true;
+			rw = (_opcode >> 9) & 7;
+			rwIsA = (_opcode & 0x0040) != 0;
+			an = _opcode & 7;
+			rx4 = (ext >> 12) & 0x0f;
+			ry4 = ext & 0x0f;
+			accN = ((~_opcode >> 7) & 1) | (((ext >> 4) & 1) << 1);
+
+			// The parallel load is ALWAYS a longword (route A's shim says so
+			// in as many words), and only these four modes exist.
+			const auto base = reg(_m, aReg(an));
+			switch(mode)
+			{
+			case 2: ea = base; break;
+			case 3: ea = base; setReg(_m, aReg(an), base + 4); break;
+			case 4: ea = base - 4; setReg(_m, aReg(an), ea); break;
+			default:
+				{
+					const auto d16 = static_cast<int16_t>(fetch16(_m));
+					ea = base + static_cast<uint32_t>(static_cast<int32_t>(d16));
+				}
+				break;
+			}
+		}
+		else
+		{
+			return Result::Unhandled;
+		}
+
+		const auto readOperand = [&_m](const uint32_t _r4)
+		{
+			return (_r4 & 8) ? reg(_m, aReg(_r4 & 7)) : reg(_m, dReg(_r4 & 7));
+		};
+		const uint32_t rawX = readOperand(rx4);
+		const uint32_t rawY = readOperand(ry4);
+
+		// The operands. ✅ Route A's `gen_mac_extract_word`: in FRACTIONAL mode
+		// a 16-bit half is placed in the HIGH half of a 32-bit value (so it is
+		// multiplied as a 1.31 fraction); in signed integer mode it is
+		// sign-extended, and in unsigned integer mode zero-extended.
+		const bool fi = (macsr(_m) & g_macsrFractional) != 0;
+		const bool su = (macsr(_m) & g_macsrSigned) != 0;
+		const auto half = [fi, su](const uint32_t _v, const bool _upper) -> uint32_t
+		{
+			if(fi)
+				return _upper ? (_v & 0xffff0000u) : (_v << 16);
+			if(su)
+				return _upper ? static_cast<uint32_t>(static_cast<int32_t>(_v) >> 16)
+							  : static_cast<uint32_t>(static_cast<int32_t>(static_cast<int16_t>(_v)));
+			return _upper ? (_v >> 16) : (_v & 0xffffu);
+		};
+		const uint32_t opX = wordOp ? half(rawX, upperRx) : rawX;
+		const uint32_t opY = wordOp ? half(rawY, upperRy) : rawY;
+
+		// ✅ Route A's three multiply helpers, verbatim in shape:
+		//   fractional (`macmulf`, as patched by
+		//   tools/unicorn_emac_fractional.patch): a SIGNED product shifted
+		//   LEFT one into 1.63 and then >> 24 -- the accumulator's own
+		//   alignment, EIGHT BITS FINER than what `movclrl` returns. ⚠️ It is
+		//   the >>24 that matters: shifting each product all the way to >>32
+		//   before accumulating loses a bit of the subtraction (see the Emac
+		//   comment above, and the M6c gate that caught it).
+		//   signed integer (`macmuls`): the product truncated to 48 bits.
+		//   unsigned integer (`macmulu`): the product masked to 40 bits.
+		int64_t addend;
+		if(fi)
+		{
+			int64_t product = static_cast<int64_t>(static_cast<int32_t>(opX))
+							* static_cast<int64_t>(static_cast<int32_t>(opY));
+			product <<= 1;
+			addend = product >> 24;			// MACSR's RT (round) bit is clear here
+		}
+		else if(su)
+		{
+			const auto product = static_cast<int64_t>(
+				static_cast<uint64_t>(opX) * static_cast<uint64_t>(opY));
+			addend = (product << 24) >> 24;
+		}
+		else
+		{
+			addend = static_cast<int64_t>(
+				(static_cast<uint64_t>(opX) * static_cast<uint64_t>(opY)) & ((1ull << 40) - 1));
+		}
+
+		int64_t acc = g_emac.acc[accN];
+		acc = subtract ? acc - addend : acc + addend;
+		// `macsatf` with OMC clear: sign-extend from 48 bits (it also sets V
+		// and the per-accumulator PAV bit, which nothing here reads).
+		if(fi)
+			acc = (acc << 16) >> 16;
+		g_emac.acc[accN] = acc;
+
+		// The load half. ⚠️ Route A writes Rw as a DATA register whatever the
+		// A/D bit says; the bit is 0 at every site this firmware reaches
+		// (`a090`, `a2a8`, `a099`, `a019` all have it clear), so the two
+		// emulators agree today and would diverge only on a form neither has
+		// met. The bit is honoured here because the encoding says so.
+		if(load)
+		{
+			const uint32_t loaded = (static_cast<uint32_t>(_m.read16(ea)) << 16) | _m.read16(ea + 2);
+			setReg(_m, rwIsA ? aReg(rw) : dReg(rw), loaded);
 		}
 		return Result::Handled;
 	}
@@ -448,6 +662,46 @@ namespace ot::v4e
 			setNZ(_m, v);
 			if(!writeEaLong(_m, mode, rn, v))
 				return Result::Unhandled;
+			return Result::Handled;
+		}
+
+		// ---- SATS ----------------------------------------------------------
+		// `0100 1100 1000 0rrr` -- ✅ `m68k-elf-as -mcpu=5475` gives 4c80 /
+		// 4c81 / 4c87 for %d0 / %d1 / %d7, and objdump reads the firmware's
+		// own 4c80 at 0x4000346a as `satsl %d0`.
+		//
+		// The site is the per-frame EMAC routine (0x400031a0) that the frame
+		// handler's completion state 5 calls, so it is on the M6c path and
+		// nowhere near the boot: the port ran O1..O5 and the whole project
+		// load without ever meeting it, then stopped dead there the moment
+		// the frame clock had something to do (measured 8 Sep 2026, O6 --
+		// "unimplemented opcode 4c80", 0 frames delivered).
+		//
+		// ✅ Semantics measured in ROUTE A'S ENGINE (six cases,
+		// `tools/ot_emu/test_emac.cpp` carries them): with V set, a result
+		// whose sign bit is CLEAR saturates to 0x80000000 and one whose sign
+		// bit is SET saturates to 0x7fffffff -- the end of the range the
+		// arithmetic wrapped away from; with V clear the value is untouched.
+		//
+		// ⚠️ THE FLAGS DISAGREE WITH THE MANUAL AND THIS FOLLOWS ROUTE A.
+		// The CFPRM says N and Z are set from the result and V and C cleared.
+		// Route A's engine updates **N only** -- a pre-set Z survives a
+		// non-zero result and V/C are left as they were. Route A is the
+		// oracle, and at the only site the firmware reaches, nothing between
+		// the `sats` and the next flag-setting instruction reads the CCR
+		// (three `movclrl`s and a `movel`). What would falsify it: a firmware
+		// site that branches on Z or V after a SATS; then the manual wins and
+		// both emulators are wrong.
+		if((_opcode & 0xfff8) == 0x4c80)
+		{
+			const uint32_t rn = _opcode & 7;
+			uint32_t v = reg(_m, dReg(rn));
+			auto sr = reg(_m, M68K_REG_SR);
+			if(sr & g_ccrV)
+				v = (v & 0x80000000u) ? 0x7fffffffu : 0x80000000u;
+			sr = (sr & ~g_ccrN) | ((v & 0x80000000u) ? g_ccrN : 0u);
+			setReg(_m, M68K_REG_SR, sr);
+			setReg(_m, dReg(rn), v);
 			return Result::Handled;
 		}
 


### PR DESCRIPTION
The M6c fidelity gate passes. With the project loaded, the transport started
through the real tasks and a trig poked on track 1 step 2, 400 frames of the
port produce exactly route A's log.

| | route A (the oracle) | `ot_emu` |
|---|---|---|
| frames since the transport start | 400 | 400 ✅ |
| sequencer ticks (vector `0x60`) | 28 | 28 ✅ |
| transport-start writes at frame 0 | `0x10` on tracks 0, 1, 2, 4, 7 | the same five, same order ✅ |
| the trig | frame **344**, track 0, bytes `0x08` then `0x18` | identical ✅ |
| saved / final / seq bank / pattern | 1 / 1 / 1 / 0 | identical ✅ |

```
scripts/o6_gate.sh
# oracle: 5 compared field(s) agree
```

## The eDMA and frame model needed no change

Five other things stood between it and the gate, each measured, none of them
reasoned about:

1. **The DSP host port needs route A's two stand-in replies.** `0x20000004`
   must read `0x0000` — the frame handler writes 140 there and polls bit 7 of
   the low byte for the DSP's handshake. An all-ones window spins forever: the
   port took exactly **one** frame interrupt and burned **352 M instructions**
   in a three-instruction loop, 0 eDMA transfers, 0 ticks. It reads as "the
   frame model is wrong"; it is a missing peripheral reply.
2. **`Region::contains` overflowed at `0xffffffff`** — with the region at 0,
   `(a-base)+size` wraps and the region claimed the address, so a legitimate
   unmapped write became a 4 GB smash: a bare SIGSEGV inside Musashi with **no
   output at all**, because stdout redirected to a file is block-buffered.
   Fixed, with three instruments so the next one prints: a bounds guard that
   stops the *machine*, an auto-map ceiling that names the runaway PC, and
   line-buffered stdout.
3. **`SATS` (`4c80|Dn`) was unimplemented** — on the M6c path only (the
   per-frame EMAC routine), which is why O1..O5 and the whole load never met
   it. Semantics measured in route A's engine. ⚠️ Its flags disagree with the
   CFPRM (route A updates N only); the port follows route A and the falsifier
   is written down.
4. **`movel #imm,%macsr` (`a93c`) was unimplemented** and desynchronised the
   instruction stream inside the frame handler.
5. **The EMAC had five fields wrong and the O2 gate covered none of them** —
   every case it tested used acc0, two data registers, the long form and no
   parallel load, the one combination in which all five are invisible:
   the accumulator number (opcode bit 7 + ext bit 4, **inverted** in the load
   form); An sources read as Dn; the operand-half bits on the wrong operands;
   the parallel load handling only `(An)+` where the firmware also uses `(An)`
   and the six-byte `(d16,An)`; and — the one that survived all the others —
   **the accumulator is 48 bits at `>>24`, not 32 bits at `>>32`**. Truncating
   each product before accumulating is off by one LSB on a subtract, and that
   is exactly the bit that made the live nibble read `0x09` where route A
   reads `0x08`, on every write of every frame. `test_emac` now carries 23
   assertions, every one watched failing first.

## How the last bit was found

`--watch-mem` (route A's own flag, now on the port too) named the writing PC;
objdump named the instruction and the table; route A's `--watch-pc` gave the
base; `--watch-mem` on both emulators showed the two *inputs* identical; which
left the arithmetic, and route A's actual model (QEMU's `macmulf`/`get_macf`
plus `tools/unicorn_emac_fractional.patch`) predicted the sign of the error
before the fix was written.

## ❌ Retraction

`RTOS_FORK.md` §8.4's **"byte `0xd3`"** and its six transport-start writes on
tracks 0, 1, 1, 2, 4, 7. Re-measured today, route A *and* the cold tool both
give five writes of `0x10` and `0x08`/`0x18` at frame 344. Propagated to §8,
§8.4 and the work order. 🟡 The EMAC fix of 7 Sep is the likely cause and is
marked inferred — nobody has re-run §8.4's tree on the stock library.

## No regression

`ctest` 6/6; the M6a oracle diff still reports **8 compared fields agree, 0
disagreements**; `make check` green.

O7b (the port loads twice) is untouched and still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)