### PR TITLE
O8 — BLOCKED at step 5: both DSP cores boot behind the host port, the sequencer gate passes with them live, the audio comparison is not started

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,17 +145,31 @@ sequencer trig
        → DSP56xxx reads the frame and synthesizes (playback, time-stretch, filters, FX)
 ```
 
-**DSP interface: MMIO at `0x20000000`** (revealed by radare2):
-- `0x2000_0000` control command (`0x81` = start DSP, `0x8C` = swap frame)
-- `0x2000_0004` command/status (write, poll bit7 busy)
-- `0x2000_0008` status/ready (bit `6`: DSP ready — polled at boot and on every transfer)
-- `0x2000_0014`/`0x18`/`0x1c` data port (the 3 bytes of each 24-bit word)
+**DSP interface: MMIO at `0x20000000`** — ❌ the first reading (radare2, "control
+command 0x81 = start DSP / 0x8C = swap frame; 0x08 bit 6 = DSP ready") is
+retracted. ✅ 8 Sep 2026 (`docs/COLDFIRE_PORT.md` O8, the emulated join runs the
+firmware's own upload and frame exchange against it): the window is the **HI08
+host-side register file** of the core the GPIO byte at `0xfc0a400c` selects,
+one byte register per 4-byte stride on a 16-bit FlexBus port (CS2, `CSCR2 =
+0x180`), and a 16-bit bus cycle delivers its two bytes to two adjacent
+registers:
+- `0x2000_0000` ICR — `0x81` = INIT|RREQ, an interface reset before each upload
+- `0x2000_0004` CVR — `0x8c` = host command HC | vector 0x0c (P:0x18) once per
+  frame; `0x88` / `0x89` = vectors 0x10 / 0x12, "DSP, DMA a block in / out";
+  bit 7 (HC) polled until the DSP takes it
+- `0x2000_0008` ISR — bits 1|2 (TXDE|TRDY) polled before every word, bit 0
+  (RXDF) for a reply
+- `0x2000_0014`/`0x18`/`0x1c` TXH/TXM/TXL (RXH/RXM/RXL on read): a halfword
+  write to `+0x1c` sends TXH:D15:8:D7:0 as one 24-bit word, a longword write
+  sends two; the per-frame blocks are 16-bit values, two per longword
 
 **DSP boot** ✓ (`FUN_40001d4c` = DSP program loader): uploads the program to the DSP
-**3 bytes at a time = 24-bit words** through the `0x20000014/18/1c` port, with a handshake on the
-ready bit of `0x20000008`, and starts the DSP by writing `0x81` to `0x20000000`. The **24-bit**
+**3 bytes at a time = 24-bit words** through the `0x20000014/18/1c` port, with a handshake on
+TXDE|TRDY of `0x20000008`, after an interface reset (`0x81` to ICR). The **24-bit**
 word size confirms that the DSP is a Freescale DSP56xxx (hardware fact deduced from the firmware
-itself). Args: `param_1`=program, `param_2`=length, `param_3`=load address in the DSP.
+itself). Args: `param_1`=program, `param_2`=length, `param_3`=load address in the DSP. The
+first 50/58 words go to the chip's own HI08 bootstrap ROM (count, address, words, jump); the
+payload then goes through that bootstrap's loader, which echoes each record's space word.
 
 **Trig → voice** ✓ (`FUN_400977cc`, dispatched by machine type): given a trig on a track, it reads its
 machine state (`FUN_40097168` → 0–4) and, depending on the event type, emits the voice command via

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -1105,13 +1105,66 @@ route A's (the non-DSP O6 report is byte-identical before and after).
 **2,400 blocks / 870,400 words to the DSPs, 1,600 blocks / 307,200 words
 back, 0 not in time**, 60,820 ticks spent holding a burst for the DSP to
 drain; per core 2,400 / 1,200 host commands taken, 204,800 / 102,400 read-back
-words produced by the DSPs' own transmit DMA. ⚠️ What is NOT measured: whether
-those words carried non-zero content. `--dsp-peek` of X:0x6080, 0x6000,
-0x6400, 0x6600, 0x6800 on both cores reads all zeros at the END of the run,
-and the pair does not yet count non-zero words pushed or pulled — the DSP may
-consume and clear its record buffers, or the port's frames may be empty, and
-the run cannot tell those apart. That counter is the next session's first
-instrument, before anything is inferred from it.
+words produced by the DSPs' own transmit DMA. 
+
+### ✅ And the frames carry content — outbound. The DSP returns silence.
+
+The counter that decides whether any of the above means anything
+(`--block-log`, non-zero words counted at the moment of the move, not peeked
+afterwards). Over the 400-frame run:
+
+| direction | blocks | words | non-zero |
+|---|---|---|---|
+| ColdFire → DSPs | 2,400 | 870,400 | **40,853** |
+| DSPs → ColdFire | 1,600 | 307,200 | **0** |
+
+✅ **The outbound path is live and it tracks the sequencer.** Non-zero words
+per 50 frames sit at 5,088 and rise to 5,100 across the trig at frame 344,
+then 5,238 — the parameter frames change when the sequencer fires. The 672-,
+128- and 64-word records carry 14, 30-33 and 11 non-zero words each: sparse,
+which is what a parameter frame with most slots idle looks like. And the words
+reach DSP memory: the landing peek reads `030004 030009 030800 … 030b40`
+where the block ended.
+
+❌ **The inbound path is zeros in every frame band, including after the trig**
+— 0 of 307,200 words, with the pull never timing out, so the DSP genuinely put
+zeros in HOTX rather than the port failing to collect them. Its own DMA1 is
+sourcing from X:0x4700/0x4780/0x4800 and those hold zeros. The DSP is
+computing silence, which is what a machine with no sample audio and a silent
+ESAI input should compute. **What has NOT been established is why** — no
+sample data reaching the DSP, or a voice that never starts, are both open and
+both sit on the audio-in path that is O9's ground.
+
+### ⚠️ The destination word is the host's, the address is the DSP's
+
+`--dsp-peek` of X:0x6080 read zeros and briefly looked like "the frames are
+empty". It was the instrument: **0x6080 is the address the HOST names, not the
+one the DSP uses.** Measured, with the command's arguments snapshotted at the
+command and both candidates peeked at the same instant:
+
+```
+cmd args 036080 03029f | DMA0 ddr 004320 dco 00029f | X@6080 000000 000000 | X@4080 030000 030000
+```
+
+The firmware sends dest `0x6080`, count `0x29f`; the DSP arms its DMA0 at
+`0x4080` and the block lands there. Every block is the same 0x2000 apart:
+0x6080 → 0x4080, 0x6000 → 0x4000, 0x6400 → 0x4400, 0x6800 → 0x4800. 🟡
+**Inferred, not located:** the payload's own dispatcher at P:0x40 sets up two
+banks of buffers — 0x4000/0x4080/0x4400/0x4600/0x4800 and
+0x2000/0x2080/0x2400/0x2600/0x2800 — and each host word is exactly the two
+banks' addresses OR'd together, so bits 14 and 13 read as a bank select the
+DSP masks down to the bank it is using (bank A throughout this run). The
+masking instruction has not been found; the handler at P:0x588 masks only to
+16 bits. Falsifier: a run where the DSP switches to bank B should land the
+same words at 0x2xxx.
+
+⚠️ Two instrument lessons, both the project's usual family. **A peek after the
+run cannot tell "nothing was sent" from "the DSP consumed it"** — count at the
+move. And **a note taken at the eDMA kick lags a whole block**: read at the
+kick, DCO0 still held the PREVIOUS block's count and it read as if the
+firmware's destination were being ignored entirely. The note is taken at the
+completion the drain gate holds, which is when the DSP-side state means
+something.
 
 ### What step 5 needs
 

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -840,129 +840,298 @@ ticks, the trig at frame 344 with bytes `0x08`/`0x18`); the M6a oracle diff
 still **8 compared fields agree, 0 disagreements**; `ctest` 6/6; `make check`
 green.
 
-## Milestone O8 — the DSP cores and the host port ⛔ IN PROGRESS (8 Sep 2026)
+## Milestone O8 — the DSP cores and the host port 🟡 BUILT THROUGH STEP 3 (8 Sep 2026)
 
-**The gate is not passed and no DSP is wired yet. What this session did is
-decode the join completely, from the firmware's own code, and fix two
-instruments that were lying about it.** The headline:
+**The two real DSP cores sit behind the host port (`--dsp`), the firmware boots
+them itself, the boot's upload is verified byte for byte by a ctest, and the
+M6a gate passes with the cores live. Steps 4 and 5 of the work order are open**
+(what they stopped on is at the end of this section). The session before this
+one decoded the join from the firmware's code (kept below, under "What runs, and
+when"); this one wired it and measured what the wiring exposed — six things in
+the vendored DSP emulator, one in the model of the shared window, and one in
+this port's own first guess at the handshake.
 
-✅ **THE FIRMWARE BOOTS THE DSPs ITSELF, DURING THE COLDFIRE BOOT, AND WE HAVE
-CAPTURED THE BYTES.** No `.mem` dump is needed for the join: the payload comes
-out of the OS image, through the host port, under the firmware's own control.
+### ❌ The host-port readings that had stood since ARCHITECTURE.md §6 — retracted
 
-### What runs, and when
+The window `0x20000000`–`0x20000fff` is the **HI08 host-side register file** of
+whichever core the GPIO byte at `0xfc0a400c` selects: one byte register per
+4-byte stride, in the LOW byte of the 16-bit access.
 
-`0x4000050c` — a **boot** address — calls `0x40001e50` ("DSP start") exactly
-once, at instruction **4,270,944** of the 10,170,953-instruction boot. It calls
-the uploader `0x40001d4c` twice:
+| offset | register | what the firmware does with it |
+|---|---|---|
+| +0x00 | ICR (RREQ 0, TREQ 1, HF0 3, HF1 4, INIT 7) | writes `0x81` = **INIT\|RREQ, an interface reset** — ❌ not "start the DSP" |
+| +0x04 | CVR (HV 6:0, HC 7) | the loader clears it; the frame handler writes `0x8c` = **HC \| vector 0x0c → P:0x18, a host command**, and polls bit 7 until the DSP takes it — ❌ not "swap frame" |
+| +0x08 | ISR (RXDF 0, TXDE 1, TRDY 2, HF2 3, HF3 4, HREQ 7) | the loaders spin on `& 6` = TXDE\|TRDY before every word and `btst #0` = RXDF for the echo — ❌ not "bit 6 = DSP ready" |
+| +0x14/18/1c | TXH/TXM/TXL, RXH/RXM/RXL | bits 23:16, 15:8, 7:0; the write of TXL sends, the read of RXL takes |
 
-| call | source | length | DSP load address |
-|---|---|---|---|
-| 1 | `0x400e21e0` | `0x96` = 150 bytes | `P:0x31000` |
-| 2 | `0x400e2276` | `0xae` = 174 bytes | `P:0x32000` |
+✅ All from the firmware's own code (`0x40001d4c`, `0x40001b18`, `0x4000aad0`),
+and confirmed by the join working: the vendored HDI08 answers those registers
+and the firmware's upload runs to completion against it. ARCHITECTURE.md §6 and
+DSP.md §1 are corrected in place.
 
-Both destinations are in the **shared window** (`0x30000`–`0x3FFFF`). The caller
-first relocates the big blobs in ColdFire RAM (77,061 words from `0x400f59ef`,
-79,563 from a register) — so the payload proper is staged in RAM and these two
-uploads are a **bootstrap**, not the program.
+### ✅ The gate, and it is self-checking: `ot_dsp_test` (ctest `dsp`, under a second)
 
-### The wire protocol, decoded and verified
-
-`--hostport-log FILE` (new) records every write into `0x20000000`–`0x20000fff`
-with its PC and instruction count. The boot makes **350 writes / 114 complete
-24-bit words**, and they frame exactly:
-
-```
-W 20000000 0081     pc 0x40001e5e     <- "start the DSP"
-W 20000004 0000     pc 0x40001d62     <- command/status
-word 000032                           <- COUNT: 50 words  (150 bytes / 3)
-word 031000                           <- LOAD ADDRESS
-word 0003f8 ... 50 words of program
-```
-
-✅ **The byte lanes come from the loader's own code** at `0x40001d74`, not from
-a reading of the manual:
+The firmware boots with the pair attached; a step hook fires at the instruction
+after each upload returns (`0x40001e96` for core 0, `0x40001edc` for core 1) and
+compares DSP memory with the image's bytes, parsed independently (DSP.md §2: the
+uploader's own walk, mirrored):
 
 ```
-movel %d0,%d1 / swap %d1 / extl %d1 / movew %d1,0x20000014   -> bits 23:16
-movel %d0,%d1 / asrl #8,%d1         / movew %d1,0x20000018   -> bits 15:8
-                                      movew %d0,0x2000001c   -> bits  7:0
+[PASS] core 0: the boot ROM took 50 words for P:0x31000 and jumped
+[PASS] core 0: P:0x31000 holds the bootstrap the image carries  50/50 words
+[PASS] core 1: the boot ROM took 58 words for P:0x32000 and jumped
+[PASS] core 1: P:0x32000 holds the bootstrap the image carries  58/58 words
+[PASS] core 0: the payload parses to its last byte  98 records, 79563 of 79563 bytes, jump 0x30000
+[PASS] core 0: every payload record had landed where it names  26221/26221 words
+[PASS] core 0: the host sent and took back exactly what the walk predicts  26569 sent (26569 predicted), 99 echoed (99 predicted)
+[PASS] core 1: the payload parses to its last byte  91 records, 77061 of 77061 bytes, jump 0x38000
+[PASS] core 1: every payload record had landed where it names  25408/25408 words
+[PASS] core 1: the host sent and took back exactly what the walk predicts  25743 sent (25743 predicted), 92 echoed (92 predicted)
+[PASS] core 0: left the bootstrap and is running the payload  pc 0x30010, no fault
+[PASS] core 1: left the bootstrap and is running the payload  pc 0x57, no fault
 ```
 
-only the LOW BYTE of each halfword is meaningful. ⚠️ Getting the lanes
-backwards makes word 2 read `0x001003` instead of `0x031000` — and `0x31000` is
-the load address the loader was *called* with, which is what says the decode is
-right. The loader also divides its byte length by 3 (`remsl #3`), which is why
-the count is 50 and the argument was 150.
+Two mechanisms that cannot fake each other agree: the firmware's ColdFire-side
+loader with its TXDE/RXDF polls and echo check, and the vendored DSP running
+first the chip's bootstrap ROM (`DspBoot`: count, address, words, jump) and then
+the firmware's own 50-word HDI08 loader, which reads a space word, echoes it,
+reads an address into r0 and a count into b1, and `dor`-loops
+`movep x:<<M_HORX,p/x/y:(r0)+` — disassembled with the vendored
+`dsp56kDisassemble`, `out/oracle/o8_blob0.dis`.
 
-### ✅ And the DSP half of the protocol, in the firmware's own words
+⚠️ **Why the check runs at upload time and not at the handoff:** the first
+version compared at the handoff and found 19 words of payload A at P:0x38000
+reading zero. That range is core 1's entry stub, and core 1 had run it and then
+cleared Y:0x38000.. as its delay buffer — the window is one memory (next
+section). "Harmless once booted", as CHIP.md predicted; a gate has to look
+before that.
 
-The 50 captured words, disassembled at their load address with the vendored
-`dsp56kDisassemble`, are an **HDI08 bootstrap loader**:
+### ✅ THE SHARED WINDOW IS ONE MEMORY, and the firmware depends on it
 
-```
-031000: ori     #$3,mr
-031002: bset    #$12,y:<<$fffff9                  ; HDI08 config
-031003: bset    #$12,y:<<$fffffa
-031004: brclr   #HSR_HRDF,x:<<M_HSR,func_031004   ; wait for a host word
-031006: movep   x:<<M_HORX,a                      ; read it
-031007: brclr   #HSR_HTDE,x:<<M_HSR,func_031007
-031009: movep   a,x:<<M_HOTX                      ; ECHO IT BACK
-03100a: brclr   #HSR_HRDF,x:<<M_HSR,func_03100a
-03100c: movep   x:<<M_HORX,r0
-03100d: cmp     #<$3,a
-03100f: jmp     (r0)                              ; run the loaded code
-```
+With P private per core (the vendored patch's dsp_host form: X with X, Y with
+Y), core 1 jumped to its entry P:0x38000 — an address only core 0's upload had
+written — found zeros, and ran off the end of P memory: the PC ring read
+`7ffc1 7ffc2 … 7ffff`, then a fault at 0x80000. CHIP.md had this measured on
+hardware already (`dsp/alias_probe.asm`: P, X and Y are the same words in
+`0x30000`–`0x3FFFF`, reachable by both cores); the port now models it that way,
+`Memory::setSharedWindow(lo, hi, all, hook)` in `tools/dsp56300.patch`, one
+64K array behind both cores' P, X and Y, the hook dropping both cores' decoded
+opcode for any word written there. `dsp_host` keeps its two-way window — it
+renders bit-identically with it and, as DSP.md says, cannot answer aliasing
+questions; that is now a documented difference between the two machines.
 
-That echo is the far side of the handshake **O6 had to fake** (`0x20000004`
-reading `0x0000`, `0x2000001c` toggling). With a real HDI08 behind the window
-the firmware programs the DSPs and the fakes come out.
+### ✅ Six things the vendored emulator does that the firmware cannot live with
 
-### ⚠️ Two instruments were lying, and both nearly produced a wrong finding
+Each one first presented as a hang or a crash with no diagnostic, and each was
+found by an instrument, not by reading — recorded with the instrument:
 
-Recorded because each one first returned a confident zero:
+1. **A hardware DO loop runs to completion inside one `execInterpreter()`
+   call** (`do_exec` nests the loop). The 50-word loader polls the host port
+   INSIDE a `dor`, so the call could never return to the ColdFire that had to
+   feed it. *Stack sample:* `op_Dor_S → do_exec → op_Brclr_pp`, forever.
+   Patch: with `setHostStepped(true)`, `do_exec` pushes the loop state and
+   returns; the host applies `doLoopEnd()` after every instruction (the same
+   test, on the same registers).
+2. **Interrupts always dispatch through the JIT** when it is compiled in, even
+   with the interpreter driving — `execInterrupt` reads `g_useJIT`, which is
+   compile-time. `dsp_host` never takes a DSP interrupt, so it never met this.
+   *lldb:* `EXC_BAD_ACCESS` in `funcCreate`, called from `execOp` with a
+   garbage `this`. Patch: a host-stepped core interprets its interrupts, and
+   `exec()` too.
+3. **A masked pending interrupt starves the peripheral clock.**
+   `execInterrupts()` returns early on a masked head and never re-hooks the
+   peripheral exec, so a core that masks interrupts for a while — core A boots
+   with `ori #3,mr` — freezes its own ESAI. *`--dsp-trace`:* the peripheral
+   target clock stuck at 845,824 while the instruction counter ran to 4 M;
+   SAISR at RDF\|ROE; 3 frames ever. Patch: service the peripherals under a
+   masked head (a masked interrupt waits; the peripherals do not).
+4. **The ESAI blocks on an empty input ring** (a condition-variable wait, meant
+   for an audio thread). *Stack sample:* `EsxiClock::exec → Esai::execRX →
+   RingBuffer::pop_front → ConditionVariable::wait`. No patch: the pair
+   installs non-blocking callbacks — silence in, output frames counted — and a
+   clock of ONE ESAI FRAME PER SAMPLE at the pair's own instructions-per-sample,
+   so the DSP's audio clock and the ColdFire's sample clock cannot drift apart.
+5. **A PC past P memory is a garbage member-function pointer** (the opcode
+   cache is indexed by the PC into a table sized to P). *lldb:* the same
+   `funcCreate` frame, from `execOp`, `this` = a DSP data word. The pair stops
+   the core, records it as a fault, and prints the last 64 PCs — which is what
+   found the window finding above.
+6. **A fast interrupt never sets the PC to its vector** (the vector's two words
+   run inline), so "HC clears when the PC lands on P:0x18" never fired and the
+   frame handler polled HC forever: 0 frames, 0 ticks, `host commands 1`.
+   Patch: an interrupt-taken hook (`setInterruptTakenHook`); HC and HCP clear
+   from it.
+7. **The DSP's own audio DMA silently moved nothing.** Core A's main loop
+   (P:0x4b..0x53) polls DMA channel 2's source pointer for 0x8070 / 0x80f0 —
+   the halves of a 256-word ring, X:0x8000.. → ESAI TX0, one word per TDE
+   request (DCR2 `0xcc6220`: source mode DualCounterDOR2, destination fixed);
+   channel 3 is the mirror for audio in (ESAI RX0 → X:0x8100.., DualCounterDOR3,
+   DCO3 `0x23f` with DOR3 = −575). *`--dsp-trace`:* DSR2 stuck at `0x8000`
+   while the ESAI put out 2,334 frames. The vendored `execTransfer` handles
+   neither address-mode pair and, in a release build, reaches an
+   `assert(false)` that is compiled out and returns "finished". Patch: the two
+   pairs, one word per request over the dual-counter ring — and **DCOL is the
+   low TWELVE bits of DCO, not eight**: `0x23f` with an offset of −0x23f only
+   returns the pointer to its base if DCOL counts 0x23f words (the firmware's
+   constants decide it, the way the reciprocal tables decided the EMAC). With
+   it DSR2 sweeps the ring, core A sends the host its first word after the
+   boot and core B its first three mailbox words, and both cores advance to
+   their next waits (P:0x97, P:0x8d).
+8. **The host DMA on the DSP side had two more.** Its receive requests are
+   rate-limited to one word per 200 instructions (a throttle for a threaded
+   host; a 672-word block at that pace is 30 samples, twice a frame), and a
+   channel armed while its request condition already holds never fires —
+   `checkTrigger` returns false unconditionally upstream — so core B's
+   transmit DMA, armed with HTDE already set, never started and its 256-word
+   read-back timed out word by word (`read-back words 256 (256 not in time)`,
+   51 M instructions spent in the pull). The pair sets the rate limit to zero;
+   the patch re-enables the initial trigger for a host-stepped core.
 
-1. **The PC watch could not see the boot.** It lived in `Rtos::stepOnce`, which
-   runs only after the handoff, so `--watch-pc 0x4000050c` reported **0 hits**
-   — for an address that runs 4.27 M instructions into the boot. The first
-   draft of this section said "the DSP loader never runs". It now lives in
-   `Machine` (consulted from both `run()` and `step()`), is armed BEFORE the
-   boot, and timestamps in instructions because the boot has no sample clock.
-2. **`--periph`'s log is capped at 4096 accesses** and the boot makes 8,235
-   peripheral writes before the DSP init, so "0 host-port touches in the
-   peripheral log" was a false negative too. `--hostport-log` is a separate,
-   uncapped-in-practice recorder for exactly this reason.
+The patch file is regenerated with `git -C vendor/dsp56300 diff >
+tools/dsp56300.patch`; `scripts/setup.sh` applies it; `dsp_host` is unchanged
+by every part of it (its window form and its non-host-stepped mode are the
+defaults).
 
-Same family as `RTOS_FORK.md` §10.3b, and the third and fourth instances this
-week. **A zero from an instrument is not a measurement until you know the
-instrument can see the thing.**
+### 🟡 The inter-core mailbox — inferred from both payloads' code
 
-### What O8 still needs, in order
+Core 1 parks at P:0x57 on `brclr #1,y:<<$ffffd3` and reads `y:<<$ffffd4`;
+core 0 writes `movep r3,y:<<$ffffd7` and waits on `brset #1,y:<<$ffffd6`, then
+sends `#2`. No vendored peripheral maps those, so the pair models a symmetric
+one-register channel (transmit data at $D7, "still unread" at $D6 bit 1;
+receive data at $D4, "one waiting" at $D3 bit 1) through a hook on unmapped
+Y-side registers. The addresses are the firmware's; the bit semantics are
+inferred from the two wait loops and nothing else. Core 0 has not sent a word
+on it yet in any run — that happens on the frame-exchange path.
 
-1. Link `dsp56kEmu` into `ot_emu` and instantiate two cores (mechanical:
-   `tools/dsp_host` already boots both with the shared-window patch).
-2. Wire `0x20000014/18/1c` → `HDI08::writeRX`, `0x20000008` → HSR (bit 6 =
-   ready), `0x20000004` → the busy/status byte, and `0x20000000`'s `0x81` /
-   `0x8c` to start / swap. The chip select at `0xFC0A400C` picks the core.
-3. Let the firmware's own bootstrap upload run, and check the DSP's `P:0x31000`
-   against the captured words — that is O8's first real gate and it is
-   self-checking.
-4. Make the eDMA MOVE data (route A's model deliberately moves none), so the
-   frame exchange carries the 336/64/32-word records `docs/DSP.md` names.
-5. Only then the milestone's own gate: `verify_twocore`'s layouts rendering
-   identically when driven by the firmware instead of `dsp_host`'s hand-rolled
-   ABI calls.
+### ✅ M6a with the cores live, and the idle fast-forward validated
 
-⚠️ **Step 5 is a bigger jump than it reads.** `verify_twocore` drives the
-EFFECT ABI directly (`r0`/`r6`/`r7`/`n7` and a `proc` call); the firmware drives
-whole FRAMES through the packer at `0x4000d3fc`. Making those render the same
-audio means the firmware's per-track records have to carry the same knob values
-the harness passes by hand, and nothing has yet checked that they can.
+`ot_emu --dsp --ms 1000 --golden`: **the M6a gate passes** (10 created, 11 ran,
+gate at 205.97 ms against 205.39 without the cores) and `oracle.py` reports
+**8 compared fields agree** against route A. The boot sends the cores one word
+after the handoff (`0x030000`); core 0 takes it and goes on running with its
+ESAI ticking.
+
+The cores are stepped in lockstep (1.14 instructions per ColdFire instruction
+in the boot, 4535 per sample under the RTOS; both knobs, neither measured), and
+a 20-second project load is 4 G instructions per core in an interpreter. So a
+core found polling — eight instructions inside a three-word window, no hardware
+loop open, no interrupt pending — is advanced to its next peripheral event the
+way the chip's own `wait` is emulated (`idleStep`, the arithmetic is
+`op_Wait`'s), then executes the poll once so it can see what changed. ⚠️ The
+first version `continue`d without that execution, and the uploader waited for
+an echo that a never-executed poll could not produce. ✅ **Validated by A/B**,
+`--dsp` against `--dsp --dsp-no-idle` over the M6a run: ESAI frames 2688 / 2686
+both, host words 26570 / 99 both, all 8 oracle fields agree between the two.
+
+### Instruments added
+
+`--dsp`, `--dsp-log FILE` (every host-side event: sel/icr/cvr/tx/rx/mail/
+hc-taken, with the DSP due count), `--dsp-trace N` (a status line per core:
+PC, SR, mode, pending, peripheral target, ESAI counts, SAISR/RCR/TCR/HSR/HCR),
+`--dsp-no-idle`, `--dsp-verbose` (the vendored log lines, off by default: 3,260
+per boot), `--edma-log FILE` (every kick with its whole TCD), the per-core PC
+ring and fault in the report, `DSP=1 scripts/o6_gate.sh`. And the build is now
+native: `/opt/homebrew/bin/cmake` — the x86 cmake at `/usr/local/bin` had been
+building `out/emu` for Rosetta.
+
+### ✅ The sequencer gate passes with the cores live
+
+`DSP=1 scripts/o6_gate.sh` (the port with `--dsp`, the same staged card, the
+same route A oracle): **400 frames, 28 ticks, the trig at frame 344 on track 0,
+bytes `0x08` then `0x18` — 5 compared fields agree.** Over those frames core A
+took 2,400 host commands and core B 1,200; the host wrote 6,400 words and took
+back 500; the pair's event log shows the frame protocol the tape had recorded
+(sel/icr/cvr/tx/rx/hc-taken), and the ColdFire's 16,800 eDMA kicks are in
+`--edma-log` with their TCDs. Before the DMA fix (item 7 above) this run
+stopped at frame 0 with 0 ticks; before the HC fix (item 6) at the first host
+command.
+
+### ✅ Step 4 — the blocks, decoded from the tape, and the lanes corrected
+
+Route A's tape (`emu_rtos.py --tape`, the `hostw` and `edma` records) gives
+the frame protocol per core, in order, and it decides the word width:
+
+| host command | words to +0x1c before it | eDMA that follows | bytes | DSP count |
+|---|---|---|---|---|
+| `0x8c` (vector 0x18, "frame") | — | — | — | — |
+| `0x89` (0x12, "DMA a block OUT") | `0x6600`, `0x1ff` | ch1 paced → ch6 → ch7 | 512+256+256 | 512 |
+| `0x89` | `0x6600`, `0x0ff` | ch1 burst | 512 | 256 |
+| `0x88` (0x10, "DMA a block IN") | `0x6080`, `0x29f` | ch0, NBYTES 0x150 × 4 | 1344 | 672 |
+| `0x88` | `0x6800`, `0x03f` | ch0, 0x20 × 4 | 128 | 64 |
+| `0x88` | `0x6000`, `0x07f` | ch0, 0x40 × 4 | 256 | 128 |
+| `0x88` | `0x6400`, `0x1ff` | ch0, 0x100 × 4 | 1024 | 512 |
+
+(two of the IN blocks repeat per frame, one per core, the GPIO byte toggling
+between them; the DSP's handlers at P:0x588 / P:0x597 read the two words,
+mask them to 16 bits, and arm DMA0 from HORX / DMA1 into HOTX for `count+1`
+words.) **Every count is exactly half the byte count.** So one DSP word rides
+each 16-bit bus cycle, a 32-bit eDMA access at +0x1c is two words (high
+halfword first), and ❌ the pair's first lane model — the odd byte of each
+halfword is the register, the even byte nothing — made every frame word 8
+bits wide. The corrected rule: on this 16-bit port the odd byte is the
+register the stride names and the even byte the register before it, so a
+halfword at +0x1c lands TXM:TXL and sends, at +0x18 TXH:TXM, at +0x14 TXH.
+The loader's byte-at-a-time upload is consistent with it (its `movew` at
++0x1c carries mm:ll, and TXM was already mm), and so is the DSP masking a
+count sent by a single `movew` to 16 bits. The DSP words carry TXH stale
+(0x03, the last upload byte) above the 16 payload bits. DSP.md's "336-word
+records" were bytes: the record is 672 words.
+
+`Rtos::installHostPortMover` then moves the data the eDMA carries: a block
+whose DADDR is the window is pushed whole at the kick, halfword by halfword,
+as the bus cycles the eDMA would make (the vendored HDI08's receive ring
+holds it until the DSP's DMA0 drains it, a word per peripheral tick); a block
+whose SADDR is the window is pulled at completion from the core the kick was
+made against, running that core until each word is in HOTX (its DMA1 puts
+them there one at a time, since HOTX is a single register). The block size
+is NBYTES × the minor-loop count (CITER bit 15 = a minor link, count in bits
+8-0), the RAM side contiguous. `--dsp-peek core:space:addr,len` reads DSP
+memory after the run.
+
+⚠️ **And one of route A's completion rules changes when the cores are
+attached.** "A host-port burst completes at once" was right for a model that
+moved nothing; with the DSP draining a real ring it let the frame handler issue
+the next block's destination and count while the DSP was still taking the
+previous block, and the DSP's handler read data words as its arguments: 7
+frames in the window, the receive ring overflowing, 36 of 64 host commands
+never taken. On the chip the completion interrupt fires when the DSP has taken
+the last word, and that is what lets the handler continue — so with the pair
+attached a burst INTO the port completes at the first tick the selected core's
+receive ring is empty (`Edma::setCompletionGate`), and without it every rule is
+route A's (the non-DSP O6 report is byte-identical before and after).
+
+✅ **With the mover, the gate still passes and the blocks flow**: 400 frames,
+28 ticks, the trig at frame 344 (`0x08`/`0x18`), 5 compared fields agree;
+**2,400 blocks / 870,400 words to the DSPs, 1,600 blocks / 307,200 words
+back, 0 not in time**, 60,820 ticks spent holding a burst for the DSP to
+drain; per core 2,400 / 1,200 host commands taken, 204,800 / 102,400 read-back
+words produced by the DSPs' own transmit DMA. ⚠️ What is NOT measured: whether
+those words carried non-zero content. `--dsp-peek` of X:0x6080, 0x6000,
+0x6400, 0x6600, 0x6800 on both cores reads all zeros at the END of the run,
+and the pair does not yet count non-zero words pushed or pulled — the DSP may
+consume and clear its record buffers, or the port's frames may be empty, and
+the run cannot tell those apart. That counter is the next session's first
+instrument, before anything is inferred from it.
+
+### What step 5 needs
+
+`verify_twocore` drives the effect ABI directly (`r0`/`r6`/`r7`/`n7` and a
+`proc` call); the firmware drives whole frames through the packer at
+`0x4000d3fc`, and with the mover those frames now reach the DSP's X:0x6080
+records. Making the two render the same audio means (a) audio IN: the ESAI
+receives silence here — the ColdFire's own audio path (the sample pool → the
+DSP) is the eDMA/ESAI-in side, untraced; (b) audio OUT: the ESAI transmit
+frames are counted, not kept; (c) a comparison of the firmware's per-track
+records against the knob values the harness passes by hand. That is O9's
+ground as much as O8's, and it was not started.
 
 ### No regression
 
-`ctest` 6/6; the M6a oracle diff **8 compared fields agree, 0 disagreements**;
-the O6 fidelity gate **5 compared fields agree**.
+`ctest` 7/7 (the new `dsp` gate included); `make check` green; the O6 gate
+without `--dsp` unchanged (5 compared fields agree, the trig at frame 344);
+the M6a oracle diff without `--dsp` 8 compared fields agree. The models are
+seeded from the same 8,235 boot writes as before — a write the co-processor
+owns is not replayed into them.
 
 ## What is NOT here yet
 

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -74,6 +74,7 @@ route A fact, not the port's problem; the golden command above already does it.
 | O6 | the eDMA and the frame clock; the sequencer | the M6c fidelity gate (`scripts/o6_gate.sh`) | ✅ 5 compared fields: 400 frames, 28 ticks, the trig at frame 344 track 0 bytes `0x08`/`0x18`, and the bank/pattern four -- byte-identical to route A |
 | O7 | the card, the mount, the project load | route A's ATA command log EQUALS the port's | ✅ all 6,189 commands identical line for line, 30,467 sectors read, 297 written (was "a prefix"; O7b closed the gap) |
 | O7b | why the port loaded twice | name the task and PC, and make the oracle reproduce it | ✅ `sys`'s media case reloads a NAMED project; the split is `strlen(name)` = 0 vs 3, a harness ordering race. Route A reproduces the port's 12,373 with `--names-early` |
+| O8 (1-4) | the DSP cores behind the host port | ctest `dsp` (the firmware's upload lands the image's bytes) + M6a and O6 with `--dsp` | ✅ 50/50 + 58/58 bootstrap words, 26,221 + 25,408 payload words at upload time; M6a 8 compared fields; O6 5 compared fields (400 frames, 28 ticks, trig at 344) with the cores live. Step 5 open |
 
 ## Queue
 
@@ -424,7 +425,51 @@ first (the oracle), and the discrepancy stays documented as route A's.
 
 </details>
 
-### O8 — the DSP cores and the host port — ⛔ SCOPED, NOT BUILT (8 Sep 2026)
+### O8 — the DSP cores and the host port — 🟡 BUILT THROUGH STEP 4 (8 Sep 2026, branch `coldfire-o8-dsp`)
+
+**The two real cores sit behind the host port (`--dsp`), the firmware boots
+them itself, a ctest verifies the upload byte for byte, the M6a and O6 gates
+both pass with the cores live (`DSP=1 scripts/o6_gate.sh`), and the eDMA moves
+the frame blocks (870,400 words in, 307,200 back over 400 frames, none late;
+⚠️ whether they carry non-zero content is unmeasured — DSP record memory reads
+zero at the end of the run).** Step 5 — `verify_twocore`'s layouts rendering identically
+when driven by the firmware — is not started; `COLDFIRE_PORT.md` says what it
+needs. Do not re-do any of the join.
+
+What later milestones must know:
+
+1. ❌ **The host-port readings in ARCHITECTURE.md §6 were wrong** and are
+   corrected there: the window is the HI08 host-side register file at a 4-byte
+   stride on a 16-bit port, `0x81` is ICR INIT|RREQ, `0x8c` a host command,
+   the ready bit is TXDE|TRDY. And one DSP word rides each 16-bit bus cycle
+   (the tape's block counts are half their byte counts) — a longword eDMA
+   access is two words.
+2. **The shared window is ONE memory for P, X and Y of both cores**, and the
+   firmware needs it (core B's entry is written by core A's upload). `dsp_host`
+   keeps its two-way window and is a different machine on that point.
+3. **Eight things the vendored DSP emulator does that the firmware cannot live
+   with** are in `tools/dsp56300.patch` (DO loops nested in one call, JIT-only
+   interrupt dispatch, a masked interrupt starving the peripherals, the ESAI
+   blocking on an empty ring, a PC past P memory as a garbage pointer, a fast
+   interrupt never reaching its vector's PC, the ring-buffer DMA modes and a
+   12-bit DCOL, the host DMA's disabled initial trigger and 200-instruction
+   receive throttle). Every one was found by an instrument — stack sample, `lldb
+   -k`, `--dsp-trace` — after presenting as a silent hang or a bare crash.
+   Regenerate the patch with `git -C vendor/dsp56300 diff`; `make check` only
+   sees it after `cmake --build vendor/dsp56300/build`.
+4. **With the cores attached, a burst into the host port completes when the
+   DSP has drained it**, not at once (route A's rule stands without them): the
+   completion interrupt is what lets the frame handler issue the next block.
+5. 🟡 The inter-core mailbox at Y:$FFFFD3/D4 and $FFFFD6/D7 is inferred from
+   the two payloads' wait loops and modelled symmetrically.
+6. The idle fast-forward is on by default and validated by A/B (`--dsp-no-idle`);
+   a sequencer run with the cores costs ~25 minutes either way.
+7. The build is native now (`/opt/homebrew/bin/cmake`); the x86 cmake had been
+   building `out/emu` under Rosetta.
+
+<details><summary>the scoping entry it replaces</summary>
+
+### O8 — the DSP cores and the host port — ⛔ SCOPED, NOT BUILT (8 Sep 2026, the original)
 
 **The join is fully decoded and no DSP is wired yet.** `COLDFIRE_PORT.md` has
 the account; the headline is that ✅ **the firmware boots the DSPs ITSELF,
@@ -463,6 +508,8 @@ the judgment this milestone was reserved for.
 see the boot, and `--periph`'s log is capped at 4096 accesses — full long before
 the DSP init. Fixed, and `--hostport-log` added. **A zero from an instrument is
 not a measurement until you know the instrument can see the thing.**
+
+</details>
 
 ### O9 — audio out *(Fable)*
 

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -430,9 +430,11 @@ first (the oracle), and the discrepancy stays documented as route A's.
 **The two real cores sit behind the host port (`--dsp`), the firmware boots
 them itself, a ctest verifies the upload byte for byte, the M6a and O6 gates
 both pass with the cores live (`DSP=1 scripts/o6_gate.sh`), and the eDMA moves
-the frame blocks (870,400 words in, 307,200 back over 400 frames, none late;
-⚠️ whether they carry non-zero content is unmeasured — DSP record memory reads
-zero at the end of the run).** Step 5 — `verify_twocore`'s layouts rendering identically
+the frame blocks (870,400 words in, 307,200 back over 400 frames, none late).
+✅ **The outbound frames carry content and track the sequencer** — 40,853
+non-zero words, rising across the trig at frame 344 — and they reach DSP
+memory. ❌ **The inbound direction is zeros in every frame band**: the DSP
+computes silence, and why is open on the audio-in path (O9's ground).** Step 5 — `verify_twocore`'s layouts rendering identically
 when driven by the firmware — is not started; `COLDFIRE_PORT.md` says what it
 needs. Do not re-do any of the join.
 
@@ -462,9 +464,15 @@ What later milestones must know:
    completion interrupt is what lets the frame handler issue the next block.
 5. 🟡 The inter-core mailbox at Y:$FFFFD3/D4 and $FFFFD6/D7 is inferred from
    the two payloads' wait loops and modelled symmetrically.
-6. The idle fast-forward is on by default and validated by A/B (`--dsp-no-idle`);
+6. **The DSP lands a block at its own address, not the one the host names**
+   (dest `0x6080` → X:0x4080, consistently 0x2000 apart; 🟡 a bank select).
+   A `--dsp-peek` of the host's address reads zeros and looks like an empty
+   frame — count non-zero words at the move (`--block-log`) instead, and take
+   any DSP-side note at the drain's completion, never at the eDMA kick, where
+   it lags a whole block.
+7. The idle fast-forward is on by default and validated by A/B (`--dsp-no-idle`);
    a sequencer run with the cores costs ~25 minutes either way.
-7. The build is native now (`/opt/homebrew/bin/cmake`); the x86 cmake had been
+8. The build is native now (`/opt/homebrew/bin/cmake`); the x86 cmake had been
    building `out/emu` under Rosetta.
 
 <details><summary>the scoping entry it replaces</summary>

--- a/docs/DSP.md
+++ b/docs/DSP.md
@@ -15,18 +15,24 @@ unless prefixed `P:` / `X:` / `Y:`, which are DSP word addresses.
 `FUN_40001e50`, called from the boot path at `0x4000050c`:
 
 ```asm
-move.b #0,(0xfc0a400c)                       ; GPIO select
-move.w #0x81,(0x20000000)                    ; DSP control: start
-FUN_40001d4c(0x400e21e0, 0x96,  0x31000)     ; bootstrap A -> P:0x31000  (50 words)
+move.b #0,(0xfc0a400c)                       ; GPIO select (core A)
+move.w #0x81,(0x20000000)                    ; HI08 ICR: INIT|RREQ (an interface reset -- NOT "start")
+FUN_40001d4c(0x400e21e0, 0x96,  0x31000)     ; bootstrap A -> P:0x31000  (50 words, via the chip's boot ROM)
                                              ; ~10,000-iteration delay loop
-FUN_40001b18(0x400e2324)                     ; payload A  (79,563 B)
-move.b #1,(0xfc0a400c)                       ; GPIO select -- FLIPPED
-move.w #0x81,(0x20000000)                    ; DSP control: start
+FUN_40001b18(0x400e2324)                     ; payload A  (79,563 B), via that bootstrap's loader
+move.b #1,(0xfc0a400c)                       ; GPIO select -- FLIPPED (core B)
+move.w #0x81,(0x20000000)                    ; HI08 ICR: INIT|RREQ
 FUN_40001d4c(0x400e2276, 0xae,  0x32000)     ; bootstrap B -> P:0x32000  (58 words)
                                              ; delay loop
 FUN_40001b18(0x400f59ef)                     ; payload B  (77,061 B)
 move.l #0xfff0000,(0xfc00801c)               ; FlexBus / chip-select config
 ```
+
+❌ "0x81 = DSP control: start" is retracted (8 Sep 2026): the window is the
+HI08 host-side register file and `0x81` is ICR INIT|RREQ. ✅ The whole sequence
+now runs in the ColdFire port against the two emulated cores and lands every
+byte (`docs/COLDFIRE_PORT.md`, O8). Payload B's entry P:0x38000 is written by
+payload A's upload -- the shared window is one memory, both cores, P/X/Y.
 
 **Two DSPs (or two banks), not one.** The sequence runs twice, identically, with
 the GPIO at `0xfc0a400c` toggled between passes, and each pass has its own

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -219,7 +219,13 @@ refactoring risk into a mechanical check.
 `dsp_host -mem A.mem -memB B.mem` boots **both payloads** as two complete
 DSPs in one process, with X/Y `0x30000–0x3FFFF` of core 1 redirected into
 core 0's arrays (a patch to the vendored emulator's `Memory`,
-`tools/dsp56300.patch`) so the shared window really is shared. Each core
+`tools/dsp56300.patch`) so the shared window really is shared. ⚠️ That is
+X with X and Y with Y, P private -- which renders bit-identically and
+cannot answer aliasing questions. The ColdFire port's DSP pair
+(`tools/ot_emu/dsp.h`, O8) uses the same patch's THREE-WAY form, P/X/Y one
+memory, because the firmware's own boot needs it (`docs/COLDFIRE_PORT.md`).
+The patch also carries the host-stepped mode that port drives the cores in;
+`dsp_host` is untouched by it. Each core
 runs its **own** setup routine: the harness finds it by opcode pattern —
 payload B keeps it at `P:0x17a` where A's is at `P:0x372`, the same code
 relocated (✅ measured by matching the instruction sequence; the old

--- a/scripts/o6_gate.sh
+++ b/scripts/o6_gate.sh
@@ -41,11 +41,14 @@ else
         | grep -v '^   ' | tail -20
 fi
 
-echo "== the port"
+echo "== the port${DSP:+ (with the two DSP cores behind the host port, O8)}"
 cmake --build out/emu -j8 >/dev/null
+# DSP=1 puts the real DSP cores behind the host port (O8): the firmware boots
+# them itself, and the frame handshake runs against them instead of the two
+# stand-in replies. Both forms are gated against the same route A oracle.
 ./out/emu/ot_emu --image "$IMAGE" --card out/o6_card.img --set "$SET" --project "$NAME" \
     --sequencer --internal-clock --poke-trig "$STEP" --frames "$FRAMES" --load-ms "$MS" \
-    --m6c-golden out/oracle/port_m6c.json | tail -30
+    ${DSP:+--dsp} --m6c-golden out/oracle/port_m6c.json | tail -30
 
 echo "== the diff"
 python3 tools/ot_emu/oracle.py out/oracle/m6c.json out/oracle/port_m6c.json

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -104,12 +104,16 @@ if [ ! -x "$DIS" ]; then
     [ -d vendor/dsp56300 ] || git clone --depth 1 \
       https://github.com/dsp56300/dsp56300.git vendor/dsp56300
     git -C vendor/dsp56300 submodule update --init --depth 1 --recursive
-    # MPYRI (immediate multiply, rounded) is unimplemented upstream in both
-    # the interpreter and the JIT; Elektron's stock LO-FI uses it, so a
-    # render of LO-FI aborted with "Not Implemented: MPYRI" (2 Sep 2026).
+    # The patch carries: MPYRI (unimplemented upstream in interpreter and
+    # JIT; stock LO-FI uses it, 2 Sep 2026); the shared window, two-way for
+    # dsp_host (X with X, Y with Y) and three-way for the ColdFire port's DSP
+    # pair (P, X and Y one memory, as the chip has it); and the host-stepped
+    # mode the port drives the cores in (DO loops stepped, interrupts
+    # interpreted, peripherals serviced under a masked interrupt, an idle
+    # step) plus hooks for Y-side registers it does not map (8 Sep 2026, O8).
     EMUPATCH=$(pwd)/tools/dsp56300.patch
     if git -C vendor/dsp56300 apply --check "$EMUPATCH" 2>/dev/null; then
-      git -C vendor/dsp56300 apply "$EMUPATCH" && echo "   emulator patch applied (MPYRI)"
+      git -C vendor/dsp56300 apply "$EMUPATCH" && echo "   emulator patch applied (MPYRI, shared window, host-stepped cores)"
     else
       echo "   emulator patch already applied (or upstream changed: check $EMUPATCH)"
     fi

--- a/tools/dsp56300.patch
+++ b/tools/dsp56300.patch
@@ -8,6 +8,220 @@ index ffbf791..350a71a 100644
  endif()
 +
 +add_subdirectory(dsp_host)
+diff --git a/source/dsp56kEmu/dma.cpp b/source/dsp56kEmu/dma.cpp
+index bd3e603..8176a6e 100644
+--- a/source/dsp56kEmu/dma.cpp
++++ b/source/dsp56kEmu/dma.cpp
+@@ -59,7 +59,12 @@ namespace dsp56k
+ 
+ 		bool checkTrigger(Peripherals56362& _p, const RequestSource _src)
+ 		{
+-			return false;
++			// octabam: a channel armed while its request condition already
++			// holds must fire once, or a transmit DMA whose HTDE is already set
++			// never starts. Only for a host-stepped core: upstream disabled
++			// this for its own (threaded, JIT) timing.
++			if(!_p.getDSP().isHostStepped())
++				return false;
+ 			switch (_src)
+ 			{
+ 			case RequestSource::EsaiReceiveData:			return _p.getEsai().getSR().test(Esai::M_RDF);
+@@ -156,7 +161,11 @@ namespace dsp56k
+ 		else
+ 		{
+ 			m_dcohInit = m_dco >> 12;
+-			m_dcolInit = m_dco & 0xff;
++			// octabam: DCOL is the LOW TWELVE bits (DCOH the high twelve). The
++			// Octatrack's ESAI-in ring is DCO3 = 0x23f with DOR3 = -575 = -0x23f:
++			// the pointer returns to its base only if DCOL counts 0x23f words,
++			// so the firmware's own constants say 12, not 8.
++			m_dcolInit = m_dco & 0xfff;
+ 
+ 			m_dcoh = m_dcohInit;
+ 			m_dcol = m_dcolInit;
+@@ -716,6 +725,25 @@ namespace dsp56k
+ 			return false;
+ 		}
+ 
++		// octabam: a dual-counter RING on the memory side and a fixed
++		// peripheral register on the other -- the Octatrack DSP's audio out
++		// (DMA2: X:0x8000.. DualCounterDOR2 -> ESAI TX0) and audio in (DMA3:
++		// ESAI RX0 -> X:0x8100.. DualCounterDOR3), one word per request. The
++		// release build reached the assert below for both, returned "finished"
++		// without moving a word, and the DSP polled DSR2 for 0x8070/0x80f0
++		// forever (measured 8 Sep 2026, `ot_emu --dsp --dsp-trace`).
++		const auto isDual = [](const AddressGenMode _m) { return static_cast<uint32_t>(_m) <= 3; };
++		if (isDual(agmS) && agmD == AddressGenMode::SingleCounterAnoUpdate)
++		{
++			memWrite(areaD, m_ddr, memRead(areaS, m_dsr));
++			return dualModeIncrement(m_dsr, m_dma.getDOR(static_cast<uint32_t>(agmS)));
++		}
++		if (agmS == AddressGenMode::SingleCounterAnoUpdate && isDual(agmD))
++		{
++			memWrite(areaD, m_ddr, memRead(areaS, m_dsr));
++			return dualModeIncrement(m_ddr, m_dma.getDOR(static_cast<uint32_t>(agmD)));
++		}
++
+ 		assert(false && "DMA transfer mode not supported yet");
+ 		return true;
+ 	}
+diff --git a/source/dsp56kEmu/dsp.cpp b/source/dsp56kEmu/dsp.cpp
+index db792a8..b1af305 100644
+--- a/source/dsp56kEmu/dsp.cpp
++++ b/source/dsp56kEmu/dsp.cpp
+@@ -178,7 +178,18 @@ namespace dsp56k
+ 		const auto vba = interrupt;
+ 
+ 		if(isInterruptMasked(vba))
++		{
++			// octabam: a masked interrupt WAITS; the peripherals do not. Without
++			// this the peripheral clock is never serviced again until the DSP
++			// lowers its mask -- the Octatrack's core A boots with `ori #3,mr`,
++			// takes a peripheral interrupt into the queue, and its ESAI stopped
++			// after three frames (measured 8 Sep 2026: SAISR stuck at RDF|ROE,
++			// the peripheral target clock frozen at 845,824 while the
++			// instruction counter ran on).
++			if(m_hostStepped)
++				m_execPeripheralsFunc(this);
+ 			return;
++		}
+ 
+ 		// it is important that the processing mode is switched first before popping the vector to prevent a possible race condition in hasPendingInterrupt()
+ 		{
+@@ -194,12 +205,15 @@ namespace dsp56k
+ 		pcCurrentInstruction = vba;
+ 		m_processingMode = FastInterrupt;
+ 
++		if(m_onInterruptTaken)	// octabam
++			m_onInterruptTaken(vba);
++
+ #if DSP56300_DEBUGGER
+ 		if(m_debugger)
+ 			m_debugger->onExec(vba);
+ #endif
+ 
+-		if(g_useJIT)
++		if(g_useJIT && !m_hostStepped)	// octabam: a host-stepped core interprets its interrupts too
+ 		{
+ 			LOGJITPC(vba);
+ 			const auto pc = getPC();
+@@ -496,6 +510,10 @@ namespace dsp56k
+ 
+ 		traceOp();
+ 
++		// octabam: the stepping host applies the loop-end test itself
++		if(m_hostStepped)
++			return true;
++
+ 		// __________________
+ 		//
+ 
+@@ -524,6 +542,48 @@ namespace dsp56k
+ 		return true;
+ 	}
+ 
++	// octabam: see dsp.h. The arithmetic is op_Wait's.
++	uint64_t DSP::idleStep(const uint64_t _maxDelay)
++	{
++		auto delay = perif[0]->getTargetClock();
++
++		if (delay > m_instructions)
++			delay = std::max(delay - m_instructions, static_cast<uint64_t>(PeripheralsProcessingStepSize));
++		else
++			delay = PeripheralsProcessingStepSize;
++
++		if(delay > _maxDelay)
++			delay = std::max<uint64_t>(_maxDelay, 1);
++
++		m_instructions += delay;
++		m_cycles += delay;
++
++		if(perif[0]->getTargetClock() <= m_instructions)
++			m_execPeripheralsFunc(this);
++
++		return delay;
++	}
++
++	// octabam: the body of the nested loop above, applied once per stepped
++	// instruction. Nested DO loops work because do_end restores the outer
++	// LA/LC, so the next test is the outer loop's.
++	bool DSP::doLoopEnd()
++	{
++		if(!sr_test_noCache(SR_LF))
++			return false;
++		if(reg.pc.var != (reg.la.var+1))
++			return false;
++		if( reg.lc.var <= 1 )
++		{
++			setPC(reg.la.var+1);
++			do_end();
++			return true;
++		}
++		--reg.lc.var;
++		setPC(hiword(reg.ss[ssIndex()]));
++		return true;
++	}
++
+ 	// _____________________________________________________________________________
+ 	// exec_do_end
+ 	//
+diff --git a/source/dsp56kEmu/dsp.h b/source/dsp56kEmu/dsp.h
+index 423b699..a2851ae 100644
+--- a/source/dsp56kEmu/dsp.h
++++ b/source/dsp56kEmu/dsp.h
+@@ -1,5 +1,7 @@
+ #pragma once
+ 
++#include <functional>
++
+ #include "disasm.h"
+ #include "dspconfig.h"
+ #include "dspregs.h"
+@@ -171,7 +173,7 @@ namespace dsp56k
+ 
+ 		ASMJIT_FORCE_INLINE void exec() noexcept
+ 		{
+-			if(g_useJIT)
++			if(g_useJIT && !m_hostStepped)	// octabam: see setHostStepped
+ 				execJit();
+ 			else
+ 				execInterpreter();
+@@ -375,6 +377,35 @@ namespace dsp56k
+ 		bool	do_exec							( TWord _loopcount, TWord _addr );
+ 		bool	do_end							();
+ 
++	public:
++		// octabam: a host that steps this core ONE INSTRUCTION AT A TIME
++		// through execInterpreter(), alongside another processor. Two things
++		// change: (1) `do_exec` cannot run a hardware DO loop to completion
++		// inside one call -- a loop body that polls the host port then never
++		// returns to the host that has to feed it -- so it pushes the loop
++		// state and returns, and the host applies `doLoopEnd()` after every
++		// instruction (the same end-of-loop test, on the same registers);
++		// (2) `execInterrupt` takes its interpreter branch, because the JIT
++		// branch it takes by default (g_useJIT is compile-time) faults when
++		// nothing else has been running the JIT.
++		void	setHostStepped					( bool _on )						{ m_hostStepped = _on; }
++		bool	isHostStepped					() const							{ return m_hostStepped; }
++		bool	doLoopEnd						();
++		// octabam: one step of what `wait` does -- advance the instruction
++		// clock to the next peripheral service point (at most _maxDelay) and
++		// service the peripherals -- for a host that has found the core in a
++		// poll loop and wants the peripherals, not the polls. Returns the
++		// instructions skipped.
++		uint64_t idleStep						( uint64_t _maxDelay );
++		// octabam: told when an interrupt is TAKEN (its vector executed), so a
++		// host-side status bit that the chip clears on acknowledge -- the
++		// HI08's HC/HCP -- can be cleared at the right moment. A fast
++		// interrupt never sets the PC to the vector, so the PC cannot tell.
++		void	setInterruptTakenHook			( std::function<void(TWord)> _f )	{ m_onInterruptTaken = std::move(_f); }
++	private:
++		bool	m_hostStepped = false;
++		std::function<void(TWord)> m_onInterruptTaken;
++
+ 		bool	rep_exec						(TWord _loopCount);
+ 
+ 		void	traceOp							();
 diff --git a/source/dsp56kEmu/dsp_ops_alu.inl b/source/dsp56kEmu/dsp_ops_alu.inl
 index 386e30f..996c82a 100644
 --- a/source/dsp56kEmu/dsp_ops_alu.inl
@@ -72,37 +286,62 @@ index f9f8180..714776e 100644
  	{
  		const bool	ab = getFieldValue<Maci_xxxx, Field_d>(op);
 diff --git a/source/dsp56kEmu/memory.cpp b/source/dsp56kEmu/memory.cpp
-index 98c2226..c408d00 100644
+index 98c2226..a2b1357 100644
 --- a/source/dsp56kEmu/memory.cpp
 +++ b/source/dsp56kEmu/memory.cpp
-@@ -145,6 +145,12 @@ namespace dsp56k
+@@ -145,6 +145,14 @@ namespace dsp56k
  			}
  		}
  */
-+		if (m_sharedX && _area != MemArea_P && _offset >= m_sharedLo && _offset < m_sharedHi)
++		if (m_sharedX && (_area != MemArea_P || m_sharedP) && _offset >= m_sharedLo && _offset < m_sharedHi)
 +		{
-+			(_area == MemArea_X ? m_sharedX : m_sharedY)[_offset - m_sharedLo] = _value & 0x00ffffff;
++			(_area == MemArea_X ? m_sharedX : _area == MemArea_Y ? m_sharedY : m_sharedP)[_offset - m_sharedLo] = _value & 0x00ffffff;
++			if(m_sharedWriteHook)
++				m_sharedWriteHook(_offset);
 +			return true;
 +		}
 +
  		if (_offset < size(_area))		// Fix the amazing "write to wrong address" bug
  			m_mem[_area][_offset] = _value & 0x00ffffff;
  
-@@ -178,6 +184,9 @@ namespace dsp56k
+@@ -178,6 +186,9 @@ namespace dsp56k
  			return 0;
  		}
  
-+		if (m_sharedX && _area != MemArea_P && _offset >= m_sharedLo && _offset < m_sharedHi)
-+			return (_area == MemArea_X ? m_sharedX : m_sharedY)[_offset - m_sharedLo];
++		if (m_sharedX && (_area != MemArea_P || m_sharedP) && _offset >= m_sharedLo && _offset < m_sharedHi)
++			return (_area == MemArea_X ? m_sharedX : _area == MemArea_Y ? m_sharedY : m_sharedP)[_offset - m_sharedLo];
 +
  		const auto res = m_mem[_area][_offset];
  
  #ifdef _DEBUG
+@@ -211,6 +222,14 @@ namespace dsp56k
+ 		}
+ #endif
+ 
++		// octabam: an opcode fetched from the three-way shared window
++		if (m_sharedP && _offset >= m_sharedLo && _offset < m_sharedHi)
++		{
++			_wordA = m_sharedP[_offset - m_sharedLo];
++			_wordB = _offset + 1 < m_sharedHi ? m_sharedP[_offset + 1 - m_sharedLo] : p[_offset+1];
++			return;
++		}
++
+ 		_wordA = p[_offset];
+ 		_wordB = p[_offset+1];
+ 
 diff --git a/source/dsp56kEmu/memory.h b/source/dsp56kEmu/memory.h
-index 567d068..a409872 100644
+index 567d068..3a18046 100644
 --- a/source/dsp56kEmu/memory.h
 +++ b/source/dsp56kEmu/memory.h
-@@ -63,6 +63,14 @@ namespace dsp56k
+@@ -1,5 +1,7 @@
+ #pragma once
+ 
++#include <functional>
++
+ #include <map>
+ #include <set>
+ #include <vector>
+@@ -63,6 +65,23 @@ namespace dsp56k
  		TWord*												p;
  
  		TWord												m_bridgedMemoryAddress;
@@ -114,10 +353,19 @@ index 567d068..a409872 100644
 +		TWord												m_sharedHi = 0;
 +		TWord*												m_sharedX = nullptr;
 +		TWord*												m_sharedY = nullptr;
++		// octabam: the THREE-WAY alias. The DSP56721's shared window is one
++		// physical memory that P, X and Y all address (CHIP.md, measured on
++		// hardware with dsp/alias_probe.asm), and the firmware relies on it:
++		// core B's entry point P:0x38000 is written by core A's upload. When
++		// set, all three areas of [lo,hi) read and write this one array, and
++		// every write reports its address so the owner can drop any decoded
++		// opcode both cores hold for it.
++		TWord*												m_sharedP = nullptr;
++		std::function<void(TWord)>							m_sharedWriteHook;
  		
  		struct STransaction
  		{
-@@ -124,6 +132,13 @@ namespace dsp56k
+@@ -124,6 +143,19 @@ namespace dsp56k
  
  		const TWord&		getBridgedMemoryAddress() const { return m_bridgedMemoryAddress; }
  
@@ -125,9 +373,76 @@ index 567d068..a409872 100644
 +		// arrays at _lo). Pass nullptr to clear.
 +		void				setSharedWindow		(TWord _lo, TWord _hi, TWord* _x, TWord* _y)
 +		{
-+			m_sharedLo = _lo; m_sharedHi = _hi; m_sharedX = _x; m_sharedY = _y;
++			m_sharedLo = _lo; m_sharedHi = _hi; m_sharedX = _x; m_sharedY = _y; m_sharedP = nullptr;
++		}
++		// octabam: P, X and Y of [_lo,_hi) all alias _all (see m_sharedP).
++		void				setSharedWindow		(TWord _lo, TWord _hi, TWord* _all, std::function<void(TWord)> _onWrite)
++		{
++			m_sharedLo = _lo; m_sharedHi = _hi; m_sharedX = m_sharedY = m_sharedP = _all;
++			m_sharedWriteHook = std::move(_onWrite);
 +		}
 +
  		TWord*				getMemAreaPtr		(EMemArea _area)
  		{
  			switch (_area)
+diff --git a/source/dsp56kEmu/peripherals.cpp b/source/dsp56kEmu/peripherals.cpp
+index 67c3dfd..a97e2fb 100644
+--- a/source/dsp56kEmu/peripherals.cpp
++++ b/source/dsp56kEmu/peripherals.cpp
+@@ -767,6 +767,12 @@ namespace dsp56k
+ 		case Esai::M_RSMA_1:		return m_esai.readRSMA();
+ 		case Esai::M_RSMB_1:		return m_esai.readRSMB();
+ 		default:
++			if(m_readHook)	// octabam
++			{
++				TWord v;
++				if(m_readHook(_addr, v))
++					return v;
++			}
+ 			return m_mem[_addr - XIO_Reserved_High_First];
+ 		}
+ 	}
+@@ -792,6 +798,8 @@ namespace dsp56k
+ 		case Esai::M_RSMA_1:	m_esai.writeRSMA(_val);								return;
+ 		case Esai::M_RSMB_1:	m_esai.writeRSMB(_val);								return;
+ 		default:
++			if(m_writeHook && m_writeHook(_addr, _val))	// octabam
++				return;
+ 			break;
+ 		}
+ 		if (_addr != 0xffffd5)
+diff --git a/source/dsp56kEmu/peripherals.h b/source/dsp56kEmu/peripherals.h
+index adbac77..4257ef4 100644
+--- a/source/dsp56kEmu/peripherals.h
++++ b/source/dsp56kEmu/peripherals.h
+@@ -1,5 +1,7 @@
+ #pragma once
+ 
++#include <functional>
++
+ #include "dma.h"
+ #include "esai.h"
+ #include "esaiclock.h"
+@@ -255,6 +257,14 @@ namespace dsp56k
+ 		const TWord* readAsPtr(TWord _addr, Instruction _inst) override { return nullptr; }
+ 		void write(TWord _addr, TWord _val) override;
+ 
++		// octabam: a host-supplied model for Y-space peripheral registers this
++		// class does not map (the DSP56721's inter-core mailbox at
++		// Y:$FFFFD3..$FFFFD7, as the Octatrack firmware uses it). Return true
++		// to claim the access; unclaimed ones fall through as before.
++		using ReadHook = std::function<bool(TWord _addr, TWord& _val)>;
++		using WriteHook = std::function<bool(TWord _addr, TWord _val)>;
++		void setUnmappedHooks(ReadHook _r, WriteHook _w) { m_readHook = std::move(_r); m_writeHook = std::move(_w); }
++
+ 		uint32_t exec() noexcept { return MaxDelayCycles; }
+ 
+ 		void reset() override;
+@@ -274,5 +284,7 @@ namespace dsp56k
+ 	private:
+ 		std::array<TWord, XIO_Reserved_High_Last - XIO_Reserved_High_First + 1> m_mem;
+ 		Esai m_esai;
++		ReadHook m_readHook;
++		WriteHook m_writeHook;
+ 	};
+ }

--- a/tools/ot_emu/CMakeLists.txt
+++ b/tools/ot_emu/CMakeLists.txt
@@ -22,9 +22,16 @@ set(OT_VENDOR "${CMAKE_CURRENT_SOURCE_DIR}/../../vendor" CACHE PATH "vendored em
 # divide and HI08 tests, and they are the contract this port stands on.
 add_subdirectory("${OT_VENDOR}/mc68k" "${CMAKE_CURRENT_BINARY_DIR}/mc68k")
 
-add_library(ot_machine STATIC machine.cpp machine.h v4e.cpp v4e.h periph.cpp periph.h card.cpp card.h rtos.cpp rtos.h)
+# dsp56300: the vendored DSP56300 emulator `tools/dsp_host` is built on, with
+# the shared-window patch (tools/dsp56300.patch). Its own tree adds a test
+# runner, a disassembler and dsp_host; EXCLUDE_FROM_ALL keeps them out of this
+# build and links only the library (O8, 8 Sep 2026).
+add_subdirectory("${OT_VENDOR}/dsp56300/source" "${CMAKE_CURRENT_BINARY_DIR}/dsp56300" EXCLUDE_FROM_ALL)
+
+add_library(ot_machine STATIC machine.cpp machine.h v4e.cpp v4e.h periph.cpp periph.h card.cpp card.h rtos.cpp rtos.h dsp.cpp dsp.h)
 target_include_directories(ot_machine PUBLIC "${OT_VENDOR}" "${CMAKE_CURRENT_SOURCE_DIR}")
-target_link_libraries(ot_machine PUBLIC 68kEmu)
+target_include_directories(ot_machine PUBLIC "${OT_VENDOR}/dsp56300/source")
+target_link_libraries(ot_machine PUBLIC 68kEmu dsp56kEmu)
 
 add_executable(ot_emu main.cpp)
 target_link_libraries(ot_emu PRIVATE ot_machine)
@@ -49,3 +56,10 @@ add_test(NAME periph COMMAND ot_periph_test)
 add_executable(ot_rtos_test test_rtos.cpp)
 target_link_libraries(ot_rtos_test PRIVATE ot_machine)
 add_test(NAME rtos COMMAND ot_rtos_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+
+# O8: the firmware's own DSP upload, through the emulated host port, lands the
+# bytes the image carries -- both bootstrap ROMs and both payloads, record for
+# record, parsed independently from the image (docs/DSP.md section 2).
+add_executable(ot_dsp_test test_dsp.cpp)
+target_link_libraries(ot_dsp_test PRIVATE ot_machine)
+add_test(NAME dsp COMMAND ot_dsp_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../..)

--- a/tools/ot_emu/dsp.cpp
+++ b/tools/ot_emu/dsp.cpp
@@ -1,0 +1,611 @@
+#include "dsp.h"
+
+#include <cstdio>
+#include <algorithm>
+#include <cstring>
+#include <array>
+
+#include "dsp56kEmu/dsp.h"
+#include "dsp56kEmu/dspBootCode.h"
+#include "dsp56kEmu/esai.h"
+#include "dsp56kEmu/esaiclock.h"
+#include "dsp56kEmu/hdi08.h"
+#include "dsp56kEmu/memory.h"
+#include "dsp56kEmu/peripherals.h"
+#include "dsp56kBase/logging.h"
+
+namespace ot
+{
+	namespace
+	{
+		class AllowAll final : public dsp56k::IMemoryValidator
+		{
+		public:
+			bool memValidateAccess(dsp56k::EMemArea, dsp56k::TWord, bool) const override { return true; }
+		};
+
+		// ICR bits, host side.
+		constexpr uint32_t ICR_RREQ = 0x01, ICR_TREQ = 0x02, ICR_INIT = 0x80;
+	}
+
+	struct DspPair::Core
+	{
+		AllowAll validator;
+		std::unique_ptr<dsp56k::Memory> mem;
+		std::unique_ptr<dsp56k::Peripherals56362> px;
+		std::unique_ptr<dsp56k::Peripherals56367> py;
+		std::unique_ptr<dsp56k::DSP> dsp;
+		std::unique_ptr<dsp56k::DspBoot> boot;
+
+		uint64_t executed = 0, wordsIn = 0, wordsOut = 0, commands = 0, dropped = 0;
+		uint64_t rxFrames = 0, txFrames = 0;	// ESAI frames taken in (silence) / put out
+		uint64_t idleSkipped = 0;
+		uint64_t pulled = 0, pullShort = 0;	// read-back words taken / not produced in time
+		uint64_t nextTrace = 0;			// the fast-forward skips past exact multiples
+		uint32_t lastPcLo = 0, lastPcHi = 0;	// the PC window of the last few instructions
+		int windowRun = 0;
+		uint32_t lastTx[2] = {0, 0};		// slot 0 of the last output frame, TX0/TX1
+		// The host-side registers this model keeps itself; the rest are
+		// derived from the vendored HDI08 on every read.
+		uint8_t icr = 0, cvr = 0x32, ivr = 0x0f, txh = 0, txm = 0;
+		uint32_t lastRx = 0;		// the last word taken: RXH/RXM read it back
+		bool hcPending = false;
+		uint32_t hcVector = 0;
+		// THE PC RING AND THE FAULT. The interpreter indexes its opcode cache by
+		// the PC into a table sized to P memory (0x80000 words here), so a PC
+		// beyond it is a garbage member-function pointer and a SIGBUS with no
+		// diagnostic -- measured 8 Sep 2026 under lldb (funcCreate, called
+		// from DSP::execOp with a garbage `this`). Stop the core instead, and
+		// keep the last 64 PCs so the report can say how it got there.
+		std::array<uint32_t, 64> pcRing = {};
+		uint64_t pcRingPos = 0;
+		bool faulted = false;
+		std::string why;
+
+		dsp56k::HDI08& hdi() { return px->getHDI08(); }
+	};
+
+	DspPair::DspPair(const double _ratio, const double _ips)
+		: m_ratio(_ratio), m_ips(_ips), m_shared(g_shareHi - g_shareLo, 0)
+	{
+		// The vendored library logs every ESAI register write and every
+		// transmit underrun to stdout (3,260 lines over one boot). Off unless
+		// asked: `setVerbose(true)` restores them.
+		setVerbose(false);
+		for(int i = 0; i < 2; ++i)
+		{
+			m_cores.emplace_back(new Core);
+			Core& c = *m_cores.back();
+			// The sizes `tools/dsp_host` uses (the library's own tests').
+			c.mem.reset(new dsp56k::Memory(c.validator, 0x080000, 0x800000, 0x200000));
+			// The Y-side peripherals first: the X side's ESAI clock also drives
+			// the Y side's ESAI when it is told about it (dsp_host passes
+			// nothing, and calls the effects directly, so it never needed to).
+			c.py.reset(new dsp56k::Peripherals56367);
+			c.px.reset(new dsp56k::Peripherals56362(c.py.get()));
+			c.dsp.reset(new dsp56k::DSP(*c.mem, c.px.get(), c.py.get()));
+			// ⚠️ NOT dsp_host's window. dsp_host shares X with X and Y with Y and
+			// keeps P private, which renders the effects bit-identically and
+			// cannot answer aliasing questions (DSP.md). The firmware needs the
+			// real thing: ✅ measured 8 Sep 2026, with P private core 1 jumped to
+			// its entry P:0x38000 -- written only by core 0's upload -- found
+			// zeros, and ran off the end of P memory (the PC ring read 7ffc1..
+			// 7ffff, then the fault). A write anywhere in the window drops both
+			// cores' decoded opcode for that address, because P is what changed.
+			c.mem->setSharedWindow(g_shareLo, g_shareHi, m_shared.data(), [this](dsp56k::TWord _a)
+			{
+				for(auto& k : m_cores)
+					k->dsp->clearOpcodeCache(_a);
+			});
+			// AFTER the DSP: its constructor resets the peripherals, and the
+			// boot ROM's first act is to enable the host port (HPCR.HEN).
+			c.boot.reset(new dsp56k::DspBoot(*c.dsp));
+			// HOTX is ONE register: with this clear the DSP's `movep a,x:<<M_HOTX`
+			// blocks on HTDE the way the chip does, instead of queueing 8192
+			// words (dsp_host's finding of 2 Sep 2026).
+			c.hdi().setTransmitDataAlwaysEmpty(false);
+			// The receive DMA moves a word per request, not one per 200
+			// instructions (the vendored default is a throttle for a threaded
+			// host): a 672-word block at 200 is 30 samples, twice a frame.
+			c.hdi().setRXRateLimit(0);
+			// HOST-STEPPED (tools/dsp56300.patch): a hardware DO loop is stepped,
+			// not run to completion in one call -- the firmware's 50-word loader
+			// polls the host port INSIDE one (`dor`), and the ColdFire has to
+			// run between its iterations -- and interrupts go through the
+			// interpreter, not the JIT. ✅ Both measured 8 Sep 2026: a stack
+			// sample of the first attempt sat in DSP::op_Dor_S -> do_exec ->
+			// op_Brclr_pp forever; the second faulted in the JIT's funcCreate
+			// on the first DSP interrupt (lldb, EXC_BAD_ACCESS).
+			c.dsp->setHostStepped(true);
+			// HC and HCP clear when the DSP TAKES the host command. ✅ Measured
+			// 8 Sep 2026: watching for the PC to land on the vector never fired
+			// -- a fast interrupt runs the vector's two words inline -- so the
+			// frame handler polled HC forever and the sequencer ran 0 frames.
+			c.dsp->setInterruptTakenHook([this, i](dsp56k::TWord _vba)
+			{
+				Core& k = *m_cores[i];
+				if(!k.hcPending || _vba != k.hcVector)
+					return;
+				k.hcPending = false;
+				k.cvr &= 0x7f;
+				auto& h = k.hdi();
+				h.writeStatusRegister(h.readStatusRegister() & ~(1u << dsp56k::HDI08::HSR_HCP));
+				const int sel = m_sel;
+				m_sel = i;
+				note("hc-taken", _vba);
+				m_sel = sel;
+			});
+
+			// THE ESAI, NON-BLOCKING. ✅ Measured 8 Sep 2026: with the vendored
+			// defaults the DSP program's own ESAI setup ran, the first receive
+			// frame popped an EMPTY input ring, and the emulator sat in a
+			// condition variable forever (stack sample: EsxiClock::exec ->
+			// Esai::execRX -> RingBuffer::pop_front -> ConditionVariable::wait).
+			// Nothing here supplies audio yet (O9), so the input is silence and
+			// the output is counted -- and the clock is ONE FRAME PER SAMPLE at
+			// the pair's own instructions-per-sample, so the DSP's audio clock
+			// and the ColdFire's sample clock cannot drift apart.
+			auto silence = [&c](uint64_t&, dsp56k::Audio::RxFrame& _f)
+			{
+				for(uint32_t i = 0; i < dsp56k::Audio::MaxSlotsPerFrame; ++i)
+					for(auto& w : _f[i])
+						w = 0;
+				_f.resize(dsp56k::Audio::MaxSlotsPerFrame);
+				++c.rxFrames;
+			};
+			auto sink = [&c](uint64_t&, const dsp56k::Audio::TxFrame& _f)
+			{
+				++c.txFrames;
+				if(_f.size())
+				{
+					c.lastTx[0] = _f[0][0];
+					c.lastTx[1] = _f[0][1];
+				}
+			};
+			for(dsp56k::Esai* e : {&c.px->getEsai(), &c.py->getEsai()})
+			{
+				e->setReadRxCallback(silence);
+				e->setWriteTxCallback(sink);
+			}
+			c.px->getEsaiClock().setCyclesPerSample(static_cast<uint32_t>(_ips));
+
+			// The inter-core mailbox (see dsp.h), on the Y-side peripherals.
+			c.py->setUnmappedHooks(
+				[this, i](dsp56k::TWord _a, dsp56k::TWord& _v)
+				{
+					switch(_a)
+					{
+					case 0xffffd3: _v = m_mail[i ^ 1].full ? 2u : 0u; return true;
+					case 0xffffd4:
+						_v = m_mail[i ^ 1].data;
+						m_mail[i ^ 1].full = false;
+						return true;
+					case 0xffffd6: _v = m_mail[i].full ? 2u : 0u; return true;
+					case 0xffffd7: _v = m_mail[i].data; return true;
+					default: return false;
+					}
+				},
+				[this, i](dsp56k::TWord _a, dsp56k::TWord _v)
+				{
+					if(_a != 0xffffd7)
+						return false;
+					m_mail[i].data = _v & 0xffffff;
+					m_mail[i].full = true;
+					++m_mail[i].words;
+					const int sel = m_sel;
+					m_sel = i;
+					note("mail", _v & 0xffffff);
+					m_sel = sel;
+					return true;
+				});
+		}
+	}
+
+	DspPair::~DspPair() = default;
+
+	void DspPair::setVerbose(const bool _on)
+	{
+		// (A null function crashes the vendored logger; give it a printer.)
+		Logging::setLogFunc(_on ? [](const std::string& _s) { std::puts(_s.c_str()); } : [](const std::string&) {});
+	}
+
+	void DspPair::note(const char* _kind, const uint32_t _val)
+	{
+		if(!m_logOn || m_log.size() >= 4000000)
+			return;
+		Event e{};
+		e.due = static_cast<uint64_t>(m_due);
+		e.core = m_sel & 1;
+		std::strncpy(e.kind, _kind, sizeof e.kind - 1);
+		e.val = _val;
+		m_log.push_back(e);
+	}
+
+	// -- the register file ----------------------------------------------------
+
+	void DspPair::icrWrite(const uint32_t _v)
+	{
+		Core& c = cur();
+		auto& h = c.hdi();
+		c.icr = static_cast<uint8_t>(_v & 0x7f);		// INIT reads back clear
+		note("icr", _v & 0xff);
+		if(_v & ICR_INIT)
+		{
+			// INIT's effect is selected by TREQ/RREQ (the family manual's
+			// table, and the only reading under which the firmware's `0x81`
+			// makes sense as a per-core reset before an upload):
+			//   RREQ: the DSP-to-host path -- RXDF := 0, HTDE := 1
+			//   TREQ: the host-to-DSP path -- TXDE := 1, HRDF := 0
+			if(_v & ICR_RREQ)
+				while(h.hasTX())
+					h.readTX();
+			if(_v & ICR_TREQ)
+				h.clearRX();
+		}
+		h.setHostFlags((_v >> 3) & 1, (_v >> 4) & 1);
+	}
+
+	void DspPair::cvrWrite(const uint32_t _v)
+	{
+		Core& c = cur();
+		c.cvr = static_cast<uint8_t>(_v & 0xff);
+		note("cvr", _v & 0xff);
+		if(!(_v & 0x80))
+			return;
+		// HC set: a host command interrupt at P:(HV * 2). The frame handler's
+		// 0x8c is vector 0x18. HC (and the DSP's HCP) stay set until the DSP
+		// takes it -- `runDue` clears both when the PC lands on the vector.
+		c.hcVector = (_v & 0x7f) << 1;
+		c.hcPending = true;
+		++c.commands;
+		auto& h = c.hdi();
+		h.writeStatusRegister(h.readStatusRegister() | (1u << dsp56k::HDI08::HSR_HCP));
+		c.dsp->injectInterrupt(c.hcVector);
+	}
+
+	uint32_t DspPair::isrRead()
+	{
+		Core& c = cur();
+		auto& h = c.hdi();
+		// RXDF: the DSP has written HOTX and the host has not taken it.
+		// TXDE: the host's last word has been TAKEN by the DSP (the receive
+		// ring is empty) -- or is still being swallowed by the boot ROM, which
+		// takes every word at once. TRDY adds "and HRDF is clear", which is
+		// the same condition in this single-register model.
+		const bool rxdf = h.hasTX();
+		const bool txde = !c.boot->finished() || !h.hasRXData();
+		uint32_t v = (rxdf ? 1u : 0u) | (txde ? 2u : 0u) | (txde ? 4u : 0u);
+		v |= ((h.readControlRegister() >> 3) & 3) << 3;		// HF2/HF3 from the DSP's HCR
+		if((rxdf && (c.icr & ICR_RREQ)) || (txde && (c.icr & ICR_TREQ)))
+			v |= 0x80;											// HREQ
+		return v;
+	}
+
+	void DspPair::sendWord(const uint32_t _word)
+	{
+		Core& c = cur();
+		++c.wordsIn;
+		note("tx", _word);
+		if(!c.boot->finished())
+		{
+			c.boot->hdiWriteTX(_word);
+			return;
+		}
+		auto& h = c.hdi();
+		if(h.dataRXFull())
+		{
+			// Never block the emulator on a ring: the chip would simply have
+			// overwritten HRX. Count it so the report can say so.
+			++c.dropped;
+			return;
+		}
+		const dsp56k::TWord w = _word;
+		h.writeRX(&w, 1);
+	}
+
+	uint32_t DspPair::rxPeek()
+	{
+		Core& c = cur();
+		auto& h = c.hdi();
+		return h.hasTX() ? h.txData().front() : c.lastRx;
+	}
+
+	uint32_t DspPair::rxTake()
+	{
+		Core& c = cur();
+		auto& h = c.hdi();
+		if(h.hasTX())
+		{
+			c.lastRx = h.readTX();
+			++c.wordsOut;
+			note("rx", c.lastRx);
+		}
+		return c.lastRx;
+	}
+
+	bool DspPair::read(const uint32_t _addr, const uint8_t _size, uint32_t& _out)
+	{
+		if(_addr == g_select && _size == 1)
+		{
+			_out = static_cast<uint32_t>(m_sel);
+			return true;
+		}
+		if(_addr < g_window || _addr >= g_windowEnd)
+			return false;
+		// THE LANES. A 16-bit port (CS2, CSCR2 = 0x180): the odd byte of a
+		// halfword is the register the stride names, (a >> 2) & 7, and the even
+		// byte is the register BEFORE it. ✅ Decoded 8 Sep 2026 from route A's
+		// tape: the DSP's count word for every per-frame block is exactly half
+		// the block's byte count, so one DSP word rides each 16-bit cycle --
+		// the loader's byte-at-a-time writes are consistent with it (TXH:hh at
+		// +0x14 lands hh in TXH; hh:mm at +0x18 in TXH:TXM; mm:ll at +0x1c in
+		// TXM:TXL and sends), and so is the DSP masking a count it was sent
+		// with a single `movew` to +0x1c to 16 bits. A longword access is two
+		// cycles, high halfword first. ❌ The first model (odd byte only) made
+		// every frame word 8 bits wide.
+		uint32_t v = 0;
+		for(uint32_t i = 0; i < _size; ++i)
+		{
+			const auto a = _addr + i;
+			const int r = static_cast<int>((a >> 2) & 7) - ((a & 1) ? 0 : 1);
+			uint32_t b = 0;
+			Core& c = cur();
+			switch(r)
+			{
+			case 0: b = c.icr; break;
+			case 1: b = c.cvr; break;
+			case 2: b = isrRead(); break;
+			case 3: b = c.ivr; break;
+			case 5: b = (rxPeek() >> 16) & 0xff; break;
+			case 6: b = (rxPeek() >> 8) & 0xff; break;
+			case 7: b = rxTake() & 0xff; break;
+			default: break;
+			}
+			v = (v << 8) | (b & 0xff);
+		}
+		_out = v;
+		return true;
+	}
+
+	bool DspPair::write(const uint32_t _addr, const uint8_t _size, const uint32_t _val)
+	{
+		if(_addr == g_select && _size == 1)
+		{
+			m_sel = static_cast<int>(_val & 1);
+			note("sel", _val & 0xff);
+			return true;
+		}
+		if(_addr < g_window || _addr >= g_windowEnd)
+			return false;
+		for(uint32_t i = 0; i < _size; ++i)
+		{
+			const auto a = _addr + i;
+			const int r = static_cast<int>((a >> 2) & 7) - ((a & 1) ? 0 : 1);
+			const uint32_t b = (_val >> (8 * (_size - 1 - i))) & 0xff;
+			Core& c = cur();
+			switch(r)
+			{
+			case 0: icrWrite(b); break;
+			case 1: cvrWrite(b); break;
+			case 3: c.ivr = static_cast<uint8_t>(b); break;
+			case 5: c.txh = static_cast<uint8_t>(b); break;
+			case 6: c.txm = static_cast<uint8_t>(b); break;
+			case 7: sendWord((c.txh << 16) | (c.txm << 8) | b); break;
+			default: break;				// ISR is read-only; register 4 is nothing
+			}
+		}
+		return true;
+	}
+
+	// -- the eDMA's side ------------------------------------------------------
+
+	void DspPair::pushHalfwords(const uint32_t _addr, const std::vector<uint16_t>& _hw)
+	{
+		// The cycles the eDMA would make: a 32-bit write at _addr is two
+		// halfwords at +0 and +2, and both land on the same two registers.
+		for(size_t i = 0; i < _hw.size(); ++i)
+			write(_addr + 2 * static_cast<uint32_t>(i & 1), 2, _hw[i]);
+	}
+
+	size_t DspPair::pullHalfwords(const uint32_t _addr, const int _core, std::vector<uint16_t>& _out, const size_t _n)
+	{
+		const int sel = m_sel;
+		m_sel = _core & 1;
+		Core& c = cur();
+		size_t missing = 0;
+		for(size_t i = 0; i < _n; ++i)
+		{
+			// RXDF, the way the eDMA's request line would gate it -- and the
+			// DSP's own DMA has to put the next word in HOTX for that.
+			const bool ready = runCoreUntil(m_sel, [&c]{ return c.hdi().hasTX(); }, 200000);
+			if(!ready)
+				++missing;
+			uint32_t v = 0;
+			read(_addr + 2 * static_cast<uint32_t>(i & 1), 2, v);
+			_out.push_back(static_cast<uint16_t>(v));
+			++c.pulled;
+		}
+		c.pullShort += missing;
+		m_sel = sel;
+		return missing;
+	}
+
+	bool DspPair::runCoreUntil(const int _core, const std::function<bool()>& _ready, const uint64_t _budget)
+	{
+		Core& c = *m_cores[_core & 1];
+		for(uint64_t n = 0; n < _budget; ++n)
+		{
+			if(_ready())
+				return true;
+			if(c.faulted)
+				return false;
+			const auto pc = c.dsp->getPC().toWord();
+			if(pc >= g_pSize)
+			{
+				c.faulted = true;
+				c.why = "PC outside P memory during a read-back";
+				return false;
+			}
+			c.dsp->execInterpreter();
+			c.dsp->doLoopEnd();
+			++c.executed;
+		}
+		return _ready();
+	}
+
+	// -- the clock ------------------------------------------------------------
+
+	void DspPair::tickInstructions(const uint64_t _n)
+	{
+		m_due += static_cast<double>(_n) * m_ratio;
+		runDue();
+	}
+
+	void DspPair::tickSamples(const double _n)
+	{
+		m_due += _n * m_ips;
+		runDue();
+	}
+
+	void DspPair::runDue()
+	{
+		for(int i = 0; i < 2; ++i)
+		{
+			Core& c = *m_cores[i];
+			if(!c.boot->finished())
+			{
+				// Held in the bootstrap ROM until its last word lands; the
+				// ROM's jump is the first instruction this core runs.
+				if(static_cast<double>(c.executed) < m_due)
+					c.executed = static_cast<uint64_t>(m_due);
+				continue;
+			}
+			if(c.faulted)
+			{
+				c.executed = static_cast<uint64_t>(m_due);
+				continue;
+			}
+			while(static_cast<double>(c.executed) < m_due)
+			{
+				const auto pc = c.dsp->getPC().toWord();
+				c.pcRing[c.pcRingPos++ % c.pcRing.size()] = pc;
+				if(pc >= g_pSize)
+				{
+					c.faulted = true;
+					char msg[96];
+					std::snprintf(msg, sizeof msg, "PC %#x is outside P memory (%#x words)", pc, g_pSize);
+					c.why = msg;
+					c.executed = static_cast<uint64_t>(m_due);
+					break;
+				}
+				// The idle fast-forward (dsp.h): eight instructions in a row
+				// inside a three-word window, no hardware loop open.
+				if(pc < c.lastPcLo || pc > c.lastPcHi)
+				{
+					c.lastPcLo = pc;
+					c.lastPcHi = pc + 2;
+					c.windowRun = 0;
+				}
+				else if(++c.windowRun >= 8 && m_idleSkip && !(c.dsp->regs().sr.var & 0x8000)
+					&& !c.dsp->hasPendingInterrupts())
+				{
+					// Skip to the next peripheral event (or the due count), then
+					// FALL THROUGH and execute the poll once, so it can see what
+					// changed. ⚠️ `continue` here left the poll never executed
+					// and the uploader waiting for an echo forever (measured
+					// 8 Sep 2026: "unrecognised spin at 40001b82").
+					const auto room = static_cast<uint64_t>(m_due - static_cast<double>(c.executed));
+					const auto skipped = c.dsp->idleStep(room ? room : 1);
+					c.executed += skipped;
+					c.idleSkipped += skipped;
+				}
+				c.dsp->execInterpreter();
+				c.dsp->doLoopEnd();
+				++c.executed;
+				if(m_traceEvery && c.executed >= c.nextTrace && m_trace.size() < 100000)
+				{
+					char line[256];
+					std::snprintf(line, sizeof line,
+						"core %d exec %llu dspctr %llu pc %06x sr %06x mode %d pending %d periph-target %llu esai in %llu out %llu SAISR %06x RCR %06x TCR %06x HSR %06x HCR %06x DCR2 %06x DCO2 %06x DSR2 %06x DSR3 %06x",
+						i, static_cast<unsigned long long>(c.executed),
+						static_cast<unsigned long long>(c.dsp->getInstructionCounter()), pc,
+						c.dsp->regs().sr.var & 0xffffff,
+						static_cast<int>(c.dsp->getProcessingMode()), c.dsp->hasPendingInterrupts() ? 1 : 0,
+						static_cast<unsigned long long>(c.px->getTargetClock()),
+						static_cast<unsigned long long>(c.rxFrames), static_cast<unsigned long long>(c.txFrames),
+						c.px->read(0xffffb3, dsp56k::Nop), c.px->read(0xffffb7, dsp56k::Nop), c.px->read(0xffffb5, dsp56k::Nop),
+						c.hdi().readStatusRegister(), c.hdi().readControlRegister(),
+						c.px->read(0xffffe4, dsp56k::Nop), c.px->read(0xffffe5, dsp56k::Nop),
+						c.px->read(0xffffe7, dsp56k::Nop), c.px->read(0xffffe3, dsp56k::Nop));
+					m_trace.emplace_back(line);
+					c.nextTrace = (c.executed / m_traceEvery + 1) * m_traceEvery;
+				}
+			}
+		}
+	}
+
+	// -- probes ---------------------------------------------------------------
+
+	uint32_t DspPair::peekP(const int _core, const uint32_t _addr) const
+	{
+		return m_cores[_core & 1]->mem->get(dsp56k::MemArea_P, _addr);
+	}
+	uint32_t DspPair::peekX(const int _core, const uint32_t _addr) const
+	{
+		return m_cores[_core & 1]->mem->get(dsp56k::MemArea_X, _addr);
+	}
+	uint32_t DspPair::peekY(const int _core, const uint32_t _addr) const
+	{
+		return m_cores[_core & 1]->mem->get(dsp56k::MemArea_Y, _addr);
+	}
+	uint32_t DspPair::pc(const int _core) const { return m_cores[_core & 1]->dsp->getPC().toWord(); }
+	bool DspPair::faulted(const int _core) const { return m_cores[_core & 1]->faulted; }
+	uint64_t DspPair::idleSkipped(const int _core) const { return m_cores[_core & 1]->idleSkipped; }
+	bool DspPair::hostRingEmpty(const int _core) const { return !m_cores[_core & 1]->hdi().hasRXData(); }
+	uint64_t DspPair::pulled(const int _core) const { return m_cores[_core & 1]->pulled; }
+	uint64_t DspPair::pullShort(const int _core) const { return m_cores[_core & 1]->pullShort; }
+	uint64_t DspPair::mailboxWords(const int _from) const { return m_mail[_from & 1].words; }
+	bool DspPair::bootFinished(const int _core) const { return m_cores[_core & 1]->boot->finished(); }
+	uint64_t DspPair::executed(const int _core) const { return m_cores[_core & 1]->executed; }
+	uint64_t DspPair::hostWordsIn(const int _core) const { return m_cores[_core & 1]->wordsIn; }
+	uint64_t DspPair::hostWordsOut(const int _core) const { return m_cores[_core & 1]->wordsOut; }
+	uint64_t DspPair::hostCommands(const int _core) const { return m_cores[_core & 1]->commands; }
+	uint32_t DspPair::bootLength(const int _core) const { return m_cores[_core & 1]->boot->getLength(); }
+	uint32_t DspPair::bootAddress(const int _core) const { return m_cores[_core & 1]->boot->getInitialPC(); }
+
+	std::string DspPair::report() const
+	{
+		std::string s;
+		for(int i = 0; i < 2; ++i)
+		{
+			const Core& c = *m_cores[i];
+			char line[512];
+			std::snprintf(line, sizeof line,
+				"             core %d: boot ROM %s (%u words -> P:%#07x), pc %#07x, %llu instructions, "
+				"host words in %llu / out %llu, host commands %llu%s\n"
+				"                     ESAI frames in %llu / out %llu, last out slot 0 = %06x %06x; idle-skipped %llu; mailbox sent %llu; read-back words %llu (%llu not in time)\n",
+				i, c.boot->finished() ? "done" : "WAITING", c.boot->getLength(), c.boot->getInitialPC(),
+				c.dsp->getPC().toWord(), static_cast<unsigned long long>(c.executed),
+				static_cast<unsigned long long>(c.wordsIn), static_cast<unsigned long long>(c.wordsOut),
+				static_cast<unsigned long long>(c.commands),
+				c.dropped ? " (words DROPPED on a full ring)" : "",
+				static_cast<unsigned long long>(c.rxFrames), static_cast<unsigned long long>(c.txFrames),
+				c.lastTx[0], c.lastTx[1], static_cast<unsigned long long>(c.idleSkipped),
+				static_cast<unsigned long long>(m_mail[i].words),
+				static_cast<unsigned long long>(c.pulled), static_cast<unsigned long long>(c.pullShort));
+			s += line;
+			if(c.faulted)
+			{
+				s += "                     FAULT: " + c.why + "; last PCs:";
+				const auto n = std::min<uint64_t>(c.pcRingPos, c.pcRing.size());
+				for(uint64_t k = c.pcRingPos - n; k < c.pcRingPos; ++k)
+				{
+					std::snprintf(line, sizeof line, " %x", c.pcRing[k % c.pcRing.size()]);
+					s += line;
+				}
+				s += "\n";
+			}
+		}
+		return s;
+	}
+}

--- a/tools/ot_emu/dsp.cpp
+++ b/tools/ot_emu/dsp.cpp
@@ -41,6 +41,10 @@ namespace ot
 		uint64_t rxFrames = 0, txFrames = 0;	// ESAI frames taken in (silence) / put out
 		uint64_t idleSkipped = 0;
 		uint64_t pulled = 0, pullShort = 0;	// read-back words taken / not produced in time
+		uint32_t lastSent[2] = {0, 0};		// a rolling pair of the last two words sent
+		uint32_t cmdArgs[2] = {0, 0};		// ⚠️ SNAPSHOT AT THE COMMAND. Taken at drain time
+											// instead, this held the block's last two DATA words
+											// and read as if the firmware sent a dest of 0x030000.
 		uint64_t nextTrace = 0;			// the fast-forward skips past exact multiples
 		uint32_t lastPcLo = 0, lastPcHi = 0;	// the PC window of the last few instructions
 		int windowRun = 0;
@@ -256,6 +260,8 @@ namespace ot
 		// 0x8c is vector 0x18. HC (and the DSP's HCP) stay set until the DSP
 		// takes it -- `runDue` clears both when the PC lands on the vector.
 		c.hcVector = (_v & 0x7f) << 1;
+		c.cmdArgs[0] = c.lastSent[0];
+		c.cmdArgs[1] = c.lastSent[1];
 		c.hcPending = true;
 		++c.commands;
 		auto& h = c.hdi();
@@ -299,6 +305,8 @@ namespace ot
 			++c.dropped;
 			return;
 		}
+		c.lastSent[0] = c.lastSent[1];
+		c.lastSent[1] = _word;
 		const dsp56k::TWord w = _word;
 		h.writeRX(&w, 1);
 	}
@@ -561,6 +569,39 @@ namespace ot
 	uint32_t DspPair::pc(const int _core) const { return m_cores[_core & 1]->dsp->getPC().toWord(); }
 	bool DspPair::faulted(const int _core) const { return m_cores[_core & 1]->faulted; }
 	uint64_t DspPair::idleSkipped(const int _core) const { return m_cores[_core & 1]->idleSkipped; }
+	// The DSP's own host DMA, as its frame handlers arm it (P:0x588 reads two
+	// host words into DDR0/DCO0 and starts DMA0 = HORX -> X memory; P:0x597
+	// does the same for DMA1 = X memory -> HOTX). Reading them says where the
+	// block being moved is actually landing, at the moment it lands, which is
+	// what an end-of-run peek of a buffer the DSP has already consumed cannot.
+	std::string DspPair::blockNote(const int _core)
+	{
+		Core& c = *m_cores[_core & 1];
+		char b[192];
+		std::snprintf(b, sizeof b,
+			"dsp: cmd args %06x %06x | DMA0 ddr %06x dco %06x | X@%04x %06x %06x | X@%04x %06x %06x | rx ring %zu",
+			c.cmdArgs[0], c.cmdArgs[1],
+			c.px->read(0xffffee, dsp56k::Nop), c.px->read(0xffffed, dsp56k::Nop),
+			c.cmdArgs[0] & 0xffff,
+			c.mem->get(dsp56k::MemArea_X, c.cmdArgs[0] & 0xffff),
+			c.mem->get(dsp56k::MemArea_X, (c.cmdArgs[0] & 0xffff) + 1),
+			(c.cmdArgs[0] & 0xffff) - 0x2000,
+			c.mem->get(dsp56k::MemArea_X, ((c.cmdArgs[0] & 0xffff) - 0x2000) & 0xffffff),
+			c.mem->get(dsp56k::MemArea_X, (((c.cmdArgs[0] & 0xffff) - 0x2000) & 0xffffff) + 1),
+			c.hdi().rxData().size());
+		return b;
+	}
+
+	uint32_t DspPair::peekWord(const int _core, const char _space, const uint32_t _addr) const
+	{
+		// 'R' is not a memory space: it reads the DSP's own DMA0 destination
+		// pointer, which post-increments as the block drains, so the caller can
+		// find where the words it just sent actually landed.
+		if(_space == 'R')
+			return const_cast<dsp56k::Peripherals56362*>(m_cores[_core & 1]->px.get())->read(0xffffee, dsp56k::Nop);
+		return _space == 'P' ? peekP(_core, _addr) : _space == 'Y' ? peekY(_core, _addr) : peekX(_core, _addr);
+	}
+
 	bool DspPair::hostRingEmpty(const int _core) const { return !m_cores[_core & 1]->hdi().hasRXData(); }
 	uint64_t DspPair::pulled(const int _core) const { return m_cores[_core & 1]->pulled; }
 	uint64_t DspPair::pullShort(const int _core) const { return m_cores[_core & 1]->pullShort; }

--- a/tools/ot_emu/dsp.h
+++ b/tools/ot_emu/dsp.h
@@ -1,0 +1,166 @@
+// The two DSP56300 cores behind the ColdFire's host port -- milestone O8.
+//
+// WHAT THE WINDOW IS. `0x20000000`-`0x20000fff` is the HI08 HOST-SIDE
+// register file of whichever core the GPIO byte at `0xfc0a400c` selects,
+// one byte register per 4-byte stride, in the LOW byte of a 16-bit access:
+//
+//   +0x00  ICR   interrupt control   (RREQ 0, TREQ 1, HF0 3, HF1 4, INIT 7)
+//   +0x04  CVR   command vector      (HV 6:0, HC 7)
+//   +0x08  ISR   interrupt status    (RXDF 0, TXDE 1, TRDY 2, HF2 3, HF3 4, HREQ 7)
+//   +0x0c  IVR   interrupt vector
+//   +0x14  TXH / RXH   bits 23:16 of the 24-bit word
+//   +0x18  TXM / RXM   bits 15:8
+//   +0x1c  TXL / RXL   bits 7:0 -- the write that SENDS, the read that TAKES
+//
+// ✅ Every one of those comes from the firmware's own code, not the manual
+// (docs/COLDFIRE_PORT.md, O8): the loader at `0x40001d4c` writes 0 to +0x04,
+// spins on `+0x08 & 6` (TXDE|TRDY) before every word, writes the three lanes
+// high-mid-low, and the payload uploader at `0x40001b18` spins on `+0x08 & 1`
+// (RXDF) and reads +0x14/+0x18/+0x1c back for the DSP's echo. The frame
+// handler at `0x4000aad0` writes `0x8c` to +0x04 (HC | vector 0x0c) and polls
+// bit 7 until the DSP takes the host command. And `0x81` to +0x00 -- read for
+// months as "start the DSP" -- is ICR INIT|RREQ: an interface reset.
+//
+// THE DSP SIDE is the vendored dsp56kEmu, exactly as `tools/dsp_host` builds
+// it (two cores, X/Y 0x30000-0x3ffff of core 1 aliased onto core 0's arrays),
+// plus its `DspBoot`: the emulation of the chip's HI08 bootstrap ROM (count,
+// address, words, jump) that the firmware's 50- and 58-word uploads are
+// written for. Once the ROM has jumped, host words go to the real HDI08 and
+// the firmware's own bootstrap code echoes them back -- the far side of the
+// handshake O6 had to fake.
+//
+// TIMING. The cores are stepped in lockstep with the ColdFire: `ratio` DSP
+// instructions per ColdFire instruction during the boot (which has no sample
+// clock), `ips` instructions per sample once the RTOS runs. Both are knobs;
+// neither is measured. ⚠️ A core whose bootstrap ROM has not finished is HELD
+// (the ROM jumps only after the last word), and a core is never run past the
+// due count, so the ColdFire's polls see the DSP make progress between them
+// and not before.
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "machine.h"
+
+namespace dsp56k
+{
+	class Memory;
+	class Peripherals56362;
+	class Peripherals56367;
+	class DSP;
+	class DspBoot;
+	class HDI08;
+	class IMemoryValidator;
+}
+
+namespace ot
+{
+	class DspPair final : public Coprocessor
+	{
+	public:
+		static constexpr uint32_t g_window = 0x20000000, g_windowEnd = 0x20001000;
+		static constexpr uint32_t g_select = 0xfc0a400c;
+		static constexpr uint32_t g_shareLo = 0x30000, g_shareHi = 0x40000;
+		static constexpr uint32_t g_pSize = 0x80000;			// the P memory each core is built with
+		bool faulted(int _core) const;
+
+		// `_ratio`: DSP instructions per ColdFire instruction (boot clock);
+		// `_ips`: DSP instructions per sample (RTOS clock). 200 MIPS against
+		// the port's 3990 ColdFire instructions per sample at 44.1 kHz gives
+		// 4535 and 1.14 -- docs/CHIP.md's clocks, not a measurement of either
+		// emulator's cadence.
+		DspPair(double _ratio = 1.14, double _ips = 4535.0);
+		~DspPair() override;
+
+		bool read(uint32_t _addr, uint8_t _size, uint32_t& _out) override;
+		bool write(uint32_t _addr, uint8_t _size, uint32_t _val) override;
+		void tickInstructions(uint64_t _n) override;
+		void tickSamples(double _n) override;
+		int selected() const override { return m_sel; }
+		bool hostRingEmpty(int _core) const override;
+		void pushHalfwords(uint32_t _addr, const std::vector<uint16_t>& _hw) override;
+		size_t pullHalfwords(uint32_t _addr, int _core, std::vector<uint16_t>& _out, size_t _n) override;
+		uint64_t pulled(int _core) const;
+		uint64_t pullShort(int _core) const;
+
+		// -- probes ----------------------------------------------------------
+		uint32_t peekP(int _core, uint32_t _addr) const;
+		uint32_t peekX(int _core, uint32_t _addr) const;
+		uint32_t peekY(int _core, uint32_t _addr) const;
+		uint32_t pc(int _core) const;
+		bool bootFinished(int _core) const;
+		uint64_t executed(int _core) const;
+		uint64_t hostWordsIn(int _core) const;		// words the host sent (ROM + HDI08)
+		uint64_t hostWordsOut(int _core) const;		// words the host took back
+		uint64_t hostCommands(int _core) const;
+		uint32_t bootLength(int _core) const;		// what the ROM was told
+		uint32_t bootAddress(int _core) const;
+		// Every host-side event, in order, when enabled: "sel", "icr", "cvr",
+		// "tx", "rx", "hc-taken". Cheap enough to leave on for a boot.
+		struct Event { uint64_t due; int core; char kind[8]; uint32_t val; };
+		void setLog(bool _on) { m_logOn = _on; }
+		const std::vector<Event>& log() const { return m_log; }
+		std::string report() const;
+		// A line per core every `_every` executed instructions: the PC, the
+		// DSP's own instruction counter, the ESAI frame counters and the ESAI /
+		// HDI08 status registers -- what to read when a core stops making
+		// progress and the question is when it stopped.
+		void setTrace(uint64_t _every) { m_traceEvery = _every; }
+		// The idle fast-forward: a core found in a poll loop (the last PCs in
+		// a window of three words, outside any hardware DO loop) is advanced
+		// to its next peripheral event instead of executing the polls. What it
+		// polls -- the host port, the mailbox, memory -- can only change when
+		// the ColdFire or the other core runs, and both keep running. Default
+		// on; `setIdleSkip(false)` for a fidelity check.
+		void setIdleSkip(bool _on) { m_idleSkip = _on; }
+		// The vendored library's own log lines (ESAI register writes, underruns).
+		static void setVerbose(bool _on);
+		uint64_t idleSkipped(int _core) const;
+		// The inter-core mailbox: words core 0 sent core 1 and back.
+		uint64_t mailboxWords(int _from) const;
+		const std::vector<std::string>& trace() const { return m_trace; }
+
+		// Run both cores up to the due count now (the ticks only book it).
+		void runDue();
+		// Run ONE core until `_ready` or `_budget` instructions (the read-back
+		// needs the DSP to produce each word). Returns whether it became ready.
+		bool runCoreUntil(int _core, const std::function<bool()>& _ready, uint64_t _budget);
+
+	private:
+		struct Core;
+		Core& cur() { return *m_cores[m_sel & 1]; }
+		void note(const char* _kind, uint32_t _val);
+		void icrWrite(uint32_t _v);
+		void cvrWrite(uint32_t _v);
+		uint32_t isrRead();
+		void sendWord(uint32_t _word);
+		uint32_t rxPeek();
+		uint32_t rxTake();
+
+		std::vector<std::unique_ptr<Core>> m_cores;
+		// THE SHARED WINDOW, ONE MEMORY: P, X and Y of both cores at
+		// 0x30000-0x3ffff (CHIP.md: measured on hardware; and the firmware
+		// needs it -- core 1's entry P:0x38000 is written by core 0's upload).
+		std::vector<uint32_t> m_shared;
+		int m_sel = 0;
+		double m_ratio, m_ips;
+		double m_due = 0.0;
+		bool m_logOn = false;
+		uint64_t m_traceEvery = 0;
+		bool m_idleSkip = true;
+		// THE INTER-CORE MAILBOX, one register each way. 🟡 Inferred from the
+		// firmware's use, not from a datasheet: core A writes Y:$FFFFD7 and
+		// waits while bit 1 of Y:$FFFFD6 is set; core B waits for bit 1 of
+		// Y:$FFFFD3 and reads Y:$FFFFD4 (docs/COLDFIRE_PORT.md, O8). Modelled
+		// symmetrically: $D7 = my transmit data, $D6 bit 1 = it is still
+		// unread; $D4 = my receive data, $D3 bit 1 = one is waiting.
+		struct Mailbox { uint32_t data = 0; bool full = false; uint64_t words = 0; };
+		Mailbox m_mail[2];		// m_mail[k]: written by core k, read by core k^1
+		std::vector<std::string> m_trace;
+		std::vector<Event> m_log;
+	};
+}

--- a/tools/ot_emu/dsp.h
+++ b/tools/ot_emu/dsp.h
@@ -84,6 +84,8 @@ namespace ot
 		bool hostRingEmpty(int _core) const override;
 		void pushHalfwords(uint32_t _addr, const std::vector<uint16_t>& _hw) override;
 		size_t pullHalfwords(uint32_t _addr, int _core, std::vector<uint16_t>& _out, size_t _n) override;
+		std::string blockNote(int _core) override;
+		uint32_t peekWord(int _core, char _space, uint32_t _addr) const override;
 		uint64_t pulled(int _core) const;
 		uint64_t pullShort(int _core) const;
 

--- a/tools/ot_emu/machine.cpp
+++ b/tools/ot_emu/machine.cpp
@@ -62,8 +62,13 @@ namespace ot
 		// ✅ THE DSP HOST PORT AS ROUTE A FAKES IT -- and without it the frame
 		// handler never returns. Route A carries exactly two replies in its
 		// EXTRA_OVERRIDES (`emu_rtos.attach`, "the DSP host port as M5 faked
-		// it"), and both are stand-ins for the DSP that milestone O8 will put
-		// behind this window:
+		// it"), and both are stand-ins for the DSP. Since O8 (8 Sep 2026) the
+		// real cores can sit behind this window (`--dsp`, dsp.h); a
+		// co-processor is consulted BEFORE these, so with it attached both
+		// stand-ins are bypassed and without it every gate stays as measured.
+		// In HI08 terms 0x20000004 is the CVR (bit 7 = HC, cleared when the
+		// DSP takes the host command) and 0x2000001c is RXL, the low byte of
+		// the word the DSP sent back.
 		//
 		//   0x20000004 reads 0x0000. The frame handler at 0x4000ab1a writes
 		//   140 there and then polls `movew 0x20000004,%d0 / tstb %d0 / blts`
@@ -197,6 +202,16 @@ namespace ot
 
 	uint32_t Machine::peripheralRead(const uint32_t _addr, const uint8_t _size)
 	{
+		if(m_coproc)
+		{
+			uint32_t v = 0;
+			if(m_coproc->read(_addr, _size, v))
+			{
+				if(m_periphTraceOn && m_periphTrace.size() < 300000)
+					m_periphTrace.push_back({'R', pc(), _addr, _size, v});
+				return v;
+			}
+		}
 		// The models first, once installed; anything they do not own falls
 		// through to the boot's override table below.
 		if(m_periphReadFn)
@@ -241,11 +256,16 @@ namespace ot
 		if(m_hostPortLogOn && _addr >= 0x20000000 && _addr < 0x20001000
 			&& m_hostPortLog.size() < 4000000)
 			m_hostPortLog.push_back({m_instructions, currentPc(), _addr, _val, _size});
+		if(m_periphTraceOn && m_periphTrace.size() < 300000)
+			m_periphTrace.push_back({'W', pc(), _addr, _size, _val});
+		// A write the co-processor owns is not a boot write for the models to
+		// replay (with the DSPs attached the boot makes 164,829 host-port
+		// writes; the models' seed stays the 8,235 route A counts).
+		if(m_coproc && m_coproc->write(_addr, _size, _val))
+			return;
 		m_periphWrites.push_back({_addr, _size, _val});
 		if(m_periphLog.size() < 4096)
 			m_periphLog.push_back({'W', pc(), _addr, _size, _val});
-		if(m_periphTraceOn && m_periphTrace.size() < 300000)
-			m_periphTrace.push_back({'W', pc(), _addr, _size, _val});
 		if(m_periphWriteFn)
 			m_periphWriteFn(_addr, _size, _val);
 	}
@@ -270,11 +290,15 @@ namespace ot
 			if(v4e::execute(*this, op) == v4e::Result::Handled)
 			{
 				++m_v4e;
+				if(m_coproc)
+					m_coproc->tickInstructions(1);
 				return true;
 			}
 			setPC(p);
 		}
 		exec();
+		if(m_coproc)
+			m_coproc->tickInstructions(1);
 		return !m_illegal;
 	}
 
@@ -609,6 +633,8 @@ namespace ot
 				if(v4e::execute(*this, op) == v4e::Result::Handled)
 				{
 					++m_v4e;
+					if(m_coproc)
+						m_coproc->tickInstructions(1);
 					continue;
 				}
 				setPC(p);				// not ours: let Musashi take its exception
@@ -628,6 +654,8 @@ namespace ot
 			if(m_step)
 				m_step(*this, p);
 			exec();
+			if(m_coproc)
+				m_coproc->tickInstructions(1);
 			if(m_illegal)
 				return Stop::Illegal;
 

--- a/tools/ot_emu/machine.h
+++ b/tools/ot_emu/machine.h
@@ -68,6 +68,32 @@ namespace ot
 		}
 	};
 
+	// A co-processor behind a peripheral window: the two DSP cores (O8). It is
+	// asked FIRST, before the models and the boot's override table, so the
+	// stand-in replies for the host port (below) are bypassed the moment a
+	// real one is attached -- and stay in force when none is, which keeps
+	// every gate that was measured against them bit-identical. It is also
+	// clocked from both run loops: per ColdFire instruction during the boot
+	// (no sample clock exists yet) and per sample once the RTOS runs.
+	class Coprocessor
+	{
+	public:
+		virtual ~Coprocessor() = default;
+		virtual bool read(uint32_t _addr, uint8_t _size, uint32_t& _out) = 0;
+		virtual bool write(uint32_t _addr, uint8_t _size, uint32_t _val) = 0;
+		virtual void tickInstructions(uint64_t _n) = 0;
+		virtual void tickSamples(double _n) = 0;
+		// The eDMA's side of the host port (O8 step 4). A block going TO the
+		// co-processor is pushed whole at the kick, halfword by halfword, as
+		// the bus cycles the eDMA would make; a block coming FROM it is pulled
+		// at completion from the core the kick was made against, running that
+		// core until each word is there. Returns the words it could not get.
+		virtual int selected() const = 0;
+		virtual bool hostRingEmpty(int _core) const = 0;	// the DSP has taken every word pushed so far
+		virtual void pushHalfwords(uint32_t _addr, const std::vector<uint16_t>& _hw) = 0;
+		virtual size_t pullHalfwords(uint32_t _addr, int _core, std::vector<uint16_t>& _out, size_t _n) = 0;
+	};
+
 	// A peripheral window: reads answer from `overrides` if the address has
 	// one, else all-ones; writes are logged. This is route A's model, and the
 	// boot never needs more than it (`emu_bringup.boot`).
@@ -174,6 +200,9 @@ namespace ot
 		// these in `EXTRA_OVERRIDES`; the boot needs only the PLL, the card
 		// needs one more (see `Rtos::attachCard`).
 		void setOverride8(uint32_t _addr, uint8_t _val) { m_overrides[_addr] = _val; }
+
+		void setCoprocessor(Coprocessor* _c) { m_coproc = _c; }
+		Coprocessor* coprocessor() const { return m_coproc; }
 
 		// Interception, the whole point of a headless build: a callback per
 		// instruction (nullptr = off), and direct memory access for probes.
@@ -343,6 +372,7 @@ namespace ot
 		std::unordered_map<uint32_t, uint8_t> m_overrides;
 		std::unordered_map<uint32_t, std::function<uint32_t()>> m_overrideFns;
 		void override32(uint32_t _addr, uint32_t _val);
+		Coprocessor* m_coproc = nullptr;
 		PeriphRead m_periphReadFn;
 		PeriphWrite m_periphWriteFn;
 		std::vector<PeriphWriteRec> m_periphWrites;

--- a/tools/ot_emu/machine.h
+++ b/tools/ot_emu/machine.h
@@ -92,6 +92,10 @@ namespace ot
 		virtual bool hostRingEmpty(int _core) const = 0;	// the DSP has taken every word pushed so far
 		virtual void pushHalfwords(uint32_t _addr, const std::vector<uint16_t>& _hw) = 0;
 		virtual size_t pullHalfwords(uint32_t _addr, int _core, std::vector<uint16_t>& _out, size_t _n) = 0;
+		// What the co-processor was told about the block just moved, for the
+		// block log: where its own DMA is putting it and how much is left.
+		virtual std::string blockNote(int _core) = 0;
+		virtual uint32_t peekWord(int _core, char _space, uint32_t _addr) const = 0;
 	};
 
 	// A peripheral window: reads answer from `overrides` if the address has

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -80,6 +80,7 @@ int main(int _argc, char** _argv)
 	bool dspVerbose = false;	// the vendored DSP library's own log lines
 	std::string edmaLog;		// every eDMA kick with its TCD fields -> FILE (O8 step 4)
 	std::string dspPeek;		// core:space:addr,len[;...] -- DSP memory to print at the end
+	std::string blockLog;		// every host-port BLOCK with its non-zero count -> FILE
 
 	for(int i = 1; i < _argc; ++i)
 	{
@@ -123,6 +124,7 @@ int main(int _argc, char** _argv)
 		else if(a == "--dsp-verbose")			dspVerbose = true;
 		else if(a == "--edma-log" && i + 1 < _argc)	edmaLog = _argv[++i];
 		else if(a == "--dsp-peek" && i + 1 < _argc)	dspPeek = _argv[++i];
+		else if(a == "--block-log" && i + 1 < _argc)	blockLog = _argv[++i];
 		else
 		{
 			std::printf("usage: ot_emu [--image FILE] [--max N] [--periph] [--profile]\n"
@@ -230,6 +232,7 @@ int main(int _argc, char** _argv)
 			std::printf("card       : %s, %u sectors\n", cardImage.c_str(), card->totalSectors());
 		}
 		rtos.install();
+		rtos.setBlockLog(!blockLog.empty());
 		std::ofstream edmaOut;
 		if(!edmaLog.empty())
 		{
@@ -497,10 +500,19 @@ int main(int _argc, char** _argv)
 							ks[i].sample, ks[i].vector, ks[i].level, ot::taskName(ks[i].tcb), ks[i].pc, ks[i].slot);
 				}
 				if(dspPair)
-			std::printf("             host port: %llu blocks / %llu words to the DSPs, %llu blocks / %llu words back (%llu not in time); %llu ticks a burst waited for the DSP to drain\n",
+			std::printf("             host port: %llu blocks / %llu words to the DSPs (%llu NON-ZERO), %llu blocks / %llu words back (%llu NON-ZERO, %llu not in time); %llu ticks a burst waited for the DSP to drain\n",
 				static_cast<unsigned long long>(rtos.hostBlocksOut()), static_cast<unsigned long long>(rtos.hostWordsOut()),
+				static_cast<unsigned long long>(rtos.hostNonZeroOut()),
 				static_cast<unsigned long long>(rtos.hostBlocksIn()), static_cast<unsigned long long>(rtos.hostWordsIn()),
+				static_cast<unsigned long long>(rtos.hostNonZeroIn()),
 				static_cast<unsigned long long>(rtos.hostWordsShort()), static_cast<unsigned long long>(rtos.edma().gatedWaits()));
+		if(!blockLog.empty())
+		{
+			std::ofstream b(blockLog);
+			for(const auto& l : rtos.blockLog())
+				b << l << '\n';
+			std::printf("block log  : %s (%zu blocks)\n", blockLog.c_str(), rtos.blockLog().size());
+		}
 		std::printf("             ticks %llu, eDMA transfers %llu\n",
 					static_cast<unsigned long long>(rtos.ticks() - ticks0),
 					static_cast<unsigned long long>(rtos.edmaStarted()));

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -24,6 +24,7 @@
 
 #include "machine.h"
 #include "rtos.h"
+#include "dsp.h"
 
 namespace
 {
@@ -71,6 +72,14 @@ int main(int _argc, char** _argv)
 	std::string watchPc;		// comma-separated addresses -- log registers there (route A's own flag)
 	bool namesEarly = false;	// write the SET/PROJECT names BEFORE the mount -- see O7b
 	std::string hostPortLog;	// every write into the DSP host-port window -> FILE (O8)
+	bool dsp = false;			// O8: put the two real DSP cores behind the host port
+	double dspRatio = 1.14, dspIps = 4535.0;	// their clock, in DSP instructions per ColdFire instruction / per sample
+	std::string dspLog;			// every host-side event on the DSP pair -> FILE
+	uint64_t dspTrace = 0;		// a status line per core every N DSP instructions
+	bool dspNoIdle = false;		// execute every poll of an idle core (fidelity check; slow)
+	bool dspVerbose = false;	// the vendored DSP library's own log lines
+	std::string edmaLog;		// every eDMA kick with its TCD fields -> FILE (O8 step 4)
+	std::string dspPeek;		// core:space:addr,len[;...] -- DSP memory to print at the end
 
 	for(int i = 1; i < _argc; ++i)
 	{
@@ -105,6 +114,15 @@ int main(int _argc, char** _argv)
 		else if(a == "--watch-pc" && i + 1 < _argc)	watchPc = _argv[++i];
 		else if(a == "--names-early")			namesEarly = true;
 		else if(a == "--hostport-log" && i + 1 < _argc)	hostPortLog = _argv[++i];
+		else if(a == "--dsp")					dsp = true;
+		else if(a == "--dsp-ratio" && i + 1 < _argc)	dspRatio = std::atof(_argv[++i]);
+		else if(a == "--dsp-ips" && i + 1 < _argc)	dspIps = std::atof(_argv[++i]);
+		else if(a == "--dsp-log" && i + 1 < _argc)	dspLog = _argv[++i];
+		else if(a == "--dsp-trace" && i + 1 < _argc)	dspTrace = std::strtoull(_argv[++i], nullptr, 0);
+		else if(a == "--dsp-no-idle")			dspNoIdle = true;
+		else if(a == "--dsp-verbose")			dspVerbose = true;
+		else if(a == "--edma-log" && i + 1 < _argc)	edmaLog = _argv[++i];
+		else if(a == "--dsp-peek" && i + 1 < _argc)	dspPeek = _argv[++i];
 		else
 		{
 			std::printf("usage: ot_emu [--image FILE] [--max N] [--periph] [--profile]\n"
@@ -148,6 +166,20 @@ int main(int _argc, char** _argv)
 	}
 	if(!hostPortLog.empty())
 		m.setHostPortLog(true);		// before the boot: the DSP upload happens IN it
+	// The DSP pair, BEFORE the boot for the same reason: the firmware programs
+	// both cores through the host port at instruction ~4.27M of the boot.
+	std::unique_ptr<ot::DspPair> dspPair;
+	if(dsp)
+	{
+		dspPair = std::make_unique<ot::DspPair>(dspRatio, dspIps);
+		dspPair->setLog(!dspLog.empty());
+		dspPair->setTrace(dspTrace);
+		dspPair->setIdleSkip(!dspNoIdle);
+		ot::DspPair::setVerbose(dspVerbose);
+		m.setCoprocessor(dspPair.get());
+		std::printf("dsp        : two cores behind the host port, %.2f instructions per ColdFire instruction, %.0f per sample\n",
+			dspRatio, dspIps);
+	}
 	const auto stop = m.run(maxInstructions);
 
 	static const char* const g_names[] = {"HANDOFF", "ILLEGAL", "BUDGET", "FAULT"};
@@ -155,6 +187,8 @@ int main(int _argc, char** _argv)
 	std::printf("instructions: %llu (%llu supplied by the V4e layer)\n",
 		static_cast<unsigned long long>(m.instructions()),
 		static_cast<unsigned long long>(m.v4eExecuted()));
+	if(dspPair)
+		std::printf("dsp        : after the boot\n%s", dspPair->report().c_str());
 
 	if(profile)
 	{
@@ -196,6 +230,24 @@ int main(int _argc, char** _argv)
 			std::printf("card       : %s, %u sectors\n", cardImage.c_str(), card->totalSectors());
 		}
 		rtos.install();
+		std::ofstream edmaOut;
+		if(!edmaLog.empty())
+		{
+			edmaOut.open(edmaLog);
+			rtos.edma().setTransferHook([&](const uint32_t _ch, const bool _paced)
+			{
+				const auto& e = rtos.edma();
+				char line[256];
+				std::snprintf(line, sizeof line,
+					"kick ch %2u %s sample %.1f saddr %08x soff %d attr %04x nbytes %08x slast %d daddr %08x doff %d citer %04x dlast %d biter %04x csr %04x\n",
+					_ch, _paced ? "paced" : "burst", rtos.sample(),
+					e.tcdField(_ch, 0, 4), static_cast<int16_t>(e.tcdField(_ch, 4, 2)), e.tcdField(_ch, 6, 2),
+					e.tcdField(_ch, 8, 4), static_cast<int32_t>(e.tcdField(_ch, 0xc, 4)), e.tcdField(_ch, 0x10, 4),
+					static_cast<int16_t>(e.tcdField(_ch, 0x16, 2)), e.tcdField(_ch, 0x14, 2),
+					static_cast<int32_t>(e.tcdField(_ch, 0x18, 4)), e.tcdField(_ch, 0x1c, 2), e.tcdField(_ch, 0x1e, 2));
+				edmaOut << line;
+			});
+		}
 		if(!watchMem.empty())
 		{
 			const auto comma = watchMem.find(',');
@@ -444,7 +496,12 @@ int main(int _argc, char** _argv)
 						std::printf("               [%9.1f] v%#04x lvl %u in %-10s at pc %#x -> slot %#x\n",
 							ks[i].sample, ks[i].vector, ks[i].level, ot::taskName(ks[i].tcb), ks[i].pc, ks[i].slot);
 				}
-				std::printf("             ticks %llu, eDMA transfers %llu\n",
+				if(dspPair)
+			std::printf("             host port: %llu blocks / %llu words to the DSPs, %llu blocks / %llu words back (%llu not in time); %llu ticks a burst waited for the DSP to drain\n",
+				static_cast<unsigned long long>(rtos.hostBlocksOut()), static_cast<unsigned long long>(rtos.hostWordsOut()),
+				static_cast<unsigned long long>(rtos.hostBlocksIn()), static_cast<unsigned long long>(rtos.hostWordsIn()),
+				static_cast<unsigned long long>(rtos.hostWordsShort()), static_cast<unsigned long long>(rtos.edma().gatedWaits()));
+		std::printf("             ticks %llu, eDMA transfers %llu\n",
 					static_cast<unsigned long long>(rtos.ticks() - ticks0),
 					static_cast<unsigned long long>(rtos.edmaStarted()));
 				if(pcRing && rtos.pcRingArmed())
@@ -533,12 +590,52 @@ int main(int _argc, char** _argv)
 		}
 	}
 
+	if(dspPair)
+	{
+		std::printf("dsp        : at the end\n%s", dspPair->report().c_str());
+		size_t q = 0;
+		while(q < dspPeek.size())
+		{
+			auto e = dspPeek.find(';', q);
+			if(e == std::string::npos) e = dspPeek.size();
+			const auto spec = dspPeek.substr(q, e - q);
+			q = e + 1;
+			int core = 0; char space = 'X'; unsigned addr = 0, len = 8;
+			if(std::sscanf(spec.c_str(), "%d:%c:%x,%u", &core, &space, &addr, &len) < 3)
+				continue;
+			std::printf("             core %d %c:%#07x:", core, space, addr);
+			for(unsigned k = 0; k < len; ++k)
+			{
+				const auto w = space == 'P' ? dspPair->peekP(core, addr + k)
+					: space == 'Y' ? dspPair->peekY(core, addr + k) : dspPair->peekX(core, addr + k);
+				std::printf(" %06x", w);
+			}
+			std::printf("\n");
+		}
+		for(const auto& t : dspPair->trace())
+			std::printf("             %s\n", t.c_str());
+		if(!dspLog.empty())
+		{
+			std::ofstream t(dspLog);
+			for(const auto& e : dspPair->log())
+			{
+				char line[96];
+				std::snprintf(line, sizeof line, "%-8s core %d %06x  due %llu\n", e.kind, e.core, e.val,
+					static_cast<unsigned long long>(e.due));
+				t << line;
+			}
+			std::printf("dsp log    : %s (%zu events)\n", dspLog.c_str(), dspPair->log().size());
+		}
+	}
+
 	if(!hostPortLog.empty())
 	{
 		// The raw writes, and the 24-bit words reassembled from the
-		// 0x14/0x18/0x1c triples the loader sends (low, mid, high -- the order
-		// `0x40001d82`.. writes them). A `0x20000000` write of 0x81 is "start
-		// the DSP" and 0x8c is "swap frame" (docs/ARCHITECTURE.md §6).
+		// 0x14/0x18/0x1c triples the loader sends (high, mid, low -- the order
+		// `0x40001d82`.. writes them). ❌ "0x81 to 0x20000000 is start the DSP"
+		// (ARCHITECTURE.md §6) is retracted: the window is the HI08 host-side
+		// register file, 0x81 is ICR INIT|RREQ, and 0x8c to 0x20000004 is a
+		// host command (HC | vector 0x0c) -- see dsp.h (O8, 8 Sep 2026).
 		std::ofstream t(hostPortLog);
 		uint32_t w = 0; int have = 0; uint64_t words = 0;
 		for(const auto& e : m.hostPortLog())

--- a/tools/ot_emu/periph.cpp
+++ b/tools/ot_emu/periph.cpp
@@ -165,6 +165,8 @@ namespace ot
 	{
 		if(m_onTransfer)
 			m_onTransfer(_ch, _paced);
+		if(m_onKick)
+			m_onKick(_ch);
 		setCsr(_ch, static_cast<uint16_t>(csr(_ch) & ~DONE));
 		++m_started;
 		if(_paced)
@@ -175,12 +177,16 @@ namespace ot
 			// it and left the ISR spinning in state 6. `setdefault`: a channel
 			// already booked keeps its EARLIER completion.
 			m_due.emplace(_ch & 15, m_boundary);
+		else if(m_canComplete && !m_canComplete(_ch))
+			m_due.emplace(_ch & 15, 0.0);		// due now, held by the gate
 		else
 			complete(_ch);
 	}
 
 	void Edma::complete(const uint32_t _ch)
 	{
+		if(m_onDone)
+			m_onDone(_ch);
 		const auto c = csr(_ch);
 		setCsr(_ch, static_cast<uint16_t>((c & ~START) | DONE));
 		if(c & INTMAJOR)
@@ -193,6 +199,12 @@ namespace ot
 	{
 		for(auto it = m_due.begin(); it != m_due.end();)
 		{
+			if(_now >= it->second && m_canComplete && !m_canComplete(it->first))
+			{
+				++m_gatedWaits;
+				++it;
+				continue;
+			}
 			if(_now >= it->second)
 			{
 				const auto ch = it->first;

--- a/tools/ot_emu/periph.h
+++ b/tools/ot_emu/periph.h
@@ -192,6 +192,31 @@ namespace ot
 
 		// The TAPE hook: (channel, paced). Route A's `on_transfer`.
 		void setTransferHook(std::function<void(uint32_t, bool)> _fn) { m_onTransfer = std::move(_fn); }
+		// THE DATA (O8 step 4): route A's model moves none; with the DSP cores
+		// attached the bytes have to go. `_kick` runs at every start, `_done`
+		// at every completion (a linked channel's before its own link starts).
+		void setDataHooks(std::function<void(uint32_t)> _kick, std::function<void(uint32_t)> _done)
+		{
+			m_onKick = std::move(_kick);
+			m_onDone = std::move(_done);
+		}
+		// With the DSP cores attached a burst INTO the host port completes
+		// when the DSP has taken every word, not at once: on the chip the
+		// completion interrupt is what lets the frame handler issue the next
+		// block's destination and count, and a DSP still draining the previous
+		// block would read those as data. ✅ Measured 8 Sep 2026 without this
+		// gate: 7 frames in the window, the receive ring overflowing, 36 of 64
+		// host commands never taken. The hook answers "may channel _ch complete
+		// now"; unset, every rule is route A's.
+		void setCompletionGate(std::function<bool(uint32_t)> _fn) { m_canComplete = std::move(_fn); }
+		uint64_t gatedWaits() const { return m_gatedWaits; }
+		// CITER/BITER carry a minor-loop link in bit 15 with the channel in
+		// bits 14-9 and the count in bits 8-0; without it the count is 15 bits.
+		uint32_t minorLoops(uint32_t _ch) const
+		{
+			const auto c = field(_ch, 0x14, 2);
+			return (c & 0x8000) ? (c & 0x1ff) : (c & 0x7fff);
+		}
 
 		uint32_t tcdField(uint32_t _ch, uint32_t _off, uint32_t _n) const { return field(_ch, _off, _n); }
 
@@ -210,6 +235,9 @@ namespace ot
 		double m_boundary = g_framePeriod;
 		uint64_t m_started = 0;
 		std::function<void(uint32_t, bool)> m_onTransfer;
+		std::function<void(uint32_t)> m_onKick, m_onDone;
+		std::function<bool(uint32_t)> m_canComplete;
+		uint64_t m_gatedWaits = 0;
 	};
 
 	// ---- INTC --------------------------------------------------------------

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -209,6 +209,8 @@ namespace ot
 			for(auto* u : {&m_uart64, &m_uart68})
 				u->clearTransmitInterrupt();
 
+		installHostPortMover();
+
 		m_machine.setPeripheralHandlers(
 			[this](uint32_t a, uint8_t s, uint32_t& o) { return peripheralRead(a, s, o); },
 			[this](uint32_t a, uint8_t s, uint32_t v) { peripheralWrite(a, s, v, false); });
@@ -236,6 +238,60 @@ namespace ot
 		m_intc0.setForceHook([this](uint64_t) { ++m_forces; });
 		m_intc1.setForceHook([this](uint64_t) { ++m_forces; });
 		m_installed = true;
+	}
+
+	// O8 step 4 -- THE DATA. Decoded from route A's tape (8 Sep 2026): every
+	// block is a 32-bit eDMA stream at 0x2000001c, and the DSP's count word for
+	// each is exactly half its byte count -- 672 words for 4 x 336 bytes, 64
+	// for 128, 128 for 256, 512 for 1024, and the read-back chain ch1+ch6+ch7
+	// of 512+256+256 bytes is the DSP's 512-word block. So one DSP word rides
+	// each 16-BIT BUS CYCLE (a longword is two, high halfword first), which is
+	// what the DspPair's lane model does with a halfword at +0x1c. The RAM
+	// side is contiguous (SOFF/DOFF equal the burst size), the port side is a
+	// fixed address, and a block is NBYTES x the minor-loop count.
+	void Rtos::installHostPortMover()
+	{
+		auto* co = m_machine.coprocessor();
+		if(!co)
+			return;
+		m_edma.setDataHooks(
+			[this, co](const uint32_t _ch)
+			{
+				const auto daddr = m_edma.tcdField(_ch, 0x10, 4);
+				const auto saddr = m_edma.tcdField(_ch, 0, 4);
+				m_kickSel[_ch & 15] = co->selected();
+				if(daddr < Edma::g_hostPortLo || daddr >= Edma::g_hostPortHi)
+					return;
+				const auto bytes = m_edma.tcdField(_ch, 8, 4) * m_edma.minorLoops(_ch);
+				std::vector<uint16_t> hw;
+				hw.reserve(bytes / 2);
+				for(uint32_t i = 0; i + 1 < bytes; i += 2)
+					hw.push_back(m_machine.read16(saddr + i));
+				co->pushHalfwords(daddr, hw);
+				++m_hostBlocksOut;
+				m_hostWordsOut += hw.size();
+			},
+			[this, co](const uint32_t _ch)
+			{
+				const auto saddr = m_edma.tcdField(_ch, 0, 4);
+				const auto daddr = m_edma.tcdField(_ch, 0x10, 4);
+				if(saddr < Edma::g_hostPortLo || saddr >= Edma::g_hostPortHi)
+					return;
+				const auto bytes = m_edma.tcdField(_ch, 8, 4) * m_edma.minorLoops(_ch);
+				std::vector<uint16_t> hw;
+				m_hostWordsShort += co->pullHalfwords(saddr, m_kickSel[_ch & 15], hw, bytes / 2);
+				for(size_t i = 0; i < hw.size(); ++i)
+					m_machine.write16(daddr + 2 * static_cast<uint32_t>(i), hw[i]);
+				++m_hostBlocksIn;
+				m_hostWordsIn += hw.size();
+			});
+		m_edma.setCompletionGate([this, co](const uint32_t _ch)
+		{
+			const auto daddr = m_edma.tcdField(_ch, 0x10, 4);
+			if(daddr < Edma::g_hostPortLo || daddr >= Edma::g_hostPortHi)
+				return true;
+			return co->hostRingEmpty(m_kickSel[_ch & 15]);
+		});
 	}
 
 	void Rtos::tickTimers()
@@ -416,6 +472,10 @@ namespace ot
 					m_why = "idle at main's spin with no timer armed: deadlock";
 					return Stop::Fault;
 				}
+				// The DSPs keep running through a skipped idle: book them the
+				// samples the clock jumps (O8).
+				if(auto* c = m_machine.coprocessor(); c && ex > m_sample)
+					c->tickSamples(ex - m_sample);
 				m_sample = std::max(m_sample, ex);
 				++m_idleSkips;
 				tickTimers();

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -268,13 +268,47 @@ namespace ot
 				for(uint32_t i = 0; i + 1 < bytes; i += 2)
 					hw.push_back(m_machine.read16(saddr + i));
 				co->pushHalfwords(daddr, hw);
+				uint64_t nz = 0;
+				for(const auto w : hw)
+					if(w)
+						++nz;
 				++m_hostBlocksOut;
 				m_hostWordsOut += hw.size();
+				m_hostNonZeroOut += nz;
+				m_pendingOut[_ch & 15] = {saddr, hw, nz};
 			},
 			[this, co](const uint32_t _ch)
 			{
 				const auto saddr = m_edma.tcdField(_ch, 0, 4);
 				const auto daddr = m_edma.tcdField(_ch, 0x10, 4);
+				// ⚠️ An OUTBOUND block's DSP-side state is only meaningful HERE,
+				// at the completion the drain gate holds until the ring is
+				// empty. Noted at the kick it lagged by a whole block (DCO0
+				// still held the PREVIOUS block's count) and read as if the
+				// host's destination word were being ignored.
+				if(daddr >= Edma::g_hostPortLo && daddr < Edma::g_hostPortHi)
+				{
+					const auto& p = m_pendingOut[_ch & 15];
+					if(!p.hw.empty())
+					{
+						const int core = m_kickSel[_ch & 15];
+						// Where DMA0 has just left off, and the tail of what
+						// landed there: the direct test of whether the words
+						// the port sent reached DSP memory.
+						const auto ddr = co->peekWord(core, 'R', 0);	// 'R' = DMA0's DDR, see DspPair
+						char t[160];
+						std::string tail = " landed@";
+						std::snprintf(t, sizeof t, "%04x:", ddr >= 8 ? ddr - 8 : 0);
+						tail += t;
+						for(uint32_t k = 0; k < 8 && ddr >= 8; ++k)
+						{
+							std::snprintf(t, sizeof t, " %06x", co->peekWord(core, 'X', ddr - 8 + k));
+							tail += t;
+						}
+						noteBlock('>', _ch, p.saddr, p.hw, p.nonZero, co->blockNote(core) + tail);
+						m_pendingOut[_ch & 15] = {};
+					}
+				}
 				if(saddr < Edma::g_hostPortLo || saddr >= Edma::g_hostPortHi)
 					return;
 				const auto bytes = m_edma.tcdField(_ch, 8, 4) * m_edma.minorLoops(_ch);
@@ -282,8 +316,14 @@ namespace ot
 				m_hostWordsShort += co->pullHalfwords(saddr, m_kickSel[_ch & 15], hw, bytes / 2);
 				for(size_t i = 0; i < hw.size(); ++i)
 					m_machine.write16(daddr + 2 * static_cast<uint32_t>(i), hw[i]);
+				uint64_t nz = 0;
+				for(const auto w : hw)
+					if(w)
+						++nz;
 				++m_hostBlocksIn;
 				m_hostWordsIn += hw.size();
+				m_hostNonZeroIn += nz;
+				noteBlock('<', _ch, daddr, hw, nz, co->blockNote(m_kickSel[_ch & 15]));
 			});
 		m_edma.setCompletionGate([this, co](const uint32_t _ch)
 		{
@@ -292,6 +332,24 @@ namespace ot
 				return true;
 			return co->hostRingEmpty(m_kickSel[_ch & 15]);
 		});
+	}
+
+	void Rtos::noteBlock(const char _dir, const uint32_t _ch, const uint32_t _ramAddr,
+		const std::vector<uint16_t>& _hw, const uint64_t _nonZero, const std::string& _note)
+	{
+		if(!m_blockLogOn || m_blockLog.size() >= 200000)
+			return;
+		char line[512];
+		std::snprintf(line, sizeof line, "%c frame %6llu ch %2u core %d ram %08x %5zu words, %5llu non-zero  first",
+			_dir, static_cast<unsigned long long>(m_frameCount), _ch, m_kickSel[_ch & 15], _ramAddr,
+			_hw.size(), static_cast<unsigned long long>(_nonZero));
+		std::string s = line;
+		for(size_t i = 0; i < _hw.size() && i < 8; ++i)
+		{
+			std::snprintf(line, sizeof line, " %04x", _hw[i]);
+			s += line;
+		}
+		m_blockLog.push_back(s + "  " + _note);
 	}
 
 	void Rtos::tickTimers()

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -21,6 +21,8 @@
 // sample (`ips`) is a knob with a default, not a truth.
 #pragma once
 
+#include <array>
+
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -320,6 +322,13 @@ namespace ot
 		const Intc& intc1() const { return m_intc1; }
 		uint64_t edmaStarted() const { return m_edma.started(); }
 		Edma& edma() { return m_edma; }
+		// O8 step 4: blocks the eDMA carried over the host port, and words a
+		// read-back could not get from the DSP in time.
+		uint64_t hostBlocksOut() const { return m_hostBlocksOut; }
+		uint64_t hostBlocksIn() const { return m_hostBlocksIn; }
+		uint64_t hostWordsOut() const { return m_hostWordsOut; }
+		uint64_t hostWordsIn() const { return m_hostWordsIn; }
+		uint64_t hostWordsShort() const { return m_hostWordsShort; }
 		uint64_t ataInterrupts() const { return m_ataInterrupts; }
 		bool ataLineAsserted() const { return m_ataIrq; }
 		// Every access to the task-file window, in order, for diffing against
@@ -390,6 +399,9 @@ namespace ot
 		Intc m_intc0, m_intc1;
 		Uart m_uart64{"UART@fc064000", g_uartA}, m_uart68{"UART@fc068000", g_uartB};
 		Dspi m_dspi;
+		std::array<int, 16> m_kickSel = {};		// which core each channel was kicked against
+		uint64_t m_hostBlocksOut = 0, m_hostBlocksIn = 0, m_hostWordsOut = 0, m_hostWordsIn = 0, m_hostWordsShort = 0;
+		void installHostPortMover();
 		AtaCard* m_card = nullptr;
 		// ⚠️ INTRQ IS NOT INSTANTANEOUS, and the firmware depends on it. The
 		// driver writes the command and THEN calls the RTOS event wait; a

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -329,6 +329,15 @@ namespace ot
 		uint64_t hostWordsOut() const { return m_hostWordsOut; }
 		uint64_t hostWordsIn() const { return m_hostWordsIn; }
 		uint64_t hostWordsShort() const { return m_hostWordsShort; }
+		// ⚠️ THE COUNT THAT DECIDES WHETHER ANY OF IT MEANS ANYTHING. Blocks and
+		// words moved say the plumbing runs; only a non-zero count says the
+		// frames carry content. An end-of-run peek of the DSP's record buffer
+		// cannot tell "the port sent zeros" from "the DSP consumed and cleared
+		// it" -- these are counted at the moment of the move.
+		uint64_t hostNonZeroOut() const { return m_hostNonZeroOut; }
+		uint64_t hostNonZeroIn() const { return m_hostNonZeroIn; }
+		void setBlockLog(bool _on) { m_blockLogOn = _on; }
+		const std::vector<std::string>& blockLog() const { return m_blockLog; }
 		uint64_t ataInterrupts() const { return m_ataInterrupts; }
 		bool ataLineAsserted() const { return m_ataIrq; }
 		// Every access to the task-file window, in order, for diffing against
@@ -401,6 +410,13 @@ namespace ot
 		Dspi m_dspi;
 		std::array<int, 16> m_kickSel = {};		// which core each channel was kicked against
 		uint64_t m_hostBlocksOut = 0, m_hostBlocksIn = 0, m_hostWordsOut = 0, m_hostWordsIn = 0, m_hostWordsShort = 0;
+		uint64_t m_hostNonZeroOut = 0, m_hostNonZeroIn = 0;
+		struct PendingOut { uint32_t saddr = 0; std::vector<uint16_t> hw; uint64_t nonZero = 0; };
+		std::array<PendingOut, 16> m_pendingOut;
+		bool m_blockLogOn = false;
+		std::vector<std::string> m_blockLog;
+		void noteBlock(char _dir, uint32_t _ch, uint32_t _ramAddr, const std::vector<uint16_t>& _hw,
+			uint64_t _nonZero, const std::string& _note);
 		void installHostPortMover();
 		AtaCard* m_card = nullptr;
 		// ⚠️ INTRQ IS NOT INSTANTANEOUS, and the firmware depends on it. The

--- a/tools/ot_emu/test_dsp.cpp
+++ b/tools/ot_emu/test_dsp.cpp
@@ -1,0 +1,205 @@
+// O8's first real gate, and it is self-checking: let the firmware's OWN boot
+// program the two DSP cores through the emulated host port, then compare what
+// landed in DSP memory against the bytes the image carries -- parsed here
+// independently of both the firmware's uploader and the port's register model
+// (docs/DSP.md section 2: 24-bit little-endian words; the bootstrap blobs are
+// plain word lists, the payloads are `space, address, count, words` records).
+//
+// Two mechanisms have to agree for this to pass: the firmware's loader code
+// running on the ColdFire side of the window (with its TXDE/RXDF polls and
+// its echo check), and the vendored DSP running the chip's bootstrap ROM and
+// then the firmware's own 50-word HDI08 loader on the DSP side. Neither can
+// be faked into agreement by the other.
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "dsp.h"
+#include "machine.h"
+
+namespace
+{
+	int g_failures = 0;
+
+	void check(const char* _what, const bool _ok, const std::string& _detail = {})
+	{
+		if(!_ok)
+			++g_failures;
+		std::printf("  [%s] %s%s%s\n", _ok ? "PASS" : "FAIL", _what,
+			_detail.empty() ? "" : "  ", _detail.c_str());
+	}
+
+	uint32_t le24(const std::vector<uint8_t>& _img, const uint32_t _cfAddr)
+	{
+		const auto o = _cfAddr - ot::Machine::g_imageBase;
+		if(o + 3 > _img.size())
+			return 0xffffffff;
+		return _img[o] | (_img[o + 1] << 8) | (_img[o + 2] << 16);
+	}
+
+	struct Record { uint32_t space, addr, count, dataAt; };
+
+	// The uploader's walk at 0x40001b18, mirrored: an optional header word 3
+	// and an optional header word 4 (six bytes each), then records until a
+	// space word above 2; the word after the terminator is the jump address.
+	std::vector<Record> parsePayload(const std::vector<uint8_t>& _img, const uint32_t _base,
+		uint32_t& _jump, uint32_t& _bytes)
+	{
+		std::vector<Record> out;
+		uint32_t a = _base;
+		if((le24(_img, a) & 0xff) == 3) a += 6;
+		if((le24(_img, a) & 0xff) == 4) a += 6;
+		for(;;)
+		{
+			const auto space = le24(_img, a);
+			if((space & 0xff) > 2)
+			{
+				_jump = le24(_img, a + 3);
+				_bytes = a + 6 - _base;
+				return out;
+			}
+			Record r{space & 0xff, le24(_img, a + 3), le24(_img, a + 6), a + 9};
+			out.push_back(r);
+			a += 9 + 3 * r.count;
+			if(a - _base > 0x40000)
+				return out;
+		}
+	}
+
+	uint32_t peek(const ot::DspPair& _d, const int _core, const uint32_t _space, const uint32_t _addr)
+	{
+		switch(_space)
+		{
+		case 0: return _d.peekP(_core, _addr);
+		case 1: return _d.peekX(_core, _addr);
+		default: return _d.peekY(_core, _addr);
+		}
+	}
+}
+
+int main(int _argc, char** _argv)
+{
+	const std::string image = _argc > 1 ? _argv[1] : "out/raw/section_3_MAIN_OS.bin";
+	std::ifstream f(image, std::ios::binary);
+	if(!f)
+	{
+		std::printf("SKIP: %s is not present (run `make os`)\n", image.c_str());
+		return 0;
+	}
+	const std::vector<uint8_t> img((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+
+	std::printf("dsp gate (the firmware's own upload lands the image's bytes):\n");
+	ot::Machine m(img);
+	ot::DspPair pair;
+	m.setCoprocessor(&pair);
+
+	// The payload check runs AT THE MOMENT each upload returns -- the
+	// instruction after the `jsr 0x40001b18` for core 0 (0x40001e96) and for
+	// core 1 (0x40001edc) -- because the window is one memory and the cores
+	// go on to use it: ✅ measured 8 Sep 2026, by the handoff core 1 had
+	// cleared Y:0x38000.. over its own entry stub, 19 words of payload A.
+	struct Payload { int core; uint32_t base, size, at; };
+	const Payload payloads[] = {{0, 0x400e2324, 79563, 0x40001e96}, {1, 0x400f59ef, 77061, 0x40001edc}};
+	struct Result { bool seen = false; uint64_t words = 0, bad = 0, sent = 0, echoed = 0; std::string firstBad; };
+	Result results[2];
+	m.setStepHook([&](ot::Machine&, const uint32_t _pc)
+	{
+		for(const auto& p : payloads)
+		{
+			if(_pc != p.at || results[p.core].seen)
+				continue;
+			Result& r = results[p.core];
+			r.seen = true;
+			uint32_t jump = 0, bytes = 0;
+			for(const auto& rec : parsePayload(img, p.base, jump, bytes))
+				for(uint32_t i = 0; i < rec.count; ++i)
+				{
+					const auto want = le24(img, rec.dataAt + 3 * i);
+					const auto got = peek(pair, p.core, rec.space, rec.addr + i);
+					++r.words;
+					if(want != got && !r.bad++)
+					{
+						char b[96];
+						std::snprintf(b, sizeof b, " -- first at %c:%#x want %06x got %06x",
+							"PXY"[rec.space], rec.addr + i, want, got);
+						r.firstBad = b;
+					}
+				}
+			r.sent = pair.hostWordsIn(p.core);
+			r.echoed = pair.hostWordsOut(p.core);
+		}
+	});
+	const auto boot = m.run(50'000'000);
+	check("boots to the RTOS handoff with the DSPs attached", boot == ot::Machine::Stop::Handoff, m.why());
+	if(boot != ot::Machine::Stop::Handoff)
+		return 1;
+	std::printf("%s", pair.report().c_str());
+
+	// -- the bootstrap ROM: count, address, words, jump -----------------------
+	struct Boot { int core; uint32_t src, bytes, addr; };
+	for(const Boot b : {Boot{0, 0x400e21e0, 0x96, 0x31000}, Boot{1, 0x400e2276, 0xae, 0x32000}})
+	{
+		char what[96];
+		std::snprintf(what, sizeof what, "core %d: the boot ROM took %u words for P:%#x and jumped", b.core, b.bytes / 3, b.addr);
+		check(what, pair.bootFinished(b.core) && pair.bootLength(b.core) == b.bytes / 3
+			&& pair.bootAddress(b.core) == b.addr);
+		uint32_t bad = 0, first = 0;
+		for(uint32_t i = 0; i < b.bytes / 3; ++i)
+		{
+			const auto want = le24(img, b.src + 3 * i);
+			const auto got = pair.peekP(b.core, b.addr + i);
+			if(want != got && !bad++)
+				first = i;
+		}
+		char detail[128];
+		std::snprintf(detail, sizeof detail, "%u/%u words%s", b.bytes / 3 - bad, b.bytes / 3,
+			bad ? " -- first mismatch at word " : "");
+		std::snprintf(what, sizeof what, "core %d: P:%#x holds the bootstrap the image carries", b.core, b.addr);
+		check(what, bad == 0, bad ? detail + std::to_string(first) : detail);
+	}
+
+	// -- the payload: every record, in the space it names, at upload time ----
+	for(const Payload& p : payloads)
+	{
+		uint32_t jump = 0, bytes = 0;
+		const auto recs = parsePayload(img, p.base, jump, bytes);
+		char what[128], detail[160];
+		std::snprintf(what, sizeof what, "core %d: the payload parses to its last byte", p.core);
+		std::snprintf(detail, sizeof detail, "%zu records, %u of %u bytes, jump %#x", recs.size(), bytes, p.size, jump);
+		check(what, bytes == p.size, detail);
+
+		const Result& r = results[p.core];
+		std::snprintf(what, sizeof what, "core %d: the upload returned to the firmware (pc %#x)", p.core, p.at);
+		check(what, r.seen);
+		std::snprintf(what, sizeof what, "core %d: every payload record had landed where it names", p.core);
+		std::snprintf(detail, sizeof detail, "%llu/%llu words%s",
+			static_cast<unsigned long long>(r.words - r.bad), static_cast<unsigned long long>(r.words), r.firstBad.c_str());
+		check(what, r.seen && r.bad == 0, detail);
+
+		// What the firmware sent: 2 ROM words + the bootstrap, then per record
+		// space/address/count + the words, then the terminator and the jump.
+		uint64_t expect = 2 + (p.core ? 0xae : 0x96) / 3 + 2;
+		for(const auto& rec : recs)
+			expect += 3 + rec.count;
+		// And what came back: one echo per record's space word, one for the
+		// terminator (the loader at P:0x31000 echoes the word it dispatches on).
+		const uint64_t echoes = recs.size() + 1;
+		std::snprintf(what, sizeof what, "core %d: the host sent and took back exactly what the walk predicts", p.core);
+		std::snprintf(detail, sizeof detail, "%llu sent (%llu predicted), %llu echoed (%llu predicted)",
+			static_cast<unsigned long long>(r.sent), static_cast<unsigned long long>(expect),
+			static_cast<unsigned long long>(r.echoed), static_cast<unsigned long long>(echoes));
+		check(what, r.sent == expect && r.echoed == echoes, detail);
+	}
+	// After the boot, both cores are running the program, not the loader.
+	for(int c = 0; c < 2; ++c)
+	{
+		char what[96], detail[96];
+		std::snprintf(what, sizeof what, "core %d: left the bootstrap and is running the payload", c);
+		std::snprintf(detail, sizeof detail, "pc %#x, %s", pair.pc(c), pair.faulted(c) ? "FAULTED" : "no fault");
+		check(what, !pair.faulted(c) && pair.pc(c) != 0x31000 + 4 && pair.pc(c) != 0x32000 + 4 && pair.bootFinished(c), detail);
+	}
+
+	std::printf("dsp gate: %d failure(s)\n", g_failures);
+	return g_failures ? 1 : 0;
+}


### PR DESCRIPTION
**Draft, per the work order: O8's own gate (step 5, `verify_twocore` driven by the firmware) is not attempted.** Steps 1-4 are built and gated. `docs/COLDFIRE_PORT.md` (O8) has the account; the headlines:

## ✅ The firmware boots both real DSP cores, and every byte lands

`ot_emu --dsp` puts the two vendored dsp56kEmu cores behind the host port. `ot_dsp_test` (ctest `dsp`, under a second) lets the firmware's own boot upload run and compares DSP memory with the image's bytes at the instruction each upload returns: 50/50 and 58/58 bootstrap words, 26,221 + 25,408 payload words, the word and echo counts the uploader's walk predicts. The M6a gate passes with the cores live (8 compared fields agree) and so does the O6 sequencer gate (`DSP=1 scripts/o6_gate.sh`: 400 frames, 28 ticks, the trig at frame 344, 5 compared fields agree), with the eDMA now carrying the frame blocks — 870,400 words in, 307,200 back, none late.

## ❌ Retracted: the host-port readings that stood since ARCHITECTURE.md §6

The window is the HI08 host-side register file at a 4-byte stride on a 16-bit port. `0x81` is ICR INIT|RREQ, not "start the DSP"; `0x8c` is a host command (vector 0x18), not "swap frame"; the ready bit is TXDE|TRDY, not bit 6. And **one DSP word rides each 16-bit bus cycle** — route A's tape shows every block's count word is exactly half its byte count — so a longword eDMA access is two words and DSP.md's "336-word records" are 672 words.

## ✅ The shared window is one memory for P, X and Y of both cores

Core 1's entry P:0x38000 is written by core 0's upload. With P private (dsp_host's window) core 1 ran off the end of P memory. The pair uses a three-way form; `dsp_host` is unchanged and is now a documented different machine on this point.

## Eight things the vendored DSP emulator does that the firmware cannot live with

All in `tools/dsp56300.patch`, each found by an instrument after presenting as a silent hang or a bare crash (stack sample, `lldb -k`, `--dsp-trace`, the tape): DO loops nested in one call; interrupts dispatched through the JIT even under the interpreter; a masked pending interrupt starving the peripheral clock; the ESAI blocking on an empty input ring; a PC past P memory as a garbage member pointer; a fast interrupt never setting the PC to its vector (HC never cleared); the dual-counter ring DMA modes unimplemented and DCOL 8 bits instead of 12; the host DMA's initial trigger disabled and a 200-instruction receive throttle. Plus one of route A's completion rules changes with the cores attached: a burst into the port completes when the DSP has drained it.

## 🟡 Inferred

The inter-core mailbox at Y:$FFFFD3/D4 and $FFFFD6/D7, modelled symmetrically from the two payloads' wait loops.

## ⚠️ Not measured

Whether the frame words carry non-zero content: DSP record memory reads zero at the end of the run, and the pair does not yet count non-zero words. That counter is the next session's first instrument.

## No regression

`ctest` 7/7; `make check` green with the vendored harness rebuilt on the patched library; the O6 and M6a reports without `--dsp` byte-identical to before; the models still seed from the same 8,235 boot writes. `out/emu` is now an arm64 build (`/opt/homebrew/bin/cmake`; the x86 one had been building it under Rosetta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
