### PR TITLE
O8: the blocks land on the payload's own bank pointers; DMA0 cannot be read at the eDMA kick

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -1148,15 +1148,34 @@ cmd args 036080 03029f | DMA0 ddr 004320 dco 00029f | X@6080 000000 000000 | X@4
 
 The firmware sends dest `0x6080`, count `0x29f`; the DSP arms its DMA0 at
 `0x4080` and the block lands there. Every block is the same 0x2000 apart:
-0x6080 → 0x4080, 0x6000 → 0x4000, 0x6400 → 0x4400, 0x6800 → 0x4800. 🟡
-**Inferred, not located:** the payload's own dispatcher at P:0x40 sets up two
-banks of buffers — 0x4000/0x4080/0x4400/0x4600/0x4800 and
-0x2000/0x2080/0x2400/0x2600/0x2800 — and each host word is exactly the two
-banks' addresses OR'd together, so bits 14 and 13 read as a bank select the
-DSP masks down to the bank it is using (bank A throughout this run). The
-masking instruction has not been found; the handler at P:0x588 masks only to
-16 bits. Falsifier: a run where the DSP switches to bank B should land the
-same words at 0x2xxx.
+0x6080 → 0x4080, 0x6000 → 0x4000, 0x6400 → 0x4400, 0x6800 → 0x4800.
+
+✅ **The landing addresses are the payload's own bank pointers, exactly.** The
+dispatcher at P:0x40 loads two banks and takes one per frame:
+
+```
+bank A:  r6 = $4000   r7 = $4080   r2 = $4400   r5 = $4600   r4 = $4800
+bank B:  r6 = $2000   r7 = $2080   r2 = $2400   r5 = $2600   r4 = $2800
+```
+
+Every block landed on a bank-A pointer, and each host word is exactly the two
+banks' addresses OR'd together (`0x4080 | 0x2080 = 0x6080`). 🟡 **Inferred,
+not located:** that bits 14 and 13 are a bank select the DSP masks down to the
+bank it is running. The masking instruction has not been found — the handler
+at P:0x588 is the only write to DMA0's destination register in the payload and
+it masks to 16 bits only, which would leave 0x6080. Falsifier: a run in which
+the DSP takes bank B should land the same words at 0x2xxx.
+
+⚠️ **And DMA0 cannot be read at the eDMA kick to settle it** — a third
+instance of the same lesson, and it nearly went into this document as a
+finding. The command's two argument words and the CVR write all precede the
+kick, but the CVR only *injects* the interrupt: at the kick the DSP has not
+taken it, so its handler has not read the arguments, and DMA0 still holds the
+PREVIOUS block's arming (measured: DCO0 always one block behind). That is not
+a defect — the ring is a FIFO, so the arguments sit ahead of the data and the
+DSP reads them first, arms, then drains. It does mean the armed value has no
+readable moment in this model, and the destination has to be read from where
+the pointer ends up.
 
 ⚠️ Two instrument lessons, both the project's usual family. **A peek after the
 run cannot tell "nothing was sent" from "the DSP consumed it"** — count at the

--- a/tools/ot_emu/dsp.cpp
+++ b/tools/ot_emu/dsp.cpp
@@ -42,6 +42,7 @@ namespace ot
 		uint64_t idleSkipped = 0;
 		uint64_t pulled = 0, pullShort = 0;	// read-back words taken / not produced in time
 		uint32_t lastSent[2] = {0, 0};		// a rolling pair of the last two words sent
+		uint32_t ddrAtArm = 0, dcoAtArm = 0;	// DMA0 as the DSP's handler left it, before any word drains
 		uint32_t cmdArgs[2] = {0, 0};		// ⚠️ SNAPSHOT AT THE COMMAND. Taken at drain time
 											// instead, this held the block's last two DATA words
 											// and read as if the firmware sent a dest of 0x030000.
@@ -409,6 +410,20 @@ namespace ot
 
 	void DspPair::pushHalfwords(const uint32_t _addr, const std::vector<uint16_t>& _hw)
 	{
+		// ⚠️ DMA0 AS OF THE KICK IS THE **PREVIOUS** BLOCK'S ARMING, and that is
+		// not a defect. The command's two argument words and the CVR write all
+		// precede the kick, but the CVR only INJECTS the interrupt: the DSP has
+		// not taken it yet, so its handler has not read the arguments. The FIFO
+		// is what makes this correct -- the arguments sit ahead of the data in
+		// the ring, so when the DSP does take the interrupt it reads them first,
+		// arms DMA0, and only then drains the block. ✅ Measured 8 Sep 2026:
+		// read here, DCO0 always holds the count of the block BEFORE this one.
+		// The third instance this session of a note taken at the wrong moment.
+		{
+			Core& c = cur();
+			c.ddrAtArm = c.px->read(0xffffee, dsp56k::Nop);
+			c.dcoAtArm = c.px->read(0xffffed, dsp56k::Nop);
+		}
 		// The cycles the eDMA would make: a 32-bit write at _addr is two
 		// halfwords at +0 and +2, and both land on the same two registers.
 		for(size_t i = 0; i < _hw.size(); ++i)
@@ -579,8 +594,8 @@ namespace ot
 		Core& c = *m_cores[_core & 1];
 		char b[192];
 		std::snprintf(b, sizeof b,
-			"dsp: cmd args %06x %06x | DMA0 ddr %06x dco %06x | X@%04x %06x %06x | X@%04x %06x %06x | rx ring %zu",
-			c.cmdArgs[0], c.cmdArgs[1],
+			"dsp: cmd args %06x %06x | DMA0 at kick (previous block) ddr %06x dco %06x -> ended ddr %06x dco %06x | X@%04x %06x %06x | X@%04x %06x %06x | rx ring %zu",
+			c.cmdArgs[0], c.cmdArgs[1], c.ddrAtArm, c.dcoAtArm,
 			c.px->read(0xffffee, dsp56k::Nop), c.px->read(0xffffed, dsp56k::Nop),
 			c.cmdArgs[0] & 0xffff,
 			c.mem->get(dsp56k::MemArea_X, c.cmdArgs[0] & 0xffff),


### PR DESCRIPTION
A small follow-up to #148, closing out the one inferred claim it published and recording an instrument that failed.

## ✅ The landing addresses are the payload's own bank pointers, exactly

#148 measured that the firmware names X:0x6080 and the block lands at X:0x4080, every block 0x2000 apart, and inferred a bank select. The corroboration: the payload's dispatcher at P:0x40 loads two banks and takes one per frame —

```
bank A:  r6 = $4000   r7 = $4080   r2 = $4400   r5 = $4600   r4 = $4800
bank B:  r6 = $2000   r7 = $2080   r2 = $2400   r5 = $2600   r4 = $2800
```

— every block landed on a bank-A pointer, and each host word is exactly the two banks' addresses OR'd (`0x4080 | 0x2080 = 0x6080`). So the data lands in the buffers the DSP's own code then reads.

🟡 **Still inferred, and left that way:** that bits 14 and 13 are a bank select the DSP masks off. The masking instruction is not located — P:0x588 is the only write to DMA0's destination register in the payload and it masks to 16 bits only, which would leave 0x6080. Falsifier unchanged: a run in which the DSP takes bank B should land the same words at 0x2xxx.

## ⚠️ The instrument that would have settled it does not work, and nearly became a finding

Reading DMA0 at the eDMA kick looked like the way to see the armed destination directly. It returns the **previous** block's arming: DCO0 is always one block behind. The command's two argument words and the CVR write all precede the kick, but the CVR only *injects* the interrupt — at the kick the DSP has not taken it, so its handler has not read the arguments yet.

That is not a defect. The ring is a FIFO, so the arguments sit ahead of the data and the DSP reads them first, arms, then drains. It does mean the armed value has no readable moment in this model, and the destination has to be read from where the pointer ends up. The instrument is relabelled rather than removed, since the ordering it documents is worth keeping.

Third instance this session of a note taken at the wrong moment, after the end-of-run peek and the kick-time DSP note.

`ctest` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
