### PR TITLE
O8 — BLOCKED: the join is decoded, no DSP wired yet

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -840,6 +840,130 @@ ticks, the trig at frame 344 with bytes `0x08`/`0x18`); the M6a oracle diff
 still **8 compared fields agree, 0 disagreements**; `ctest` 6/6; `make check`
 green.
 
+## Milestone O8 — the DSP cores and the host port ⛔ IN PROGRESS (8 Sep 2026)
+
+**The gate is not passed and no DSP is wired yet. What this session did is
+decode the join completely, from the firmware's own code, and fix two
+instruments that were lying about it.** The headline:
+
+✅ **THE FIRMWARE BOOTS THE DSPs ITSELF, DURING THE COLDFIRE BOOT, AND WE HAVE
+CAPTURED THE BYTES.** No `.mem` dump is needed for the join: the payload comes
+out of the OS image, through the host port, under the firmware's own control.
+
+### What runs, and when
+
+`0x4000050c` — a **boot** address — calls `0x40001e50` ("DSP start") exactly
+once, at instruction **4,270,944** of the 10,170,953-instruction boot. It calls
+the uploader `0x40001d4c` twice:
+
+| call | source | length | DSP load address |
+|---|---|---|---|
+| 1 | `0x400e21e0` | `0x96` = 150 bytes | `P:0x31000` |
+| 2 | `0x400e2276` | `0xae` = 174 bytes | `P:0x32000` |
+
+Both destinations are in the **shared window** (`0x30000`–`0x3FFFF`). The caller
+first relocates the big blobs in ColdFire RAM (77,061 words from `0x400f59ef`,
+79,563 from a register) — so the payload proper is staged in RAM and these two
+uploads are a **bootstrap**, not the program.
+
+### The wire protocol, decoded and verified
+
+`--hostport-log FILE` (new) records every write into `0x20000000`–`0x20000fff`
+with its PC and instruction count. The boot makes **350 writes / 114 complete
+24-bit words**, and they frame exactly:
+
+```
+W 20000000 0081     pc 0x40001e5e     <- "start the DSP"
+W 20000004 0000     pc 0x40001d62     <- command/status
+word 000032                           <- COUNT: 50 words  (150 bytes / 3)
+word 031000                           <- LOAD ADDRESS
+word 0003f8 ... 50 words of program
+```
+
+✅ **The byte lanes come from the loader's own code** at `0x40001d74`, not from
+a reading of the manual:
+
+```
+movel %d0,%d1 / swap %d1 / extl %d1 / movew %d1,0x20000014   -> bits 23:16
+movel %d0,%d1 / asrl #8,%d1         / movew %d1,0x20000018   -> bits 15:8
+                                      movew %d0,0x2000001c   -> bits  7:0
+```
+
+only the LOW BYTE of each halfword is meaningful. ⚠️ Getting the lanes
+backwards makes word 2 read `0x001003` instead of `0x031000` — and `0x31000` is
+the load address the loader was *called* with, which is what says the decode is
+right. The loader also divides its byte length by 3 (`remsl #3`), which is why
+the count is 50 and the argument was 150.
+
+### ✅ And the DSP half of the protocol, in the firmware's own words
+
+The 50 captured words, disassembled at their load address with the vendored
+`dsp56kDisassemble`, are an **HDI08 bootstrap loader**:
+
+```
+031000: ori     #$3,mr
+031002: bset    #$12,y:<<$fffff9                  ; HDI08 config
+031003: bset    #$12,y:<<$fffffa
+031004: brclr   #HSR_HRDF,x:<<M_HSR,func_031004   ; wait for a host word
+031006: movep   x:<<M_HORX,a                      ; read it
+031007: brclr   #HSR_HTDE,x:<<M_HSR,func_031007
+031009: movep   a,x:<<M_HOTX                      ; ECHO IT BACK
+03100a: brclr   #HSR_HRDF,x:<<M_HSR,func_03100a
+03100c: movep   x:<<M_HORX,r0
+03100d: cmp     #<$3,a
+03100f: jmp     (r0)                              ; run the loaded code
+```
+
+That echo is the far side of the handshake **O6 had to fake** (`0x20000004`
+reading `0x0000`, `0x2000001c` toggling). With a real HDI08 behind the window
+the firmware programs the DSPs and the fakes come out.
+
+### ⚠️ Two instruments were lying, and both nearly produced a wrong finding
+
+Recorded because each one first returned a confident zero:
+
+1. **The PC watch could not see the boot.** It lived in `Rtos::stepOnce`, which
+   runs only after the handoff, so `--watch-pc 0x4000050c` reported **0 hits**
+   — for an address that runs 4.27 M instructions into the boot. The first
+   draft of this section said "the DSP loader never runs". It now lives in
+   `Machine` (consulted from both `run()` and `step()`), is armed BEFORE the
+   boot, and timestamps in instructions because the boot has no sample clock.
+2. **`--periph`'s log is capped at 4096 accesses** and the boot makes 8,235
+   peripheral writes before the DSP init, so "0 host-port touches in the
+   peripheral log" was a false negative too. `--hostport-log` is a separate,
+   uncapped-in-practice recorder for exactly this reason.
+
+Same family as `RTOS_FORK.md` §10.3b, and the third and fourth instances this
+week. **A zero from an instrument is not a measurement until you know the
+instrument can see the thing.**
+
+### What O8 still needs, in order
+
+1. Link `dsp56kEmu` into `ot_emu` and instantiate two cores (mechanical:
+   `tools/dsp_host` already boots both with the shared-window patch).
+2. Wire `0x20000014/18/1c` → `HDI08::writeRX`, `0x20000008` → HSR (bit 6 =
+   ready), `0x20000004` → the busy/status byte, and `0x20000000`'s `0x81` /
+   `0x8c` to start / swap. The chip select at `0xFC0A400C` picks the core.
+3. Let the firmware's own bootstrap upload run, and check the DSP's `P:0x31000`
+   against the captured words — that is O8's first real gate and it is
+   self-checking.
+4. Make the eDMA MOVE data (route A's model deliberately moves none), so the
+   frame exchange carries the 336/64/32-word records `docs/DSP.md` names.
+5. Only then the milestone's own gate: `verify_twocore`'s layouts rendering
+   identically when driven by the firmware instead of `dsp_host`'s hand-rolled
+   ABI calls.
+
+⚠️ **Step 5 is a bigger jump than it reads.** `verify_twocore` drives the
+EFFECT ABI directly (`r0`/`r6`/`r7`/`n7` and a `proc` call); the firmware drives
+whole FRAMES through the packer at `0x4000d3fc`. Making those render the same
+audio means the firmware's per-track records have to carry the same knob values
+the harness passes by hand, and nothing has yet checked that they can.
+
+### No regression
+
+`ctest` 6/6; the M6a oracle diff **8 compared fields agree, 0 disagreements**;
+the O6 fidelity gate **5 compared fields agree**.
+
 ## What is NOT here yet
 
 - **The rest of the peripherals.** The eDMA with its completion-timing rules

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -424,13 +424,45 @@ first (the oracle), and the discrepancy stays documented as route A's.
 
 </details>
 
-### O8 — the DSP cores and the host port *(Fable — judgment)*
+### O8 — the DSP cores and the host port — ⛔ SCOPED, NOT BUILT (8 Sep 2026)
 
-Join `dsp56kEmu` (both cores, the shared-window patch) to the machine
-through the host-port protocol decoded on 7 Sep 2026 (`COLDFIRE_PORT.md`
-"What is NOT here yet"). Gate: `tools/verify_twocore.py`'s layouts render
-identically when driven by the firmware instead of by `dsp_host`'s
-hand-rolled calls. Not to be started unattended.
+**The join is fully decoded and no DSP is wired yet.** `COLDFIRE_PORT.md` has
+the account; the headline is that ✅ **the firmware boots the DSPs ITSELF,
+during the ColdFire boot, and the bytes are captured**: `0x40001e50` (called
+once from the boot at `0x4000050c`, instruction 4,270,944) uploads a 50-word
+bootstrap to `P:0x31000` and a 58-word one to `P:0x32000` through
+`0x20000014/18/1c`, and those 50 words disassemble as an **HDI08 bootstrap
+loader** that echoes each host word back — the far side of the handshake O6 had
+to fake. So the join needs no `.mem` dump: wire the window to a real HDI08 and
+the firmware programs the cores.
+
+**Do these in order** (details and the byte lanes in `COLDFIRE_PORT.md`):
+
+1. Link `dsp56kEmu` into `ot_emu`, two cores, shared-window patch (mechanical —
+   `tools/dsp_host` already does it).
+2. Wire the window: `0x14/18/1c` → `HDI08::writeRX` (bits 23:16, 15:8, 7:0 —
+   low byte of each halfword only), `0x20000008` → HSR, `0x20000004` → the
+   busy/status byte, `0x20000000` `0x81`/`0x8c` = start/swap, chip select at
+   `0xFC0A400C`.
+3. **First real gate, and it is self-checking:** let the firmware's own upload
+   run and compare the DSP's `P:0x31000` against the captured words
+   (`--hostport-log`).
+4. Make the eDMA MOVE data — route A's model deliberately moves none — so the
+   frame exchange carries the 336/64/32-word records `docs/DSP.md` names.
+5. Only then the milestone's own gate: `verify_twocore`'s layouts rendering
+   identically when driven by the firmware.
+
+⚠️ **Step 5 is a bigger jump than it reads.** `verify_twocore` drives the effect
+ABI directly (`r0`/`r6`/`r7`/`n7` + `proc`); the firmware drives whole FRAMES
+through the packer at `0x4000d3fc`. Nothing has yet checked that the firmware's
+per-track records can carry the knob values the harness passes by hand. That is
+the judgment this milestone was reserved for.
+
+⚠️ **And two instruments were lying about all of this before they were fixed**
+(both returned a confident zero for something that runs): the PC watch could not
+see the boot, and `--periph`'s log is capped at 4096 accesses — full long before
+the DSP init. Fixed, and `--hostport-log` added. **A zero from an instrument is
+not a measurement until you know the instrument can see the thing.**
 
 ### O9 — audio out *(Fable)*
 

--- a/tools/ot_emu/machine.cpp
+++ b/tools/ot_emu/machine.cpp
@@ -238,6 +238,9 @@ namespace ot
 
 	void Machine::peripheralWrite(const uint32_t _addr, const uint8_t _size, const uint32_t _val)
 	{
+		if(m_hostPortLogOn && _addr >= 0x20000000 && _addr < 0x20001000
+			&& m_hostPortLog.size() < 4000000)
+			m_hostPortLog.push_back({m_instructions, currentPc(), _addr, _val, _size});
 		m_periphWrites.push_back({_addr, _size, _val});
 		if(m_periphLog.size() < 4096)
 			m_periphLog.push_back({'W', pc(), _addr, _size, _val});
@@ -255,6 +258,8 @@ namespace ot
 	bool Machine::step()
 	{
 		const auto p = pc();
+		if(!m_watchPc.empty())
+			notePcWatch(p);
 		const auto op = read16(p);
 		// The EMAC and mov3q are A-line: Musashi routes 0xAxxx to the A-line
 		// EXCEPTION, not to the illegal-instruction callback the V4e layer
@@ -442,6 +447,21 @@ namespace ot
 		return m68k_get_reg(const_cast<void*>(static_cast<const void*>(getCpuState())), M68K_REG_D0);
 	}
 
+	void Machine::notePcWatch(const uint32_t _pc)
+	{
+		if(m_pcHits.size() >= 4000)
+			return;
+		for(const auto a : m_watchPc)
+			if(a == _pc)
+			{
+				PcHit h{m_instructions, _pc, getD(0), getD(1), getA(0), getA(1), getA7(), {}};
+				for(int i = 0; i < 5; ++i)
+					h.stack[i] = peek32(h.sp + 4 * static_cast<uint32_t>(i));
+				m_pcHits.push_back(h);
+				return;
+			}
+	}
+
 	uint32_t Machine::getD(const int _n) const
 	{
 		return m68k_get_reg(const_cast<void*>(static_cast<const void*>(getCpuState())),
@@ -603,6 +623,8 @@ namespace ot
 			}
 			if(m_profileEvery && (m_instructions % m_profileEvery) == 0)
 				++m_profile[p];
+			if(!m_watchPc.empty())
+				notePcWatch(p);
 			if(m_step)
 				m_step(*this, p);
 			exec();

--- a/tools/ot_emu/machine.h
+++ b/tools/ot_emu/machine.h
@@ -183,6 +183,39 @@ namespace ot
 		// reach the handoff is almost always spinning on a flag no peripheral
 		// model answers, and the hot address names it -- route A grew the same
 		// thing (its stall detector) for the same reason.
+		// ⚠️ THE PC WATCH LIVES HERE, NOT IN `Rtos`, AND THAT IS THE POINT.
+		// It was in `Rtos::stepOnce` first, which runs only AFTER the handoff
+		// -- so a watch on an address in the BOOT's own range reported "0
+		// hits" whether it ran or not. That is the silent-instrument trap
+		// again (RTOS_FORK §10.3b), and it nearly produced a wrong finding
+		// about the DSP program loader on 8 Sep 2026 (O8): `0x4000050c`, the
+		// only caller of the DSP start, is at a boot address. Consulted from
+		// BOTH `run()` and `step()`, the answer covers the whole run.
+		//
+		// The timestamp is the INSTRUCTION COUNT rather than the sample clock,
+		// because the boot has no sample clock -- `Rtos` prints its own sample
+		// beside it for hits it saw.
+		struct PcHit { uint64_t instruction; uint32_t pc, d0, d1, a0, a1, sp, stack[5]; };
+		void watchPc(std::vector<uint32_t> _addrs) { m_watchPc = std::move(_addrs); }
+
+		// ✅ THE DSP HOST PORT, RECORDED. The firmware programs the DSPs
+		// ITSELF -- `0x40001e50` (called once, from the boot at `0x4000050c`)
+		// uploads through `0x20000014/18/1c`, three halfwords per 24-bit word,
+		// with a ready handshake on `0x20000008` (measured 8 Sep 2026, O8).
+		// So the words it sends ARE the payload, and capturing them is how the
+		// protocol decode gets checked against `out/dsp/mem_*.mem` before a
+		// single line of DSP emulation exists.
+		//
+		// ⚠️ This is a SEPARATE log from `peripheralLog`, which is capped at
+		// 4096 accesses and therefore full long before the DSP init runs at
+		// instruction ~4.27M -- reading "0 host-port touches" out of it was a
+		// false negative that cost a measurement.
+		struct HostPortWrite { uint64_t instruction; uint32_t pc, addr, val; uint8_t size; };
+		void setHostPortLog(bool _on) { m_hostPortLogOn = _on; }
+		const std::vector<HostPortWrite>& hostPortLog() const { return m_hostPortLog; }
+		const std::vector<PcHit>& pcHits() const { return m_pcHits; }
+		void notePcWatch(uint32_t _pc);
+
 		void setProfile(uint32_t _every) { m_profileEvery = _every; }
 		const std::unordered_map<uint32_t, uint64_t>& profile() const { return m_profile; }
 		// Registers a borrowed call needs: main's stack pointer to push the
@@ -339,6 +372,10 @@ namespace ot
 		AckHook m_ack;
 		uint64_t m_instructions = 0;
 		uint64_t m_v4e = 0;			// instructions the V4e layer supplied
+		bool m_hostPortLogOn = false;
+		std::vector<HostPortWrite> m_hostPortLog;
+		std::vector<uint32_t> m_watchPc;
+		std::vector<PcHit> m_pcHits;
 		uint32_t m_profileEvery = 0;
 		std::unordered_map<uint32_t, uint64_t> m_profile;
 		std::string m_why;

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -70,6 +70,7 @@ int main(int _argc, char** _argv)
 	std::string watchMem;		// ADDR,LEN -- log every write into that range (route A's own flag)
 	std::string watchPc;		// comma-separated addresses -- log registers there (route A's own flag)
 	bool namesEarly = false;	// write the SET/PROJECT names BEFORE the mount -- see O7b
+	std::string hostPortLog;	// every write into the DSP host-port window -> FILE (O8)
 
 	for(int i = 1; i < _argc; ++i)
 	{
@@ -103,6 +104,7 @@ int main(int _argc, char** _argv)
 		else if(a == "--watch-mem" && i + 1 < _argc)	watchMem = _argv[++i];
 		else if(a == "--watch-pc" && i + 1 < _argc)	watchPc = _argv[++i];
 		else if(a == "--names-early")			namesEarly = true;
+		else if(a == "--hostport-log" && i + 1 < _argc)	hostPortLog = _argv[++i];
 		else
 		{
 			std::printf("usage: ot_emu [--image FILE] [--max N] [--periph] [--profile]\n"
@@ -126,6 +128,26 @@ int main(int _argc, char** _argv)
 	ot::Machine m(img);
 	if(profile)
 		m.setProfile(64);
+	// ⚠️ BEFORE THE BOOT RUNS. Installed after it (where it used to be, behind
+	// `rtos.install()`), a watch on a BOOT address reported zero hits whether
+	// the address ran or not -- and the only caller of the DSP program loader
+	// is at 0x4000050c, which is a boot address (O8, 8 Sep 2026).
+	if(!watchPc.empty())
+	{
+		std::vector<uint32_t> addrs;
+		size_t q = 0;
+		while(q < watchPc.size())
+		{
+			auto e = watchPc.find(',', q);
+			if(e == std::string::npos) e = watchPc.size();
+			addrs.push_back(static_cast<uint32_t>(std::strtoul(watchPc.substr(q, e - q).c_str(), nullptr, 0)));
+			q = e + 1;
+		}
+		m.watchPc(addrs);
+		std::printf("watch-pc   : %zu address(es), armed before the boot\n", addrs.size());
+	}
+	if(!hostPortLog.empty())
+		m.setHostPortLog(true);		// before the boot: the DSP upload happens IN it
 	const auto stop = m.run(maxInstructions);
 
 	static const char* const g_names[] = {"HANDOFF", "ILLEGAL", "BUDGET", "FAULT"};
@@ -174,20 +196,6 @@ int main(int _argc, char** _argv)
 			std::printf("card       : %s, %u sectors\n", cardImage.c_str(), card->totalSectors());
 		}
 		rtos.install();
-		if(!watchPc.empty())
-		{
-			std::vector<uint32_t> addrs;
-			size_t q = 0;
-			while(q < watchPc.size())
-			{
-				auto e = watchPc.find(',', q);
-				if(e == std::string::npos) e = watchPc.size();
-				addrs.push_back(static_cast<uint32_t>(std::strtoul(watchPc.substr(q, e - q).c_str(), nullptr, 0)));
-				q = e + 1;
-			}
-			rtos.watchPc(addrs);
-			std::printf("watch-pc   : %zu address(es)\n", addrs.size());
-		}
 		if(!watchMem.empty())
 		{
 			const auto comma = watchMem.find(',');
@@ -486,12 +494,14 @@ int main(int _argc, char** _argv)
 
 		if(!watchPc.empty())
 		{
-			std::printf("watch-pc   : %zu hit(s)\n", rtos.pcHits().size());
-			for(const auto& h : rtos.pcHits())
-				std::printf("   [%10.1f] at %#x d0=%#x d1=%#x a0=%#x a1=%#x in %s "
+			std::printf("watch-pc   : %zu hit(s) (the timestamp is the instruction count: "
+				"the BOOT has no sample clock, and a watch that could not see the boot "
+				"reported 0 for a boot address whether it ran or not)\n", m.pcHits().size());
+			for(const auto& h : m.pcHits())
+				std::printf("   [%12llu] at %#x d0=%#x d1=%#x a0=%#x a1=%#x "
 					"[sp %#x: %#x %#x %#x %#x %#x]\n",
-					h.sample, h.pc, h.d0, h.d1, h.a0, h.a1, ot::taskName(h.tcb), h.sp,
-					h.stack[0], h.stack[1], h.stack[2], h.stack[3], h.stack[4]);
+					static_cast<unsigned long long>(h.instruction), h.pc, h.d0, h.d1, h.a0, h.a1,
+					h.sp, h.stack[0], h.stack[1], h.stack[2], h.stack[3], h.stack[4]);
 		}
 		if(!watchMem.empty())
 		{
@@ -521,6 +531,50 @@ int main(int _argc, char** _argv)
 			rtos.writeGoldenJson(golden);
 			std::printf("golden     : %s\n", golden.c_str());
 		}
+	}
+
+	if(!hostPortLog.empty())
+	{
+		// The raw writes, and the 24-bit words reassembled from the
+		// 0x14/0x18/0x1c triples the loader sends (low, mid, high -- the order
+		// `0x40001d82`.. writes them). A `0x20000000` write of 0x81 is "start
+		// the DSP" and 0x8c is "swap frame" (docs/ARCHITECTURE.md §6).
+		std::ofstream t(hostPortLog);
+		uint32_t w = 0; int have = 0; uint64_t words = 0;
+		for(const auto& e : m.hostPortLog())
+		{
+			char line[128];
+			std::snprintf(line, sizeof line, "W %08x %u %04x  pc %#010x  #%llu",
+				e.addr, e.size, e.val & 0xffff, e.pc,
+				static_cast<unsigned long long>(e.instruction));
+			t << line;
+			// ✅ THE BYTE LANES, from the loader's own code at 0x40001d74..:
+			//   movel %d0,%d1 / swap %d1 / extl %d1 / movew %d1,0x20000014
+			//   movel %d0,%d1 / asrl #8,%d1        / movew %d1,0x20000018
+			//   movew %d0,0x2000001c
+			// so only the LOW BYTE of each halfword matters, and it is bits
+			// 23:16, 15:8 and 7:0 in that order. ⚠️ Getting the lanes backwards
+			// made word 2 read 0x001003 instead of 0x031000 -- which is the
+			// LOAD ADDRESS the loader was called with, and the thing that says
+			// the decode is right.
+			if(e.addr == 0x20000014)      { w = (w & 0x00ffff) | ((e.val & 0xff) << 16); have = 1; }
+			else if(e.addr == 0x20000018) { w = (w & 0xff00ff) | ((e.val & 0xff) << 8); have |= 2; }
+			else if(e.addr == 0x2000001c)
+			{
+				w = (w & 0xffff00) | (e.val & 0xff);
+				if((have | 4) == 7)
+				{
+					char word[32];
+					std::snprintf(word, sizeof word, "   word %06x", w);
+					t << word;
+					++words;
+				}
+				have = 0; w = 0;
+			}
+			t << '\n';
+		}
+		std::printf("hostport   : %s (%zu writes, %llu complete 24-bit words)\n",
+			hostPortLog.c_str(), m.hostPortLog().size(), static_cast<unsigned long long>(words));
 	}
 
 	// ⚠️ Unmapped memory: route A FAULTS here and this machine answers

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -452,17 +452,6 @@ namespace ot
 			m_pcRing[m_pcRingPos % m_pcRing.size()] = pc;
 			++m_pcRingPos;
 		}
-		if(!m_watchPc.empty() && m_pcHits.size() < 4000)
-			for(const auto a : m_watchPc)
-				if(a == pc)
-				{
-					PcHit h{m_sample, curTcb(), pc, m_machine.getD(0), m_machine.getD(1),
-						m_machine.getA(0), m_machine.getA(1), m_machine.getA7(), {}};
-					for(int i = 0; i < 5; ++i)
-						h.stack[i] = m_machine.peek32(h.sp + 4 * i);
-					m_pcHits.push_back(h);
-					break;
-				}
 		if(pc == g_create)
 			recordCreate();
 
@@ -762,7 +751,9 @@ namespace ot
 
 	void Rtos::watchPc(const std::vector<uint32_t>& _addrs)
 	{
-		m_watchPc = _addrs;
+		// Delegated to the machine, which sees the boot as well -- see
+		// Machine::notePcWatch for why that matters.
+		m_machine.watchPc(_addrs);
 	}
 
 	void Rtos::watchMem(const uint32_t _addr, const uint32_t _len)

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -246,9 +246,7 @@ namespace ot
 		// callee names its caller and its arguments. ⚠️ The check runs per
 		// instruction, so it is guarded on the list being empty; with no
 		// address watched it costs one compare.
-		struct PcHit { double sample; uint32_t tcb, pc, d0, d1, a0, a1, sp, stack[5]; };
 		void watchPc(const std::vector<uint32_t>& _addrs);
-		const std::vector<PcHit>& pcHits() const { return m_pcHits; }
 
 		struct MemWrite { double sample; uint32_t tcb, pc, addr, val; uint8_t size; };
 		void watchMem(uint32_t _addr, uint32_t _len);
@@ -431,8 +429,6 @@ namespace ot
 		// `rte` is not the ack.
 		std::vector<TrigWrite> m_liveNibble, m_trigWords;
 		std::vector<MemWrite> m_memWrites;
-		std::vector<uint32_t> m_watchPc;
-		std::vector<PcHit> m_pcHits;
 		bool m_trigLogInstalled = false;
 		bool m_partPtrWatched = false;
 		int m_savedBank = -1;


### PR DESCRIPTION
**Draft / BLOCKED per the work order's stop condition.** O8's gate —
`verify_twocore`'s layouts rendering identically when driven by the firmware —
is not passed and no DSP is wired. What this session did is decode the join
completely from the firmware's own code, and fix two instruments that were
lying about it.

## ✅ The firmware boots the DSPs itself, and the bytes are captured

The join needs **no `.mem` dump**. `0x4000050c` — a *boot* address — calls the
DSP start `0x40001e50` once, at instruction **4,270,944** of the boot, which
calls the uploader twice:

| call | source | length | DSP load address |
|---|---|---|---|
| 1 | `0x400e21e0` | 150 bytes | `P:0x31000` |
| 2 | `0x400e2276` | 174 bytes | `P:0x32000` |

Both in the shared window. `--hostport-log` (new) captures the boot's **350
writes / 114 complete 24-bit words**, framed exactly as `count, address,
count words`.

The byte lanes come from the loader's own code at `0x40001d74`, not the manual:

```
movel %d0,%d1 / swap %d1 / extl %d1 / movew %d1,0x20000014   -> bits 23:16
movel %d0,%d1 / asrl #8,%d1         / movew %d1,0x20000018   -> bits 15:8
                                      movew %d0,0x2000001c   -> bits  7:0
```

The check that says the decode is right: word 2 reads `0x031000` — the load
address the loader was *called* with. (Backwards lanes give `0x001003`.) The
loader also divides its byte length by 3, which is why the count is 50 and the
argument was 150.

## ✅ And the DSP half of the protocol, in the firmware's own words

The 50 captured words, disassembled at their load address with the vendored
`dsp56kDisassemble`:

```
031000: ori     #$3,mr
031002: bset    #$12,y:<<$fffff9                  ; HDI08 config
031004: brclr   #HSR_HRDF,x:<<M_HSR,func_031004   ; wait for a host word
031006: movep   x:<<M_HORX,a                      ; read it
031009: movep   a,x:<<M_HOTX                      ; ECHO IT BACK
03100c: movep   x:<<M_HORX,r0
03100f: jmp     (r0)                              ; run the loaded code
```

That echo is the far side of the handshake **O6 had to fake**. With a real
HDI08 behind the window, the fakes come out.

## ⚠️ Two instruments were lying, and each returned a confident zero

1. **The PC watch could not see the boot.** It lived in `Rtos::stepOnce`, which
   runs only after the handoff, so `--watch-pc 0x4000050c` reported **0 hits**
   for an address that runs 4.27 M instructions into the boot. My first draft
   of this write-up said "the DSP loader never runs". Moved into `Machine`,
   consulted from both `run()` and `step()`, armed before the boot.
2. **`--periph`'s log is capped at 4096 accesses** and the boot makes 8,235
   peripheral writes before the DSP init — so "0 host-port touches" was a false
   negative too.

Same family as `RTOS_FORK.md` §10.3b. **A zero from an instrument is not a
measurement until you know the instrument can see the thing.**

## The plan, in the work order

1. Link `dsp56kEmu`, two cores, shared-window patch (mechanical).
2. Wire the window and the chip select at `0xFC0A400C`.
3. **First real gate, self-checking:** run the firmware's own upload and compare
   the DSP's `P:0x31000` against the captured words.
4. Make the eDMA MOVE data (route A's model moves none).
5. Only then `verify_twocore`. ⚠️ Bigger than it reads: that gate drives the
   effect ABI directly (`r0`/`r6`/`r7`/`n7` + `proc`) while the firmware drives
   whole frames through the packer at `0x4000d3fc`, and nothing has checked
   that the firmware's per-track records can carry the knobs the harness passes
   by hand. That is the judgment this milestone was reserved for.

## No regression

`ctest` 6/6; the M6a oracle diff **8 compared fields agree, 0 disagreements**;
the O6 fidelity gate **5 compared fields agree**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)