### PR TITLE
O9: the ESAI path -- audio in proven, the 0.27% clock walk closed, audio out silent because no track ever starts (route A agrees)

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -1491,6 +1491,163 @@ the M6a oracle diff without `--dsp` 8 compared fields agree. The models are
 seeded from the same 8,235 boot writes as before — a write the co-processor
 owns is not replayed into them.
 
+## Milestone O9 — the audio path: input proven, output silent, the clock walk closed (8 Sep 2026, branch `coldfire-o9`)
+
+O9 was "the ESAI path, untraced". It is traced now, in both directions, with
+instruments that stay in the tree; half of it works and the other half stops
+at a place that is not the port's.
+
+### The instruments
+
+| flag | what |
+|---|---|
+| `--audio-out PREFIX` | every X-side ESAI TX0 frame a core puts out, eight slots, to `PREFIX_core<k>.wav` (24-bit, 44.1 kHz), with the transport start's frame index in the report |
+| `--audio-in FILE.wav` / `--audio-in tones` | RX0's slots from the transport start on: the file's channels onto slots 0..n−1, or slot k = a sine at 500·(k+1) Hz, −20 dBFS |
+| `--dsp-map FILE` | at every frame command, the count of non-zero words per 4K chunk of both cores' X and Y — where anything LIVES |
+| `--dsp-writes FILE` | at every frame command, the count of NON-ZERO WRITES per 256-word region of both cores' X and Y since the last one — where anything PASSES THROUGH. Needs the tenth vendored patch: a write hook in `Memory::dspWrite` (one branch per write, unset by default) |
+| report lines | `audio (O9)`: transport start frame, TX0/RX0 non-zero per slot, the DSP's own instruction counter and its surplus over interpreter calls; `shared window ... non-zero words now`; `non-zero writes into the ESAI-out ring` with the first one's address and value |
+| `stage_card.py --audio SRC:CARDPATH` | a sample on the card (route A's own `--stage-audio`, exposed) |
+
+⚠️ Two instrument corrections found on the way: `--dsp-peek` (and the map)
+read the shared window through `Memory::get`, which answers 0 for any offset
+past the core's own size BEFORE it looks at the window — so a peek at 0x30000+
+was blind and read as "empty"; it reads the pair's array now. And the first
+activity maps were taken at the frame command, where the window is always
+zero (below) — a snapshot instrument cannot see a buffer that is consumed
+inside the frame; the write map can.
+
+### ✅ The clock walk of O8b is closed: `rep` iterations
+
+O8b left 17 host frames of 399 taking 17 ESAI frames, a 0.27 % drift "always
+one way". The cause was the budget's unit: `runDue` counted ONE per
+interpreter call, while the ESAI clock reads the DSP's own instruction
+counter, which a `rep` advances once per ITERATION (`DSP::rep_exec`). The
+payload's `rep`s put the DSP's audio clock ahead of the ColdFire's sample
+clock by the iteration surplus. The budget now spends the DSP's own counter
+delta per call (idle steps included), and the report prints the surplus:
+
+| | before | after |
+|---|---|---|
+| ESAI frames per host frame, exactly 16 | 382 of 399 | **399 of 399**, and **1599 of 1599** |
+| surplus over interpreter calls, 400 frames | — | 83,398 = 208 per frame = 0.31 % of 66,560 |
+
+The candidate O8b named (the read-back pull running outside the budget) was
+wrong: the pull's instructions were already counted. ✅ Measured; the number
+that only makes sense one way is the surplus per frame matching the drift.
+
+### ✅ Audio IN works, end to end
+
+With `--audio-in tones`, over 400 frames (the RIG fixture, T1 THRU trigged at
+frame 344 by the poke):
+
+- the ESAI-in ring X:0x8100–0x833f holds the sines (`--dsp-peek 0:X:8100`),
+  DMA3 writing ~128 non-zero words per frame (the write map's `0X08200/0X08300`);
+- core 0 copies 64 input words into the shared window each frame (`0X30000`
+  non-zero writes 72 with tones, 8 without) and core 1 takes them (its
+  `1Y00200` 66 vs 1); the frame command sees the window at zero every time,
+  so the traffic is transient — written and consumed inside the frame;
+- **the ColdFire gets the inputs back**: eDMA channel 7's 128-word block per
+  frame (a ring of buffers `0x80005460..0x80005e60`, page-stepped) reads
+  126–128 non-zero words = 8 slots × 16 samples, **50,298 words over 400
+  frames against 9 without tones**. That is the input-capture staging Bryan
+  inferred from count and shape (`EXTERNAL.md` §8) — measured by content now
+  for channel 7; channel 6's fixed block at `0x80005e60` stayed zero and is
+  still 🟡.
+
+So O8's "the DSP computes silence" on the inbound direction was the absence of
+input, not a defect: feed the ESAI and the read-back carries it.
+
+### The frame's audio topology, measured from the block log
+
+Per host frame, from the log's directions, sizes and addresses (✅), with
+what each block carries (🟡 unless said):
+
+| direction | eDMA ch | words | ColdFire side | carries |
+|---|---|---|---|---|
+| → DSP | 0 | 672 | `0x800021d0`/`0x80002c50` (A), `0x80001c90`/`0x80002710` (B), ping | 8 × 84-word track records (`DSP.md`); ~14 non-zero |
+| → DSP | 0 | 64 | `0x80005460 + n·0x80`, rotating | a slot record (`DSP.md`); ~11 non-zero |
+| → DSP | 0 | 128 | `0x80000110`/`0x80000310` (B), `0x80000210`/`0x80000410` (A) | per-voice records; ~30 non-zero |
+| → DSP, **core 0 only** | 0 | 512 | `0x80003190`/`0x80003590`, ping | ✅ the two cores' 256-word read-backs of the previous ping, forwarded; **zero in every run** |
+| ← DSP, each core | 1 | 256 | core 1 → `0x80003190`/`0x80003590`, core 0 → `0x80003390`/`0x80003790` | 🟡 the core's track output mix; **zero in every run** |
+| ← DSP, core 0 | 6 | 128 | `0x80005e60`, fixed | unknown; zero |
+| ← DSP, core 0 | 7 | 128 | `0x80005460..0x80005e60` ring | ✅ the eight input slots × 16 samples |
+
+❌ `DSP.md`'s table has `0x80003190` as "read-back (DSP → CPU), 256 words":
+the address is right, the direction is half the story — core 1's read-back
+lands there and the ColdFire then sends 512 words FROM it to core 0. The
+reading that fits (🟡): core 0 owns the ESAI, so tracks 1–4's mix goes core 1
+→ ColdFire → core 0 to be summed into the output ring.
+
+### ❌ Audio OUT is silent, and the place it stops is not the port's
+
+TX0 is zero on all eight slots in every run, and the write hook says why in
+the narrowest possible terms: **core 0 never writes a non-zero word into the
+ESAI-out ring X:0x8000–0x80ff** during the run (186 writes at boot, the
+payload's init; none after). Tried, all silent, all with the sequencer
+running and the poked trig firing at frame 344:
+
+| fixture | what it would have shown |
+|---|---|
+| the RIG as staged (T1 THRU, master track on), tones in | a THRU track passing the inputs, tracks 1–4 → core 1 → ColdFire → core 0 |
+| the same, `MASTER_TRACK=0` | the master track was the gate |
+| T5 THRU with a trig in A01 step 2, tones in, master on and off | a THRU on the ESAI core itself, no inter-core hop |
+| T1 FLEX on slot 1 with `KICK.WAV` staged (`stage_card.py --audio`), `TSMODE=0` | the ColdFire rendering a sample into the 512-word block |
+
+What the instruments say about where it stops:
+
+- the sample IS loaded: the card log shows 47 READ commands covering all 176
+  sectors of `KICK.WAV` during the load, and the load does more work (forces
+  6,488 vs 6,424) — but the 512-word outbound block and both 256-word
+  read-backs stay zero before and after the trig;
+- the trig reaches the DSP as ONE changed word in core 1's 128-word voice
+  block (30 → 31 non-zero) and nothing follows on core 1 — no region of
+  track size is written after frame 344 (`--dsp-writes`, frames 343/346/351/399
+  compared) and core 1 never writes the shared window;
+- the T5 file trig (A01, TRAC mask 0, step 2 — set after finding `pattern-trig`'s
+  pattern index is 0-based, so the first attempt landed in A02) does not fire
+  at all: the live-nibble log shows only the poked T1 trig. Whether file trigs
+  fire under the emulators is untested beyond this (🟡);
+- **route A does the same on the same card** (the O6 oracle on the KICK card:
+  the same seven live-nibble writes, nothing at `0x80004f1c`), so this is not a
+  port/oracle disagreement — it is a path neither emulator drives: the
+  sequencer's trig never becomes a DSP voice. `FW_TRIG_WORDS` (`0x46104d26`)
+  is zero in every plain-trig run, as it has been since M5 (`RTOS_FORK.md`
+  §10.14's control shows the recorder masks reaching it).
+
+Reading the dispatcher's output stage (P:0x1cb–0x203: per output channel,
+16 squared samples, a peak, a one-pole envelope and a gain that ramps toward
+0 or 0x80 on a threshold compare) says the ring is written by a
+limiter-shaped stage — but that is reading, and the write hook says the
+stage's input is zero, so nothing about it has been measured. Do not start
+there.
+
+**Gate for the remaining half (O9b), not passing:** a THRU track trigged
+with `--audio-in tones` puts the tones on TX0 (the WAV carries them, the
+ring's non-zero write count is non-zero). It waits on the trig → voice path
+on the ColdFire, which is oracle-side work (route A first, `RTOS_FORK.md`
+§10), not the port's.
+
+### What the port can do NOW that it could not before
+
+The recorder records the INPUTS, and the inputs now carry content all the way
+into the ColdFire's capture buffers. Bryan's click question (the seam-patch
+falsification, 8 Sep) asked for exactly "content injected at the source, the
+packed pool blocks and the outbound flex stream read across the arm" — the
+port can inject it at the ESAI, which is the true source, with the recorder
+fixture (`~/octa/backups/RECTRIG_20260906_step9`). Playing the recording back
+still needs the voice path above.
+
+### Cost
+
+A 400-frame sequencer run with the cores is **~1 minute wall** (51–61 s
+measured, 1,600 frames in 56 s; the load dominates). The "~25 minutes" in the
+O8 notes is stale.
+
+### No regression
+
+`ctest` 7/7; O6 with the cores 5/5 against the stored oracle; M6a with the
+cores; `make check` — see the PR.
+
 ## What is NOT here yet
 
 - **The rest of the peripherals.** The eDMA with its completion-timing rules
@@ -1506,7 +1663,9 @@ owns is not replayed into them.
   ColdFire alternates the cores, writes `0x81`, sends a destination/count pair
   to `0x2000001c`, then DMAs — 336-word per-track records plus a 128-word and a
   64-word block per core, with one 64-word block read back.
-- **Audio out.** The ESAI path is untraced.
+- **Audio out.** ~~The ESAI path is untraced.~~ Traced in O9: input proven to
+  the ColdFire's capture buffers, output silent because no track ever starts
+  under either emulator (the trig → voice path, oracle-side).
 
 ## The oracle, made concrete (7 Sep 2026)
 

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -77,6 +77,7 @@ route A fact, not the port's problem; the golden command above already does it.
 | O8 (1-4) | the DSP cores behind the host port | ctest `dsp` (the firmware's upload lands the image's bytes) + M6a and O6 with `--dsp` | ✅ 50/50 + 58/58 bootstrap words, 26,221 + 25,408 payload words at upload time; M6a 8 compared fields; O6 5 compared fields (400 frames, 28 ticks, trig at 344) with the cores live. Step 5 open |
 | O8a | the ESAI rate | the falsifier: bank B gets taken | ✅ the port's ESAI ran 8× slow (a per-SLOT clock fed a per-sample count); the rate is the firmware's own 4160 instructions/sample; a ninth vendored DMA defect found on the way. Bank B 850 of 2,400 blocks (was 0) |
 | O8b | the host-port burst time | `ESAI frames per host frame` reads 16, O6 still 5/5 | ✅ FlexBus 66 MHz × 4 clocks/word from `PCR` and `CSCR2` in the image: 16 on 382 of 399 (was 0 of 399), O6 5/5, M6a 8/8 |
+| O9 (half) | the ESAI path | audio in: the read-back carries what the ESAI receives; the clock walk: 16 on 399/399 | ✅ tones on RX0 come back in eDMA ch 7's 128-word blocks (50,298 non-zero words / 400 frames, 9 without); ✅ O8b's 0.27 % walk was `rep` iterations counted once per call — 399/399 and 1599/1599 now. ❌ Audio OUT silent: the ring never gets a non-zero write; the trig never becomes a voice, and route A agrees — see O9b below |
 
 ## Queue
 
@@ -609,9 +610,54 @@ one way. 🟡 Candidate: the read-back pull runs a core outside the sample
 budget (`runCoreUntil`). **Hand it to O9** — an audio path resamples by
 exactly this error.
 
-### O9 — audio out *(Fable)*
+### ~~O9 — audio out~~ 🟡 HALF DONE (8 Sep 2026, branch `coldfire-o9`)
 
-The ESAI path, untraced. Not to be started unattended.
+`COLDFIRE_PORT.md` O9 has the account. Instruments: `--audio-out`,
+`--audio-in FILE|tones`, `--dsp-map`, `--dsp-writes` (a tenth vendored patch:
+a write hook), `stage_card.py --audio`, and the `audio (O9)` / ring-write
+report lines. Three things later milestones must know:
+
+1. **The DSP's budget is spent in the DSP's own instruction counter**, not
+   in interpreter calls: a `rep` advances the counter once per iteration and
+   the ESAI clock reads that counter. That was O8b's residual (0.27 % ≈ 208
+   surplus instructions per 66,560-instruction frame).
+2. **The frame's audio topology is measured** (the table in `COLDFIRE_PORT.md`
+   O9): eDMA ch 7 back = the eight input slots × 16 samples (proven by
+   content); ch 1 back = 256 words per core, 🟡 the core's track mix; the
+   512-word block the ColdFire sends core 0 each frame is the two read-backs
+   forwarded. ❌ `DSP.md`'s "0x80003190 = read-back, 256 words" is half the
+   story and is corrected there.
+3. **Nothing starts a track under either emulator.** A poked trig changes
+   one word of a voice record and nothing follows; a staged FLEX sample is
+   read in full from the card and never rendered; a file trig in A01 does not
+   fire. Route A on the same card does the same. Do not look for this in the
+   DSP: the ring's write count is the instrument, and it reads zero because
+   its input is zero.
+
+### O9b — the trig → voice path *(oracle-side first; Fable for the scoping)*
+
+**Gate:** with `--audio-in tones` and a THRU track trigged, TX0 carries the
+tones (`--audio-out` WAV non-zero on some slot; `non-zero writes into the
+ESAI-out ring` > 0). **Where to start:** route A, not the port — a note trig
+that the sequencer fires (`FW_LIVE_NIBBLE` byte `0x08`/`0x18` at frame 344)
+must reach a voice: `RTOS_FORK.md` §10.14's control reached `0x46104d26`
+through the recorder masks and the arm caller `0x40005ff0`; the note trig's
+equivalent is unlocated. Instruments that exist: `--watch-calls`,
+`--watch-mem`, the block log's per-block non-zero counts (a rendering voice
+shows as ≥ 16 non-zero words per frame in the 512-word block), and the port's
+write map for the DSP side once the ColdFire sends anything. **Falsifier for
+"the emulators cannot start a voice":** the same project on the unit plays
+(it does — it is Sam's rig), so this is a fidelity gap, not firmware
+behaviour; the question is which peripheral or flag the voice start waits on.
+
+### O10 — the recorder with real input *(after O9b or in parallel; Opus)*
+
+The inputs reach the ColdFire's capture buffers now. Bryan's click
+(`octabam-seam-patch-falsified`) wants content injected at the source and the
+pool blocks read across the arm: the RECTRIG fixture with `--audio-in tones`
+(or a WAV) and `--block-log`, reading the packed pool blocks
+(`RTOS_FORK.md` §10.16's write path `0x400068e4`). No DSP voice needed to
+RECORD; playing it back does.
 
 ## Running it overnight
 

--- a/docs/DSP.md
+++ b/docs/DSP.md
@@ -789,7 +789,8 @@ destination (`0x6000 | X address`) and the count in halfwords (two per
 | `0x800021d0` (A) / `0x80001c90` (B) + ping·`0xa80` | 336 | `X:0x080` | **four 84-word per-track records** (`0x150` bytes each) |
 | `0x80000110` / `0x80000210` + ping·`0x200` | 64 | `X:0x000` | four 16-word per-voice records |
 | `0x80005460` + slot·`0x80` | 32 | `X:0x800` | a sample-slot record, on demand |
-| `0x80003190` + ping·`0x400` | 256 | ← `X:0x400` | read-back (DSP → CPU) |
+| `0x80003190` + ping·`0x400` | 256 | ← `X:0x400` | read-back (DSP → CPU) — ❌ half the story: ✅ measured 8 Sep 2026 (`COLDFIRE_PORT.md` O9), core 1's read-back lands here and core 0's at `+0x200`, and the ColdFire then sends the 512 words FROM `0x80003190` TO core 0 every frame (eDMA ch 0); 🟡 the two cores' track mixes, forwarded to the core that owns the ESAI |
+| `0x80005460..0x80005e60`, page-stepped | 128 | ← | ✅ the eight ESAI input slots × 16 samples (eDMA ch 7; proven by content, O9) |
 
 The 336-word block is assembled by the packer at `0x4000d3fc`–`0x4000d55e`:
 for each of 8 tracks it calls the machine-type handler from the table at

--- a/tools/dsp56300.patch
+++ b/tools/dsp56300.patch
@@ -328,13 +328,16 @@ index f9f8180..714776e 100644
  	{
  		const bool	ab = getFieldValue<Maci_xxxx, Field_d>(op);
 diff --git a/source/dsp56kEmu/memory.cpp b/source/dsp56kEmu/memory.cpp
-index 98c2226..a2b1357 100644
+index 98c2226..18b660c 100644
 --- a/source/dsp56kEmu/memory.cpp
 +++ b/source/dsp56kEmu/memory.cpp
-@@ -145,6 +145,14 @@ namespace dsp56k
+@@ -145,6 +145,17 @@ namespace dsp56k
  			}
  		}
  */
++		if(m_writeHook)
++			m_writeHook(_area, _offset, _value);
++
 +		if (m_sharedX && (_area != MemArea_P || m_sharedP) && _offset >= m_sharedLo && _offset < m_sharedHi)
 +		{
 +			(_area == MemArea_X ? m_sharedX : _area == MemArea_Y ? m_sharedY : m_sharedP)[_offset - m_sharedLo] = _value & 0x00ffffff;
@@ -346,7 +349,7 @@ index 98c2226..a2b1357 100644
  		if (_offset < size(_area))		// Fix the amazing "write to wrong address" bug
  			m_mem[_area][_offset] = _value & 0x00ffffff;
  
-@@ -178,6 +186,9 @@ namespace dsp56k
+@@ -178,6 +189,9 @@ namespace dsp56k
  			return 0;
  		}
  
@@ -356,7 +359,7 @@ index 98c2226..a2b1357 100644
  		const auto res = m_mem[_area][_offset];
  
  #ifdef _DEBUG
-@@ -211,6 +222,14 @@ namespace dsp56k
+@@ -211,6 +225,14 @@ namespace dsp56k
  		}
  #endif
  
@@ -372,7 +375,7 @@ index 98c2226..a2b1357 100644
  		_wordB = p[_offset+1];
  
 diff --git a/source/dsp56kEmu/memory.h b/source/dsp56kEmu/memory.h
-index 567d068..3a18046 100644
+index 567d068..8ea2123 100644
 --- a/source/dsp56kEmu/memory.h
 +++ b/source/dsp56kEmu/memory.h
 @@ -1,5 +1,7 @@
@@ -383,7 +386,7 @@ index 567d068..3a18046 100644
  #include <map>
  #include <set>
  #include <vector>
-@@ -63,6 +65,23 @@ namespace dsp56k
+@@ -63,6 +65,26 @@ namespace dsp56k
  		TWord*												p;
  
  		TWord												m_bridgedMemoryAddress;
@@ -404,10 +407,13 @@ index 567d068..3a18046 100644
 +		// opcode both cores hold for it.
 +		TWord*												m_sharedP = nullptr;
 +		std::function<void(TWord)>							m_sharedWriteHook;
++		// octabam: every data write (P, X, Y), after address translation, for
++		// an activity instrument -- one branch per write when unset.
++		std::function<void(EMemArea, TWord, TWord)>			m_writeHook;
  		
  		struct STransaction
  		{
-@@ -124,6 +143,19 @@ namespace dsp56k
+@@ -124,6 +146,20 @@ namespace dsp56k
  
  		const TWord&		getBridgedMemoryAddress() const { return m_bridgedMemoryAddress; }
  
@@ -417,6 +423,7 @@ index 567d068..3a18046 100644
 +		{
 +			m_sharedLo = _lo; m_sharedHi = _hi; m_sharedX = _x; m_sharedY = _y; m_sharedP = nullptr;
 +		}
++		void				setWriteHook		(std::function<void(EMemArea, TWord, TWord)> _hook) { m_writeHook = std::move(_hook); }
 +		// octabam: P, X and Y of [_lo,_hi) all alias _all (see m_sharedP).
 +		void				setSharedWindow		(TWord _lo, TWord _hi, TWord* _all, std::function<void(TWord)> _onWrite)
 +		{

--- a/tools/ot_emu/dsp.cpp
+++ b/tools/ot_emu/dsp.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cstring>
 #include <array>
+#include <cmath>
 
 #include "dsp56kEmu/dsp.h"
 #include "dsp56kEmu/dspBootCode.h"
@@ -54,6 +55,16 @@ namespace ot
 		uint32_t lastPcLo = 0, lastPcHi = 0;	// the PC window of the last few instructions
 		int windowRun = 0;
 		uint32_t lastTx[2] = {0, 0};		// slot 0 of the last output frame, TX0/TX1
+		// O9: the audio. Frames counted from the ESAI's first, the transport
+		// start latched at the first 0x8c so a WAV can be trimmed to it.
+		std::vector<int32_t> capture;
+		bool firstCmdSeen = false;
+		uint64_t txAtFirstCmd = 0, rxAtFirstCmd = 0;
+		std::array<uint64_t, DspPair::g_audioSlots> txNZ = {}, rxNZ = {};
+		uint64_t surplus = 0, zeroDelta = 0;	// instruction-counter delta beyond one per interpreter call / calls that moved it not at all
+		std::array<std::array<uint32_t, 1024>, 2> nzWrites = {};	// [X/Y][region of 256 words]: non-zero writes since the last flush
+		uint64_t ringNzWrites = 0, ringFirstAt = 0;	// non-zero writes into the ESAI-out ring X:0x8000-0x80ff
+		uint32_t ringFirstAddr = 0, ringFirstVal = 0;
 		// The host-side registers this model keeps itself; the rest are
 		// derived from the vendored HDI08 on every read.
 		uint8_t icr = 0, cvr = 0x32, ivr = 0x0f, txh = 0, txm = 0;
@@ -105,6 +116,21 @@ namespace ot
 			{
 				for(auto& k : m_cores)
 					k->dsp->clearOpcodeCache(_a);
+			});
+			c.mem->setWriteHook([this, &c](const dsp56k::EMemArea _area, const dsp56k::TWord _off, const dsp56k::TWord _val)
+			{
+				if(!m_writesOn || _area == dsp56k::MemArea_P || !(_val & 0xffffff) || _off >= 0x40000)
+					return;
+				++c.nzWrites[_area == dsp56k::MemArea_Y ? 1 : 0][_off >> 8];
+				if(_area == dsp56k::MemArea_X && _off >= 0x8000 && _off < 0x8100)
+				{
+					if(!c.ringNzWrites++)
+					{
+						c.ringFirstAt = c.executed;
+						c.ringFirstAddr = _off;
+						c.ringFirstVal = _val & 0xffffff;
+					}
+				}
 			});
 			// AFTER the DSP: its constructor resets the peripherals, and the
 			// boot ROM's first act is to enable the host port (HPCR.HEN).
@@ -163,21 +189,47 @@ namespace ot
 			// 128, the dispatcher's DSR2 == 0x80f0 bank never came, and every
 			// block landed in bank A (COLDFIRE_PORT.md O8, "the bank is the
 			// audio ring's phase"). One slot per `_ips / 8`: 520 at 4160.
-			auto silence = [&c](uint64_t&, dsp56k::Audio::RxFrame& _f)
+			// O9: RX0 carries the input (a file or the tones) from the
+			// transport start on, silence before it and on every other slot
+			// register; TX0's eight slots are counted per slot and kept.
+			auto silence = [this, &c](uint64_t&, dsp56k::Audio::RxFrame& _f)
 			{
 				for(uint32_t i = 0; i < dsp56k::Audio::MaxSlotsPerFrame; ++i)
 					for(auto& w : _f[i])
 						w = 0;
 				_f.resize(dsp56k::Audio::MaxSlotsPerFrame);
+				if(c.firstCmdSeen && (m_tones || m_inputChannels))
+				{
+					const uint64_t n = c.rxFrames - c.rxAtFirstCmd;
+					for(uint32_t s = 0; s < g_audioSlots; ++s)
+					{
+						int32_t v = 0;
+						if(m_tones)
+							v = static_cast<int32_t>(std::lrint(0.1 * 8388607.0 * std::sin(2.0 * M_PI * 500.0 * (s + 1) * static_cast<double>(n) / 44100.0)));
+						else if(s < m_inputChannels && (n + 1) * m_inputChannels <= m_input.size())
+							v = m_input[n * m_inputChannels + s];
+						if(v)
+							++c.rxNZ[s];
+						_f[s][0] = static_cast<uint32_t>(v) & 0xffffff;
+					}
+				}
 				++c.rxFrames;
 			};
-			auto sink = [&c](uint64_t&, const dsp56k::Audio::TxFrame& _f)
+			auto sink = [this, &c](uint64_t&, const dsp56k::Audio::TxFrame& _f)
 			{
 				++c.txFrames;
 				if(_f.size())
 				{
 					c.lastTx[0] = _f[0][0];
 					c.lastTx[1] = _f[0][1];
+				}
+				for(uint32_t s = 0; s < g_audioSlots; ++s)
+				{
+					const uint32_t w = s < _f.size() ? (_f[s][0] & 0xffffff) : 0;
+					if(w)
+						++c.txNZ[s];
+					if(m_capture)
+						c.capture.push_back(static_cast<int32_t>(w << 8) >> 8);
 				}
 			};
 			auto silence1 = [&c](uint64_t&, dsp56k::Audio::RxFrame& _f)
@@ -287,6 +339,50 @@ namespace ot
 		c.cmdArgs[1] = c.lastSent[1];
 		c.hcPending = true;
 		++c.commands;
+		if(c.hcVector == 0x18 && m_writesOn && m_sel == 0 && m_writeMap.size() < 20000)
+		{
+			std::string line = "cmd " + std::to_string(c.commands) + " tx " + std::to_string(c.txFrames);
+			for(int k = 0; k < 2; ++k)
+				for(int space = 0; space < 2; ++space)
+					for(uint32_t r = 0; r < 1024; ++r)
+					{
+						auto& n = m_cores[k]->nzWrites[space][r];
+						if(n)
+						{
+							char f[40];
+							std::snprintf(f, sizeof f, " %d%c%05x:%u", k, space ? 'Y' : 'X', r << 8, n);
+							line += f;
+							n = 0;
+						}
+					}
+			m_writeMap.push_back(line);
+		}
+		if(c.hcVector == 0x18 && m_mapOn && m_sel == 0 && m_map.size() < 20000)
+		{
+			std::string line = "cmd " + std::to_string(c.commands) + " tx " + std::to_string(c.txFrames);
+			for(int k = 0; k < 2; ++k)
+				for(int space = 0; space < 2; ++space)
+					for(uint32_t base = 0; base < 0x40000; base += 0x1000)
+					{
+						uint32_t n = 0;
+						for(uint32_t a = base; a < base + 0x1000; ++a)
+							if((space ? peekY(k, a) : peekX(k, a)) & 0xffffff)
+								++n;
+						if(n)
+						{
+							char f[40];
+							std::snprintf(f, sizeof f, " %d%c%05x:%u", k, space ? 'Y' : 'X', base, n);
+							line += f;
+						}
+					}
+			m_map.push_back(line);
+		}
+		if(c.hcVector == 0x18 && !c.firstCmdSeen)
+		{
+			c.firstCmdSeen = true;
+			c.txAtFirstCmd = c.txFrames;
+			c.rxAtFirstCmd = c.rxFrames;
+		}
 		if(c.hcVector == 0x18 && c.txFrames)
 		{
 			// Frames per frame: count from the second 0x8c on, once the ESAI
@@ -505,9 +601,13 @@ namespace ot
 				c.why = "PC outside P memory during a read-back";
 				return false;
 			}
+			const auto before = c.dsp->getInstructionCounter();
 			c.dsp->execInterpreter();
 			c.dsp->doLoopEnd();
-			++c.executed;
+			const auto d = c.dsp->getInstructionCounter() - before;
+			c.executed += d ? d : 1;
+			if(d > 1) c.surplus += d - 1;
+			if(!d) ++c.zeroDelta;
 		}
 		return _ready();
 	}
@@ -559,6 +659,14 @@ namespace ot
 				}
 				// The idle fast-forward (dsp.h): eight instructions in a row
 				// inside a three-word window, no hardware loop open.
+				// O9: the budget counts the DSP's OWN instruction counter, the
+				// one its ESAI clock reads -- a `rep` advances it once per
+				// iteration where this loop makes ONE interpreter call, so
+				// counting calls ran the ESAI 0.27% fast against the frame
+				// clock (17 ESAI frames in a host frame, 17 of 399 -- O8b's
+				// residual). The delta is taken across the idle step too.
+				const auto before = c.dsp->getInstructionCounter();
+				uint64_t skipped = 0;
 				if(pc < c.lastPcLo || pc > c.lastPcHi)
 				{
 					c.lastPcLo = pc;
@@ -574,13 +682,15 @@ namespace ot
 					// and the uploader waiting for an echo forever (measured
 					// 8 Sep 2026: "unrecognised spin at 40001b82").
 					const auto room = static_cast<uint64_t>(m_due - static_cast<double>(c.executed));
-					const auto skipped = c.dsp->idleStep(room ? room : 1);
-					c.executed += skipped;
+					skipped = c.dsp->idleStep(room ? room : 1);
 					c.idleSkipped += skipped;
 				}
 				c.dsp->execInterpreter();
 				c.dsp->doLoopEnd();
-				++c.executed;
+				const auto d = c.dsp->getInstructionCounter() - before;
+				c.executed += d ? d : 1;
+				if(d > skipped + 1) c.surplus += d - skipped - 1;
+				if(!d) ++c.zeroDelta;
 				if(m_traceEvery && c.executed >= c.nextTrace && m_trace.size() < 100000)
 				{
 					char line[256];
@@ -612,12 +722,19 @@ namespace ot
 	{
 		return m_cores[_core & 1]->mem->get(dsp56k::MemArea_P, _addr);
 	}
+	// The shared window is read from the pair's own array: Memory::get
+	// answers 0 for any offset past the core's own size before it looks at
+	// the window, so a peek at 0x30000+ through it was blind (O9, 8 Sep).
 	uint32_t DspPair::peekX(const int _core, const uint32_t _addr) const
 	{
+		if(_addr >= g_shareLo && _addr < g_shareHi)
+			return m_shared[_addr - g_shareLo];
 		return m_cores[_core & 1]->mem->get(dsp56k::MemArea_X, _addr);
 	}
 	uint32_t DspPair::peekY(const int _core, const uint32_t _addr) const
 	{
+		if(_addr >= g_shareLo && _addr < g_shareHi)
+			return m_shared[_addr - g_shareLo];
 		return m_cores[_core & 1]->mem->get(dsp56k::MemArea_Y, _addr);
 	}
 	uint32_t DspPair::pc(const int _core) const { return m_cores[_core & 1]->dsp->getPC().toWord(); }
@@ -670,6 +787,14 @@ namespace ot
 	uint64_t DspPair::framesPerCommandSixteen(const int _core) const { return m_cores[_core & 1]->fpcSixteen; }
 	uint32_t DspPair::bootLength(const int _core) const { return m_cores[_core & 1]->boot->getLength(); }
 	uint32_t DspPair::bootAddress(const int _core) const { return m_cores[_core & 1]->boot->getInitialPC(); }
+	const std::vector<int32_t>& DspPair::audioOut(const int _core) const { return m_cores[_core & 1]->capture; }
+	void DspPair::setAudioInput(std::vector<int32_t> _interleaved, const uint32_t _channels) { m_input = std::move(_interleaved); m_inputChannels = _channels; }
+	uint64_t DspPair::txAtFirstCommand(const int _core) const { return m_cores[_core & 1]->txAtFirstCmd; }
+	uint64_t DspPair::rxAtFirstCommand(const int _core) const { return m_cores[_core & 1]->rxAtFirstCmd; }
+	uint64_t DspPair::txSlotNonZero(const int _core, const uint32_t _slot) const { return m_cores[_core & 1]->txNZ[_slot & 7]; }
+	uint64_t DspPair::rxSlotNonZero(const int _core, const uint32_t _slot) const { return m_cores[_core & 1]->rxNZ[_slot & 7]; }
+	uint64_t DspPair::counterSurplus(const int _core) const { return m_cores[_core & 1]->surplus; }
+	uint64_t DspPair::zeroDeltaCalls(const int _core) const { return m_cores[_core & 1]->zeroDelta; }
 
 	std::string DspPair::report() const
 	{
@@ -677,12 +802,13 @@ namespace ot
 		for(int i = 0; i < 2; ++i)
 		{
 			const Core& c = *m_cores[i];
-			char line[512];
+			char line[1024];
 			std::snprintf(line, sizeof line,
 				"             core %d: boot ROM %s (%u words -> P:%#07x), pc %#07x, %llu instructions, "
 				"host words in %llu / out %llu, host commands %llu%s\n"
 				"                     ESAI frames in %llu / out %llu (ESAI_1 %llu / %llu), last out slot 0 = %06x %06x; idle-skipped %llu; mailbox sent %llu; read-back words %llu (%llu not in time)\n"
-				"                     ESAI frames per host frame (0x8c to 0x8c): min %llu max %llu, exactly 16 on %llu of %llu; TCCR %06x (%u slots), %u instructions per slot\n",
+				"                     ESAI frames per host frame (0x8c to 0x8c): min %llu max %llu, exactly 16 on %llu of %llu; TCCR %06x (%u slots), %u instructions per slot\n"
+				"                     audio (O9): transport start at ESAI frame %llu out / %llu in; TX0 non-zero per slot %llu %llu %llu %llu %llu %llu %llu %llu; RX0 non-zero per slot %llu %llu %llu %llu %llu %llu %llu %llu; DSP counter %llu, surplus over interpreter calls %llu (%.3f%%), zero-delta calls %llu\n",
 				i, c.boot->finished() ? "done" : "WAITING", c.boot->getLength(), c.boot->getInitialPC(),
 				c.dsp->getPC().toWord(), static_cast<unsigned long long>(c.executed),
 				static_cast<unsigned long long>(c.wordsIn), static_cast<unsigned long long>(c.wordsOut),
@@ -696,8 +822,35 @@ namespace ot
 				static_cast<unsigned long long>(c.fpcSamples ? c.fpcMin : 0), static_cast<unsigned long long>(c.fpcMax),
 				static_cast<unsigned long long>(c.fpcSixteen), static_cast<unsigned long long>(c.fpcSamples),
 				c.px->read(0xffffb6, dsp56k::Nop), ((c.px->read(0xffffb6, dsp56k::Nop) >> 9) & 0x1f) + 1,
-				c.esaiCyclesPerSlot);
+				c.esaiCyclesPerSlot,
+				static_cast<unsigned long long>(c.txAtFirstCmd), static_cast<unsigned long long>(c.rxAtFirstCmd),
+				static_cast<unsigned long long>(c.txNZ[0]), static_cast<unsigned long long>(c.txNZ[1]), static_cast<unsigned long long>(c.txNZ[2]), static_cast<unsigned long long>(c.txNZ[3]),
+				static_cast<unsigned long long>(c.txNZ[4]), static_cast<unsigned long long>(c.txNZ[5]), static_cast<unsigned long long>(c.txNZ[6]), static_cast<unsigned long long>(c.txNZ[7]),
+				static_cast<unsigned long long>(c.rxNZ[0]), static_cast<unsigned long long>(c.rxNZ[1]), static_cast<unsigned long long>(c.rxNZ[2]), static_cast<unsigned long long>(c.rxNZ[3]),
+				static_cast<unsigned long long>(c.rxNZ[4]), static_cast<unsigned long long>(c.rxNZ[5]), static_cast<unsigned long long>(c.rxNZ[6]), static_cast<unsigned long long>(c.rxNZ[7]),
+				static_cast<unsigned long long>(c.dsp->getInstructionCounter()), static_cast<unsigned long long>(c.surplus),
+				c.executed ? 100.0 * static_cast<double>(c.surplus) / static_cast<double>(c.executed) : 0.0,
+				static_cast<unsigned long long>(c.zeroDelta));
 			s += line;
+			if(i == 0)
+			{
+				uint64_t nz = 0;
+				for(const auto w : m_shared) if(w & 0xffffff) ++nz;
+				s += "                     shared window (P/X/Y 0x30000-0x3ffff, one memory): " + std::to_string(nz) + " non-zero words now\n";
+			}
+			if(m_writesOn)
+			{
+				char w[200];
+				std::snprintf(w, sizeof w, "                     non-zero writes into the ESAI-out ring X:0x8000-0x80ff: %llu%s\n",
+					static_cast<unsigned long long>(c.ringNzWrites), c.ringNzWrites ? "" : " (NEVER)");
+				s += w;
+				if(c.ringNzWrites)
+				{
+					std::snprintf(w, sizeof w, "                     first at executed %llu: X:%#06x <- %06x\n",
+						static_cast<unsigned long long>(c.ringFirstAt), c.ringFirstAddr, c.ringFirstVal);
+					s += w;
+				}
+			}
 			if(c.faulted)
 			{
 				s += "                     FAULT: " + c.why + "; last PCs:";

--- a/tools/ot_emu/dsp.h
+++ b/tools/ot_emu/dsp.h
@@ -143,6 +143,44 @@ namespace ot
 		uint64_t mailboxWords(int _from) const;
 		const std::vector<std::string>& trace() const { return m_trace; }
 
+		// -- audio (O9) -------------------------------------------------------
+		// The X-side ESAI's eight slots, TX0 out and RX0 in: the only audio
+		// port either payload sets up (payload A, P:0x30024, DMA2 out of the
+		// X:0x8000 ring and DMA3 into X:0x8100; payload B configures none, and
+		// core 1 reports 0 ESAI frames). ESAI_1 is configured alongside but
+		// no DMA feeds it. Which physical input or output each slot is has
+		// NOT been measured -- see docs/COLDFIRE_PORT.md O9.
+		static constexpr uint32_t g_audioSlots = 8;
+		// Keep every transmitted frame (8 words, slot order) for a WAV.
+		void setAudioCapture(const bool _on) { m_capture = _on; }
+		const std::vector<int32_t>& audioOut(int _core) const;
+		// Feed RX0 from the transport start (the first 0x8c) on: `_channels`
+		// interleaved channels onto slots 0..channels-1, silence past the end
+		// -- or the built-in tones (slot k = a sine at 500 x (k+1) Hz, -20 dBFS).
+		void setAudioInput(std::vector<int32_t> _interleaved, uint32_t _channels);
+		void setAudioTones(const bool _on) { m_tones = _on; }
+		uint64_t txAtFirstCommand(int _core) const;
+		uint64_t rxAtFirstCommand(int _core) const;
+		uint64_t txSlotNonZero(int _core, uint32_t _slot) const;
+		uint64_t rxSlotNonZero(int _core, uint32_t _slot) const;
+		// The DSP's own instruction counter (which clocks its ESAI) minus the
+		// interpreter calls the budget used to count -- `rep` iterations, mostly.
+		uint64_t counterSurplus(int _core) const;
+		uint64_t zeroDeltaCalls(int _core) const;
+		// The activity map: at every frame command (0x8c) on core 0, the count
+		// of non-zero words in each 4K chunk of X and Y of BOTH cores (the
+		// shared window included) -- one line per command. Where audio (or
+		// anything) lives on the DSP, frame by frame, without knowing where
+		// to look first.
+		void setActivityMap(const bool _on) { m_mapOn = _on; }
+		const std::vector<std::string>& activityMap() const { return m_map; }
+		// The write map: every NON-ZERO data write either core makes, binned
+		// by 256-word region of X and Y, flushed as one line per frame
+		// command. A region written with content is where audio (or state)
+		// passes through, whatever the buffer is called.
+		void setWriteMap(const bool _on) { m_writesOn = _on; }
+		const std::vector<std::string>& writeMap() const { return m_writeMap; }
+
 		// Run both cores up to the due count now (the ticks only book it).
 		void runDue();
 		// Run ONE core until `_ready` or `_budget` instructions (the read-back
@@ -171,6 +209,10 @@ namespace ot
 		bool m_logOn = false;
 		uint64_t m_traceEvery = 0;
 		bool m_idleSkip = true;
+		bool m_capture = false, m_tones = false, m_mapOn = false, m_writesOn = false;
+		std::vector<std::string> m_map, m_writeMap;
+		std::vector<int32_t> m_input;
+		uint32_t m_inputChannels = 0;
 		// THE INTER-CORE MAILBOX, one register each way. 🟡 Inferred from the
 		// firmware's use, not from a datasheet: core A writes Y:$FFFFD7 and
 		// waits while bit 1 of Y:$FFFFD6 is set; core B waits for bit 1 of

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -25,6 +25,7 @@
 #include "machine.h"
 #include "rtos.h"
 #include "dsp.h"
+#include "wav.h"
 
 namespace
 {
@@ -82,6 +83,10 @@ int main(int _argc, char** _argv)
 	std::string edmaLog;		// every eDMA kick with its TCD fields -> FILE (O8 step 4)
 	std::string dspPeek;		// core:space:addr,len[;...] -- DSP memory to print at the end
 	std::string blockLog;		// every host-port BLOCK with its non-zero count -> FILE
+	std::string audioOut;		// O9: PREFIX -> PREFIX_core<k>.wav, every X-side ESAI TX0 frame (8 slots) the core put out
+	std::string audioIn;		// O9: a WAV onto RX0's slots from the transport start, or "tones"
+	std::string dspMap;		// O9: per-frame non-zero counts per 4K chunk of both cores' X and Y -> FILE
+	std::string dspWrites;		// O9: per-frame NON-ZERO WRITE counts per 256-word region of both cores' X and Y -> FILE
 
 	for(int i = 1; i < _argc; ++i)
 	{
@@ -127,6 +132,10 @@ int main(int _argc, char** _argv)
 		else if(a == "--edma-log" && i + 1 < _argc)	edmaLog = _argv[++i];
 		else if(a == "--dsp-peek" && i + 1 < _argc)	dspPeek = _argv[++i];
 		else if(a == "--block-log" && i + 1 < _argc)	blockLog = _argv[++i];
+		else if(a == "--audio-out" && i + 1 < _argc)	audioOut = _argv[++i];
+		else if(a == "--audio-in" && i + 1 < _argc)	audioIn = _argv[++i];
+		else if(a == "--dsp-map" && i + 1 < _argc)	dspMap = _argv[++i];
+		else if(a == "--dsp-writes" && i + 1 < _argc)	dspWrites = _argv[++i];
 		else
 		{
 			std::printf("usage: ot_emu [--image FILE] [--max N] [--periph] [--profile]\n"
@@ -180,6 +189,24 @@ int main(int _argc, char** _argv)
 		dspPair->setTrace(dspTrace);
 		dspPair->setIdleSkip(!dspNoIdle);
 		ot::DspPair::setVerbose(dspVerbose);
+		dspPair->setAudioCapture(!audioOut.empty());
+		dspPair->setActivityMap(!dspMap.empty());
+		dspPair->setWriteMap(!dspWrites.empty());
+		if(audioIn == "tones")
+			dspPair->setAudioTones(true);
+		else if(!audioIn.empty())
+		{
+			std::vector<int32_t> pcm;
+			uint32_t ch = 0, rate = 0;
+			if(!ot::readWavPcm(audioIn, pcm, ch, rate))
+			{
+				std::printf("audio in   : %s is not a 16/24-bit PCM WAV\n", audioIn.c_str());
+				return 1;
+			}
+			std::printf("audio in   : %s, %u channel(s) onto RX0 slots 0..%u, %zu frames at %u Hz (fed at 44100)\n",
+				audioIn.c_str(), ch, ch - 1, pcm.size() / ch, rate);
+			dspPair->setAudioInput(std::move(pcm), ch);
+		}
 		m.setCoprocessor(dspPair.get());
 		std::printf("dsp        : two cores behind the host port, %.2f instructions per ColdFire instruction, %.0f per sample\n",
 			dspRatio, dspIps);
@@ -609,6 +636,34 @@ int main(int _argc, char** _argv)
 	if(dspPair)
 	{
 		std::printf("dsp        : at the end\n%s", dspPair->report().c_str());
+		if(!dspWrites.empty())
+		{
+			std::ofstream t(dspWrites);
+			for(const auto& l : dspPair->writeMap())
+				t << l << '\n';
+			std::printf("dsp writes : %s (%zu frame commands)\n", dspWrites.c_str(), dspPair->writeMap().size());
+		}
+		if(!dspMap.empty())
+		{
+			std::ofstream t(dspMap);
+			for(const auto& l : dspPair->activityMap())
+				t << l << '\n';
+			std::printf("dsp map    : %s (%zu frame commands)\n", dspMap.c_str(), dspPair->activityMap().size());
+		}
+		if(!audioOut.empty())
+		{
+			for(int core = 0; core < 2; ++core)
+			{
+				const auto& pcm = dspPair->audioOut(core);
+				if(pcm.empty())
+					continue;
+				const auto path = audioOut + "_core" + std::to_string(core) + ".wav";
+				const bool ok = ot::writeWav24(path, pcm, ot::DspPair::g_audioSlots);
+				std::printf("audio out  : %s%s, %zu frames x 8 slots (24-bit, 44100 Hz), transport start at frame %llu\n",
+					path.c_str(), ok ? "" : " COULD NOT BE WRITTEN", pcm.size() / ot::DspPair::g_audioSlots,
+					static_cast<unsigned long long>(dspPair->txAtFirstCommand(core)));
+			}
+		}
 		size_t q = 0;
 		while(q < dspPeek.size())
 		{

--- a/tools/ot_emu/stage_card.py
+++ b/tools/ot_emu/stage_card.py
@@ -32,9 +32,13 @@ def main():
                          "run concurrent with route A's needs its own")
     ap.add_argument("--image-mb", type=int, default=64)
     ap.add_argument("--out", default="out/o6_card.img")
+    ap.add_argument("--audio", action="append", default=[],
+                    help="'<src wav>:<card path relative to the SET folder>' -- a sample to put on "
+                         "the card as well (route A stages none by default, which is why every "
+                         "sample slot is empty and the DSP has nothing to play: O9); repeatable")
     a = ap.parse_args()
     img, staged = emu_rtos.stage_project(a.project, a.set_name, a.name,
-                                         tree=a.tree, image_mb=a.image_mb)
+                                         tree=a.tree, image_mb=a.image_mb, audio=a.audio)
     pathlib.Path(a.out).parent.mkdir(parents=True, exist_ok=True)
     with open(a.out, "wb") as f:
         f.write(img)

--- a/tools/ot_emu/wav.h
+++ b/tools/ot_emu/wav.h
@@ -1,0 +1,93 @@
+// A WAV file, the minimum of it: N channels of 24-bit PCM out, 16- or 24-bit
+// PCM in. Samples are 24-bit two's complement in an int32 -- the DSP's own
+// word -- so a slot of an ESAI frame goes to disk untouched (O9).
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace ot
+{
+	inline bool writeWav24(const std::string& _path, const std::vector<int32_t>& _interleaved, const uint32_t _channels, const uint32_t _rate = 44100)
+	{
+		if(!_channels)
+			return false;
+		std::FILE* f = std::fopen(_path.c_str(), "wb");
+		if(!f)
+			return false;
+		const uint32_t frames = static_cast<uint32_t>(_interleaved.size() / _channels);
+		const uint32_t dataBytes = frames * _channels * 3;
+		auto put16 = [f](const uint32_t _v){ const uint8_t b[2] = {uint8_t(_v), uint8_t(_v >> 8)}; std::fwrite(b, 1, 2, f); };
+		auto put32 = [f](const uint32_t _v){ const uint8_t b[4] = {uint8_t(_v), uint8_t(_v >> 8), uint8_t(_v >> 16), uint8_t(_v >> 24)}; std::fwrite(b, 1, 4, f); };
+		std::fwrite("RIFF", 1, 4, f); put32(36 + dataBytes); std::fwrite("WAVE", 1, 4, f);
+		std::fwrite("fmt ", 1, 4, f); put32(16); put16(1); put16(_channels); put32(_rate);
+		put32(_rate * _channels * 3); put16(_channels * 3); put16(24);
+		std::fwrite("data", 1, 4, f); put32(dataBytes);
+		std::vector<uint8_t> buf;
+		buf.reserve(dataBytes);
+		for(uint32_t i = 0; i < frames * _channels; ++i)
+		{
+			const uint32_t v = static_cast<uint32_t>(_interleaved[i]) & 0xffffff;
+			buf.push_back(uint8_t(v)); buf.push_back(uint8_t(v >> 8)); buf.push_back(uint8_t(v >> 16));
+		}
+		std::fwrite(buf.data(), 1, buf.size(), f);
+		std::fclose(f);
+		return true;
+	}
+
+	// Returns false if the file is not PCM 16/24-bit. `_out` is interleaved,
+	// every sample sign-extended into an int32 holding a 24-bit word (a 16-bit
+	// file is shifted up eight).
+	inline bool readWavPcm(const std::string& _path, std::vector<int32_t>& _out, uint32_t& _channels, uint32_t& _rate)
+	{
+		std::FILE* f = std::fopen(_path.c_str(), "rb");
+		if(!f)
+			return false;
+		std::vector<uint8_t> d;
+		{
+			uint8_t buf[65536];
+			size_t n;
+			while((n = std::fread(buf, 1, sizeof buf, f)) > 0)
+				d.insert(d.end(), buf, buf + n);
+		}
+		std::fclose(f);
+		auto u16 = [&d](const size_t _o){ return uint32_t(d[_o]) | (uint32_t(d[_o + 1]) << 8); };
+		auto u32 = [&d](const size_t _o){ return uint32_t(d[_o]) | (uint32_t(d[_o + 1]) << 8) | (uint32_t(d[_o + 2]) << 16) | (uint32_t(d[_o + 3]) << 24); };
+		if(d.size() < 12 || std::string(d.begin(), d.begin() + 4) != "RIFF" || std::string(d.begin() + 8, d.begin() + 12) != "WAVE")
+			return false;
+		uint32_t bits = 0, fmt = 0;
+		_channels = 0; _rate = 0;
+		size_t o = 12;
+		while(o + 8 <= d.size())
+		{
+			const std::string id(d.begin() + o, d.begin() + o + 4);
+			const uint32_t len = u32(o + 4);
+			const size_t body = o + 8;
+			if(id == "fmt " && len >= 16)
+			{
+				fmt = u16(body); _channels = u16(body + 2); _rate = u32(body + 4); bits = u16(body + 14);
+			}
+			else if(id == "data")
+			{
+				if((fmt != 1 && fmt != 0xfffe) || (bits != 16 && bits != 24) || !_channels)
+					return false;
+				const uint32_t bytes = bits / 8;
+				const size_t n = std::min<size_t>(len, d.size() - body) / bytes;
+				_out.clear();
+				_out.reserve(n);
+				for(size_t i = 0; i < n; ++i)
+				{
+					const size_t p = body + i * bytes;
+					int32_t v = bits == 16 ? int32_t(int16_t(u16(p))) << 8
+						: int32_t((uint32_t(d[p]) | (uint32_t(d[p + 1]) << 8) | (uint32_t(d[p + 2]) << 16)) << 8) >> 8;
+					_out.push_back(v);
+				}
+				return true;
+			}
+			o = body + len + (len & 1);
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
## What this is

Milestone O9 of the ColdFire port, half done. `docs/COLDFIRE_PORT.md` O9 has the account; `docs/COLDFIRE_WORKORDER.md` carries O9b and O10.

## Measured

- **Audio IN works end to end.** `--audio-in tones` (slot k = a sine at 500·(k+1) Hz) lands in the ESAI-in ring, 64 words a frame go through the shared window to core 1, and the ColdFire gets the eight input slots back in eDMA channel 7's 128-word blocks: 50,298 non-zero words over 400 frames against 9 without. O8's "the DSP computes silence" was the absence of input.
- **O8b's 0.27 % clock walk is closed.** The budget counted one per interpreter call; the ESAI clock reads the DSP's own instruction counter, which `rep` advances per iteration. Spending the counter delta: 16 ESAI frames per host frame on 399/399 and 1599/1599 (was 382/399). The surplus is 208 per 66,560-instruction frame, which is the drift.
- **The frame's audio topology, from the block log:** ch 1 back = 256 words per core; the 512-word block the ColdFire sends core 0 each frame is both read-backs forwarded; ch 7 back = the inputs; ch 6 (`0x80005e60`) zero and unknown. `DSP.md`'s `0x80003190` row corrected.
- **Audio OUT is silent** on every slot in five fixtures (T1 THRU, T5 THRU with a file trig, master track on and off, a staged FLEX sample read in full from the card), and the write hook says the ESAI-out ring never receives a non-zero write. The poked trig changes one voice-record word and nothing follows; route A on the same card does the same. The trig → voice path is unlocated and oracle-side: **O9b**.

## Instruments added

`--audio-out PREFIX`, `--audio-in FILE|tones`, `--dsp-map FILE`, `--dsp-writes FILE` (a tenth vendored patch: a write hook in `Memory::dspWrite`, unset by default), `stage_card.py --audio`, and report lines for the transport-start frame, per-slot content, the counter surplus, the shared window and the ring's writes. Two instrument corrections: peeks were blind to the shared window (`Memory::get`'s size check precedes the window); a frame-command snapshot cannot see a buffer consumed inside the frame.

## Gates

- `ctest` 7/7
- O6 with the cores against the stored oracle: 5/5
- M6a with the cores: 8/8
- `make check`: all runnable checks passed
- No build change (`make bus` untouched), so no refhash run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)