### PR TITLE
O7b (re-target to main): the port loaded twice because the HARNESS named the project first

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -701,8 +701,13 @@ opcode is not evidence the part lacks it; the image is).
 `ctest` 6/6; oracle diff 8 compared fields, zero disagreements; the serial
 stream 5,731 bytes identical.
 
-**⚠️ OPEN — the port runs PAST route A's end, and that is a divergence, not
-a budget.** Route A stops at 6,189 commands with `M6b load: PASS` at a
+> ✅ **CLOSED 8 Sep 2026 by O7b (below): it was the harness's project-name
+> ordering, not a firmware divergence, and the two now issue the same 6,189
+> commands line for line. The 🟡 "select bank 0" hypothesis below is
+> RETRACTED.**
+
+**⚠️ OPEN (superseded) — the port runs PAST route A's end, and that is a
+divergence, not a budget.** Route A stops at 6,189 commands with `M6b load: PASS` at a
 6,000 ms budget **and at a 12,000 ms budget** (re-measured 8 Sep 2026: same
 6,189 / 30,467 / 297). The port's load runs on to **12,373 commands /
 60,677 sectors / 562 written** and parks in main, the same total at 6,000
@@ -716,6 +721,124 @@ which is right. **The next measurement is which task and PC issue command
 6,190 in the port** (`--ata-trace` carries the PC; its 200,000-access cap
 will need raising or arming at a command index), then the same site in
 route A to see why it does not.
+
+## Milestone O7b — why the port loaded twice ✅ (8 Sep 2026)
+
+**It was a race in the HARNESS, not a difference in the firmware, and the two
+emulators now issue the same 6,189 ATA commands line for line.**
+
+```
+diff <(cut -d'|' -f1 out/oracle/o7b_port_cmds2.txt) out/oracle/o7b_routeA_cmds.txt
+# (no output)
+6189 ATA command(s): 1 IDENTIFY, 5921 READ, 30467 sector(s) read, 297 written
+```
+
+### The mechanism, measured
+
+The port's extra 6,184 commands were a **second, complete project load** — its
+tail is its own head again, differing only in the writes the first pass had
+already made. Both loads are issued by the `engine`, and both arrive the same
+way: something posts LOAD PROJECT. So the question was who posts it twice.
+
+✅ **`--watch-pc` on `0x40023c7c` (the post) and `0x40085336` (the engine's
+LOAD PROJECT case) answers it directly.** The port hits each **twice**, route A
+**once**. The port's second post comes from **`sys`**, with the return address
+`0x4002576a` — a call site the image contains exactly once:
+
+```
+4006203a: jsr 0x40056600
+40062040: jsr 0x40056744
+40062046: tstl %d0
+40062048: bnes 0x40062050      ; non-zero: do nothing
+4006204a: jsr 0x4002574c       ; zero: "reload the current project"
+40062050: ...                  ; the join point
+
+4002574c: pea 0x100f8378       ; <- the PROJECT NAME
+40025752: jsr 0x40013db0
+40025758: addql #4,%sp
+4002575a: tstl %d0
+4002575c: bles 0x4002576c      ; nothing named: return
+4002575e: pea 0x100f8378
+40025764: jsr 0x40023c7c       ; post LOAD PROJECT
+```
+
+`0x40013db0` is **`strlen`** (`clrl %d0 / addql #1,%d0 / tstb %a0@(0,%d0:l) /
+bnes / rts`). So `sys`'s media case says, in as many instructions: **a card
+appeared — if a project is named, load it.**
+
+✅ **Both emulators run that path identically, instruction for instruction,
+and split on one value.** `--watch-pc` on `0x40062000`, `0x4006200c`,
+`0x40062046`, `0x4006204a`, `0x40025752`, `0x4002575e` gives the same registers
+at the same five sites in both (`d0 = 0`, then `2`, then `0`) — and then:
+
+| | route A | `ot_emu` (before the fix) |
+|---|---|---|
+| reaches `0x40025752` (the `strlen`) | ✅ at sample 10,361 | ✅ at sample 10,210 |
+| `strlen(0x100f8378)` returns | **0** — nothing named yet | **3** — `"RIG"` |
+| reaches `0x4002575e` (the post) | ❌ never | ✅ |
+| ATA commands | 6,189 | 12,373 |
+
+The whole divergence is **whether the harness has written the project name by
+the time `sys` next gets the CPU**. Route A's mount tail runs about 200 samples
+longer, so its media case fires *before* `set_names`; this port's fired after.
+
+✅ **The falsifier, run:** told to write the name first (`emu_rtos.py
+--load-project --names-early`, a flag added for exactly this and off by
+default), **route A reproduces the port's numbers exactly** — 12,373 commands,
+60,677 sectors, 562 written — and its `--watch-pc` shows the same
+`0x4002575e` → `0x40023c7c` from `sys` with `d0 = 3`. That is what turns this
+account from a story into a measurement.
+
+❌ **RETRACTED: the work order's 🟡 hypothesis that this was SYS's reset-time
+"select bank 0" going to the card.** The select-bank case is not on this path
+at all; the second load is a media-mount response, and the deciding value is a
+string length.
+
+### What the port does about it
+
+Neither order is the firmware's — the firmware's rule is unambiguous and both
+emulators agree on it. What differed was the harness, so the harness now
+*chooses*:
+
+- **Default (route A's order, and what the O7 gate measures):**
+  `loadProjectLive` waits for `sys`'s media case to reach its join point
+  (`g_mediaCaseJoin`, `0x40062050`) before writing the names, so the name is
+  provably not yet set when the case runs. One load, 6,189 commands,
+  byte-identical to route A's log.
+- **`--names-early`:** write the names before requesting the mount. Two loads,
+  12,373 commands. ⚠️ **This is arguably what HARDWARE does** — on the unit the
+  project name is set long before a card goes in — so the flag is not a
+  mistake to be avoided, it is the other real configuration. Nothing on
+  hardware has been measured either way.
+
+The load report now says which order ran and whether the media case was seen:
+
+```
+names after the mount; sys's media case ran before the name
+```
+
+### Instruments added
+
+`--watch-pc ADDR[,ADDR…]` on the C++ port (route A's own flag: registers and
+the top of the stack at each hit, so a hit on a callee names its caller and its
+arguments), `--cmd-log` on **route A** (the counterpart of the port's, so the
+two logs diff line for line), and the port's `--cmd-log` now carries the PC and
+the task per command after a `|` — `cut -d'|' -f1` still reproduces the old
+form exactly, so O7's diff method is unchanged.
+
+⚠️ **And a third instance of the silent-instrument trap.** `_watch_report()` was
+called from route A's M6c branch and (since 8 Sep) its plain branch, but **not
+from `--load-project`** — so `--watch-pc` on a load run printed nothing whether
+the address fired twice or never, which is precisely the question O7b exists to
+ask. Fixed. `RTOS_FORK.md` §10.3b records this trap; this is its third
+appearance, in the third branch.
+
+### No regression
+
+The O6 fidelity gate still reports **5 compared fields agree** (400 frames, 28
+ticks, the trig at frame 344 with bytes `0x08`/`0x18`); the M6a oracle diff
+still **8 compared fields agree, 0 disagreements**; `ctest` 6/6; `make check`
+green.
 
 ## What is NOT here yet
 

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -72,7 +72,8 @@ route A fact, not the port's problem; the golden command above already does it.
 | O4 | the run loop: the kernel runs | `ctest` rtos + the oracle diff | ✅ 6 compared fields (❌ was written "8/8": the diff counted 2 it never compared); 10 created, 11 ran, 204.88 ms vs 204.95 |
 | O5 | the rest of the memory; the serial stream | `ctest` rtos + the oracle diff | ✅ 8 compared fields; route A's 4831 serial bytes matched byte for byte (❌ its account of *why* route A has the extra memory was wrong — corrected in O7) |
 | O6 | the eDMA and the frame clock; the sequencer | the M6c fidelity gate (`scripts/o6_gate.sh`) | ✅ 5 compared fields: 400 frames, 28 ticks, the trig at frame 344 track 0 bytes `0x08`/`0x18`, and the bank/pattern four -- byte-identical to route A |
-| O7 | the card, the mount, the project load | route A's ATA command log is a prefix of the port's | ✅ all 6,189 commands identical, 297 written; ⚠️ OPEN: the port runs on to 12,373 and route A stops at 6,189 at ANY budget (`COLDFIRE_PORT.md` O7) |
+| O7 | the card, the mount, the project load | route A's ATA command log EQUALS the port's | ✅ all 6,189 commands identical line for line, 30,467 sectors read, 297 written (was "a prefix"; O7b closed the gap) |
+| O7b | why the port loaded twice | name the task and PC, and make the oracle reproduce it | ✅ `sys`'s media case reloads a NAMED project; the split is `strlen(name)` = 0 vs 3, a harness ordering race. Route A reproduces the port's 12,373 with `--names-early` |
 
 ## Queue
 
@@ -210,7 +211,44 @@ ended:` line — O7's "stall" was an ILLEGAL that looked like one.
 
 </details>
 
-### O7b — why the port loads twice — *(Opus, measurement first)*
+### ~~O7b — why the port loads twice~~ ✅ DONE (8 Sep 2026)
+
+**It was the harness, not the firmware.** `sys`'s media case (`0x4006203a`)
+answers a mount with "if a project is NAMED, load it" — `0x4002574c` is
+`if(strlen(0x100f8378)) post LOAD PROJECT`, and `0x40013db0` is `strlen`. Both
+emulators run that path identically and split on one value: the name is
+written by the time this port's case runs (`strlen` = 3) and not by the time
+route A's does (`strlen` = 0), because route A's mount tail runs ~200 samples
+longer. ✅ Told to write the name first (`--names-early`), **route A
+reproduces the port's 12,373 commands exactly**.
+
+❌ The 🟡 hypothesis in the entry below — SYS's reset-time "select bank 0"
+going to the card — is **retracted**. The select-bank case is not on this path.
+
+The port now waits for that case's join point before naming the project, so
+the order is a choice rather than a race, and its load is **byte-identical to
+route A's, command for command** (6,189 / 30,467 / 297). `--names-early` takes
+the other order deliberately: ⚠️ two loads, and arguably what HARDWARE does,
+since the unit has a project named long before a card goes in. Nothing on
+hardware has been measured either way — that is the open question this leaves.
+
+Three things worth carrying:
+
+1. **`--watch-pc` now exists on BOTH emulators** and answered this in two
+   runs: registers plus the top of the stack at each hit, so a hit on a callee
+   names its caller and its arguments.
+2. **`--cmd-log` now exists on route A too**, in the port's own first-field
+   format, so the two logs diff line for line.
+3. ⚠️ **The silent-instrument trap, third instance.** `_watch_report()` was
+   missing from route A's `--load-project` branch, so `--watch-pc` on a load
+   run printed nothing whether the address fired twice or never — the exact
+   question O7b asks. Fixed. Check the OTHER branches before trusting a
+   silent watch.
+
+<details><summary>the entry it replaces</summary>
+
+### O7b — why the port loads twice — (the original)
+
 
 Route A's load ends at 6,189 ATA commands at any budget; the port's runs to
 12,373 with route A's log as an exact prefix. Find which task and PC issue
@@ -220,6 +258,8 @@ other does not. 🟡 The hypothesis is SYS's reset-time "select bank 0"
 (RTOS_FORK.md §7) going to the card in the port and not in route A. Not a
 blocker for O6 (the load's first half is identical and the part pointer
 agrees), but it decides which emulator is telling the truth about the load.
+
+</details>
 
 <details><summary>the BLOCKED entry it replaces</summary>
 
@@ -346,9 +386,11 @@ and then polled TXEMP forever, which the UART model never set. Fix =
 MOV3Q to every alterable destination (`writeEaLong`); TXEMP is reported
 too, which is what made the fault legible. **Now: 12,373 commands / 60,677
 sectors / 562 written, and route A's whole 6,189-command log is an exact
-prefix.** ⚠️ Route A stops at 6,189 at a 12 s budget too, so the port's
-extra 6,184 commands are an OPEN divergence (a second bank parse, 🟡
-inferred), carried as O7b below. `COLDFIRE_PORT.md` has the instrument-by-instrument account and
+prefix.** ✅ **CLOSED by O7b:** the extra
+6,184 commands were a SECOND project load, triggered by `sys`'s media case
+because the harness had already written the project name; the port now waits
+for that case and issues route A's 6,189 line for line. The 🟡 "second bank
+parse" reading was wrong. `COLDFIRE_PORT.md` has the instrument-by-instrument account and
 the attribution. Instruments added: `--cmd-log FILE`, a true PC ring, and
 the load report's `load run ended: TIME|FAULT|ILLEGAL` line — **read that
 line before calling anything a stall.**

--- a/tools/emu_rtos.py
+++ b/tools/emu_rtos.py
@@ -1255,7 +1255,8 @@ class Rtos:
         self.uc.mem_write(FW_MIDI_SETTINGS, bytes([midi & ~1]))
         return midi
 
-    def load_project_live(self, set_name, project_name, run_ms=6000, mount_ms=3000):
+    def load_project_live(self, set_name, project_name, run_ms=6000, mount_ms=3000,
+                          names_early=False):
         """M6b: drive a project load the way hardware would, then let the
         REAL sys, engine and storage tasks do the rest -- no engine_run_once
         stand-in, no hand-run init list. Two real actions, neither of which
@@ -1298,6 +1299,17 @@ class Rtos:
         nothing here."""
         start = self.sample
         self.run(until=lambda r: r.pc == MAIN_SPIN)
+        if names_early:
+            # ⚠️ AN EXPERIMENT, NOT A FIX, and it is off by default. `sys`'s
+            # media case (0x4006203a) reloads the current project when
+            # `strlen(0x100f8378)` is non-zero -- so whether the mount
+            # triggers a SECOND load depends only on whether the name has
+            # been written by the time `sys` gets the CPU. Route A writes it
+            # after; the C++ port writes it before, and loads twice
+            # (COLDFIRE_PORT.md O7b). Setting it early here makes route A do
+            # the same, which is what turns that account from a story into a
+            # measurement.
+            ec.set_names(self, set_name, project_name)
         self.request_card_mount()
         self.run(ms=mount_ms, until=lambda r: int.from_bytes(
             r.uc.mem_read(0x460d1cb8, 4), "big") != 0)
@@ -1732,6 +1744,15 @@ def _cli():
                     help="with --sequencer: record every host-port-bound eDMA transfer (fields + "
                          "source bytes), every CPU write into the host-port window and every "
                          "DSP-select GPIO write to this JSON-lines file -- tier 2's parameter tape")
+    ap.add_argument("--names-early", action="store_true",
+                    help="with --load-project: write the SET/PROJECT names BEFORE requesting the "
+                         "mount instead of after. An EXPERIMENT (COLDFIRE_PORT.md O7b): sys's media "
+                         "case reloads the current project when its name is non-empty, so this makes "
+                         "route A load twice the way the C++ port does")
+    ap.add_argument("--cmd-log", default="",
+                    help="write every ATA command in order (`WHAT LBA COUNT`, one per line) "
+                         "to FILE -- the counterpart of the C++ port's --cmd-log, so the two "
+                         "logs can be diffed line for line instead of compared by count")
     ap.add_argument("--stock-emac", action="store_true",
                     help="run even though this Unicorn's EMAC fails emu_bringup.emac_selftest "
                          "(fractional products halved; RTOS_FORK section 10.16)")
@@ -1823,6 +1844,24 @@ def _cli():
                       f"at pc {pc:#x} in {rt._name(task)}")
             if len(writes) > cap:
                 print(f"   ... {len(writes) - cap} more (raise cap in emu_rtos.py)")
+
+    def _cmd_log(path, rt):
+        """Every ATA command in order, the shape the C++ port's --cmd-log
+        writes its first field group in, so `diff` names the first divergence
+        instead of a count difference naming none (O7's method, made a flag)."""
+        if not path or not rt.card:
+            return
+        pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            for e in rt.card.log:
+                # ⚠️ The entries are VARIABLE length: ("IDENTIFY",),
+                # ("READ", lba, n), ("CFA-TRANSLATE", lba). Pad to three so a
+                # short one lines up with the port's, which always writes all
+                # three fields.
+                lba = e[1] if len(e) > 1 else 0
+                n = e[2] if len(e) > 2 else 0
+                f.write(f"{e[0]} {lba} {n}\n")
+        print(f"cmd log    : {path} ({len(rt.card.log)} commands)")
 
     def _fault(e):
         why = f"FAULT {e} pc={rt.pc:#x} task={rt._name(rt._cur())}"
@@ -1956,6 +1995,7 @@ def _cli():
             print(f"arm-phase  : {len(fixes)} trig word(s) had bit 7 cleared (COMPENSATION): "
                   + ", ".join(f"track {t} {w:#x} @ {s_:.0f}" for s_, t, w in fixes[:8]))
         _watch_report()
+        _cmd_log(a.cmd_log, rt)
         if a.golden:
             # THE M6c ORACLE, in the shape tools/ot_emu/oracle.py compares:
             # the trig log with frame numbers relative to the transport start,
@@ -1985,7 +2025,7 @@ def _cli():
             if not rt.gate_m6a()[0]:
                 rt.run(ms=1000, until=lambda x: x.gate_m6a()[0])
             mounted, posted, saved_bank, final_bank, elapsed = rt.load_project_live(
-                a.set, staged_name, run_ms=a.ms)
+                a.set, staged_name, run_ms=a.ms, names_early=a.names_early)
         except (RtosFault, eb.UcError) as e:
             print(f"stopped    : {_fault(e)}")
             print(rt.report())
@@ -2001,6 +2041,14 @@ def _cli():
         if rt.card:
             print(f"card       : {len(rt.card.log)} commands, {rt.card.reads} sectors read, "
                   f"{rt.card.writes} written; last: {rt.card.log[-8:]}")
+        _cmd_log(a.cmd_log, rt)
+        # ⚠️ THE SILENT-INSTRUMENT TRAP, IN A THIRD BRANCH. `_watch_report`
+        # was called from the M6c path and (since 8 Sep) from the plain one,
+        # and NOT from here -- so `--watch-pc` on a `--load-project` run
+        # printed nothing whether the address fired twice or never. Found
+        # 8 Sep 2026 by O7b, whose whole question is "how many times".
+        # Section 10.3b records this trap; this is its third instance.
+        _watch_report()
         ok = bool(mounted) and saved_bank is not None
         if not ok:
             print(rt.starvation())

--- a/tools/ot_emu/card.h
+++ b/tools/ot_emu/card.h
@@ -40,8 +40,20 @@ namespace ot
 
 		// What the run did, in the shape route A's log has it: the gate for
 		// the project load is a COUNT of commands and sectors.
-		struct Entry { std::string what; uint32_t lba = 0, count = 0; };
+		// ⚠️ `pc` and `tcb` are stamped by `Rtos` AFTER the command register
+		// write returns -- the card model has no view of the CPU. They are
+		// what O7b needs: "which task and PC issue command 6,190" is not
+		// answerable from a count.
+		struct Entry { std::string what; uint32_t lba = 0, count = 0, pc = 0, tcb = 0; };
 		const std::vector<Entry>& log() const { return m_log; }
+		void stampLastCommand(const uint32_t _pc, const uint32_t _tcb)
+		{
+			if(!m_log.empty() && !m_log.back().pc)
+			{
+				m_log.back().pc = _pc;
+				m_log.back().tcb = _tcb;
+			}
+		}
 		uint64_t sectorsRead() const { return m_reads; }
 		uint64_t sectorsWritten() const { return m_writes; }
 

--- a/tools/ot_emu/machine.cpp
+++ b/tools/ot_emu/machine.cpp
@@ -442,6 +442,18 @@ namespace ot
 		return m68k_get_reg(const_cast<void*>(static_cast<const void*>(getCpuState())), M68K_REG_D0);
 	}
 
+	uint32_t Machine::getD(const int _n) const
+	{
+		return m68k_get_reg(const_cast<void*>(static_cast<const void*>(getCpuState())),
+			static_cast<m68k_register_t>(M68K_REG_D0 + _n));
+	}
+
+	uint32_t Machine::getA(const int _n) const
+	{
+		return m68k_get_reg(const_cast<void*>(static_cast<const void*>(getCpuState())),
+			static_cast<m68k_register_t>(M68K_REG_A0 + _n));
+	}
+
 	uint32_t Machine::peek32(const uint32_t _addr)
 	{
 		return read32(_addr);

--- a/tools/ot_emu/machine.h
+++ b/tools/ot_emu/machine.h
@@ -190,6 +190,8 @@ namespace ot
 		uint32_t getA7() const;
 		void     setA7(uint32_t _v);
 		uint32_t getD0() const;
+		uint32_t getD(int _n) const;
+		uint32_t getA(int _n) const;
 
 		uint32_t peek32(uint32_t _addr);
 		void     poke32(uint32_t _addr, uint32_t _val);

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -68,6 +68,8 @@ int main(int _argc, char** _argv)
 	int bankOverride = -1;		// with --sequencer: switch to this bank (default: the file's saved bank)
 	std::string m6cGolden;		// the M6c facts as JSON, for tools/ot_emu/oracle.py
 	std::string watchMem;		// ADDR,LEN -- log every write into that range (route A's own flag)
+	std::string watchPc;		// comma-separated addresses -- log registers there (route A's own flag)
+	bool namesEarly = false;	// write the SET/PROJECT names BEFORE the mount -- see O7b
 
 	for(int i = 1; i < _argc; ++i)
 	{
@@ -99,6 +101,8 @@ int main(int _argc, char** _argv)
 		else if(a == "--bank" && i + 1 < _argc)		bankOverride = std::atoi(_argv[++i]);
 		else if(a == "--m6c-golden" && i + 1 < _argc)	m6cGolden = _argv[++i];
 		else if(a == "--watch-mem" && i + 1 < _argc)	watchMem = _argv[++i];
+		else if(a == "--watch-pc" && i + 1 < _argc)	watchPc = _argv[++i];
+		else if(a == "--names-early")			namesEarly = true;
 		else
 		{
 			std::printf("usage: ot_emu [--image FILE] [--max N] [--periph] [--profile]\n"
@@ -170,6 +174,20 @@ int main(int _argc, char** _argv)
 			std::printf("card       : %s, %u sectors\n", cardImage.c_str(), card->totalSectors());
 		}
 		rtos.install();
+		if(!watchPc.empty())
+		{
+			std::vector<uint32_t> addrs;
+			size_t q = 0;
+			while(q < watchPc.size())
+			{
+				auto e = watchPc.find(',', q);
+				if(e == std::string::npos) e = watchPc.size();
+				addrs.push_back(static_cast<uint32_t>(std::strtoul(watchPc.substr(q, e - q).c_str(), nullptr, 0)));
+				q = e + 1;
+			}
+			rtos.watchPc(addrs);
+			std::printf("watch-pc   : %zu address(es)\n", addrs.size());
+		}
 		if(!watchMem.empty())
 		{
 			const auto comma = watchMem.find(',');
@@ -208,7 +226,7 @@ int main(int _argc, char** _argv)
 				const auto forces0 = rtos.forces();
 				const auto disp0 = rtos.dispatches().size();
 				m.setPeriphTrace(!periphTrace.empty());
-				load = rtos.loadProjectLive(setName, projectName, loadMs);
+				load = rtos.loadProjectLive(setName, projectName, loadMs, 3000.0, namesEarly);
 				const auto& r = load;
 				m.setPeriphTrace(false);
 				std::printf("             card ready: %#x, LOAD PROJECT posted: %s, "
@@ -219,6 +237,9 @@ int main(int _argc, char** _argv)
 				// is not on its own evidence that a project loaded (O7). The
 				// bank the engine PARSED is: it comes from the write the
 				// BANK= parse makes, and it is the number route A reports.
+				std::printf("             names %s the mount; sys's media case %s before the name\n",
+					namesEarly ? "BEFORE (--names-early: expect a second load)" : "after",
+					r.mediaCaseSeen ? "ran" : "did NOT run");
 				std::printf("             saved_bank: %d, final bank: %u%s\n",
 					r.savedBank, r.finalBank,
 					r.savedBank >= 0 && r.finalBank != static_cast<uint32_t>(r.savedBank)
@@ -327,8 +348,19 @@ int main(int _argc, char** _argv)
 			if(!cmdLog.empty())
 			{
 				std::ofstream t(cmdLog);
+				size_t n = 0;
 				for(const auto& e : card->log())
-					t << e.what << ' ' << e.lba << ' ' << e.count << '\n';
+				{
+					char line[160];
+					// ⚠️ THE FIRST FIELD GROUP MUST STAY BYTE-COMPATIBLE with route
+					// A's dump, because diffing the two logs is what proved
+					// the port's first 1,407 commands were route A's (O7).
+					// Everything O7b needs goes after a `|`, so
+					// `cut -d'|' -f1` still reproduces the old form exactly.
+					std::snprintf(line, sizeof line, "%s %u %u | #%zu pc %#010x %s",
+						e.what.c_str(), e.lba, e.count, n++, e.pc, ot::taskName(e.tcb));
+					t << line << '\n';
+				}
 				std::printf("             cmd log: %s (%zu commands)\n",
 					cmdLog.c_str(), card->log().size());
 			}
@@ -452,6 +484,15 @@ int main(int _argc, char** _argv)
 			}
 		}
 
+		if(!watchPc.empty())
+		{
+			std::printf("watch-pc   : %zu hit(s)\n", rtos.pcHits().size());
+			for(const auto& h : rtos.pcHits())
+				std::printf("   [%10.1f] at %#x d0=%#x d1=%#x a0=%#x a1=%#x in %s "
+					"[sp %#x: %#x %#x %#x %#x %#x]\n",
+					h.sample, h.pc, h.d0, h.d1, h.a0, h.a1, ot::taskName(h.tcb), h.sp,
+					h.stack[0], h.stack[1], h.stack[2], h.stack[3], h.stack[4]);
+		}
 		if(!watchMem.empty())
 		{
 			// ⚠️ PRINT THEM ALL (capped only against a flood). A watch that

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -134,6 +134,10 @@ namespace ot
 			// asserts only once the drive has absorbed a sector.
 			if(off == AtaCard::R_CMD)
 			{
+				// Who issued it. The command register write is the moment the
+				// command exists, and `currentPc()` is the instruction making
+				// it (not the fetch pointer) -- see Machine::currentPc.
+				m_card->stampLastCommand(m_machine.currentPc(), curTcb());
 				if((_val & 0xff) != 0x30)
 					m_ataIrqDue = m_sample + m_ataLatency;
 				if(!m_pcRing.empty() && !m_pcRingArmed)
@@ -448,6 +452,17 @@ namespace ot
 			m_pcRing[m_pcRingPos % m_pcRing.size()] = pc;
 			++m_pcRingPos;
 		}
+		if(!m_watchPc.empty() && m_pcHits.size() < 4000)
+			for(const auto a : m_watchPc)
+				if(a == pc)
+				{
+					PcHit h{m_sample, curTcb(), pc, m_machine.getD(0), m_machine.getD(1),
+						m_machine.getA(0), m_machine.getA(1), m_machine.getA7(), {}};
+					for(int i = 0; i < 5; ++i)
+						h.stack[i] = m_machine.peek32(h.sp + 4 * i);
+					m_pcHits.push_back(h);
+					break;
+				}
 		if(pc == g_create)
 			recordCreate();
 
@@ -597,14 +612,21 @@ namespace ot
 		write(g_projectName, _project);
 	}
 
+	Rtos::Stop Rtos::runToPc(const uint32_t _pc, const double _ms)
+	{
+		return runUntil(_ms, [this, _pc] { return m_machine.pc() == _pc; });
+	}
+
 	Rtos::LoadResult Rtos::loadProjectLive(const std::string& _set, const std::string& _project,
-		const double _runMs, const double _mountMs)
+		const double _runMs, const double _mountMs, const bool _namesEarly)
 	{
 		LoadResult out;
 		const double start = m_sample;
 
 		if(runToMainSpin() != Stop::Gate)
 			return out;
+		if(_namesEarly)
+			setNames(_set, _project);
 		if(!requestCardMount())
 			return out;
 
@@ -617,9 +639,23 @@ namespace ot
 				return out;
 		out.ready = m_machine.peek32(g_cardReady);
 
+		// ⚠️ WAIT FOR `sys`'S MEDIA CASE TO PASS BEFORE NAMING THE PROJECT,
+		// or the name is a RACE. ✅ Measured 8 Sep 2026 (O7b): the case at
+		// `0x4006203a` reloads whatever project is named, and the two
+		// emulators disagreed by 6,184 ATA commands for no other reason than
+		// that route A's mount tail runs ~200 samples longer, so its case
+		// fired BEFORE its harness wrote the name and this port's fired after.
+		// Route A reproduces the port's 12,373 exactly when told to write the
+		// name first (`--names-early`), which is what turns this from a story
+		// into a measurement. Waiting for the join point makes the order a
+		// choice; `_namesEarly` takes the other one deliberately.
+		if(!_namesEarly)
+			out.mediaCaseSeen = runToPc(g_mediaCaseJoin, 2000.0) == Stop::Gate;
+
 		if(runToMainSpin() != Stop::Gate)
 			return out;
-		setNames(_set, _project);
+		if(!_namesEarly)
+			setNames(_set, _project);
 		// Route A's own watch: the engine's BANK= parse is the write to
 		// PART_PTR made at 0x40087d44, and it is the ONLY thing that tells
 		// the saved bank apart from every other writer of that word (`sys`'s
@@ -722,6 +758,11 @@ namespace ot
 		const auto v = static_cast<uint8_t>(m_machine.read8(at) | (1u << ((_step - 1) % 8)));
 		m_machine.write8(at, v);
 		return v;
+	}
+
+	void Rtos::watchPc(const std::vector<uint32_t>& _addrs)
+	{
+		m_watchPc = _addrs;
 	}
 
 	void Rtos::watchMem(const uint32_t _addr, const uint32_t _len)

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -57,6 +57,17 @@ namespace ot
 	inline constexpr uint32_t g_postLoad    = 0x40023c7c;	// (name*) -> posts engine command 4
 	inline constexpr uint32_t g_partPtr     = 0x46c82456;	// null until a project loads
 
+	// ✅ O7b, 8 Sep 2026. `sys`'s media case reloads the current project when
+	// one is named: `0x4006203a` calls `0x40056744` and, if it answers ZERO,
+	// calls `0x4002574c` -- which is `if(strlen(0x100f8378)) post LOAD
+	// PROJECT`. So whether a mount triggers a SECOND full load depends on
+	// nothing but whether the project NAME has been written by the time `sys`
+	// next gets the CPU. `g_mediaCaseJoin` is where that decision rejoins the
+	// case, and waiting for it is how the harness makes the order a CHOICE
+	// instead of a race (see `Rtos::loadProjectLive`).
+	inline constexpr uint32_t g_mediaCaseJoin = 0x40062050;
+	inline constexpr uint32_t g_projectExists = 0x4002574c;	// if(strlen(name)) post LOAD PROJECT
+
 	// -- M6c: the sequencer, from route A's own constants ------------------
 	// The bank blobs in RAM: PART_PTR = g_bankBlob + bank * g_bankStride,
 	// i.e. the CURRENT bank's data. 0x400e21e0 is bank A, 0x4017d520 bank B.
@@ -230,6 +241,15 @@ namespace ot
 		// sample, the task, the PC and the value. The counterpart instrument
 		// to route A's, so a divergence can be diffed line for line instead of
 		// reasoned about.
+		// Route A's `--watch-pc`: the registers and the top of the stack each
+		// time one of these addresses is ABOUT to execute -- so a hit on a
+		// callee names its caller and its arguments. ⚠️ The check runs per
+		// instruction, so it is guarded on the list being empty; with no
+		// address watched it costs one compare.
+		struct PcHit { double sample; uint32_t tcb, pc, d0, d1, a0, a1, sp, stack[5]; };
+		void watchPc(const std::vector<uint32_t>& _addrs);
+		const std::vector<PcHit>& pcHits() const { return m_pcHits; }
+
 		struct MemWrite { double sample; uint32_t tcb, pc, addr, val; uint8_t size; };
 		void watchMem(uint32_t _addr, uint32_t _len);
 		const std::vector<MemWrite>& memWrites() const { return m_memWrites; }
@@ -263,13 +283,27 @@ namespace ot
 		// the working bank back to A (RTOS_FORK.md §7).
 		struct LoadResult { uint32_t ready = 0, partPtr = 0; bool posted = false; double ms = 0;
 			int savedBank = -1; uint32_t finalBank = 0;
+			// Did `sys`'s media case run before the name was written? If it
+			// did not, the mount may have triggered a second load.
+			bool mediaCaseSeen = false;
 			std::string postWhy;
 			// How the load's own run ENDED. Time is the ordinary case (the
 			// budget ran out); Fault/Illegal say the machine stopped, which
 			// the ATA counts alone cannot distinguish from a stall.
 			Stop stop = Stop::Time; std::string stopWhy; };
+		// ⚠️ `_namesEarly` DECIDES WHETHER THE PROJECT LOADS ONCE OR TWICE, and
+		// it is a property of the HARNESS, not of the firmware. See
+		// `g_mediaCaseJoin`: with the name already written when `sys` runs its
+		// media case, the firmware reloads the project and the run issues
+		// 12,373 ATA commands instead of 6,189. Both orders are real -- on the
+		// unit the name is set long before a card goes in, so the reload IS
+		// what hardware does -- but only one of them is comparable with route
+		// A's own numbers, so `false` (the name written after the media case)
+		// is the default and is what the O7 gate measures.
 		LoadResult loadProjectLive(const std::string& _set, const std::string& _project,
-			double _runMs = 6000.0, double _mountMs = 3000.0);
+			double _runMs = 6000.0, double _mountMs = 3000.0, bool _namesEarly = false);
+		// Run until the PC reaches an address, or the budget runs out.
+		Stop runToPc(uint32_t _pc, double _ms);
 
 		// -- what the oracle compares ---------------------------------------
 		struct Created { double sample; uint32_t tcb, entry, prio, stack, size, creator; };
@@ -397,6 +431,8 @@ namespace ot
 		// `rte` is not the ack.
 		std::vector<TrigWrite> m_liveNibble, m_trigWords;
 		std::vector<MemWrite> m_memWrites;
+		std::vector<uint32_t> m_watchPc;
+		std::vector<PcHit> m_pcHits;
 		bool m_trigLogInstalled = false;
 		bool m_partPtrWatched = false;
 		int m_savedBank = -1;


### PR DESCRIPTION
⚠️ **#145 is marked merged but its work never reached `main`.** It was based on
`coldfire-o6-fidelity`, and #144 merged that branch to `main` *before* #145
merged into it — so `b317c43` lives on the branch and nowhere else:

```
git merge-base --is-ancestor b317c43 origin/main   # NO
git log --oneline origin/main..origin/coldfire-o6-fidelity
  1718524 Merge pull request #145 from sambanks/coldfire-o7b
  b317c43 O7b: the port loaded twice because the HARNESS named the project first
```

This PR carries exactly that commit onto `main`. Nothing has changed since
#145; its description is the record of the work, reproduced below.

---

The port's extra 6,184 ATA commands were a **second, complete project load**,
and it was a race in the harness rather than a difference in the firmware. The
two emulators now issue the same 6,189 commands **line for line**.

## The mechanism

`--watch-pc` on `0x40023c7c` (the post) and `0x40085336` (the engine's LOAD
PROJECT case): the port hits each **twice**, route A **once**, and the port's
second post comes from **`sys`** with a return address the image contains
exactly once:

```
4006203a: jsr 0x40056744
40062046: tstl %d0
40062048: bnes 0x40062050     ; non-zero: do nothing
4006204a: jsr 0x4002574c      ; zero: "reload the current project"

4002574c: pea 0x100f8378      ; <- the PROJECT NAME
40025752: jsr 0x40013db0      ; strlen
4002575c: bles 0x4002576c     ; nothing named: return
40025764: jsr 0x40023c7c      ; post LOAD PROJECT
```

`0x40013db0` is **`strlen`**. So `sys`'s media case says, in as many
instructions: *a card appeared — if a project is named, load it.*

Both emulators run that path **identically** (same registers at the same five
sites) and split on one value:

| | route A | `ot_emu` (before) |
|---|---|---|
| reaches the `strlen` | ✅ sample 10,361 | ✅ sample 10,210 |
| `strlen(0x100f8378)` | **0** — nothing named yet | **3** — `"RIG"` |
| reaches the post | ❌ never | ✅ |
| ATA commands | 6,189 | 12,373 |

Route A's mount tail runs ~200 samples longer, so its media case fires *before*
`set_names` and this port's fired after. That is the whole difference.

## The falsifier, run

Told to write the name first (`emu_rtos.py --load-project --names-early`, added
for this and off by default), **route A reproduces the port exactly** — 12,373
commands, 60,677 sectors, 562 written, and the same `0x4002575e` →
`0x40023c7c` post from `sys` with `d0 = 3`.

## ❌ Retraction

The 🟡 hypothesis that this was SYS's reset-time "select bank 0" going to the
card. The select-bank case is not on this path at all.

## What the port does about it

Neither order is the firmware's, so the harness now *chooses*:

- **Default (route A's order):** wait for the media case's join point
  (`0x40062050`) before naming the project. One load — **6,189 / 30,467 / 297,
  byte-identical to route A's log**, so O7's gate goes from "a prefix of" to
  "equal to".
- **`--names-early`:** name it first. Two loads. ⚠️ Arguably what *hardware*
  does — the unit has a project named long before a card goes in — so this is
  the other real configuration, not a mistake. **Nothing on hardware has been
  measured either way; that is what this leaves open.**

## Instruments

`--watch-pc` on the C++ port (route A's own flag), `--cmd-log` on route A (the
port's own format, so the logs diff line for line), and the port's `--cmd-log`
now carries the PC and task after a `|` — `cut -d'|' -f1` still reproduces the
old form, so O7's diff method is unchanged.

⚠️ **The silent-instrument trap, third instance:** `_watch_report()` was missing
from route A's `--load-project` branch, so `--watch-pc` on a load run printed
nothing whether the address fired twice or never — the exact question this
milestone asks. Fixed.

## No regression

O6's fidelity gate still **5 compared fields agree**; the M6a oracle diff still
**8 compared fields agree, 0 disagreements**; `ctest` 6/6; `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)