### PR TITLE
O8: the ESAI rate and the host-port burst time -- the port ran its ESAI 8x slow, a ninth vendored DMA defect, and the frame is 16 samples again

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -296,6 +296,13 @@ a lever first.
 
 ### Cycles — per core, 4,535/sample ✅ arithmetic (200 MIPS ÷ 44.1 kHz)
 
+🟡 **8 Sep 2026: probably 4,160, not 4,535.** The payload never writes the
+DSP's PLL (reset default = EXTAL × 8.125) and clocks the ESAI from EXTAL at
+÷512, so instructions per sample = 512 × 8.125 = 4,160 whatever the crystal.
+Inferred from the firmware's register writes + the DSP56720 manual, not
+measured; every hardware-measured budget below is an instruction count and
+stands. `docs/CHIP.md` §2, `docs/COLDFIRE_PORT.md` O8 "the ESAI rate".
+
 Cycles are not the current constraint. `make cycles` is **remix-aware since
 29 Aug 2026** and prints a **WORST ONE CORE** figure derived from the
 selection: four FX2 slots, at most one server (the design rule, and what

--- a/docs/CHIP.md
+++ b/docs/CHIP.md
@@ -114,7 +114,7 @@ FX1 = FILTER. Every FX1 filter you turn on eats into that figure.
 |---|---|---|
 | CPU | Freescale ColdFire **MCF54454VR266**, 32-bit big-endian, 266 MHz | ✅ board photo (an MKI board reads `MCF54454`; an earlier note said `MCF5445A` — same family, likely a misread digit) |
 | Audio DSP | Freescale Symphony **DSP56721** (`DSPB56721AG`) | ✅ board photo |
-| DSP cores | **Two** DSP5636x cores, **200 MHz / 200 MIPS each** | ✅ datasheet |
+| DSP cores | **Two** DSP5636x cores, **200 MHz / 200 MIPS each** | ✅ datasheet — the part's MAXIMUM. 🟡 This board runs the PLL at its reset default from a crystal the payload makes the audio clock: **183.456 MHz = 4 160 cycles/sample** (§2, `COLDFIRE_PORT.md` O8 "the ESAI rate") |
 | External memory controller | **None.** No EMC on this part — all memory is on-chip | ✅ datasheet block diagram |
 | Shared memory | **8 blocks × 8 K words = 64 K words at `$030000`**, reachable by *both* cores; P/X/Y alias there | ✅ reference manual + hardware |
 | Storage | CompactFlash (FAT16/32) | ✅ official |
@@ -131,7 +131,8 @@ no external memory. `DSP.md:449` / `DSP.md:744` still say otherwise.
 
 | | | |
 |---|---|---|
-| Per core, per sample @ 44.1 kHz | 200 MIPS ÷ 44 100 = **4 535 cycles** | ✅ arithmetic |
+| Per core, per sample @ 44.1 kHz | 200 MIPS ÷ 44 100 = **4 535 cycles** | ✅ arithmetic — on the DATASHEET clock. ❌ Not this board's; the row below is |
+| Per core, per sample, from the firmware's own clock setup (8 Sep 2026) | PLL never written → reset `0x2B60C2` = EXTAL × 195/24; ESAI clocked from EXTAL (Port H `0xaa0000`), TPSR=1/TPM=0/TFP=0, 8 × 32-bit slots → fs = EXTAL/512; ratio **4 160 cycles/sample exactly** (Fsys 183.456 MHz if EXTAL = 22.5792 MHz) | 🟡 inferred from the payload's register writes + DSP56720RM; falsified by a PCTL write nobody has found, PINIT = 0, or a DSP crystal that is not 22.5792 MHz. `COLDFIRE_PORT.md` O8 |
 | **Measured ceiling for FX work** | **~2 350** (with 4× FX1 FILTER as environment) — RE-CONFIRMED 23 Aug 2026, second independent sweep | ✅ hardware, burn probe ×2 |
 | Spare with the R46 reverb + 4× FILTER + running sequencer | **704 cycles/sample** (breakup at p3=22 × 32; p3=23 = high-pitch squeal, the deep-overrun signature) | ✅ hardware, 23 Aug 2026 |
 | **The R46 reverb's true cost** | **≈1 650/sample** (2 356 − 704) — `cycle_count.py` prices it 1 384, so the pricer reads **~270 low** on the reverb (and ~264 high on the delay since the phead roll) | ✅ by two consistent sweeps |
@@ -139,7 +140,7 @@ no external memory. `DSP.md:449` / `DSP.md:744` still say otherwise.
 | **One FX1 FILTER's true cost** | **192 cycles/sample** ((1 088 − 704)/2, measured differentially) — retires the old ~260 inference | ✅ hardware, 23 Aug 2026 |
 | **Total DSP-usable budget** | **≈3 120 cycles/sample** (all three sweeps agree: reverb 1 652 + 4×192 + 704 = 3 124; 7 Aug's 964 + 768 + 1 392 = same) | ✅ triangulated from 3 sweeps |
 | Safe planning number | **~500** on top of the current reverb in a 4-FILTER bank; **~900** with 2 | 🟡 sweep minus contention margin |
-| Stock's own share | **≈1 410** (4 535 − 3 120) — revised DOWN from "~2 400, half the core" | ✅ by subtraction from measured budget |
+| Stock's own share | **≈1 410** (4 535 − 3 120) — revised DOWN from "~2 400, half the core"; **≈1 040** on the 🟡 4 160 clock | ✅ by subtraction from measured budget (the minuend is the open question, not the measurement) |
 | ⚠️ Historic spare "1 392, exactly" | superseded as a headline (it was the 7 Aug bank's spare, ceiling 964+1392=2356 — consistent with today) | ✅ then, 🟡 as guidance now |
 
 **How the ceiling was measured.** `dsp/burn_probe.asm` (in git history) adds `16 × p3`

--- a/docs/CHIP.md
+++ b/docs/CHIP.md
@@ -113,6 +113,7 @@ FX1 = FILTER. Every FX1 filter you turn on eats into that figure.
 | | | |
 |---|---|---|
 | CPU | Freescale ColdFire **MCF54454VR266**, 32-bit big-endian, 266 MHz | ✅ board photo (an MKI board reads `MCF54454`; an earlier note said `MCF5445A` — same family, likely a misread digit) |
+| CPU **clock tree**, as the firmware programs it | crystal **24 MHz** → VCO **528** → **CPU 264 MHz**, internal bus **132**, **FlexBus 66** | ✅ from the image + MCF54455RM — see below |
 | Audio DSP | Freescale Symphony **DSP56721** (`DSPB56721AG`) | ✅ board photo |
 | DSP cores | **Two** DSP5636x cores, **200 MHz / 200 MIPS each** | ✅ datasheet — the part's MAXIMUM. 🟡 This board runs the PLL at its reset default from a crystal the payload makes the audio clock: **183.456 MHz = 4 160 cycles/sample** (§2, `COLDFIRE_PORT.md` O8 "the ESAI rate") |
 | External memory controller | **None.** No EMC on this part — all memory is on-chip | ✅ datasheet block diagram |
@@ -124,6 +125,49 @@ is corrected; `BUS.md` still carries the old framing in places.
 
 ❌ **"Y:0x30000–0x3FFFF is EXTERNAL memory, and external is slower."** There is
 no external memory. `DSP.md:449` / `DSP.md:744` still say otherwise.
+
+
+### The ColdFire's clock tree — measured 8 Sep 2026, from the firmware's own words
+
+`PCR` (`0xFC0C4000`) is written with **`0x16777731`** at all four sites that
+touch it (`0x400e165c`, `0x16d0`, `0x173c`, `0x17a8`) and never again:
+PFDR = 22, OUTDIV1 = 1, OUTDIV2 = 3, OUTDIV3 = 7. The boot at `0x40000418`
+reads PCR back, multiplies its top byte by 12,000,000, checks the answer is
+264,000,000, and keeps it at `0x400b9654`.
+
+✅ **That stored number is the CPU clock, not the VCO**, and the UART settles
+it: the baud setup at `0x40010f76` loads it, **shifts it right one**, and
+divides by 32 × baud — and the manual says the internal bus clock is what
+clocks the UARTs (RM §32, "The internal bus clock can clock each of the three
+independent UARTs"). So the bus is half the stored value. The MIDI rate falls
+out exactly: 132 MHz / (32 × 31250) = **132**, an integer divisor.
+
+| | | |
+|---|---|---|
+| crystal (f_REF) | **24 MHz** | 🟡 inferred: f_VCO ÷ PFDR |
+| f_VCO | **528 MHz** | 🟡 CPU × (OUTDIV1+1) |
+| **CPU (f_SYS)** | **264 MHz** | ✅ the firmware's own stored constant, and the VR266 part's rating |
+| **internal bus** (f_SYS/2) — UARTs, PIT, DSPI | **132 MHz** | ✅ the UART's own shift, + RM |
+| **FlexBus (FB_CLK)** | **66 MHz** | ✅ f_VCO ÷ (OUTDIV3+1), RM Eqn. 8-4 — and exactly the RM's own ceiling, "FB_CLK must also not exceed 66 MHz" |
+
+Every divider constraint the manual imposes holds for this word (OUTDIV2's
+divider twice OUTDIV1's, OUTDIV3's four times it), which is the check that
+the reading is the right one.
+
+⚠️ **A consequence nobody has acted on: route A's PIT clock is the CPU clock
+where the hardware uses the BUS clock, so the modelled RTOS tick is TWICE as
+fast as the unit's.** The firmware sets `PCSR = 0x0b36` (prescaler 2048) and
+`PMR = stored/409600 − 1 = 643` at `0x400005a8`, and 409,600 = 2048 × 200.
+Fed the CPU clock that is a 5 ms tick, which is what `--pit-clock 264e6`
+models (route A's own flag calls it "a knob"); fed the bus clock the chip
+actually uses, the period is **2048 × 644 / 132 MHz = 9.99 ms**, a 100 Hz
+tick. Both emulators share the knob, so no oracle diff can see it, and event
+ORDER — which is what the gates compare — is unaffected; every wall-clock
+figure in the port's records (`gate at 204.95 ms`, `28 ticks in 400 frames`)
+is a factor of two out if this is right. 🟡 **Not acted on and not yet
+reviewed**: it is a claim about what the firmware means, it would move every
+recorded timing number, and the falsifier is a hardware measurement of the
+unit's tick rate (or a PIT clock source on this part that is not the bus).
 
 ---
 

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -1219,6 +1219,153 @@ firmware's destination were being ignored entirely. The note is taken at the
 completion the drain gate holds, which is when the DSP-side state means
 something.
 
+### ✅ The ESAI rate, settled from the firmware's own constants (8 Sep 2026)
+
+The "unmeasured knob" above had two halves, and the payload pins both.
+
+**1. The port's ESAI ran eight times slow, and that is why bank B never
+came.** The vendored clock's `setCyclesPerSample` is per SLOT, not per frame:
+`Esai::execTX` advances `m_txSlotCounter` once per call and the frame
+callback fires when it wraps, and `EsxiClock::updateCyclesPerSample`'s own
+derivation halves the per-sample count with the comment "2 samples = 1 frame
+(stereo)". `DspPair` passed `ips` (4535) straight through, so with the
+payload's `TDC = 7` (eight slots) one audio frame cost 8 × 4535 instructions
+— the 256-word ring at X:0x8000 advanced 16 words per 16-sample host frame
+instead of 128, and the dispatcher's `DSR2 == 0x80f0` never arrived before
+the next `0x8070`. ✅ Read from the vendored source, not inferred from the
+symptom. The fix is one division: one slot per `ips / 8`, and a report line
+that counts ESAI frames between consecutive `0x8c` host commands, whose
+value the ring needs to be exactly **16**.
+
+**2. The rate itself.** Payload A's setup (`out/dsp/payload_A.asm`,
+`P:0x30024..0x3007f`, `tools/dsp_disasm_all.py`):
+
+```
+030024: movep #>$aa0000,x:<<$ffff98      ; PDRH: ETI1 ERI1 ETI0 ERI0 = 1
+030026: movep #>$40,x:<<M_SAICR          ; SYN = 1
+03002a: movep #>$f40f00,x:<<M_TCCR       ; THCKD TFSD TCKD; TPSR=1 TPM=0 TFP=0 TDC=7
+03002c: movep #>$37d01,x:<<M_TCR         ; network, TSWS=$1f (32-bit slot), TE0
+03002e: movep #>$f40f00,x:<<M_RCCR
+03006d: movep #>$f00f00,y:<<M_TCCR_1     ; the second port: the same dividers, TSWS=$1e
+```
+
+`X:$FFFF98` on the DSP56720 is the Port H data register, whose top byte is
+the **ESAI/EXTAL clock control** (DSP56720RM §8.2.2.4, Table 8-4): with
+`ETI0`/`ERI0`/`ETI1`/`ERI1` set, *"the EXTAL clock can be used to generate
+the ESAI transmitter/receiver clocks"* — the audio clock is derived from the
+crystal, not from the core clock. The chain (RM Figure 9-3) is EXTAL → ÷2 →
+prescale ÷1 (`TPSR = 1`) → ÷(TPM+1) = 1 → ÷(TFP+1) = 1 → bit clock; the frame
+is 8 slots × 32 bits = 256 bit clocks. So
+
+    fs = EXTAL / (2 × 256) = EXTAL / 512       (bit clock = EXTAL / 2)
+
+🟡 The manual's prose says the *maximum* internally generated bit clock is
+"Fsys/4", one ÷2 more than its own block diagram shows, and it is not
+self-consistent (its stated minimum, Fsys/(2 × 8 × 256), counts only one). The
+÷2 reading is the one the rest of the chip allows — see the PLL below; the
+÷4 reading needs a 45.16 MHz crystal and a 367 MHz core, above the part's
+200 MHz. **And the frame arithmetic does not depend on which**: the DSP's
+instruction count per sample is fixed by the PLL alone.
+
+**3. The core clock.** ✅ Neither payload, nor the 50-word bootstrap, writes
+`PCTL` (`X:$FFFF7D` on this part — on the shared peripheral bus, not a
+`<<` short address; grep `ffff7d` over both listings and `o8_blob0.dis`: no
+hit). So the PLL keeps its reset value, RM §7.3.3.2: **`0x2B60C2` when
+PINIT = 1** — `R = 11` (NR = 12), `OD = 1` (NO = 2), `F = 0xC2` (NF = 195),
+`DF = 0`, PEN = 1:
+
+    Fsys = EXTAL × NF / (NR × NO) = EXTAL × 195 / 24 = EXTAL × 8.125
+
+(PINIT = 0 would be bypass, Fsys = EXTAL: ~512 instructions per sample, and
+the burn probe has measured over 3,000 — so PINIT = 1.) Divide the two:
+
+    Fsys / fs = 512 × 8.125 = **4160 instructions per sample, exactly**,
+    520 per ESAI slot — whatever the crystal is.
+
+With the ÷2 reading and fs = 44.1 kHz the crystal is **22.5792 MHz = 512 fs**
+(the common audio crystal; `Fref` = 1.88 MHz sits just under the RM's 2 MHz
+floor, and `Fvco` = 367 MHz inside 200–400) and **Fsys = 183.456 MHz**. 🟡
+Inferred — no one has photographed the crystal or measured the SCKT pin;
+either would settle it. What it would take to falsify 4160 itself: a
+`PCTL` write we have not found (none exists in the uploaded code; a host
+command could not reach it, the payloads have no such handler), or PINIT = 0.
+
+❌ **4535 (200 MIPS ÷ 44.1 kHz) was the datasheet's ceiling, not this
+board's clock.** `CHIP.md` and `PLAN.md` carry the 🟡 4160 beside it;
+`DspPair` now defaults to 4160 per sample (ratio 4160/3990 in the boot) and
+520 instructions per ESAI slot. Nothing measured on hardware changes — the
+burn-probe ceilings were counted in instructions, and 4160 sits above every
+one of them (`CHIP.md` §2: 3,120 static floor) with 1,040 for the stock
+dispatcher instead of 1,415.
+
+**The gate** — the same O6 run (`DSP=1 scripts/o6_gate.sh`, 400 frames) with
+`--block-log`, and the falsifier is "bank B is taken": ✅ **Passed, and the falsifier turned up the next thing.** Same O6 run,
+`--block-log`, cores live: **400 frames, 28 ticks, trig at 344 — 5 compared
+fields agree**, M6a 8 compared fields agree, `ctest` 7/7, `make check` green,
+and the landing addresses now split **bank A 1,193 / bank B 1,207** of 2,400
+outbound blocks (`landed@2078/2318/25f8/2838` beside `4078/4318/45f8/4838`),
+where every one of the 2,400 before was bank A. ESAI frames in = out
+(1,870,163 / 1,870,161; before the DMA fix out fell behind in and the
+transmitter died), and the read-back carries **196 non-zero words** where it
+carried none.
+
+❌ **But the new report line reads `ESAI frames per host frame (0x8c to
+0x8c): min 160 max 194, exactly 16 on 0 of 399`** — not 16. The ring makes
+5.5 passes between host frames, so the bank alternation is a *random* phase
+against the frame clock, not the locked double buffer the dispatcher
+expects. The DSP's clock is the firmware's; what is stretched is the PORT's
+host frame period: the frame interrupt is a latch (`Rtos::tickTimers`,
+"remembers ONE edge"), so a handler that outlives its 16 samples coalesces
+the missed frames, and the handler spends its time inside the eDMA drain
+gate (`65,327` gated waits over 400 frames; the same order before the
+pacing fix, when it read 22 ESAI frames per host frame — the stretch was
+there all along and no parameter gate can see it). Where the samples go —
+the DSP's own per-frame work, the vendored HDI08's one-word-per-exec drain,
+or the port's idle stepping — is the next measurement (stamped block log:
+`kicked@`/`done@`/`at@` in samples). 🟡 Until it reads 16, no audio the port
+produces has the chip's timing.
+
+### ✅ A ninth vendored-emulator defect, found by the falsifier: the receive DMA's ring never reloaded (8 Sep 2026)
+
+The first run at the corrected pacing did not alternate banks — it took **zero
+frames**: the frame handler's first 672-word push was never drained, the
+read-back pulls came back "not in time", and core 0 sat at `P:0x97` (the
+`HTDE` wait) with **`TCR = 000000` and DMA2 finished** (`DCR2 4c6220`,
+`DSR2 8000`) long before the first `0x8c`. The transmitter was dead, so the
+audio ring never moved and the dispatcher's bank wait could not end.
+
+Nothing in either payload writes `TCR` after setup (grep `M_TCR` over both
+listings: the two setup `movep`s only), and the vendored `Esai::reset` runs
+only from the constructor. A `LOG` with the PC in
+`writeTransmitControlRegister` said: **`Write ESAI TCR 000000 at pc 000097`**
+— the idle loop, so not an instruction; a DMA. The widened `--dsp-trace`
+(every channel's DSR/DDR/DCO/DCR) showed **`DDR3` wandering over the whole
+24-bit space with `DCO3 = 0`**: `4f186a, ac3264, 0947e0, 665d5c, …` — the
+ESAI-in ring's destination, which should cycle X:0x8100–0x833f.
+
+The cause is in `DmaChannel::dualModeIncrement`: on the word that ends the
+block it adds `DOR` and returns "finished" **without reloading `DCOL`/`DCOH`**.
+For a channel the DSP re-arms itself (DMA2, mode 001, DE cleared) the arming
+reloads them; for the firmware's ESAI-in channel — DMA3, `DCR3 = ac59c0`
+(mode 101: line, DE **not** cleared), `DCO3 = 0x23f`, `DOR3 = −575` — nothing
+re-arms, so after its first pass every received word added −575: the pointer
+wrapped below zero into the peripheral space, sprayed silent samples across X
+memory at a 575-word stride, and after **1,215,032 words** landed on
+`X:$FFFFB5` = `TCR`. ✅ The arithmetic reproduces the observation: DMA3 moves
+two words per RX frame here (trace: ΔDDR3 = −575 × 2 × Δframes mod 2²⁴), so
+the hit falls at ~160,800 RX frames; the trace has it between 160,000 and
+160,966. The firmware's own `DOR3 = −DCO3` is the constant that only makes
+sense one way: a ring, i.e. **the counters reload at the end of the block**,
+which is what `tools/dsp56300.patch` now does.
+
+⚠️ **This was live in every O8 run**, spraying zeros through X memory at −575
+per received sample — including the shared window and the parameter banks —
+and the parameter gates could not see it (they compare the ColdFire's
+sequencer, and the DSP never returned anything but silence). At the old
+pacing the walk was eight times slower and the transmitter happened to
+survive to frame 400; at the right pacing it died during the project load.
+Same family as the seven before it: found by an instrument, not by reading.
+
 ### What step 5 needs
 
 `verify_twocore` drives the effect ABI directly (`r0`/`r6`/`r7`/`n7` and a

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -920,7 +920,7 @@ opcode for any word written there. `dsp_host` keeps its two-way window — it
 renders bit-identically with it and, as DSP.md says, cannot answer aliasing
 questions; that is now a documented difference between the two machines.
 
-### ✅ Six things the vendored emulator does that the firmware cannot live with
+### ✅ Six things the vendored emulator does that the firmware cannot live with (nine by 8 Sep — the ninth, the DMA ring that never reloaded, is under "the ESAI rate" below)
 
 Each one first presented as a hang or a crash with no diagnostic, and each was
 found by an instrument, not by reading — recorded with the instrument:
@@ -1324,6 +1324,25 @@ the DSP's own per-frame work, the vendored HDI08's one-word-per-exec drain,
 or the port's idle stepping — is the next measurement (stamped block log:
 `kicked@`/`done@`/`at@` in samples). 🟡 Until it reads 16, no audio the port
 produces has the chip's timing.
+
+✅ **Measured, same day (stamped block log, `kicked@`/`done@` in samples):**
+each of the frame handler's SIX serial host-port bursts is held to the *next
+16-sample boundary* by route A's completion rule, so a frame costs **80–96
+samples** (frame 200: pulls at 914840.6, bursts done at 914856.6, 914872.6,
+914888.6, 914904.6, 914904.6, 914920.6, next frame at 914936.6). The 160–194
+was that period counted on BOTH ESAI ports; the instrument now counts the
+X-side port only. Not the DSP's clock, and not the drain — the drain finishes
+inside a sample; the boundary rule holds it. `--dsp-drain-paced` (complete
+when the DSP has drained the burst) ran ONE frame at **exactly 16** ESAI
+frames per host frame and then the firmware's completion ISR lost an edge and
+the port stalled at frame 2 with source 1 asserting untaken — route A's
+"at once" symptom, reproduced with the cores. So the boundary rule stays the
+default (the O6 gate passes with it, 5/5, and without the cores 5/5) and the
+chip's own number is the open item: **a burst takes the FlexBus's cycle time
+× its words** — `CSCR2 = 0x180` for the DSP window (`ARCHITECTURE.md` §6) and
+the FlexBus clock give it, and 2,176 words per frame against 16 samples says
+it is not small. Derive that, book each burst's completion at kick + words ×
+t_cycle behind the gate, and the instrument should read 16 on 399 of 399.
 
 ### ✅ A ninth vendored-emulator defect, found by the falsifier: the receive DMA's ring never reloaded (8 Sep 2026)
 

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -1385,6 +1385,92 @@ pacing the walk was eight times slower and the transmitter happened to
 survive to frame 400; at the right pacing it died during the project load.
 Same family as the seven before it: found by an instrument, not by reading.
 
+### ✅ O8b — the host-port burst time is the FlexBus's own, and the frame is 16 samples again (8 Sep 2026)
+
+The open item above ("the port's host frame is 80–96 samples") is closed, and
+the number came out of the firmware's own constants rather than a knob.
+
+**What the chip is programmed to do.** Two register words decide it, both read
+off the image with `scripts/disasm.sh`:
+
+| where | what | reading |
+|---|---|---|
+| `0x400e165c` (and three identical sites) | `PCR = 0x16777731` | PFDR 22, OUTDIV1 1, OUTDIV2 3, OUTDIV3 7 |
+| `0x40001eee`, between a CSMR2 disable and re-enable, immediately before the ICR reset that starts an upload | `CSCR2 = 0x180` | **WS = 0**, AA = 1, PS = 1x (16-bit) |
+| `0x400e0e0a`, the boot's own chip-select init | `CSCR2 = 0x1180` | **WS = 4** — the value the loader overwrites |
+
+`CSAR2 = 0x20000000` at `0x400e0dfe` is what makes CS2 the DSP window, so
+these are the DSP's own bus terms and nothing else's.
+
+The clock tree they sit in is in `CHIP.md` §1 — crystal 24 MHz, VCO 528, CPU
+264, internal bus 132, **FlexBus 66 MHz** — and the load-bearing step is that
+the firmware's stored 264,000,000 is the CPU clock, which the UART's baud
+setup proves by shifting it right one before dividing (a ColdFire UART divides
+the internal bus clock). Read as the VCO instead, every figure below halves.
+
+**The burst time.** RM Figures 20-16 and 20-18: a no-wait-state FlexBus
+transfer is S0–S1–S2–S3, **four FB_CLK cycles**, and each wait state repeats
+S1 once more. One DSP word is one 16-bit bus cycle (O8, above), so
+
+    one word = 4 / 66 MHz = 60.6 ns = 2.673e-3 samples
+
+✅ **And the constants only make sense one way** — the test this project keeps
+coming back to. The frame exchange moves **2,944 words** (2,176 out, 768 back,
+measured), which is **178 µs against the 363 µs frame period: 49% bus
+occupancy**, half the frame for audio and half for everything else. At the
+BOOT's `WS = 4` the same exchange is 357 µs — **98% of the frame**, which
+cannot work. That is why the firmware reprograms the chip select before it
+ever speaks to a DSP, and it is why the wait states go to zero on a port that
+had four.
+
+**What changed in the model.** `Edma::start` books a host-port burst at
+`kick + words × 2.673e-3 samples` instead of at the next 16-sample boundary,
+still behind the drain gate, so a burst takes **max(bus, DSP)**.
+`--dsp-drain-paced` keeps the pure-drain rule for A/B, and without the cores
+route A's boundary rule is untouched (its own gate still passes 5/5).
+
+⚠️ **The honest reading of why that fixed it**: what was wrong was the
+QUANTISATION, not the magnitude. The drain gate binds more often than the bus
+does (1,014,303 gated waits against 65,327 under the boundary rule), so the
+period is usually the DSP's drain — but the drain resolves to a fraction of a
+sample where the boundary rounded every one of six serial bursts up to a whole
+frame.
+
+**The gate.**
+
+| | boundary rule | bus time |
+|---|---|---|
+| ESAI frames per host frame | 160–194, **16 on 0 of 399** | **16–17, 16 on 382 of 399** |
+| frames run / ticks / trig | 400 / 28 / 344 | 400 / 28 / 344 |
+| oracle diff (O6, cores live) | 5/5 agree | **5/5 agree** |
+| blocks landing in bank A / B | 1,193 / 1,207 | 1,550 / 850 |
+| outbound non-zero words | 40,949 | 54,087 |
+
+M6a with the cores 8/8, `ctest` 7/7, and the O6 gate without the cores
+unchanged at 5/5.
+
+🟡 **The residual: 17 host frames of 399 take 17 ESAI frames, a 0.27% drift**
+(one every 23.5 frames, never 15, so the DSP's clock runs slightly fast rather
+than jittering). ✅ **What it is not**: `--dsp-no-idle` reproduces the figure
+EXACTLY (16 on 382 of 399, min 16 max 17), so the DSP's idle fast-forward is
+ruled out; the host frame interval is **exactly 16.000 samples on all 399**
+(measured off the block log's `kicked@` stamps), so the frame clock is not
+drifting; and an X-side ESAI transmit frame measures **4160.3 DSP
+instructions**, one sample, over the load. So both clocks are right and it is
+their PHASE that walks, one sample every 23.5 frames, always in the same
+direction. 🟡 The candidate — not yet tested — is that the read-back pull runs
+a core OUTSIDE the sample budget (`runCoreUntil`, up to 200,000 instructions
+until the DSP puts a word in HOTX), which advances the DSP's audio clock
+during a pull; the falsifier is to bound the pull to the budget, or to count
+ESAI frames inside pulls and see whether they account for the 17. **O9 is
+where this has to be settled** — an audio path resamples by exactly this
+error, and 0.27% is about five cents of pitch.
+
+⚠️ **Not fixed by any of this, and not a regression: the read-back is still
+silence.** Inbound non-zero words moved 196 → 9 with the new pacing, which is
+a different phase of the same nothing — the DSP has no audio in. That is O9's
+ground, unchanged.
+
 ### What step 5 needs
 
 `verify_twocore` drives the effect ABI directly (`r0`/`r6`/`r7`/`n7` and a

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -449,13 +449,16 @@ What later milestones must know:
 2. **The shared window is ONE memory for P, X and Y of both cores**, and the
    firmware needs it (core B's entry is written by core A's upload). `dsp_host`
    keeps its two-way window and is a different machine on that point.
-3. **Eight things the vendored DSP emulator does that the firmware cannot live
+3. **Nine things the vendored DSP emulator does that the firmware cannot live
    with** are in `tools/dsp56300.patch` (DO loops nested in one call, JIT-only
    interrupt dispatch, a masked interrupt starving the peripherals, the ESAI
    blocking on an empty ring, a PC past P memory as a garbage pointer, a fast
    interrupt never reaching its vector's PC, the ring-buffer DMA modes and a
    12-bit DCOL, the host DMA's disabled initial trigger and 200-instruction
-   receive throttle). Every one was found by an instrument — stack sample, `lldb
+   receive throttle, and — found 8 Sep by the ESAI-rate falsifier — a
+   dual-counter DMA that never reloaded its counters at the block end, so
+   the ESAI-in ring walked its destination through all of memory and into
+   the ESAI's own TCR). Every one was found by an instrument — stack sample, `lldb
    -k`, `--dsp-trace` — after presenting as a silent hang or a bare crash.
    Regenerate the patch with `git -C vendor/dsp56300 diff`; `make check` only
    sees it after `cmake --build vendor/dsp56300/build`.
@@ -519,23 +522,51 @@ not a measurement until you know the instrument can see the thing.**
 
 </details>
 
-### ⚠️ Read this before step 5 or O9: the ESAI rate is an unmeasured knob
+### ~~⚠️ Read this before step 5 or O9: the ESAI rate is an unmeasured knob~~ ✅ SETTLED (8 Sep 2026, branch `coldfire-esai-rate`)
 
-The DSP picks its working bank by waiting on the audio-out DMA's play pointer
-(`DSR2 == 0x8070` or `0x80f0`, P:0x4a), which makes the bank the audio ring's
-phase — a double buffer, the DSP working into whichever half is not playing.
-✅ **In 400 frames the port took bank A every time**: the only landing
-addresses in the whole run are 0x4078/0x4318/0x45f8/0x4838, the 0x80f0 half is
-never reached, and the ring sits in a fixed phase against the frame clock.
+Two findings, both in `COLDFIRE_PORT.md` O8 "the ESAI rate":
 
-The rate that produces that phase is a knob nobody has measured — the pair
-drives the ESAI at one frame per sample at the cores' own
-instructions-per-sample, taken from `docs/CHIP.md`'s clocks. The parameter
-path passed every gate regardless and does not care. An audio comparison
-would not: it would be measuring a machine whose output alternation never
-happens. **Settle the ESAI rate first**, and treat "bank B is never taken" as
-the falsifier for having got it right. `docs/COLDFIRE_PORT.md` (O8) has the
-dispatcher listing.
+1. ❌ **The port's ESAI ran EIGHT TIMES SLOW.** The vendored clock's "cycles
+   per sample" is per SLOT (`Esai::execTX` advances one slot per call), and
+   `DspPair` passed the per-sample count straight through against the
+   payload's eight slots. That, not any rate knob, is why the 0x80f0 bank
+   never came. Fixed: one slot per `ips / 8`; the report now prints ESAI
+   frames per host frame (0x8c to 0x8c), which the ring needs to be 16.
+2. 🟡 **The rate is the firmware's own arithmetic, 4160 instructions per
+   sample, not 4535.** The payload routes EXTAL into the ESAI chains (Port H
+   `0xaa0000`) at ÷512, never writes PCTL, so the core runs the reset PLL
+   (EXTAL × 8.125): 512 × 8.125 = 4160 whatever the crystal (22.5792 MHz
+   and 183.456 MHz if fs = 44.1 kHz and the manual's block diagram is
+   right). `CHIP.md` and `PLAN.md` carry it beside the datasheet's 4535.
+   Falsifiers: a PCTL write, PINIT = 0, a crystal that is not 22.5792 MHz.
+
+**Gate (8 Sep):** ✅ **Passed, and the falsifier turned up the next thing.** Same O6 run,
+`--block-log`, cores live: **400 frames, 28 ticks, trig at 344 — 5 compared
+fields agree**, M6a 8 compared fields agree, `ctest` 7/7, `make check` green,
+and the landing addresses now split **bank A 1,193 / bank B 1,207** of 2,400
+outbound blocks (`landed@2078/2318/25f8/2838` beside `4078/4318/45f8/4838`),
+where every one of the 2,400 before was bank A. ESAI frames in = out
+(1,870,163 / 1,870,161; before the DMA fix out fell behind in and the
+transmitter died), and the read-back carries **196 non-zero words** where it
+carried none.
+
+❌ **But the new report line reads `ESAI frames per host frame (0x8c to
+0x8c): min 160 max 194, exactly 16 on 0 of 399`** — not 16. The ring makes
+5.5 passes between host frames, so the bank alternation is a *random* phase
+against the frame clock, not the locked double buffer the dispatcher
+expects. The DSP's clock is the firmware's; what is stretched is the PORT's
+host frame period: the frame interrupt is a latch (`Rtos::tickTimers`,
+"remembers ONE edge"), so a handler that outlives its 16 samples coalesces
+the missed frames, and the handler spends its time inside the eDMA drain
+gate (`65,327` gated waits over 400 frames; the same order before the
+pacing fix, when it read 22 ESAI frames per host frame — the stretch was
+there all along and no parameter gate can see it). Where the samples go —
+the DSP's own per-frame work, the vendored HDI08's one-word-per-exec drain,
+or the port's idle stepping — is the next measurement (stamped block log:
+`kicked@`/`done@`/`at@` in samples). 🟡 Until it reads 16, no audio the port
+produces has the chip's timing.
+
+**NEXT (open): the host frame period.** The instrument to satisfy is `exactly 16 on 399 of 399`; the block log's `kicked@`/`done@`/`at@` stamps and the DSP log's `cvr 8c` spacing say where the samples go. Not a rate question any more — an exchange-timing one, on the port's side of the host port.
 
 ### O9 — audio out *(Fable)*
 

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -75,6 +75,8 @@ route A fact, not the port's problem; the golden command above already does it.
 | O7 | the card, the mount, the project load | route A's ATA command log EQUALS the port's | ✅ all 6,189 commands identical line for line, 30,467 sectors read, 297 written (was "a prefix"; O7b closed the gap) |
 | O7b | why the port loaded twice | name the task and PC, and make the oracle reproduce it | ✅ `sys`'s media case reloads a NAMED project; the split is `strlen(name)` = 0 vs 3, a harness ordering race. Route A reproduces the port's 12,373 with `--names-early` |
 | O8 (1-4) | the DSP cores behind the host port | ctest `dsp` (the firmware's upload lands the image's bytes) + M6a and O6 with `--dsp` | ✅ 50/50 + 58/58 bootstrap words, 26,221 + 25,408 payload words at upload time; M6a 8 compared fields; O6 5 compared fields (400 frames, 28 ticks, trig at 344) with the cores live. Step 5 open |
+| O8a | the ESAI rate | the falsifier: bank B gets taken | ✅ the port's ESAI ran 8× slow (a per-SLOT clock fed a per-sample count); the rate is the firmware's own 4160 instructions/sample; a ninth vendored DMA defect found on the way. Bank B 850 of 2,400 blocks (was 0) |
+| O8b | the host-port burst time | `ESAI frames per host frame` reads 16, O6 still 5/5 | ✅ FlexBus 66 MHz × 4 clocks/word from `PCR` and `CSCR2` in the image: 16 on 382 of 399 (was 0 of 399), O6 5/5, M6a 8/8 |
 
 ## Queue
 
@@ -566,17 +568,46 @@ or the port's idle stepping — is the next measurement (stamped block log:
 `kicked@`/`done@`/`at@` in samples). 🟡 Until it reads 16, no audio the port
 produces has the chip's timing.
 
-**NEXT (open): the host-port burst time — O8b.** ✅ Measured 8 Sep: with
-route A's completion rule each of the six serial bursts per frame waits for
-the next 16-sample boundary, so the port's frame is **80–96 samples, not
-16**; `--dsp-drain-paced` (complete when drained) gives exactly 16 for one
-frame and then the completion ISR loses an edge and stalls (the "at once"
-symptom). The chip's number is the FlexBus cycle time × the burst's words:
-`CSCR2 = 0x180` (ARCHITECTURE.md §6) and the FlexBus clock. Translate that
-into `Edma::start` (kick + words × t_cycle, behind the drain gate), and the
-gate is the report line `ESAI frames per host frame ... exactly 16 on 399 of
-399` with the O6 diff still 5/5. *(Opus: a constant to derive and a rule to
-book; the falsifier exists.)*
+### ~~O8b — the host-port burst time~~ ✅ DONE (8 Sep 2026, branch `coldfire-esai-rate`)
+
+`COLDFIRE_PORT.md` O8b has the account. The port's host frame was 80–96
+samples because route A's completion rule rounded each of six serial bursts up
+to the next 16-sample boundary. A burst now completes at **kick + words ×
+2.673e-3 samples**, still behind the drain gate, and the frame is 16 samples
+again: **ESAI frames per host frame 16 on 382 of 399** (was 0 of 399), O6 with
+the cores 5/5, M6a 8/8, `ctest` 7/7, no-cores O6 unchanged.
+
+Three things later milestones must know:
+
+1. **The burst time is the chip's, derived from two register words in the
+   image, not a knob**: `CSCR2 = 0x180` (WS = 0, 16-bit port) written by the
+   DSP loader over the boot's `0x1180` (WS = 4), and `PCR = 0x16777731` giving
+   **FB_CLK = 66 MHz**; a no-wait-state transfer is four FB_CLK cycles (RM
+   Figs 20-16/20-18). One DSP word = 60.6 ns. The corroboration is that the
+   exchange then fills **49%** of the frame period and would fill **98%** at
+   the boot's wait states, which is why the loader reprograms it.
+2. **`CHIP.md` §1 now carries the whole ColdFire clock tree** (crystal 24 MHz,
+   VCO 528, CPU 264, bus 132, FlexBus 66), measured from the image. The step
+   that settles it is the UART baud setup shifting the stored clock right one
+   before dividing — read the stored 264 MHz as the VCO instead and every
+   figure halves.
+3. ⚠️ **A consequence recorded but NOT acted on: route A's PIT clock is the
+   CPU clock where the hardware uses the bus clock, so the modelled RTOS tick
+   is 5 ms where the unit's is ~10 ms.** Both emulators share the knob and the
+   gates compare order, so no diff can see it; every wall-clock figure in
+   these records (`gate at 204.95 ms`, `28 ticks in 400 frames`) is a factor
+   of two out if it holds. `CHIP.md` §1 has the evidence and the falsifier.
+   **It is a claim about what the firmware means and it moves every recorded
+   timing number — it wants a deliberate pass of its own, not a quiet edit.**
+
+🟡 Residual: 17 host frames of 399 take 17 ESAI frames rather than 16, a 0.27%
+drift in the DSP's clock (never 15, so drift not jitter). ✅ Ruled out: the DSP idle fast-forward (`--dsp-no-idle` is
+identical), the frame clock (the interval is exactly 16.000 samples on all
+399) and the ESAI rate (a transmit frame is 4160.3 instructions, one sample).
+It is the PHASE between the two that walks, one sample per 23.5 frames, always
+one way. 🟡 Candidate: the read-back pull runs a core outside the sample
+budget (`runCoreUntil`). **Hand it to O9** — an audio path resamples by
+exactly this error.
 
 ### O9 — audio out *(Fable)*
 

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -566,7 +566,17 @@ or the port's idle stepping — is the next measurement (stamped block log:
 `kicked@`/`done@`/`at@` in samples). 🟡 Until it reads 16, no audio the port
 produces has the chip's timing.
 
-**NEXT (open): the host frame period.** The instrument to satisfy is `exactly 16 on 399 of 399`; the block log's `kicked@`/`done@`/`at@` stamps and the DSP log's `cvr 8c` spacing say where the samples go. Not a rate question any more — an exchange-timing one, on the port's side of the host port.
+**NEXT (open): the host-port burst time — O8b.** ✅ Measured 8 Sep: with
+route A's completion rule each of the six serial bursts per frame waits for
+the next 16-sample boundary, so the port's frame is **80–96 samples, not
+16**; `--dsp-drain-paced` (complete when drained) gives exactly 16 for one
+frame and then the completion ISR loses an edge and stalls (the "at once"
+symptom). The chip's number is the FlexBus cycle time × the burst's words:
+`CSCR2 = 0x180` (ARCHITECTURE.md §6) and the FlexBus clock. Translate that
+into `Edma::start` (kick + words × t_cycle, behind the drain gate), and the
+gate is the report line `ESAI frames per host frame ... exactly 16 on 399 of
+399` with the O6 diff still 5/5. *(Opus: a constant to derive and a rule to
+book; the falsifier exists.)*
 
 ### O9 — audio out *(Fable)*
 

--- a/tools/dsp56300.patch
+++ b/tools/dsp56300.patch
@@ -9,7 +9,7 @@ index ffbf791..350a71a 100644
 +
 +add_subdirectory(dsp_host)
 diff --git a/source/dsp56kEmu/dma.cpp b/source/dsp56kEmu/dma.cpp
-index bd3e603..8176a6e 100644
+index bd3e603..fea36b4 100644
 --- a/source/dsp56kEmu/dma.cpp
 +++ b/source/dsp56kEmu/dma.cpp
 @@ -59,7 +59,12 @@ namespace dsp56k
@@ -39,7 +39,27 @@ index bd3e603..8176a6e 100644
  
  			m_dcoh = m_dcohInit;
  			m_dcol = m_dcolInit;
-@@ -716,6 +725,25 @@ namespace dsp56k
+@@ -469,6 +478,19 @@ namespace dsp56k
+ 		{
+ 			_dst += _dor;
+ 			_dst &= 0xffffff;
++			// octabam: THE COUNTERS RELOAD AT THE END OF THE BLOCK. Without this
++			// a continuous (DE-not-cleared) dual-counter channel added DOR on
++			// EVERY word after its first pass: the Octatrack's ESAI-in ring
++			// (DMA3, DCO3 = 0x23f, DOR3 = -575) walked its destination DOWN
++			// 575 words per received sample, wrapped below zero into the
++			// peripheral space and, 1,215,032 words later, wrote a silent
++			// sample into X:$FFFFB5 -- the ESAI's own TCR -- which killed the
++			// transmitter (measured 8 Sep 2026: `Write ESAI TCR 000000 at pc
++			// 000097`, the idle loop; nothing in either payload writes TCR
++			// after setup). The firmware's DOR3 = -DCO3 only makes sense as a
++			// ring, i.e. with the reload.
++			m_dcol = m_dcolInit;
++			m_dcoh = m_dcohInit;
+ 			return true;
+ 		}
+ 
+@@ -716,6 +738,25 @@ namespace dsp56k
  			return false;
  		}
  
@@ -244,6 +264,28 @@ index 386e30f..996c82a 100644
  	}
  	inline void DSP::op_Neg(const TWord op)
  	{
+diff --git a/source/dsp56kEmu/esai.cpp b/source/dsp56kEmu/esai.cpp
+index 5bf0bd7..52c458e 100644
+--- a/source/dsp56kEmu/esai.cpp
++++ b/source/dsp56kEmu/esai.cpp
+@@ -17,6 +17,8 @@ namespace dsp56k
+ 
+ 	void Esai::reset()
+ 	{
++		// octabam diagnostic: who resets the ESAI after boot?
++		LOG("ESAI reset (tcr was " << HEX(m_tcr) << ")");
+ 		// Reset control registers to power-on defaults
+ 		m_cr = 0;
+ 		m_tcr = 0;
+@@ -190,7 +192,7 @@ namespace dsp56k
+ 	void Esai::writeTransmitControlRegister(TWord _val)
+ 	{
+ 		m_sr.clear(M_TUE);
+-		LOG("Write ESAI TCR " << HEX(_val));
++		LOG("Write ESAI TCR " << HEX(_val) << " at pc " << HEX(m_periph.getDSP().getPC().toWord()));
+ 		const auto tem = getEnabledTransmitters();
+ 		m_tcr = _val;
+ 		if(tem != getEnabledTransmitters())
 diff --git a/source/dsp56kEmu/jitops.h b/source/dsp56kEmu/jitops.h
 index 0be2c03..5d51f90 100644
 --- a/source/dsp56kEmu/jitops.h

--- a/tools/ot_emu/dsp.cpp
+++ b/tools/ot_emu/dsp.cpp
@@ -38,7 +38,8 @@ namespace ot
 		std::unique_ptr<dsp56k::DspBoot> boot;
 
 		uint64_t executed = 0, wordsIn = 0, wordsOut = 0, commands = 0, dropped = 0;
-		uint64_t rxFrames = 0, txFrames = 0;	// ESAI frames taken in (silence) / put out
+		uint64_t rxFrames = 0, txFrames = 0;	// ESAI frames taken in (silence) / put out -- the X-side port
+		uint64_t rxFrames1 = 0, txFrames1 = 0;	// the same for ESAI_1 on the Y side (❌ the two were summed until 8 Sep, and "frames per host frame" read double)
 		uint64_t txAtCommand = 0;				// txFrames at the previous host command
 		uint64_t fpcMin = ~0ull, fpcMax = 0, fpcSixteen = 0, fpcSamples = 0;	// frames per command
 		uint32_t esaiCyclesPerSlot = 0;
@@ -179,11 +180,19 @@ namespace ot
 					c.lastTx[1] = _f[0][1];
 				}
 			};
-			for(dsp56k::Esai* e : {&c.px->getEsai(), &c.py->getEsai()})
+			auto silence1 = [&c](uint64_t&, dsp56k::Audio::RxFrame& _f)
 			{
-				e->setReadRxCallback(silence);
-				e->setWriteTxCallback(sink);
-			}
+				for(uint32_t i = 0; i < dsp56k::Audio::MaxSlotsPerFrame; ++i)
+					for(auto& w : _f[i])
+						w = 0;
+				_f.resize(dsp56k::Audio::MaxSlotsPerFrame);
+				++c.rxFrames1;
+			};
+			auto sink1 = [&c](uint64_t&, const dsp56k::Audio::TxFrame&) { ++c.txFrames1; };
+			c.px->getEsai().setReadRxCallback(silence);
+			c.px->getEsai().setWriteTxCallback(sink);
+			c.py->getEsai().setReadRxCallback(silence1);
+			c.py->getEsai().setWriteTxCallback(sink1);
 			c.esaiCyclesPerSlot = static_cast<uint32_t>(_ips / g_esaiSlots);
 			c.px->getEsaiClock().setCyclesPerSample(c.esaiCyclesPerSlot);
 
@@ -672,7 +681,7 @@ namespace ot
 			std::snprintf(line, sizeof line,
 				"             core %d: boot ROM %s (%u words -> P:%#07x), pc %#07x, %llu instructions, "
 				"host words in %llu / out %llu, host commands %llu%s\n"
-				"                     ESAI frames in %llu / out %llu, last out slot 0 = %06x %06x; idle-skipped %llu; mailbox sent %llu; read-back words %llu (%llu not in time)\n"
+				"                     ESAI frames in %llu / out %llu (ESAI_1 %llu / %llu), last out slot 0 = %06x %06x; idle-skipped %llu; mailbox sent %llu; read-back words %llu (%llu not in time)\n"
 				"                     ESAI frames per host frame (0x8c to 0x8c): min %llu max %llu, exactly 16 on %llu of %llu; TCCR %06x (%u slots), %u instructions per slot\n",
 				i, c.boot->finished() ? "done" : "WAITING", c.boot->getLength(), c.boot->getInitialPC(),
 				c.dsp->getPC().toWord(), static_cast<unsigned long long>(c.executed),
@@ -680,6 +689,7 @@ namespace ot
 				static_cast<unsigned long long>(c.commands),
 				c.dropped ? " (words DROPPED on a full ring)" : "",
 				static_cast<unsigned long long>(c.rxFrames), static_cast<unsigned long long>(c.txFrames),
+				static_cast<unsigned long long>(c.rxFrames1), static_cast<unsigned long long>(c.txFrames1),
 				c.lastTx[0], c.lastTx[1], static_cast<unsigned long long>(c.idleSkipped),
 				static_cast<unsigned long long>(m_mail[i].words),
 				static_cast<unsigned long long>(c.pulled), static_cast<unsigned long long>(c.pullShort),

--- a/tools/ot_emu/dsp.cpp
+++ b/tools/ot_emu/dsp.cpp
@@ -39,6 +39,9 @@ namespace ot
 
 		uint64_t executed = 0, wordsIn = 0, wordsOut = 0, commands = 0, dropped = 0;
 		uint64_t rxFrames = 0, txFrames = 0;	// ESAI frames taken in (silence) / put out
+		uint64_t txAtCommand = 0;				// txFrames at the previous host command
+		uint64_t fpcMin = ~0ull, fpcMax = 0, fpcSixteen = 0, fpcSamples = 0;	// frames per command
+		uint32_t esaiCyclesPerSlot = 0;
 		uint64_t idleSkipped = 0;
 		uint64_t pulled = 0, pullShort = 0;	// read-back words taken / not produced in time
 		uint32_t lastSent[2] = {0, 0};		// a rolling pair of the last two words sent
@@ -150,6 +153,15 @@ namespace ot
 			// the output is counted -- and the clock is ONE FRAME PER SAMPLE at
 			// the pair's own instructions-per-sample, so the DSP's audio clock
 			// and the ColdFire's sample clock cannot drift apart.
+			// ❌ Until 8 Sep 2026 this passed `_ips` straight through, and the
+			// vendored clock fires ONE SLOT per "cycles per sample" (Esai::execTX
+			// advances m_txSlotCounter once per call; EsxiClock's own
+			// derivation halves it "2 samples = 1 frame (stereo)"). With the
+			// payload's 8 slots that was an audio clock 8x slow: the 256-word
+			// ring at X:0x8000 advanced 16 words per 16-sample frame instead of
+			// 128, the dispatcher's DSR2 == 0x80f0 bank never came, and every
+			// block landed in bank A (COLDFIRE_PORT.md O8, "the bank is the
+			// audio ring's phase"). One slot per `_ips / 8`: 520 at 4160.
 			auto silence = [&c](uint64_t&, dsp56k::Audio::RxFrame& _f)
 			{
 				for(uint32_t i = 0; i < dsp56k::Audio::MaxSlotsPerFrame; ++i)
@@ -172,7 +184,8 @@ namespace ot
 				e->setReadRxCallback(silence);
 				e->setWriteTxCallback(sink);
 			}
-			c.px->getEsaiClock().setCyclesPerSample(static_cast<uint32_t>(_ips));
+			c.esaiCyclesPerSlot = static_cast<uint32_t>(_ips / g_esaiSlots);
+			c.px->getEsaiClock().setCyclesPerSample(c.esaiCyclesPerSlot);
 
 			// The inter-core mailbox (see dsp.h), on the Y-side peripherals.
 			c.py->setUnmappedHooks(
@@ -265,6 +278,20 @@ namespace ot
 		c.cmdArgs[1] = c.lastSent[1];
 		c.hcPending = true;
 		++c.commands;
+		if(c.hcVector == 0x18 && c.txFrames)
+		{
+			// Frames per frame: count from the second 0x8c on, once the ESAI
+			// is running, so the boot-time gap is not the minimum.
+			if(c.txAtCommand)
+			{
+				const auto d = c.txFrames - c.txAtCommand;
+				c.fpcMin = std::min(c.fpcMin, d);
+				c.fpcMax = std::max(c.fpcMax, d);
+				if(d == 16) ++c.fpcSixteen;
+				++c.fpcSamples;
+			}
+			c.txAtCommand = c.txFrames;
+		}
 		auto& h = c.hdi();
 		h.writeStatusRegister(h.readStatusRegister() | (1u << dsp56k::HDI08::HSR_HCP));
 		c.dsp->injectInterrupt(c.hcVector);
@@ -549,7 +576,7 @@ namespace ot
 				{
 					char line[256];
 					std::snprintf(line, sizeof line,
-						"core %d exec %llu dspctr %llu pc %06x sr %06x mode %d pending %d periph-target %llu esai in %llu out %llu SAISR %06x RCR %06x TCR %06x HSR %06x HCR %06x DCR2 %06x DCO2 %06x DSR2 %06x DSR3 %06x",
+						"core %d exec %llu dspctr %llu pc %06x sr %06x mode %d pending %d periph-target %llu esai in %llu out %llu SAISR %06x RCR %06x TCR %06x HSR %06x HCR %06x DCR2 %06x DCO2 %06x DSR2 %06x DSR3 %06x DDR3 %06x DCO3 %06x DCR3 %06x DDR0 %06x DCO0 %06x DCR0 %06x DSR1 %06x DCO1 %06x DCR1 %06x",
 						i, static_cast<unsigned long long>(c.executed),
 						static_cast<unsigned long long>(c.dsp->getInstructionCounter()), pc,
 						c.dsp->regs().sr.var & 0xffffff,
@@ -559,7 +586,10 @@ namespace ot
 						c.px->read(0xffffb3, dsp56k::Nop), c.px->read(0xffffb7, dsp56k::Nop), c.px->read(0xffffb5, dsp56k::Nop),
 						c.hdi().readStatusRegister(), c.hdi().readControlRegister(),
 						c.px->read(0xffffe4, dsp56k::Nop), c.px->read(0xffffe5, dsp56k::Nop),
-						c.px->read(0xffffe7, dsp56k::Nop), c.px->read(0xffffe3, dsp56k::Nop));
+						c.px->read(0xffffe7, dsp56k::Nop), c.px->read(0xffffe3, dsp56k::Nop),
+						c.px->read(0xffffe2, dsp56k::Nop), c.px->read(0xffffe1, dsp56k::Nop), c.px->read(0xffffe0, dsp56k::Nop),
+						c.px->read(0xffffee, dsp56k::Nop), c.px->read(0xffffed, dsp56k::Nop), c.px->read(0xffffec, dsp56k::Nop),
+						c.px->read(0xffffeb, dsp56k::Nop), c.px->read(0xffffe9, dsp56k::Nop), c.px->read(0xffffe8, dsp56k::Nop));
 					m_trace.emplace_back(line);
 					c.nextTrace = (c.executed / m_traceEvery + 1) * m_traceEvery;
 				}
@@ -626,6 +656,9 @@ namespace ot
 	uint64_t DspPair::hostWordsIn(const int _core) const { return m_cores[_core & 1]->wordsIn; }
 	uint64_t DspPair::hostWordsOut(const int _core) const { return m_cores[_core & 1]->wordsOut; }
 	uint64_t DspPair::hostCommands(const int _core) const { return m_cores[_core & 1]->commands; }
+	uint64_t DspPair::framesPerCommandMin(const int _core) const { const Core& c = *m_cores[_core & 1]; return c.fpcSamples ? c.fpcMin : 0; }
+	uint64_t DspPair::framesPerCommandMax(const int _core) const { return m_cores[_core & 1]->fpcMax; }
+	uint64_t DspPair::framesPerCommandSixteen(const int _core) const { return m_cores[_core & 1]->fpcSixteen; }
 	uint32_t DspPair::bootLength(const int _core) const { return m_cores[_core & 1]->boot->getLength(); }
 	uint32_t DspPair::bootAddress(const int _core) const { return m_cores[_core & 1]->boot->getInitialPC(); }
 
@@ -639,7 +672,8 @@ namespace ot
 			std::snprintf(line, sizeof line,
 				"             core %d: boot ROM %s (%u words -> P:%#07x), pc %#07x, %llu instructions, "
 				"host words in %llu / out %llu, host commands %llu%s\n"
-				"                     ESAI frames in %llu / out %llu, last out slot 0 = %06x %06x; idle-skipped %llu; mailbox sent %llu; read-back words %llu (%llu not in time)\n",
+				"                     ESAI frames in %llu / out %llu, last out slot 0 = %06x %06x; idle-skipped %llu; mailbox sent %llu; read-back words %llu (%llu not in time)\n"
+				"                     ESAI frames per host frame (0x8c to 0x8c): min %llu max %llu, exactly 16 on %llu of %llu; TCCR %06x (%u slots), %u instructions per slot\n",
 				i, c.boot->finished() ? "done" : "WAITING", c.boot->getLength(), c.boot->getInitialPC(),
 				c.dsp->getPC().toWord(), static_cast<unsigned long long>(c.executed),
 				static_cast<unsigned long long>(c.wordsIn), static_cast<unsigned long long>(c.wordsOut),
@@ -648,7 +682,11 @@ namespace ot
 				static_cast<unsigned long long>(c.rxFrames), static_cast<unsigned long long>(c.txFrames),
 				c.lastTx[0], c.lastTx[1], static_cast<unsigned long long>(c.idleSkipped),
 				static_cast<unsigned long long>(m_mail[i].words),
-				static_cast<unsigned long long>(c.pulled), static_cast<unsigned long long>(c.pullShort));
+				static_cast<unsigned long long>(c.pulled), static_cast<unsigned long long>(c.pullShort),
+				static_cast<unsigned long long>(c.fpcSamples ? c.fpcMin : 0), static_cast<unsigned long long>(c.fpcMax),
+				static_cast<unsigned long long>(c.fpcSixteen), static_cast<unsigned long long>(c.fpcSamples),
+				c.px->read(0xffffb6, dsp56k::Nop), ((c.px->read(0xffffb6, dsp56k::Nop) >> 9) & 0x1f) + 1,
+				c.esaiCyclesPerSlot);
 			s += line;
 			if(c.faulted)
 			{

--- a/tools/ot_emu/dsp.h
+++ b/tools/ot_emu/dsp.h
@@ -31,8 +31,15 @@
 //
 // TIMING. The cores are stepped in lockstep with the ColdFire: `ratio` DSP
 // instructions per ColdFire instruction during the boot (which has no sample
-// clock), `ips` instructions per sample once the RTOS runs. Both are knobs;
-// neither is measured. ⚠️ A core whose bootstrap ROM has not finished is HELD
+// clock), `ips` instructions per sample once the RTOS runs. Both are knobs.
+// `ips` defaults to 4160 = 512 x 8.125: the payload never writes PCTL, so the
+// core runs at the DSP56720's reset PLL (0x2B60C2: NF/(NR*NO) = 195/24) from
+// an EXTAL the payload itself makes the audio clock (P:0x30024 routes EXTAL
+// into both ESAI chains, TPSR=1/TPM=0/TFP=0, 8 slots x 32 bits), so
+// Fsys/fs = 512 x 8.125 whatever the crystal is (COLDFIRE_PORT.md, O8:
+// "the ESAI rate"). The ESAI fires ONE SLOT per `ips / 8` instructions -- the
+// vendored clock's "cycles per sample" is per slot (its "2 samples = 1
+// frame" comment). ⚠️ A core whose bootstrap ROM has not finished is HELD
 // (the ROM jumps only after the last word), and a core is never run past the
 // due count, so the ColdFire's polls see the DSP make progress between them
 // and not before.
@@ -69,11 +76,15 @@ namespace ot
 		bool faulted(int _core) const;
 
 		// `_ratio`: DSP instructions per ColdFire instruction (boot clock);
-		// `_ips`: DSP instructions per sample (RTOS clock). 200 MIPS against
-		// the port's 3990 ColdFire instructions per sample at 44.1 kHz gives
-		// 4535 and 1.14 -- docs/CHIP.md's clocks, not a measurement of either
-		// emulator's cadence.
-		DspPair(double _ratio = 1.14, double _ips = 4535.0);
+		// `_ips`: DSP instructions per sample (RTOS clock). 4160 is the
+		// firmware's own arithmetic (see the file comment; ❌ 4535 was the
+		// datasheet's 200 MIPS ceiling, not this board's clock); the ratio is
+		// that against the port's 3990 ColdFire instructions per sample.
+		// Neither is a measurement of either emulator's cadence.
+		static constexpr double g_dspIps = 4160.0;
+		static constexpr double g_cfIps = 3990.0;
+		static constexpr uint32_t g_esaiSlots = 8;		// TDC = 7 in both payload TCCRs
+		DspPair(double _ratio = g_dspIps / g_cfIps, double _ips = g_dspIps);
 		~DspPair() override;
 
 		bool read(uint32_t _addr, uint8_t _size, uint32_t& _out) override;
@@ -99,6 +110,12 @@ namespace ot
 		uint64_t hostWordsIn(int _core) const;		// words the host sent (ROM + HDI08)
 		uint64_t hostWordsOut(int _core) const;		// words the host took back
 		uint64_t hostCommands(int _core) const;
+		// ESAI frames put out between consecutive host commands (0x8c): the
+		// falsifier for the pacing. Sixteen per frame is what the ring's
+		// double buffer needs; anything else and one bank is never taken.
+		uint64_t framesPerCommandMin(int _core) const;
+		uint64_t framesPerCommandMax(int _core) const;
+		uint64_t framesPerCommandSixteen(int _core) const;
 		uint32_t bootLength(int _core) const;		// what the ROM was told
 		uint32_t bootAddress(int _core) const;
 		// Every host-side event, in order, when enabled: "sel", "icr", "cvr",

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -73,7 +73,7 @@ int main(int _argc, char** _argv)
 	bool namesEarly = false;	// write the SET/PROJECT names BEFORE the mount -- see O7b
 	std::string hostPortLog;	// every write into the DSP host-port window -> FILE (O8)
 	bool dsp = false;			// O8: put the two real DSP cores behind the host port
-	double dspRatio = 1.14, dspIps = 4535.0;	// their clock, in DSP instructions per ColdFire instruction / per sample
+	double dspRatio = ot::DspPair::g_dspIps / ot::DspPair::g_cfIps, dspIps = ot::DspPair::g_dspIps;	// their clock, in DSP instructions per ColdFire instruction / per sample (dsp.h says where 4160 comes from)
 	std::string dspLog;			// every host-side event on the DSP pair -> FILE
 	uint64_t dspTrace = 0;		// a status line per core every N DSP instructions
 	bool dspNoIdle = false;		// execute every poll of an idle core (fidelity check; slow)

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -76,7 +76,8 @@ int main(int _argc, char** _argv)
 	double dspRatio = ot::DspPair::g_dspIps / ot::DspPair::g_cfIps, dspIps = ot::DspPair::g_dspIps;	// their clock, in DSP instructions per ColdFire instruction / per sample (dsp.h says where 4160 comes from)
 	std::string dspLog;			// every host-side event on the DSP pair -> FILE
 	uint64_t dspTrace = 0;		// a status line per core every N DSP instructions
-	bool dspNoIdle = false;		// execute every poll of an idle core (fidelity check; slow)
+	bool dspNoIdle = false;
+	bool dspDrainPaced = false;	// EXPERIMENT: a host-port burst completes when the DSP drained it (measured 8 Sep: one frame of exactly 16 ESAI frames, then the completion ISR loses an edge and stalls)		// execute every poll of an idle core (fidelity check; slow)
 	bool dspVerbose = false;	// the vendored DSP library's own log lines
 	std::string edmaLog;		// every eDMA kick with its TCD fields -> FILE (O8 step 4)
 	std::string dspPeek;		// core:space:addr,len[;...] -- DSP memory to print at the end
@@ -121,6 +122,7 @@ int main(int _argc, char** _argv)
 		else if(a == "--dsp-log" && i + 1 < _argc)	dspLog = _argv[++i];
 		else if(a == "--dsp-trace" && i + 1 < _argc)	dspTrace = std::strtoull(_argv[++i], nullptr, 0);
 		else if(a == "--dsp-no-idle")			dspNoIdle = true;
+		else if(a == "--dsp-drain-paced")		dspDrainPaced = true;
 		else if(a == "--dsp-verbose")			dspVerbose = true;
 		else if(a == "--edma-log" && i + 1 < _argc)	edmaLog = _argv[++i];
 		else if(a == "--dsp-peek" && i + 1 < _argc)	dspPeek = _argv[++i];
@@ -233,6 +235,8 @@ int main(int _argc, char** _argv)
 		}
 		rtos.install();
 		rtos.setBlockLog(!blockLog.empty());
+		if(dspDrainPaced)
+			rtos.setDspDrainPacing(true);
 		std::ofstream edmaOut;
 		if(!edmaLog.empty())
 		{

--- a/tools/ot_emu/periph.cpp
+++ b/tools/ot_emu/periph.cpp
@@ -169,7 +169,16 @@ namespace ot
 			m_onKick(_ch);
 		setCsr(_ch, static_cast<uint16_t>(csr(_ch) & ~DONE));
 		++m_started;
-		if(_paced && !(m_drainPaced && m_canComplete))
+		if(_paced && m_busPaced && m_canComplete)
+		{
+			// The chip's own number (periph.h): the burst occupies the
+			// FlexBus for four clocks per 16-bit cycle, one cycle per DSP
+			// word, and the drain gate holds the completion beyond that if
+			// the DSP has not taken the words yet.
+			const auto words = static_cast<double>(tcdField(_ch, 8, 4) * minorLoops(_ch)) / 2.0;
+			m_due.emplace(_ch & 15, m_now + words * g_fbSamplesPerWord);
+		}
+		else if(_paced && !(m_drainPaced && m_canComplete))
 			// The DSP delivers its frame on ITS clock, so the completion is
 			// booked for the next 16-sample boundary -- NOT kick + 16, which
 			// gave an 18.5-sample period and dropped every sixth frame, and

--- a/tools/ot_emu/periph.cpp
+++ b/tools/ot_emu/periph.cpp
@@ -169,13 +169,15 @@ namespace ot
 			m_onKick(_ch);
 		setCsr(_ch, static_cast<uint16_t>(csr(_ch) & ~DONE));
 		++m_started;
-		if(_paced)
+		if(_paced && !(m_drainPaced && m_canComplete))
 			// The DSP delivers its frame on ITS clock, so the completion is
 			// booked for the next 16-sample boundary -- NOT kick + 16, which
 			// gave an 18.5-sample period and dropped every sixth frame, and
 			// NOT at once, which re-raised source 15 before state 0 could ack
 			// it and left the ISR spinning in state 6. `setdefault`: a channel
-			// already booked keeps its EARLIER completion.
+			// already booked keeps its EARLIER completion. (Without the
+			// cores, that is: with them the DSP's drain IS the clock, and
+			// the boundary held every burst a whole frame -- periph.h.)
 			m_due.emplace(_ch & 15, m_boundary);
 		else if(m_canComplete && !m_canComplete(_ch))
 			m_due.emplace(_ch & 15, 0.0);		// due now, held by the gate

--- a/tools/ot_emu/periph.h
+++ b/tools/ot_emu/periph.h
@@ -210,6 +210,18 @@ namespace ot
 		// now"; unset, every rule is route A's.
 		void setCompletionGate(std::function<bool(uint32_t)> _fn) { m_canComplete = std::move(_fn); }
 		uint64_t gatedWaits() const { return m_gatedWaits; }
+		// EXPERIMENT (`--dsp-drain-paced`): a host-port burst completes when
+		// the DSP has DRAINED it (the gate), not at the next 16-sample
+		// boundary. ✅ Measured 8 Sep 2026, cores live. Boundary rule: the
+		// frame handler's six serial bursts each waited for a boundary, so a
+		// frame cost 80-96 samples instead of 16 and the ESAI ring made 5-6
+		// passes per frame -- invisible to every frame-counting gate. Drain
+		// rule: the one frame it ran was EXACTLY 16 ESAI frames, and then the
+		// completion ISR lost an edge and the port stalled at frame 2 (route
+		// A's "at once" symptom, now with the cores). Neither is the chip:
+		// a burst takes the FlexBus's time per 16-bit cycle x its words, and
+		// that constant is the next thing to derive (the CS wait states).
+		void setDrainPaced(bool _on) { m_drainPaced = _on; }
 		// CITER/BITER carry a minor-loop link in bit 15 with the channel in
 		// bits 14-9 and the count in bits 8-0; without it the count is 15 bits.
 		uint32_t minorLoops(uint32_t _ch) const
@@ -233,6 +245,7 @@ namespace ot
 		std::array<bool, 16> m_irq = {};
 		std::unordered_map<uint32_t, double> m_due;		// channel -> sample it completes at
 		double m_boundary = g_framePeriod;
+		bool m_drainPaced = false;
 		uint64_t m_started = 0;
 		std::function<void(uint32_t, bool)> m_onTransfer;
 		std::function<void(uint32_t)> m_onKick, m_onDone;

--- a/tools/ot_emu/periph.h
+++ b/tools/ot_emu/periph.h
@@ -183,8 +183,57 @@ namespace ot
 		uint64_t started() const { return m_started; }
 		size_t outstanding() const { return m_due.size(); }
 
-		// The DSP's next frame boundary; `Rtos::tickTimers` keeps it current.
+		// The DSP's next frame boundary, and the sample clock itself;
+		// `Rtos::tickTimers` keeps both current.
 		void setBoundary(double _b) { m_boundary = _b; }
+		void setNow(double _n) { m_now = _n; }
+
+		// ✅ THE HOST-PORT BURST TIME, from the firmware's own constants and
+		// the MCF54455 reference manual -- the chip's number, not a knob:
+		//
+		//   PCR = 0x16777731, written identically at all four sites
+		//   (0x400e165c/16d0/173c/17a8): PFDR = 0x16 = 22, OUTDIV1 = 1,
+		//   OUTDIV2 = 3, OUTDIV3 = 7. The boot at 0x40000418 multiplies PFDR
+		//   by 12,000,000 and checks 264,000,000, and it keeps that at
+		//   0x400b9654. ✅ WHICH CLOCK that is, is settled by the UART: the
+		//   baud setup at 0x40010f76 loads it, SHIFTS IT RIGHT ONE, and
+		//   divides by 32 x baud -- and a ColdFire UART divides the INTERNAL
+		//   BUS clock, so the stored value is the CPU clock and the bus is
+		//   half it. (❌ Read as f_VCO instead, the whole tree halves and
+		//   FB_CLK comes out 33 MHz. The shift is the discriminator.)
+		//   So f_SYS = 264 MHz (the VR266 part's rating), bus = 132 MHz,
+		//   f_VCO = f_SYS x (OUTDIV1+1) = 528 MHz, f_REF = 528/22 = 24 MHz,
+		//   and the firmware's 12,000,000 is f_REF/(OUTDIV1+1) folded flat.
+		//   (RM Eqn. 8-4) f_FB_CLK = f_VCO / (OUTDIV3+1) = 528/8 = 66 MHz --
+		//   exactly the manual's own ceiling, "FB_CLK must also not exceed
+		//   66 MHz", which is where a designer would put it.
+		//
+		//   CSCR2 = 0x180, written at 0x40001eee between a CSMR2 disable and
+		//   re-enable, immediately before the ICR reset that starts a DSP
+		//   upload: WS = 0, AA = 1, PS = 1x = 16-bit port. A no-wait-state
+		//   FlexBus transfer is S0-S1-S2-S3 = FOUR FB_CLK cycles, and each
+		//   wait state repeats S1 once more (RM Figs 20-16 and 20-18).
+		//
+		// So one DSP word -- one 16-bit bus cycle (O8) -- costs 4 / 66 MHz =
+		// 60.6 ns = 2.673e-3 samples.
+		//
+		// ✅ THE CORROBORATION, and it is the "constants that only make sense
+		// one way" test: the frame exchange moves 2,944 words per frame
+		// (2,176 out + 768 back, measured), which at this rate is 178.4 us
+		// against the 362.8 us frame period -- **49% bus occupancy**, half a
+		// frame for the audio exchange and half for everything else. The BOOT
+		// programs CSCR2 = 0x1180 (WS = 4, EIGHT clocks a word); at that rate
+		// the same exchange is 356.8 us = 98% of the frame and cannot work.
+		// That is why the firmware reprograms the chip select before it ever
+		// talks to a DSP, and it is why the wait states are zero on a port
+		// that had four.
+		//
+		// 🟡 What would falsify it: a PCR written elsewhere (all four sites
+		// carry this value), a CSCR2 written after the loader's (none), a
+		// crystal that is not 24 MHz, or a UART whose clock is not the bus.
+		static constexpr double g_fbClockHz = 66.0e6;
+		static constexpr double g_fbClocksPerWord = 4.0;		// S0-S1-S2-S3, WS = 0
+		static constexpr double g_fbSamplesPerWord = g_fbClocksPerWord / g_fbClockHz * g_sampleHz;
 		void advance(double _now);
 
 		uint32_t read(uint32_t _addr, uint32_t _size) const;
@@ -210,18 +259,24 @@ namespace ot
 		// now"; unset, every rule is route A's.
 		void setCompletionGate(std::function<bool(uint32_t)> _fn) { m_canComplete = std::move(_fn); }
 		uint64_t gatedWaits() const { return m_gatedWaits; }
-		// EXPERIMENT (`--dsp-drain-paced`): a host-port burst completes when
-		// the DSP has DRAINED it (the gate), not at the next 16-sample
-		// boundary. ✅ Measured 8 Sep 2026, cores live. Boundary rule: the
-		// frame handler's six serial bursts each waited for a boundary, so a
-		// frame cost 80-96 samples instead of 16 and the ESAI ring made 5-6
-		// passes per frame -- invisible to every frame-counting gate. Drain
-		// rule: the one frame it ran was EXACTLY 16 ESAI frames, and then the
-		// completion ISR lost an edge and the port stalled at frame 2 (route
-		// A's "at once" symptom, now with the cores). Neither is the chip:
-		// a burst takes the FlexBus's time per 16-bit cycle x its words, and
-		// that constant is the next thing to derive (the CS wait states).
+		// ⚠️ THREE RULES WERE TRIED FOR A HOST-PORT BURST'S COMPLETION, and
+		// only the third is the chip's (all measured 8 Sep 2026, cores live):
+		//   * route A's NEXT 16-SAMPLE BOUNDARY. The frame handler issues six
+		//     bursts in series, so each waited a boundary and a frame cost
+		//     80-96 samples instead of 16 -- the ESAI ring made 5-6 passes per
+		//     host frame, and no frame-COUNTING gate could see it (ticks are
+		//     derived from frames). Right without the cores, where nothing
+		//     else can pace the pipeline; wrong with them.
+		//   * DRAINED (`--dsp-drain-paced`, kept for A/B). The one frame it
+		//     ran was exactly 16 ESAI frames, and then the completion ISR lost
+		//     an edge and the port stalled at frame 2 -- route A's own "at
+		//     once" symptom, reproduced with the cores.
+		//   * THE BUS'S OWN TIME: kick + words x g_fbSamplesPerWord, still
+		//     held behind the drain gate, so a burst takes max(bus, DSP).
+		//     That is what `installHostPortMover` selects, and it is the
+		//     default whenever the cores are attached.
 		void setDrainPaced(bool _on) { m_drainPaced = _on; }
+		void setBusPaced(bool _on) { m_busPaced = _on; }
 		// CITER/BITER carry a minor-loop link in bit 15 with the channel in
 		// bits 14-9 and the count in bits 8-0; without it the count is 15 bits.
 		uint32_t minorLoops(uint32_t _ch) const
@@ -245,7 +300,8 @@ namespace ot
 		std::array<bool, 16> m_irq = {};
 		std::unordered_map<uint32_t, double> m_due;		// channel -> sample it completes at
 		double m_boundary = g_framePeriod;
-		bool m_drainPaced = false;
+		double m_now = 0.0;
+		bool m_drainPaced = false, m_busPaced = false;
 		uint64_t m_started = 0;
 		std::function<void(uint32_t, bool)> m_onTransfer;
 		std::function<void(uint32_t)> m_onKick, m_onDone;

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -275,7 +275,7 @@ namespace ot
 				++m_hostBlocksOut;
 				m_hostWordsOut += hw.size();
 				m_hostNonZeroOut += nz;
-				m_pendingOut[_ch & 15] = {saddr, hw, nz};
+				m_pendingOut[_ch & 15] = {saddr, hw, nz, m_sample};
 			},
 			[this, co](const uint32_t _ch)
 			{
@@ -297,7 +297,12 @@ namespace ot
 						// the port sent reached DSP memory.
 						const auto ddr = co->peekWord(core, 'R', 0);	// 'R' = DMA0's DDR, see DspPair
 						char t[160];
-						std::string tail = " landed@";
+						std::string tail;
+						// The burst's own timeline in SAMPLES: kicked, and the
+						// completion the drain gate released -- the frame
+						// period is read off consecutive frames' stamps.
+						std::snprintf(t, sizeof t, " kicked@%.1f done@%.1f landed@", p.kicked, m_sample);
+						tail += t;
 						std::snprintf(t, sizeof t, "%04x:", ddr >= 8 ? ddr - 8 : 0);
 						tail += t;
 						for(uint32_t k = 0; k < 8 && ddr >= 8; ++k)
@@ -323,7 +328,9 @@ namespace ot
 				++m_hostBlocksIn;
 				m_hostWordsIn += hw.size();
 				m_hostNonZeroIn += nz;
-				noteBlock('<', _ch, daddr, hw, nz, co->blockNote(m_kickSel[_ch & 15]));
+				char at[48];
+				std::snprintf(at, sizeof at, " at@%.1f", m_sample);
+				noteBlock('<', _ch, daddr, hw, nz, co->blockNote(m_kickSel[_ch & 15]) + at);
 			});
 		m_edma.setCompletionGate([this, co](const uint32_t _ch)
 		{

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -332,6 +332,8 @@ namespace ot
 				std::snprintf(at, sizeof at, " at@%.1f", m_sample);
 				noteBlock('<', _ch, daddr, hw, nz, co->blockNote(m_kickSel[_ch & 15]) + at);
 			});
+		// With the cores attached the bus's own time paces a burst (periph.h).
+		m_edma.setBusPaced(true);
 		m_edma.setCompletionGate([this, co](const uint32_t _ch)
 		{
 			const auto daddr = m_edma.tcdField(_ch, 0x10, 4);
@@ -373,6 +375,7 @@ namespace ot
 		// its paced completions are the DSP's clock, not the interrupt's, and
 		// the TCD state is real in every run.
 		m_edma.setBoundary(m_nextFrame);
+		m_edma.setNow(m_sample);
 		m_edma.advance(m_sample);
 		if(m_ataIrqDue != 0.0 && m_sample >= m_ataIrqDue)
 		{

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -336,6 +336,7 @@ namespace ot
 		// it" -- these are counted at the moment of the move.
 		uint64_t hostNonZeroOut() const { return m_hostNonZeroOut; }
 		uint64_t hostNonZeroIn() const { return m_hostNonZeroIn; }
+		void setDspDrainPacing(bool _on) { m_edma.setDrainPaced(_on); }
 		void setBlockLog(bool _on) { m_blockLogOn = _on; }
 		const std::vector<std::string>& blockLog() const { return m_blockLog; }
 		uint64_t ataInterrupts() const { return m_ataInterrupts; }

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -336,7 +336,7 @@ namespace ot
 		// it" -- these are counted at the moment of the move.
 		uint64_t hostNonZeroOut() const { return m_hostNonZeroOut; }
 		uint64_t hostNonZeroIn() const { return m_hostNonZeroIn; }
-		void setDspDrainPacing(bool _on) { m_edma.setDrainPaced(_on); }
+		void setDspDrainPacing(bool _on) { m_edma.setDrainPaced(_on); m_edma.setBusPaced(!_on); }
 		void setBlockLog(bool _on) { m_blockLogOn = _on; }
 		const std::vector<std::string>& blockLog() const { return m_blockLog; }
 		uint64_t ataInterrupts() const { return m_ataInterrupts; }

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -411,7 +411,7 @@ namespace ot
 		std::array<int, 16> m_kickSel = {};		// which core each channel was kicked against
 		uint64_t m_hostBlocksOut = 0, m_hostBlocksIn = 0, m_hostWordsOut = 0, m_hostWordsIn = 0, m_hostWordsShort = 0;
 		uint64_t m_hostNonZeroOut = 0, m_hostNonZeroIn = 0;
-		struct PendingOut { uint32_t saddr = 0; std::vector<uint16_t> hw; uint64_t nonZero = 0; };
+		struct PendingOut { uint32_t saddr = 0; std::vector<uint16_t> hw; uint64_t nonZero = 0; double kicked = 0.0; };
 		std::array<PendingOut, 16> m_pendingOut;
 		bool m_blockLogOn = false;
 		std::vector<std::string> m_blockLog;


### PR DESCRIPTION
Two milestones on one branch: **O8a** (the ESAI rate, the falsifier the O8 record left open) and **O8b** (the host-port burst time, which the falsifier exposed).

## O8a — the ESAI rate

- **The port's ESAI ran eight times slow.** The vendored clock's "cycles per sample" is per SLOT (`Esai::execTX` advances one slot per call); `DspPair` passed the per-sample count through against the payload's eight slots. That, not any rate, is why bank B was never taken. One slot per `ips / 8` now.
- **The rate is the firmware's own arithmetic: 4160 instructions per sample**, not 4535. Payload A routes EXTAL into both ESAI chains (Port H `0xaa0000`) at ÷512 and nobody writes PCTL, so the core runs the DSP56720's reset PLL (EXTAL × 8.125). `CHIP.md` and `PLAN.md` carry it beside the datasheet's 200 MIPS figure, marked inferred with its falsifiers.
- **A ninth vendored-emulator defect**, found by the falsifier: `dualModeIncrement` never reloaded DCOL/DCOH at the block end, so the ESAI-in ring walked its destination through all of memory and wrote a silent sample into the ESAI's own TCR, killing the transmitter. The arithmetic predicts the moment it died. Live in every earlier O8 run.

## O8b — the host-port burst time

The frame was 80–96 samples because route A's rule rounded each of six serial bursts up to the next 16-sample boundary. A burst now completes at **kick + words × 2.673e-3 samples**, behind the drain gate.

The number is read off the image, not fitted: `CSCR2 = 0x180` (WS = 0, 16-bit) written by the DSP loader over the boot's `0x1180` (WS = 4), and `PCR = 0x16777731` giving **FB_CLK = 66 MHz**; a no-wait-state FlexBus transfer is four clocks. **The corroboration**: the exchange fills 49% of the frame at WS = 0 and 98% at the boot's WS = 4 — which is why the loader reprograms the chip select before it ever speaks to a DSP.

`CHIP.md` gains the measured ColdFire clock tree: crystal 24 MHz, VCO 528, **CPU 264, internal bus 132, FlexBus 66**. The discriminator is the UART baud setup shifting the stored 264,000,000 right one before dividing.

## Gates

| | before | after |
|---|---|---|
| ESAI frames per host frame | 160–194, 16 on **0** of 399 | 16–17, 16 on **382** of 399 |
| blocks landing in bank B | **0** of 2,400 | 850 of 2,400 |
| O6 with the cores / M6a / ctest | — | **5/5**, **8/8**, **7/7** |

`make check` green; the no-cores O6 gate unchanged at 5/5.

## Two things handed on, not fixed

- ⚠️ **Route A's PIT clock is the CPU clock where the hardware uses the bus clock**, so the modelled RTOS tick is 5 ms where the unit's is ~10 ms. Both emulators share the knob and the gates compare order, so no diff can see it — but every wall-clock figure in these records is a factor of two out if it holds. Deliberately not acted on: it is an interpretation claim that moves every recorded timing number.
- 🟡 A **0.27% residual phase walk** (17 host frames of 399 read 17). The idle fast-forward, the frame clock and the ESAI rate are each ruled out by measurement; the candidate is the read-back pull running a core outside the sample budget. Handed to O9, where an audio path would resample by exactly that error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)