### PR TITLE
O9b: audio out of the DSP -- main level via sys command 4, MACSR S/U = 16-bit rounding, the frame IRQ is the DSP's bank word, eleventh vendored AGU defect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,26 @@ same as "disassemble what you assemble": when firmware arithmetic comes out
 exactly 2× or ½ off, suspect the INSTRUMENT before inventing a unit, and
 find a site in the firmware whose constants only make sense one way.
 
+**MACSR S/U IS BIT 6, AND IN FRACTIONAL MODE IT IS NOT SIGNED/UNSIGNED:
+it selects 16-BIT ROUNDING ON THE ACCUMULATOR READ-OUT.** The ColdFire port
+had S/U as bit 4 (that is R/T) and returned every `movclrl` as `ACC[39:8]`;
+the firmware's level chain at `0x4000ccae` runs at MACSR `0x60` and keeps the
+LOW words of two reads as a voice record's mode:level, which the CFPRM's
+pseudocode (`OMC,S/U == 01`: `ACC[39:24]` rounded into `Rx[15:0]`, upper half
+zero) puts there and a plain `>> 8` leaves at zero — every voice rendered
+silent for a whole session (8 Sep 2026, O9b). The self-test never exercised
+S/U. Read the CFPRM's MOVCLR pseudocode before touching `accRead`.
+
+**THE VENDORED DSP AGU LEFT A MODULO BUFFER ON A PRE-DECREMENT FROM ITS
+BASE.** `x:-(r2)` with r2 = 0 and m2 = 0x3f gave `0xffffbf` where the chip
+gives `0x3f`, the next sixteen sample writes walked the peripheral registers,
+a timer interrupt came alive whose vector in payload B is `move x0,y:(r4)+`,
+and the corruption surfaced as a 196,608-iteration voice loop thirteen frames
+after the first trig. Found with a one-word write watch, a DSP PC watch with
+registers and an interrupt-vector histogram (O9b); fixed in `agu.h`. It is
+the eleventh vendored-emulator defect and `dsp_host` renders every effect on
+that AGU — `make check`'s bit-identity gates are the audit.
+
 **A REWRITTEN TRAMPOLINE IS NOT RETRANSLATED.** The ColdFire emulator's
 EMAC-with-load shim ran every shimmed instruction from one scratch address,
 rewriting its bytes each time; in a long-running Unicorn the address kept

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -1648,6 +1648,147 @@ O8 notes is stale.
 `ctest` 7/7; O6 with the cores 5/5 against the stored oracle; M6a with the
 cores; `make check` — see the PR.
 
+## Milestone O9b — the trig → voice path: audio out of the DSP (8 Sep 2026, branch `coldfire-o9b`)
+
+O9 ended with "no track ever starts under either emulator". It did start; four
+things between the trig and the ESAI were wrong, none of them the trig path,
+and each was found by an instrument added for it. **Gate: a THRU track trigged
+with `--audio-in tones` puts audio on TX0 — passes.** 400 frames, 28 ticks,
+the O6 oracle's 5 fields agree, TX0 slots 1–4 carry the mix on 6,213 of 6,399
+frames after the transport start (two stereo pairs, the second 3.7 dB lower),
+no fault, no stall.
+
+### 1. Coverage said the trig starts a voice; the voice rendered at gain zero
+
+`--coverage FILE` (every ColdFire PC from the transport start, with counts;
+`Machine::step` now counts instructions, which the PC watch's timestamps
+needed too) and a diff of a trig run against a no-trig run: the trig's own
+footprint is 124 PCs (the p-lock applier `0x4000c42c–0x4000c5a0`, an
+armed-bitmask check at `0x4000bd14`, a compare, a counter), and one more
+activity per frame from then on — a per-voice EMAC mixer at `0x40004444` that
+sums four input-capture streams into stereo, 16 samples a call, with gains
+from a voice record at `0x80000510 + 384·ping + 48·track` (byte 0 = routing
+mode, word +2 = level). Its jump table took case 0 — all gains cleared — for
+every voice because the record's level read 0.
+
+The level is written mode:level by the frame builder (`0x4000cb2e`),
+smoothed by an EMAC chain at MACSR `0xb0` (`0x4000cbfc`), then scaled by a
+**main gain table at `0x80003c60`** in a second chain at MACSR `0x60`
+(`0x4000ccae–0x4000ccfc`). ✅ That table is written by exactly two sys
+commands — **command 4 = SET MAIN LEVEL** (`msg[1]` = 0..127, handler case
+`0x40061e0a`, ten longwords of gain:(0x8000−gain) from the curve at
+`0x400bcd90`) and command 68 (`127 − msg[3]`) — and NEITHER emulator's load
+posts either: 0 writes to the table in the port and in route A. Every voice
+was multiplied by zero. `--main-level N` posts command 4 after the load
+(`Rtos::setMainLevelLive`, the same scratch-message path as select-bank); the
+report prints the table's first entry (`0xbf7fc081` at 64). Route A got the
+same post the same day (the parallel session's `set_main_level_live`).
+
+### 2. MACSR S/U is bit 6, and in fractional mode it is not signed/unsigned at all
+
+With the table filled the second chain still stored 0. Its inputs were right
+(record `0x0100:0x7f00`, gain `0xbf7f:0xc081`); the port's `movclrl` returned
+the products left-aligned and the firmware keeps the LOW words (`movclrl
+acc0,d3; swap d3; movclrl acc1,d2; movew d2,d3`). ❌ The port had S/U as bit 4
+(that is R/T) and read every accumulator out as `ACC[39:8]`. ✅ The CFPRM
+(Rev. 3, ch. 6, MOVCLR pseudocode; `MOVE from ACC` says the same) for
+`F/I = 1`:
+
+    OMC,S/U,R/T == 000  → ACC[39:8] → Rx
+    OMC,S/U,R/T == 001  → ACC[39:8] rounded by [7:0] → Rx
+    OMC,S/U     == 01   → 0 → Rx[31:16]; ACC[39:24] rounded by [23:0] → Rx[15:0]
+
+So at `0x60` the chip hands the 16-bit-rounded top of the accumulator back in
+the LOW word, which is precisely what the chain keeps. `v4e.cpp`'s `accRead`
+is now the pseudocode, every branch (integer signed/unsigned with OMC
+saturation; fractional with OMC, S/U and R/T), and `g_macsrSigned = 0x40`.
+QEMU (route A) has the S/U branch and `MACSR_SU = 0x40` already. `ctest`
+7/7 before and after — the O2 self-test never exercised S/U. **The number
+that only makes sense one way:** the record's mode byte survives the scaling
+(`0x0100 × 1.0 → 0x0100` in the low word) only under this read-out; under
+`ACC[39:8]` it is destroyed, which is why both chains cannot be satisfied by
+any operand alignment (an experiment that was tried and reverted).
+
+With that: `0x80000510` reads `0x01007f00` after the chain, outbound non-zero
+words 43,222 → 177,690 per 400 frames, inbound 50,298 → 129,619, **the
+ESAI-out ring gets non-zero writes and TX0 slots 1–4 carry the THRU tracks'
+tones** — for 348 frames, then the firmware executed `halt`.
+
+### 3. The frame interrupt is the DSP's bank word, not a timer
+
+`0x4000ab40: halt` sits under `cmpl 0x800000e0,%d0; bcc`: the frame handler
+reads the DSP's bank id from `0x2000001c` **with no ready check**
+(`0x4000aafa`) and halts unless it is 0 or 1. Under silence the read-back
+data words were 0 and a mistimed read passed by luck; with audio a data word
+landed there (`0xffffd500`). So on hardware the interrupt that runs the
+handler must be what announces the bank word. The port now raises the frame
+edge when core 0 executes its bank write — payload A's `000073: movep
+r3,x:<<M_HOTX`, once per ring half, `g_bankIdPc` — instead of the
+free-running 16-sample timer (`--frame-timer` restores it). The DSP's first
+bank id, written during the load and waiting at P:0x97 for the host, is
+delivered where route A fires its first frame (one period after the frame
+clock comes on) so the transport start keeps the oracle's phase; a ColdFire
+idle skip ends at the edge (`tickSamples` returns the samples it advanced).
+Measured: bank write → host take 0.002 samples, bank write → `0x8c` 0.004
+samples, DSP frame-to-frame 16.00 (min 15.27, max 16.95). "ESAI frames per
+host frame" now reads 16 on 395 of 399 with min 14 / max 17 — that is the
+ColdFire's own latency jitter on the command, visible now that the edge is
+the DSP's; the DSP's frames themselves are exact.
+
+### 4. A modulo pre-decrement that left the buffer — the eleventh vendored defect
+
+Then the DSP stalled 13–38 frames after the trig: core 0 at P:0xa3 waiting on
+core 1's mailbox for a whole ring half, DMA2 finished un-re-armed (the
+dispatcher only re-arms after catching `DSR2 == 0x8070/0x80f0`, a one-word
+window), core 1 in a 196,608-iteration voice loop (`do y1,>$20b` at P:0x205
+with `y1 = 0x030000` from the record's count field at Y:0x42). Instruments on
+the way: `--dsp-writes`' per-word watch (`--dsp-watch core:space:addr`: the
+last 16 writers with PC, the executed-PC ring, r0/r4/r6 and the area), a DSP
+PC watch with a register dump (`--dsp-pcwatch core:pc[:fromExecuted]`), a
+trace window (`--dsp-trace-from`), the interrupt-vector histogram in the
+report, and a trap for the first `TCSR0.TE` with the PCs and address registers
+before it. The chain, all measured:
+
+- core 1 took **vector 0x54 = TIMER0 Compare 230,027 times**; neither payload
+  writes a timer register. Payload B's word at P:0x54 is `move x0,y:(r4)+` and
+  a fast interrupt runs the two words at its vector inline — with whatever r4
+  the voice builder had, so the count field got a raw host word;
+- TCSR0 was written with `0x0c2687` (an audio sample) by the interpolator's
+  `move b,x:(r2)+` at P:0x1a78 with `r2 = 0xffff8f`;
+- r2 came from `x:-(r2)` at P:0x1a66 with **r2 = 0 and m2 = 0x3f**: the
+  vendored AGU (`agu.h updateAddressRegister`) holds r unsigned, the
+  decrement underflowed to `0xffffffff`, the lower-bound test could not see
+  it and the upper-bound test subtracted the modulo: **`0xffffbf` where the
+  chip gives `0x3f`**. The next sixteen writes walked `0xffffc0–0xffffff` and
+  the timer block.
+
+Fixed in `agu.h` (the update is done relative to the buffer base in signed
+arithmetic), `tools/dsp56300.patch` regenerated. ⚠️ `dsp_host` renders every
+effect on this AGU and a `x:-(rN)` at the base of a modulo delay line is an
+ordinary idiom, so the shipped effects were audited directly: `make check`'s
+bit-identity gates cannot see a change common to both sides of a comparison,
+but `send_probe --layout RS --wav` rendered with and without the fix is
+**byte-identical** (529,244 bytes, `cmp`), and its peak/THD/spur lines match.
+✅ No shipped effect was rendered on the underflow path.
+
+Also in this milestone: the two cores are interleaved in 64-instruction
+quanta (`stepCore`; `runCoreUntil` steps core 1 alongside core 0 inside a
+pull) — hardware runs them in parallel, and a whole budget slice each in turn
+could hold core 0's mailbox wait past the ring window. The stall's root cause
+was the AGU, not this, but the interleaving stays as the nearer model.
+
+### What the port can do now
+
+`--dsp --main-level 64 --audio-in FILE|tones --audio-out PREFIX` renders the
+firmware's own mix of the inputs through the DSP to a WAV. Step 5 of O8 (the
+firmware driving `verify_twocore`'s layouts) is reachable: audio in, the
+sequencer, the per-track records and the ESAI out all carry content. Open:
+which input slot is which physical input and which output slot is main/cue
+(a per-slot spectral pass or eight single-tone runs); the FLEX sample path
+(a staged `KICK.WAV` is read from the card but the 512-word block stays zero
+— the sample loader / voice start for FLEX is the next locate, with
+`--coverage` and the block log as the instruments); the `0x8c` jitter.
+
 ## What is NOT here yet
 
 - **The rest of the peripherals.** The eDMA with its completion-timing rules
@@ -1663,9 +1804,10 @@ cores; `make check` — see the PR.
   ColdFire alternates the cores, writes `0x81`, sends a destination/count pair
   to `0x2000001c`, then DMAs — 336-word per-track records plus a 128-word and a
   64-word block per core, with one 64-word block read back.
-- **Audio out.** ~~The ESAI path is untraced.~~ Traced in O9: input proven to
-  the ColdFire's capture buffers, output silent because no track ever starts
-  under either emulator (the trig → voice path, oracle-side).
+- **Audio out.** ~~The ESAI path is untraced.~~ ~~Traced in O9: input proven,
+  output silent because no track ever starts.~~ O9b: THRU tracks pass the
+  inputs to TX0 through the whole chain. FLEX playback (the sample loader)
+  is the open half.
 
 ## The oracle, made concrete (7 Sep 2026)
 

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -77,6 +77,7 @@ route A fact, not the port's problem; the golden command above already does it.
 | O8 (1-4) | the DSP cores behind the host port | ctest `dsp` (the firmware's upload lands the image's bytes) + M6a and O6 with `--dsp` | ✅ 50/50 + 58/58 bootstrap words, 26,221 + 25,408 payload words at upload time; M6a 8 compared fields; O6 5 compared fields (400 frames, 28 ticks, trig at 344) with the cores live. Step 5 open |
 | O8a | the ESAI rate | the falsifier: bank B gets taken | ✅ the port's ESAI ran 8× slow (a per-SLOT clock fed a per-sample count); the rate is the firmware's own 4160 instructions/sample; a ninth vendored DMA defect found on the way. Bank B 850 of 2,400 blocks (was 0) |
 | O8b | the host-port burst time | `ESAI frames per host frame` reads 16, O6 still 5/5 | ✅ FlexBus 66 MHz × 4 clocks/word from `PCR` and `CSCR2` in the image: 16 on 382 of 399 (was 0 of 399), O6 5/5, M6a 8/8 |
+| O9b | the trig → voice path | a THRU track trigged with `--audio-in tones` puts audio on TX0; O6 5/5 | ✅ four findings, none the trig path: the main gain table is filled only by sys command 4 (`--main-level`); MACSR S/U is bit 6 and means 16-bit rounding on the read-out in fractional mode (CFPRM); the frame interrupt is the DSP's bank word (the firmware halts on a mistimed read); the vendored AGU's modulo pre-decrement underflowed out of the buffer (eleventh vendored defect). TX0 slots 1-4 carry the mix on 6,213 of 6,399 frames; 400 frames, 28 ticks, O6 5/5 |
 | O9 (half) | the ESAI path | audio in: the read-back carries what the ESAI receives; the clock walk: 16 on 399/399 | ✅ tones on RX0 come back in eDMA ch 7's 128-word blocks (50,298 non-zero words / 400 frames, 9 without); ✅ O8b's 0.27 % walk was `rep` iterations counted once per call — 399/399 and 1599/1599 now. ❌ Audio OUT silent: the ring never gets a non-zero write; the trig never becomes a voice, and route A agrees — see O9b below |
 
 ## Queue
@@ -634,7 +635,36 @@ report lines. Three things later milestones must know:
    DSP: the ring's write count is the instrument, and it reads zero because
    its input is zero.
 
-### O9b — the trig → voice path *(oracle-side first; Fable for the scoping)*
+### ~~O9b — the trig → voice path~~ ✅ DONE (8 Sep 2026, branch `coldfire-o9b`)
+
+`COLDFIRE_PORT.md` O9b has the account. Four things later milestones must know:
+
+1. **Post sys command 4 (SET MAIN LEVEL) after every emulated load** —
+   `--main-level 64` on the port, `set_main_level_live` on route A. Without it
+   the main gain table `0x80003c60` is zero and every voice renders silent.
+2. **MACSR S/U = 0x40, and in fractional mode it selects 16-bit rounding on
+   the accumulator read-out** (CFPRM ch. 6). `v4e.cpp accRead` is the manual's
+   pseudocode now. Any EMAC claim made before 8 Sep at MACSR `0x60`/`0x70`
+   sites is suspect on the port side; route A (QEMU) had it right.
+3. **With the cores, the frame interrupt is the DSP's bank write** (payload A
+   P:0x73), not the 16-sample timer; the firmware reads the bank id with no
+   ready check and halts on a data word. `--frame-timer` keeps the old model.
+4. **The vendored AGU could leave a modulo buffer on a pre-decrement from the
+   base** (`agu.h`, fixed, patch regenerated). `make check`'s bit-identity
+   gates say whether any shipped effect was rendered on it.
+
+### O9c — the audio comparison (O8's step 5) *(Opus)*
+
+**Gate:** the port, driven by the firmware, renders `verify_twocore`'s
+layouts and the WAV matches `dsp_host`'s render of the same layout to the
+bit for the THRU path (the FX chain is the same code). **Needs first:** the
+slot map (which RX0 slot is input A/B/C/D, which TX0 slot is main/cue L/R —
+eight single-tone runs with `--audio-in FILE.wav`, or a spectral pass on
+`out/o9/o9b_frames.wav`), and a project where the track's FX2 is the effect
+under test. The FLEX sample path (a staged `KICK.WAV` is read from the card,
+the 512-word block stays zero) is a separate locate with `--coverage`.
+
+### O9b — the trig → voice path *(the original entry)*
 
 **Gate:** with `--audio-in tones` and a THRU track trigged, TX0 carries the
 tones (`--audio-out` WAV non-zero on some slot; `non-zero writes into the

--- a/tools/dsp56300.patch
+++ b/tools/dsp56300.patch
@@ -8,6 +8,49 @@ index ffbf791..350a71a 100644
  endif()
 +
 +add_subdirectory(dsp_host)
+diff --git a/source/dsp56kEmu/agu.h b/source/dsp56kEmu/agu.h
+index ac3853c..5acf878 100644
+--- a/source/dsp56kEmu/agu.h
++++ b/source/dsp56kEmu/agu.h
+@@ -45,20 +45,27 @@ namespace dsp56k
+ 
+ 				n = signextend<int, 24>(n);
+ 
++				// octabam (O9b, 8 Sep 2026): work RELATIVE to the buffer base in
++				// signed arithmetic. `r` is unsigned: a pre-decrement from r = 0
++				// underflowed to 0xffffffff, the lower-bound test could not see
++				// it, and the upper-bound test then subtracted the modulo and
++				// left 0xffffbf -- so `x:-(r2)` with m2 = 0x3f at r2 = 0 gave
++				// 0xffffbf where the chip gives 0x3f, and the next sixteen
++				// writes walked the DSP's peripheral registers (TCSR0 among
++				// them: a timer interrupt whose vector in payload B corrupts the
++				// voice records).
+ 				const auto lowerBound = r & ~moduloMask;
+-				const auto upperBound = lowerBound + m;
+-
++				const auto wrap = (n & moduloMask) ? modulo : 0;
++				int32_t rel = static_cast<int32_t>(r - lowerBound);
+ 				if constexpr(add)
+-					r += n;
++					rel += static_cast<int32_t>(n);
+ 				else
+-					r -= n;
+-
+-				modulo = n & moduloMask ? modulo : 0;
+-
+-				if(r < lowerBound)
+-					r += modulo;
+-				if(r > upperBound)
+-					r -= modulo;
++					rel -= static_cast<int32_t>(n);
++				if(rel < 0)
++					rel += wrap;
++				else if(rel > static_cast<int32_t>(m))
++					rel -= wrap;
++				r = (lowerBound + static_cast<TWord>(rel)) & 0xffffff;
+ 				/*
+ 				if constexpr(add)
+ 				{
 diff --git a/source/dsp56kEmu/dma.cpp b/source/dsp56kEmu/dma.cpp
 index bd3e603..fea36b4 100644
 --- a/source/dsp56kEmu/dma.cpp

--- a/tools/ot_emu/dsp.cpp
+++ b/tools/ot_emu/dsp.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <array>
 #include <cmath>
+#include <map>
 
 #include "dsp56kEmu/dsp.h"
 #include "dsp56kEmu/dspBootCode.h"
@@ -27,6 +28,9 @@ namespace ot
 
 		// ICR bits, host side.
 		constexpr uint32_t ICR_RREQ = 0x01, ICR_TREQ = 0x02, ICR_INIT = 0x80;
+		// Payload A's bank-id write, `000073: movep r3,x:<<M_HOTX` in
+		// out/dsp/payload_A.asm (O9b). A payload that moves it moves this.
+		constexpr uint32_t g_bankIdPc = 0x73;
 	}
 
 	struct DspPair::Core
@@ -62,6 +66,8 @@ namespace ot
 		uint64_t txAtFirstCmd = 0, rxAtFirstCmd = 0;
 		std::array<uint64_t, DspPair::g_audioSlots> txNZ = {}, rxNZ = {};
 		uint64_t surplus = 0, zeroDelta = 0;	// instruction-counter delta beyond one per interpreter call / calls that moved it not at all
+		// O9b: bank id -> host take latency, in this core's instructions (4160 = one sample)
+		uint64_t bankWriteAt = 0, bankTakeMax = 0, bankTakeSum = 0, bankTakes = 0, bankTakeMaxAt = 0, bankWritesInPull = 0;
 		std::array<std::array<uint32_t, 1024>, 2> nzWrites = {};	// [X/Y][region of 256 words]: non-zero writes since the last flush
 		uint64_t ringNzWrites = 0, ringFirstAt = 0;	// non-zero writes into the ESAI-out ring X:0x8000-0x80ff
 		uint32_t ringFirstAddr = 0, ringFirstVal = 0;
@@ -81,6 +87,8 @@ namespace ot
 		uint64_t pcRingPos = 0;
 		bool faulted = false;
 		std::string why;
+		std::map<uint32_t, uint64_t> vectorsTaken;		// O9b: interrupt vector -> count (every interrupt the vendored core took)
+		uint64_t timerEnabledAt = 0; uint32_t timerTcsr = 0; std::array<uint32_t, 8> timerPcs = {}; std::array<uint32_t, 8> timerR = {}, timerM = {};	// the first moment TCSR0.TE is seen set, and the PCs before it
 
 		dsp56k::HDI08& hdi() { return px->getHDI08(); }
 	};
@@ -117,8 +125,28 @@ namespace ot
 				for(auto& k : m_cores)
 					k->dsp->clearOpcodeCache(_a);
 			});
-			c.mem->setWriteHook([this, &c](const dsp56k::EMemArea _area, const dsp56k::TWord _off, const dsp56k::TWord _val)
+			c.mem->setWriteHook([this, &c, i](const dsp56k::EMemArea _area, const dsp56k::TWord _off, const dsp56k::TWord _val)
 			{
+				// O9b: a P write outside the shared window left the STALE decode
+				// in the interpreter's opcode cache (the window hook clears it
+				// only for 0x30000+). The firmware uploads each payload twice
+				// (O7b), so P:0x1d3 of core 1 ran the FIRST upload's instruction
+				// -- a Y write -- where the second had put `tfr b,a x:(r0)+,b0`,
+				// and the voice loop count at Y:0x42 became a raw host word.
+				if(_area == dsp56k::MemArea_P)
+					c.dsp->clearOpcodeCache(_off);
+				if(m_watchOn && i == m_watchCore && _off == m_watchAddr
+					&& _area == (m_watchSpace == 'Y' ? dsp56k::MemArea_Y : m_watchSpace == 'P' ? dsp56k::MemArea_P : dsp56k::MemArea_X))
+				{
+					if(m_watchHits.size() >= 16)
+						m_watchHits.erase(m_watchHits.begin());
+					WatchHit h{c.dsp->getPC().toWord(), _val & 0xffffff, c.executed, {}, 0, 0, 0, 0, static_cast<uint32_t>(c.dsp->regs().r[4].var & 0xffffff), static_cast<uint32_t>(c.dsp->regs().r[6].var & 0xffffff), static_cast<uint32_t>(_area), static_cast<uint32_t>(c.dsp->regs().r[0].var & 0xffffff)};
+					for(int k = 0; k < 4; ++k)
+						h.last[k] = c.pcRing[(c.pcRingPos + 64 - 1 - static_cast<uint64_t>(k)) % 64];
+					h.ddr0 = c.px->read(0xffffee, dsp56k::Nop); h.dco0 = c.px->read(0xffffed, dsp56k::Nop);
+					h.dsr1 = c.px->read(0xffffeb, dsp56k::Nop); h.dco1 = c.px->read(0xffffe9, dsp56k::Nop);
+					m_watchHits.push_back(h);
+				}
 				if(!m_writesOn || _area == dsp56k::MemArea_P || !(_val & 0xffffff) || _off >= 0x40000)
 					return;
 				++c.nzWrites[_area == dsp56k::MemArea_Y ? 1 : 0][_off >> 8];
@@ -159,6 +187,7 @@ namespace ot
 			c.dsp->setInterruptTakenHook([this, i](dsp56k::TWord _vba)
 			{
 				Core& k = *m_cores[i];
+				++k.vectorsTaken[_vba];
 				if(!k.hcPending || _vba != k.hcVector)
 					return;
 				k.hcPending = false;
@@ -453,13 +482,23 @@ namespace ot
 
 	uint32_t DspPair::rxTake()
 	{
+		{
+			Core& c = cur();
+			if(!m_pulling && c.bankWriteAt)
+			{
+				const auto lat = c.executed - c.bankWriteAt;
+				++c.bankTakes; c.bankTakeSum += lat;
+				if(lat > c.bankTakeMax) { c.bankTakeMax = lat; c.bankTakeMaxAt = c.bankTakes; }
+				c.bankWriteAt = 0;
+			}
+		}
 		Core& c = cur();
 		auto& h = c.hdi();
 		if(h.hasTX())
 		{
 			c.lastRx = h.readTX();
 			++c.wordsOut;
-			note("rx", c.lastRx);
+			note(m_pulling ? "rxp" : "rx", c.lastRx);
 		}
 		return c.lastRx;
 	}
@@ -568,6 +607,7 @@ namespace ot
 		m_sel = _core & 1;
 		Core& c = cur();
 		size_t missing = 0;
+		m_pulling = true;
 		for(size_t i = 0; i < _n; ++i)
 		{
 			// RXDF, the way the eDMA's request line would gate it -- and the
@@ -581,6 +621,7 @@ namespace ot
 			++c.pulled;
 		}
 		c.pullShort += missing;
+		m_pulling = false;
 		m_sel = sel;
 		return missing;
 	}
@@ -588,6 +629,7 @@ namespace ot
 	bool DspPair::runCoreUntil(const int _core, const std::function<bool()>& _ready, const uint64_t _budget)
 	{
 		Core& c = *m_cores[_core & 1];
+		Core& other = *m_cores[(_core & 1) ^ 1];
 		for(uint64_t n = 0; n < _budget; ++n)
 		{
 			if(_ready())
@@ -601,13 +643,11 @@ namespace ot
 				c.why = "PC outside P memory during a read-back";
 				return false;
 			}
-			const auto before = c.dsp->getInstructionCounter();
-			c.dsp->execInterpreter();
-			c.dsp->doLoopEnd();
-			const auto d = c.dsp->getInstructionCounter() - before;
-			c.executed += d ? d : 1;
-			if(d > 1) c.surplus += d - 1;
-			if(!d) ++c.zeroDelta;
+			// One instruction of this core, then let the other core catch
+			// up to it: the pull must not run one core a frame ahead (O9b).
+			stepCore(_core & 1, static_cast<double>(c.executed) + 1.0);
+			while(other.executed < c.executed && stepCore((_core & 1) ^ 1, static_cast<double>(c.executed)))
+				;
 		}
 		return _ready();
 	}
@@ -620,98 +660,182 @@ namespace ot
 		runDue();
 	}
 
-	void DspPair::tickSamples(const double _n)
+	double DspPair::tickSamples(const double _n)
 	{
-		m_due += _n * m_ips;
-		runDue();
+		if(!m_hostWordHook)
+		{
+			m_due += _n * m_ips;
+			runDue();
+			return _n;
+		}
+		// One sample at a time, so that a frame edge inside a ColdFire idle
+		// skip ends the skip AT the edge, not a period later.
+		double done = 0.0;
+		while(done < _n)
+		{
+			const double step = std::min(1.0, _n - done);
+			m_hostWordFired = false;
+			m_due += step * m_ips;
+			runDue();
+			done += step;
+			if(m_hostWordFired)
+				break;
+		}
+		return done;
+	}
+
+	// One instruction of core `_i`, if it is runnable and below `_limit`.
+	// Returns whether it ran. runDue and runCoreUntil are both built on it
+	// (O9b): the cores used to run one WHOLE budget slice each in turn, and
+	// a read-back pull ran core 0 alone for up to a frame -- so core 0's
+	// mailbox wait for core 1 (P:0xa3) could outlast the dispatcher's
+	// one-word window on the ring pointer (P:0x4b: DSR2 == 0x8070/0x80f0),
+	// the output DMA ran out un-re-armed, and the audio died 38 frames after
+	// the first trig. Hardware runs the cores in parallel; a small quantum
+	// is the nearest thing.
+	bool DspPair::stepCore(const int _i, const double _limit)
+	{
+		Core& c = *m_cores[_i];
+		const int i = _i;
+		if(!c.boot->finished())
+		{
+			// Held in the bootstrap ROM until its last word lands; the
+			// ROM's jump is the first instruction this core runs.
+			if(static_cast<double>(c.executed) < _limit)
+				c.executed = static_cast<uint64_t>(_limit);
+			return false;
+		}
+		if(c.faulted)
+		{
+			c.executed = static_cast<uint64_t>(_limit);
+			return false;
+		}
+		if(static_cast<double>(c.executed) >= _limit)
+			return false;
+
+			const auto pc = c.dsp->getPC().toWord();
+			c.pcRing[c.pcRingPos++ % c.pcRing.size()] = pc;
+			if(pc >= g_pSize)
+			{
+				c.faulted = true;
+				char msg[96];
+				std::snprintf(msg, sizeof msg, "PC %#x is outside P memory (%#x words)", pc, g_pSize);
+				c.why = msg;
+				c.executed = static_cast<uint64_t>(_limit);
+				return false;
+			}
+			// The idle fast-forward (dsp.h): eight instructions in a row
+			// inside a three-word window, no hardware loop open.
+			// O9: the budget counts the DSP's OWN instruction counter, the
+			// one its ESAI clock reads -- a `rep` advances it once per
+			// iteration where this loop makes ONE interpreter call, so
+			// counting calls ran the ESAI 0.27% fast against the frame
+			// clock (17 ESAI frames in a host frame, 17 of 399 -- O8b's
+			// residual). The delta is taken across the idle step too.
+			const auto before = c.dsp->getInstructionCounter();
+			uint64_t skipped = 0;
+			if(pc < c.lastPcLo || pc > c.lastPcHi)
+			{
+				c.lastPcLo = pc;
+				c.lastPcHi = pc + 2;
+				c.windowRun = 0;
+			}
+			else if(++c.windowRun >= 8 && m_idleSkip && !(c.dsp->regs().sr.var & 0x8000)
+				&& !c.dsp->hasPendingInterrupts())
+			{
+				// Skip to the next peripheral event (or the due count), then
+				// FALL THROUGH and execute the poll once, so it can see what
+				// changed. ⚠️ `continue` here left the poll never executed
+				// and the uploader waiting for an echo forever (measured
+				// 8 Sep 2026: "unrecognised spin at 40001b82").
+				const auto room = static_cast<uint64_t>(_limit - static_cast<double>(c.executed));
+				skipped = c.dsp->idleStep(room ? room : 1);
+				c.idleSkipped += skipped;
+			}
+			// O9b: the bank id is the ONE host-port word the frame handler
+			// reads with no ready check: payload A's `movep r3,x:<<M_HOTX`
+			// at P:0x73, right after the bank wait, once per ring half.
+			// (Keying on "port non-empty outside a pull" instead fired on
+			// every command echo too: 5-6 ESAI frames per host frame.)
+			const bool bankWrite = i == 0 && pc == g_bankIdPc && m_hostWordHook;
+			// O9b: nobody in either payload writes a timer register, yet core 1
+			// took TIMER0 Compare (vector 0x54 -- payload B's `move x0,y:(r4)+`)
+			// 230,027 times. Catch the first enable with the PCs before it.
+			if(!c.timerEnabledAt && (c.px->getTimers().readTCSR(0) & 1))
+			{
+				c.timerEnabledAt = c.executed;
+				c.timerTcsr = c.px->getTimers().readTCSR(0);
+				for(int k = 0; k < 8; ++k)
+				{
+					c.timerPcs[k] = c.pcRing[(c.pcRingPos + 64 - 1 - static_cast<uint64_t>(k)) % 64];
+					c.timerR[k] = c.dsp->regs().r[k].var & 0xffffff;
+					c.timerM[k] = c.dsp->regs().m[k].var & 0xffffff;
+				}
+			}
+			if(m_pcWatchOn && i == m_pcWatchCore && pc == m_pcWatchPc && c.executed >= m_pcWatchFrom && !(m_pcWatchFrom && m_pcWatchHits.size() >= 24))
+			{
+				const auto& r = c.dsp->regs();
+				if(m_pcWatchHits.size() >= 24)
+					m_pcWatchHits.erase(m_pcWatchHits.begin());
+				m_pcWatchHits.push_back({c.executed,
+					static_cast<uint32_t>((r.a.var >> 24) & 0xffffff), static_cast<uint32_t>(r.a.var & 0xffffff),
+					static_cast<uint32_t>((r.b.var >> 24) & 0xffffff), static_cast<uint32_t>(r.b.var & 0xffffff),
+					static_cast<uint32_t>(r.x.var & 0xffffff), static_cast<uint32_t>((r.x.var >> 24) & 0xffffff),
+					static_cast<uint32_t>(r.y.var & 0xffffff), static_cast<uint32_t>((r.y.var >> 24) & 0xffffff),
+					static_cast<uint32_t>(r.r[0].var & 0xffffff), static_cast<uint32_t>(r.r[4].var & 0xffffff),
+					static_cast<uint32_t>(r.r[6].var & 0xffffff), static_cast<uint32_t>(r.n[4].var & 0xffffff),
+					static_cast<uint32_t>(r.sp.var & 0xff), static_cast<uint32_t>(r.r[2].var & 0xffffff), static_cast<uint32_t>(r.m[2].var & 0xffffff)});
+			}
+			c.dsp->execInterpreter();
+			c.dsp->doLoopEnd();
+			const auto d = c.dsp->getInstructionCounter() - before;
+			c.executed += d ? d : 1;
+			if(d > skipped + 1) c.surplus += d - skipped - 1;
+			if(!d) ++c.zeroDelta;
+			if(bankWrite)
+			{
+				c.bankWriteAt = c.executed;
+				{ const int sel = m_sel; m_sel = i; note("bank", c.hdi().txData().size()); m_sel = sel; }
+				if(m_hostWordHook(0))
+					m_hostWordFired = true;
+			}
+			if(m_traceEvery && c.executed >= c.nextTrace && c.executed >= m_traceFrom && m_trace.size() < 100000)
+			{
+				char line[256];
+				std::snprintf(line, sizeof line,
+					"core %d exec %llu dspctr %llu pc %06x sr %06x sp %02x mode %d pending %d periph-target %llu esai in %llu out %llu SAISR %06x RCR %06x TCR %06x HSR %06x HCR %06x DCR2 %06x DCO2 %06x DSR2 %06x DSR3 %06x DDR3 %06x DCO3 %06x DCR3 %06x DDR0 %06x DCO0 %06x DCR0 %06x DSR1 %06x DCO1 %06x DCR1 %06x",
+					i, static_cast<unsigned long long>(c.executed),
+					static_cast<unsigned long long>(c.dsp->getInstructionCounter()), pc,
+					c.dsp->regs().sr.var & 0xffffff, c.dsp->regs().sp.var & 0xff,
+					static_cast<int>(c.dsp->getProcessingMode()), c.dsp->hasPendingInterrupts() ? 1 : 0,
+					static_cast<unsigned long long>(c.px->getTargetClock()),
+					static_cast<unsigned long long>(c.rxFrames), static_cast<unsigned long long>(c.txFrames),
+					c.px->read(0xffffb3, dsp56k::Nop), c.px->read(0xffffb7, dsp56k::Nop), c.px->read(0xffffb5, dsp56k::Nop),
+					c.hdi().readStatusRegister(), c.hdi().readControlRegister(),
+					c.px->read(0xffffe4, dsp56k::Nop), c.px->read(0xffffe5, dsp56k::Nop),
+					c.px->read(0xffffe7, dsp56k::Nop), c.px->read(0xffffe3, dsp56k::Nop),
+					c.px->read(0xffffe2, dsp56k::Nop), c.px->read(0xffffe1, dsp56k::Nop), c.px->read(0xffffe0, dsp56k::Nop),
+					c.px->read(0xffffee, dsp56k::Nop), c.px->read(0xffffed, dsp56k::Nop), c.px->read(0xffffec, dsp56k::Nop),
+					c.px->read(0xffffeb, dsp56k::Nop), c.px->read(0xffffe9, dsp56k::Nop), c.px->read(0xffffe8, dsp56k::Nop));
+				m_trace.emplace_back(line);
+				c.nextTrace = (c.executed / m_traceEvery + 1) * m_traceEvery;
+			}
+				return true;
 	}
 
 	void DspPair::runDue()
 	{
-		for(int i = 0; i < 2; ++i)
+		// Round-robin in quanta of g_quantum instructions until both cores
+		// are at the due count.
+		bool ran = true;
+		while(ran)
 		{
-			Core& c = *m_cores[i];
-			if(!c.boot->finished())
+			ran = false;
+			for(int i = 0; i < 2; ++i)
 			{
-				// Held in the bootstrap ROM until its last word lands; the
-				// ROM's jump is the first instruction this core runs.
-				if(static_cast<double>(c.executed) < m_due)
-					c.executed = static_cast<uint64_t>(m_due);
-				continue;
-			}
-			if(c.faulted)
-			{
-				c.executed = static_cast<uint64_t>(m_due);
-				continue;
-			}
-			while(static_cast<double>(c.executed) < m_due)
-			{
-				const auto pc = c.dsp->getPC().toWord();
-				c.pcRing[c.pcRingPos++ % c.pcRing.size()] = pc;
-				if(pc >= g_pSize)
-				{
-					c.faulted = true;
-					char msg[96];
-					std::snprintf(msg, sizeof msg, "PC %#x is outside P memory (%#x words)", pc, g_pSize);
-					c.why = msg;
-					c.executed = static_cast<uint64_t>(m_due);
-					break;
-				}
-				// The idle fast-forward (dsp.h): eight instructions in a row
-				// inside a three-word window, no hardware loop open.
-				// O9: the budget counts the DSP's OWN instruction counter, the
-				// one its ESAI clock reads -- a `rep` advances it once per
-				// iteration where this loop makes ONE interpreter call, so
-				// counting calls ran the ESAI 0.27% fast against the frame
-				// clock (17 ESAI frames in a host frame, 17 of 399 -- O8b's
-				// residual). The delta is taken across the idle step too.
-				const auto before = c.dsp->getInstructionCounter();
-				uint64_t skipped = 0;
-				if(pc < c.lastPcLo || pc > c.lastPcHi)
-				{
-					c.lastPcLo = pc;
-					c.lastPcHi = pc + 2;
-					c.windowRun = 0;
-				}
-				else if(++c.windowRun >= 8 && m_idleSkip && !(c.dsp->regs().sr.var & 0x8000)
-					&& !c.dsp->hasPendingInterrupts())
-				{
-					// Skip to the next peripheral event (or the due count), then
-					// FALL THROUGH and execute the poll once, so it can see what
-					// changed. ⚠️ `continue` here left the poll never executed
-					// and the uploader waiting for an echo forever (measured
-					// 8 Sep 2026: "unrecognised spin at 40001b82").
-					const auto room = static_cast<uint64_t>(m_due - static_cast<double>(c.executed));
-					skipped = c.dsp->idleStep(room ? room : 1);
-					c.idleSkipped += skipped;
-				}
-				c.dsp->execInterpreter();
-				c.dsp->doLoopEnd();
-				const auto d = c.dsp->getInstructionCounter() - before;
-				c.executed += d ? d : 1;
-				if(d > skipped + 1) c.surplus += d - skipped - 1;
-				if(!d) ++c.zeroDelta;
-				if(m_traceEvery && c.executed >= c.nextTrace && m_trace.size() < 100000)
-				{
-					char line[256];
-					std::snprintf(line, sizeof line,
-						"core %d exec %llu dspctr %llu pc %06x sr %06x mode %d pending %d periph-target %llu esai in %llu out %llu SAISR %06x RCR %06x TCR %06x HSR %06x HCR %06x DCR2 %06x DCO2 %06x DSR2 %06x DSR3 %06x DDR3 %06x DCO3 %06x DCR3 %06x DDR0 %06x DCO0 %06x DCR0 %06x DSR1 %06x DCO1 %06x DCR1 %06x",
-						i, static_cast<unsigned long long>(c.executed),
-						static_cast<unsigned long long>(c.dsp->getInstructionCounter()), pc,
-						c.dsp->regs().sr.var & 0xffffff,
-						static_cast<int>(c.dsp->getProcessingMode()), c.dsp->hasPendingInterrupts() ? 1 : 0,
-						static_cast<unsigned long long>(c.px->getTargetClock()),
-						static_cast<unsigned long long>(c.rxFrames), static_cast<unsigned long long>(c.txFrames),
-						c.px->read(0xffffb3, dsp56k::Nop), c.px->read(0xffffb7, dsp56k::Nop), c.px->read(0xffffb5, dsp56k::Nop),
-						c.hdi().readStatusRegister(), c.hdi().readControlRegister(),
-						c.px->read(0xffffe4, dsp56k::Nop), c.px->read(0xffffe5, dsp56k::Nop),
-						c.px->read(0xffffe7, dsp56k::Nop), c.px->read(0xffffe3, dsp56k::Nop),
-						c.px->read(0xffffe2, dsp56k::Nop), c.px->read(0xffffe1, dsp56k::Nop), c.px->read(0xffffe0, dsp56k::Nop),
-						c.px->read(0xffffee, dsp56k::Nop), c.px->read(0xffffed, dsp56k::Nop), c.px->read(0xffffec, dsp56k::Nop),
-						c.px->read(0xffffeb, dsp56k::Nop), c.px->read(0xffffe9, dsp56k::Nop), c.px->read(0xffffe8, dsp56k::Nop));
-					m_trace.emplace_back(line);
-					c.nextTrace = (c.executed / m_traceEvery + 1) * m_traceEvery;
-				}
+				const double lim = std::min(m_due, static_cast<double>(m_cores[i]->executed) + g_quantum);
+				while(stepCore(i, lim))
+					ran = true;
 			}
 		}
 	}
@@ -808,7 +932,8 @@ namespace ot
 				"host words in %llu / out %llu, host commands %llu%s\n"
 				"                     ESAI frames in %llu / out %llu (ESAI_1 %llu / %llu), last out slot 0 = %06x %06x; idle-skipped %llu; mailbox sent %llu; read-back words %llu (%llu not in time)\n"
 				"                     ESAI frames per host frame (0x8c to 0x8c): min %llu max %llu, exactly 16 on %llu of %llu; TCCR %06x (%u slots), %u instructions per slot\n"
-				"                     audio (O9): transport start at ESAI frame %llu out / %llu in; TX0 non-zero per slot %llu %llu %llu %llu %llu %llu %llu %llu; RX0 non-zero per slot %llu %llu %llu %llu %llu %llu %llu %llu; DSP counter %llu, surplus over interpreter calls %llu (%.3f%%), zero-delta calls %llu\n",
+				"                     audio (O9): transport start at ESAI frame %llu out / %llu in; TX0 non-zero per slot %llu %llu %llu %llu %llu %llu %llu %llu; RX0 non-zero per slot %llu %llu %llu %llu %llu %llu %llu %llu; DSP counter %llu, surplus over interpreter calls %llu (%.3f%%), zero-delta calls %llu\n"
+				"                     bank id -> host take: %llu takes, mean %.2f samples, max %.2f at take %llu (a ring half is 16; DMA2 dies past it); bank writes inside a pull %llu\n",
 				i, c.boot->finished() ? "done" : "WAITING", c.boot->getLength(), c.boot->getInitialPC(),
 				c.dsp->getPC().toWord(), static_cast<unsigned long long>(c.executed),
 				static_cast<unsigned long long>(c.wordsIn), static_cast<unsigned long long>(c.wordsOut),
@@ -830,13 +955,37 @@ namespace ot
 				static_cast<unsigned long long>(c.rxNZ[4]), static_cast<unsigned long long>(c.rxNZ[5]), static_cast<unsigned long long>(c.rxNZ[6]), static_cast<unsigned long long>(c.rxNZ[7]),
 				static_cast<unsigned long long>(c.dsp->getInstructionCounter()), static_cast<unsigned long long>(c.surplus),
 				c.executed ? 100.0 * static_cast<double>(c.surplus) / static_cast<double>(c.executed) : 0.0,
-				static_cast<unsigned long long>(c.zeroDelta));
+				static_cast<unsigned long long>(c.zeroDelta),
+				static_cast<unsigned long long>(c.bankTakes), c.bankTakes ? static_cast<double>(c.bankTakeSum) / static_cast<double>(c.bankTakes) / g_dspIps : 0.0,
+				static_cast<double>(c.bankTakeMax) / g_dspIps, static_cast<unsigned long long>(c.bankTakeMaxAt),
+				static_cast<unsigned long long>(c.bankWritesInPull));
 			s += line;
 			if(i == 0)
 			{
 				uint64_t nz = 0;
 				for(const auto w : m_shared) if(w & 0xffffff) ++nz;
 				s += "                     shared window (P/X/Y 0x30000-0x3ffff, one memory): " + std::to_string(nz) + " non-zero words now\n";
+			}
+			{
+				std::string v = "                     interrupt vectors taken:";
+				for(const auto& [vba, n] : c.vectorsTaken)
+				{
+					char f[40];
+					std::snprintf(f, sizeof f, " %#04x x%llu", vba, static_cast<unsigned long long>(n));
+					v += f;
+				}
+				s += v + "\n";
+				if(c.timerEnabledAt)
+				{
+					char f[200];
+					std::snprintf(f, sizeof f, "                     TIMER0 enabled (TCSR %06x) first seen at executed %llu, PCs before: %06x %06x %06x %06x %06x %06x %06x %06x\n",
+						c.timerTcsr, static_cast<unsigned long long>(c.timerEnabledAt), c.timerPcs[0], c.timerPcs[1], c.timerPcs[2], c.timerPcs[3], c.timerPcs[4], c.timerPcs[5], c.timerPcs[6], c.timerPcs[7]);
+					s += f;
+					std::snprintf(f, sizeof f, "                     r0-7 %06x %06x %06x %06x %06x %06x %06x %06x  m0-7 %06x %06x %06x %06x %06x %06x %06x %06x\n",
+						c.timerR[0], c.timerR[1], c.timerR[2], c.timerR[3], c.timerR[4], c.timerR[5], c.timerR[6], c.timerR[7],
+						c.timerM[0], c.timerM[1], c.timerM[2], c.timerM[3], c.timerM[4], c.timerM[5], c.timerM[6], c.timerM[7]);
+					s += f;
+				}
 			}
 			if(m_writesOn)
 			{

--- a/tools/ot_emu/dsp.h
+++ b/tools/ot_emu/dsp.h
@@ -90,7 +90,8 @@ namespace ot
 		bool read(uint32_t _addr, uint8_t _size, uint32_t& _out) override;
 		bool write(uint32_t _addr, uint8_t _size, uint32_t _val) override;
 		void tickInstructions(uint64_t _n) override;
-		void tickSamples(double _n) override;
+		double tickSamples(double _n) override;
+		void setHostWordHook(std::function<bool(int)> _f) override { m_hostWordHook = std::move(_f); }
 		int selected() const override { return m_sel; }
 		bool hostRingEmpty(int _core) const override;
 		void pushHalfwords(uint32_t _addr, const std::vector<uint16_t>& _hw) override;
@@ -129,6 +130,7 @@ namespace ot
 		// HDI08 status registers -- what to read when a core stops making
 		// progress and the question is when it stopped.
 		void setTrace(uint64_t _every) { m_traceEvery = _every; }
+		void setTraceFrom(uint64_t _executed) { m_traceFrom = _executed; }	// O9b: a window, so the cap holds the END of a run
 		// The idle fast-forward: a core found in a poll loop (the last PCs in
 		// a window of three words, outside any hardware DO loop) is advanced
 		// to its next peripheral event instead of executing the polls. What it
@@ -179,10 +181,21 @@ namespace ot
 		// command. A region written with content is where audio (or state)
 		// passes through, whatever the buffer is called.
 		void setWriteMap(const bool _on) { m_writesOn = _on; }
+		// A write watch on one DSP word: the last 16 (pc, value, executed) that wrote it (O9b).
+		void setWriteWatch(const int _core, const char _space, const uint32_t _addr) { m_watchCore = _core; m_watchSpace = _space; m_watchAddr = _addr; m_watchOn = true; }
+		struct WatchHit { uint32_t pc, val; uint64_t executed; uint32_t last[4]; uint32_t ddr0, dco0, dsr1, dco1, r4, r6, area, r0; };
+		const std::vector<WatchHit>& writeWatchHits() const { return m_watchHits; }
+		// A PC watch on one core: registers at every arrival (last 24), the DSP side of route A's --watch-pc (O9b).
+		struct PcWatchHit { uint64_t executed; uint32_t a1, a0, b1, b0, x0, x1, y0, y1, r0, r4, r6, n4, sp, r2, m2; };
+		void setPcWatch(const int _core, const uint32_t _pc, const uint64_t _from = 0) { m_pcWatchCore = _core; m_pcWatchPc = _pc; m_pcWatchFrom = _from; m_pcWatchOn = true; }
+		const std::vector<PcWatchHit>& pcWatchHits() const { return m_pcWatchHits; }
 		const std::vector<std::string>& writeMap() const { return m_writeMap; }
 
-		// Run both cores up to the due count now (the ticks only book it).
+		// Run both cores up to the due count now (the ticks only book it),
+		// interleaved in quanta of g_quantum instructions (O9b).
+		static constexpr double g_quantum = 64.0;
 		void runDue();
+		bool stepCore(int _i, double _limit);
 		// Run ONE core until `_ready` or `_budget` instructions (the read-back
 		// needs the DSP to produce each word). Returns whether it became ready.
 		bool runCoreUntil(int _core, const std::function<bool()>& _ready, uint64_t _budget);
@@ -207,9 +220,16 @@ namespace ot
 		double m_ratio, m_ips;
 		double m_due = 0.0;
 		bool m_logOn = false;
-		uint64_t m_traceEvery = 0;
+		uint64_t m_traceEvery = 0, m_traceFrom = 0;
 		bool m_idleSkip = true;
 		bool m_capture = false, m_tones = false, m_mapOn = false, m_writesOn = false;
+		bool m_pulling = false;
+		bool m_pcWatchOn = false; int m_pcWatchCore = 0; uint32_t m_pcWatchPc = 0; uint64_t m_pcWatchFrom = 0;	// with a `from`, the FIRST 24 arrivals after it are kept
+		std::vector<PcWatchHit> m_pcWatchHits;
+		bool m_watchOn = false; int m_watchCore = 0; char m_watchSpace = 'X'; uint32_t m_watchAddr = 0;
+		std::vector<WatchHit> m_watchHits;			// inside pullHalfwords: host-port words are the read-back, not the bank id
+		bool m_hostWordFired = false;	// set by runDue when the hook fired; tickSamples stops its slice on it
+		std::function<bool(int)> m_hostWordHook;
 		std::vector<std::string> m_map, m_writeMap;
 		std::vector<int32_t> m_input;
 		uint32_t m_inputChannels = 0;

--- a/tools/ot_emu/machine.cpp
+++ b/tools/ot_emu/machine.cpp
@@ -278,8 +278,11 @@ namespace ot
 	bool Machine::step()
 	{
 		const auto p = pc();
+		++m_instructions;		// O9b: the RTOS phase steps through here; without this every PC-watch stamp read the boot's last count
 		if(!m_watchPc.empty())
 			notePcWatch(p);
+		if(m_profileEvery && (m_instructions % m_profileEvery) == 0)
+			++m_profile[p];		// the RTOS phase steps through here, not run() (O9b's coverage)
 		const auto op = read16(p);
 		// The EMAC and mov3q are A-line: Musashi routes 0xAxxx to the A-line
 		// EXCEPTION, not to the illegal-instruction callback the V4e layer
@@ -473,7 +476,7 @@ namespace ot
 
 	void Machine::notePcWatch(const uint32_t _pc)
 	{
-		if(m_pcHits.size() >= 4000)
+		if(m_pcHits.size() >= 2000000)	// ⚠️ was 4,000: ten watched PCs filled it 25 frames into a run, before the trig it was set for (O9b)
 			return;
 		for(const auto a : m_watchPc)
 			if(a == _pc)
@@ -481,6 +484,10 @@ namespace ot
 				PcHit h{m_instructions, _pc, getD(0), getD(1), getA(0), getA(1), getA7(), {}};
 				for(int i = 0; i < 5; ++i)
 					h.stack[i] = peek32(h.sp + 4 * static_cast<uint32_t>(i));
+				for(int i = 0; i < 8; ++i)
+					h.d[i] = getD(i);
+				for(int i = 0; i < 7; ++i)
+					h.a[i] = getA(i);
 				m_pcHits.push_back(h);
 				return;
 			}

--- a/tools/ot_emu/machine.h
+++ b/tools/ot_emu/machine.h
@@ -82,7 +82,14 @@ namespace ot
 		virtual bool read(uint32_t _addr, uint8_t _size, uint32_t& _out) = 0;
 		virtual bool write(uint32_t _addr, uint8_t _size, uint32_t _val) = 0;
 		virtual void tickInstructions(uint64_t _n) = 0;
-		virtual void tickSamples(double _n) = 0;
+		// Returns the samples actually advanced: fewer than `_n` when the
+		// co-processor raised a host word the machine should take NOW (O9b).
+		virtual double tickSamples(double _n) = 0;
+		// O9b: called when core `_core` puts a word in its host port OUTSIDE a
+		// read-back pull -- the DSP's bank id, which on hardware is what the
+		// frame interrupt announces (the frame handler reads it with no ready
+		// check). Default: nobody listens.
+		virtual void setHostWordHook(std::function<bool(int)>) {}		// returns whether the edge was taken; if not, it is offered again
 		// The eDMA's side of the host port (O8 step 4). A block going TO the
 		// co-processor is pushed whole at the kick, halfword by halfword, as
 		// the bus cycles the eDMA would make; a block coming FROM it is pulled
@@ -228,7 +235,7 @@ namespace ot
 		// The timestamp is the INSTRUCTION COUNT rather than the sample clock,
 		// because the boot has no sample clock -- `Rtos` prints its own sample
 		// beside it for hits it saw.
-		struct PcHit { uint64_t instruction; uint32_t pc, d0, d1, a0, a1, sp, stack[5]; };
+		struct PcHit { uint64_t instruction; uint32_t pc, d0, d1, a0, a1, sp, stack[5]; uint32_t d[8], a[7]; };	// d/a: every register (O9b: a watch that showed four of them could not say which record a routine read)
 		void watchPc(std::vector<uint32_t> _addrs) { m_watchPc = std::move(_addrs); }
 
 		// ✅ THE DSP HOST PORT, RECORDED. The firmware programs the DSPs

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -77,6 +77,7 @@ int main(int _argc, char** _argv)
 	double dspRatio = ot::DspPair::g_dspIps / ot::DspPair::g_cfIps, dspIps = ot::DspPair::g_dspIps;	// their clock, in DSP instructions per ColdFire instruction / per sample (dsp.h says where 4160 comes from)
 	std::string dspLog;			// every host-side event on the DSP pair -> FILE
 	uint64_t dspTrace = 0;		// a status line per core every N DSP instructions
+	uint64_t dspTraceFrom = 0;	// ... only once a core has executed this many (a window at the end of a run)
 	bool dspNoIdle = false;
 	bool dspDrainPaced = false;	// EXPERIMENT: a host-port burst completes when the DSP drained it (measured 8 Sep: one frame of exactly 16 ESAI frames, then the completion ISR loses an edge and stalls)		// execute every poll of an idle core (fidelity check; slow)
 	bool dspVerbose = false;	// the vendored DSP library's own log lines
@@ -85,8 +86,13 @@ int main(int _argc, char** _argv)
 	std::string blockLog;		// every host-port BLOCK with its non-zero count -> FILE
 	std::string audioOut;		// O9: PREFIX -> PREFIX_core<k>.wav, every X-side ESAI TX0 frame (8 slots) the core put out
 	std::string audioIn;		// O9: a WAV onto RX0's slots from the transport start, or "tones"
+	std::string dspPcWatch;		// O9b: core:pc -- registers at the last 24 arrivals at that DSP PC
+	std::string dspWatch;		// O9b: core:space:addr -- the last 16 writers of one DSP word
 	std::string dspMap;		// O9: per-frame non-zero counts per 4K chunk of both cores' X and Y -> FILE
 	std::string dspWrites;		// O9: per-frame NON-ZERO WRITE counts per 256-word region of both cores' X and Y -> FILE
+	std::string coverage;		// O9b: every ColdFire PC executed from the transport start on, with its count -> FILE (diff two runs)
+	bool frameTimer = false;	// O9b: keep the free-running 16-sample frame timer with --dsp (default: the DSP's bank word is the frame edge)
+	int mainLevel = -1;			// O9b: post sys command 4 (SET MAIN LEVEL) with this level after the load; -1 = don't (the emulated load never does, and every voice then renders at gain zero)
 
 	for(int i = 1; i < _argc; ++i)
 	{
@@ -126,6 +132,7 @@ int main(int _argc, char** _argv)
 		else if(a == "--dsp-ips" && i + 1 < _argc)	dspIps = std::atof(_argv[++i]);
 		else if(a == "--dsp-log" && i + 1 < _argc)	dspLog = _argv[++i];
 		else if(a == "--dsp-trace" && i + 1 < _argc)	dspTrace = std::strtoull(_argv[++i], nullptr, 0);
+		else if(a == "--dsp-trace-from" && i + 1 < _argc)	dspTraceFrom = std::strtoull(_argv[++i], nullptr, 0);
 		else if(a == "--dsp-no-idle")			dspNoIdle = true;
 		else if(a == "--dsp-drain-paced")		dspDrainPaced = true;
 		else if(a == "--dsp-verbose")			dspVerbose = true;
@@ -135,7 +142,12 @@ int main(int _argc, char** _argv)
 		else if(a == "--audio-out" && i + 1 < _argc)	audioOut = _argv[++i];
 		else if(a == "--audio-in" && i + 1 < _argc)	audioIn = _argv[++i];
 		else if(a == "--dsp-map" && i + 1 < _argc)	dspMap = _argv[++i];
+		else if(a == "--dsp-watch" && i + 1 < _argc)	dspWatch = _argv[++i];
+		else if(a == "--dsp-pcwatch" && i + 1 < _argc)	dspPcWatch = _argv[++i];
 		else if(a == "--dsp-writes" && i + 1 < _argc)	dspWrites = _argv[++i];
+		else if(a == "--coverage" && i + 1 < _argc)	coverage = _argv[++i];
+		else if(a == "--main-level" && i + 1 < _argc)	mainLevel = std::atoi(_argv[++i]);
+		else if(a == "--frame-timer")				frameTimer = true;
 		else
 		{
 			std::printf("usage: ot_emu [--image FILE] [--max N] [--periph] [--profile]\n"
@@ -187,11 +199,24 @@ int main(int _argc, char** _argv)
 		dspPair = std::make_unique<ot::DspPair>(dspRatio, dspIps);
 		dspPair->setLog(!dspLog.empty());
 		dspPair->setTrace(dspTrace);
+		dspPair->setTraceFrom(dspTraceFrom);
 		dspPair->setIdleSkip(!dspNoIdle);
 		ot::DspPair::setVerbose(dspVerbose);
 		dspPair->setAudioCapture(!audioOut.empty());
 		dspPair->setActivityMap(!dspMap.empty());
 		dspPair->setWriteMap(!dspWrites.empty());
+		if(!dspPcWatch.empty())
+		{
+			int core = 0; unsigned pc = 0; unsigned long long from = 0;
+			if(std::sscanf(dspPcWatch.c_str(), "%d:%x:%llu", &core, &pc, &from) >= 2)
+				dspPair->setPcWatch(core, pc, from);
+		}
+		if(!dspWatch.empty())
+		{
+			int core = 0; char space = 'X'; unsigned addr = 0;
+			if(std::sscanf(dspWatch.c_str(), "%d:%c:%x", &core, &space, &addr) == 3)
+				dspPair->setWriteWatch(core, space, addr);
+		}
 		if(audioIn == "tones")
 			dspPair->setAudioTones(true);
 		else if(!audioIn.empty())
@@ -264,6 +289,11 @@ int main(int _argc, char** _argv)
 		rtos.setBlockLog(!blockLog.empty());
 		if(dspDrainPaced)
 			rtos.setDspDrainPacing(true);
+		if(dspPair && !frameTimer)
+		{
+			rtos.setFrameFromDsp(true);
+			std::printf("frame edge : the DSP's bank word (core 0's host port outside a pull); --frame-timer restores the 16-sample timer\n");
+		}
 		std::ofstream edmaOut;
 		if(!edmaLog.empty())
 		{
@@ -475,6 +505,12 @@ int main(int _argc, char** _argv)
 				uint32_t finalBank = load.finalBank;
 				if(bank >= 0 && finalBank != static_cast<uint32_t>(bank))
 					finalBank = rtos.selectBankLive(static_cast<uint32_t>(bank));
+				if(mainLevel >= 0)
+				{
+					const auto g = rtos.setMainLevelLive(static_cast<uint32_t>(mainLevel));
+					std::printf("main level : sys command %u posted with %d -> gain table[0] = %#x%s (bit 0 of 0x8000004a = %u)\n",
+						ot::g_setMainLevelCase, mainLevel, g, g ? "" : " -- NOT FILLED", m.read8(0x8000004a) & 1);
+				}
 				const auto pattern = m.peek32(ot::g_curPattern) >> 24;
 				const auto seq = rtos.seqSelectLive(finalBank, pattern);
 				if(internalClock)
@@ -490,6 +526,8 @@ int main(int _argc, char** _argv)
 					std::printf("poke trig  : track 1 step %d -> mask byte 7 = %#04x\n",
 						pokeTrig, rtos.pokeTrig(static_cast<uint32_t>(pokeTrig)));
 				rtos.installTrigLog();
+				if(!coverage.empty())
+					m.setProfile(1);		// every PC from here: the coverage of the frames phase
 				// Frame 0 = the first frame delivered after the transport
 				// start returned, which is what the cold tool calls frame 0:
 				// the two reports compare directly.
@@ -599,9 +637,10 @@ int main(int _argc, char** _argv)
 				"reported 0 for a boot address whether it ran or not)\n", m.pcHits().size());
 			for(const auto& h : m.pcHits())
 				std::printf("   [%12llu] at %#x d0=%#x d1=%#x a0=%#x a1=%#x "
-					"[sp %#x: %#x %#x %#x %#x %#x]\n",
+					"[sp %#x: %#x %#x %#x %#x %#x] d2-7 %#x %#x %#x %#x %#x %#x a2-6 %#x %#x %#x %#x %#x\n",
 					static_cast<unsigned long long>(h.instruction), h.pc, h.d0, h.d1, h.a0, h.a1,
-					h.sp, h.stack[0], h.stack[1], h.stack[2], h.stack[3], h.stack[4]);
+					h.sp, h.stack[0], h.stack[1], h.stack[2], h.stack[3], h.stack[4],
+					h.d[2], h.d[3], h.d[4], h.d[5], h.d[6], h.d[7], h.a[2], h.a[3], h.a[4], h.a[5], h.a[6]);
 		}
 		if(!watchMem.empty())
 		{
@@ -611,8 +650,8 @@ int main(int _argc, char** _argv)
 			// frame have to look different.
 			std::printf("watch-mem  : %zu write(s)\n", rtos.memWrites().size());
 			for(const auto& w : rtos.memWrites())
-				std::printf("   [%10.1f] [%#x] <- %#x (%u) at pc %#x in %s\n",
-					w.sample, w.addr, w.val, w.size, w.pc, ot::taskName(w.tcb));
+				std::printf("   [%10.1f] [%#x] <- %#x (%u) at pc %#x in %s  i=%llu\n",
+					w.sample, w.addr, w.val, w.size, w.pc, ot::taskName(w.tcb), static_cast<unsigned long long>(w.instr));
 		}
 
 		if(!serialOut.empty())
@@ -633,9 +672,32 @@ int main(int _argc, char** _argv)
 		}
 	}
 
+	if(!coverage.empty())
+	{
+		std::ofstream t(coverage);
+		std::vector<std::pair<uint32_t, uint64_t>> pcs(m.profile().begin(), m.profile().end());
+		std::sort(pcs.begin(), pcs.end());
+		for(const auto& e : pcs)
+			t << std::hex << e.first << ' ' << std::dec << e.second << '\n';
+		std::printf("coverage   : %s (%zu distinct PCs from the transport start)\n", coverage.c_str(), pcs.size());
+	}
 	if(dspPair)
 	{
 		std::printf("dsp        : at the end\n%s", dspPair->report().c_str());
+		if(!dspPcWatch.empty())
+		{
+			std::printf("dsp pcwatch: %s, last %zu arrival(s): executed a1:a0 b1:b0 x0 x1 y0 y1 r0 r4 r6 n4 sp r2 m2\n", dspPcWatch.c_str(), dspPair->pcWatchHits().size());
+			for(const auto& h : dspPair->pcWatchHits())
+				std::printf("             %llu %06x:%06x %06x:%06x %06x %06x %06x %06x %06x %06x %06x %06x %02x %06x %06x\n", static_cast<unsigned long long>(h.executed),
+					h.a1, h.a0, h.b1, h.b0, h.x0, h.x1, h.y0, h.y1, h.r0, h.r4, h.r6, h.n4, h.sp, h.r2, h.m2);
+		}
+		if(!dspWatch.empty())
+		{
+			std::printf("dsp watch  : %s, last %zu writer(s):\n", dspWatch.c_str(), dspPair->writeWatchHits().size());
+			for(const auto& h : dspPair->writeWatchHits())
+				std::printf("             pc %#07x <- %06x at executed %llu; last pcs %06x %06x %06x %06x; r0 %06x r4 %06x r6 %06x area %u\n", h.pc, h.val, static_cast<unsigned long long>(h.executed),
+					h.last[0], h.last[1], h.last[2], h.last[3], h.r0, h.r4, h.r6, h.area);
+		}
 		if(!dspWrites.empty())
 		{
 			std::ofstream t(dspWrites);

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -365,12 +365,27 @@ namespace ot
 	{
 		m_pit0.advance(m_sample);
 		m_pit1.advance(m_sample);
-		if(m_frame)
+		if(m_frame && !m_frameFromDsp)
 			while(m_sample >= m_nextFrame)
 			{
 				m_framePending = true;			// a latch, not a count: a masked
 				m_nextFrame += g_framePeriod;	// edge source remembers ONE edge
 			}
+		else if(m_frameFromDsp)
+		{
+			// The DSP's first bank id has been waiting since the load (it
+			// blocks at P:0x97 until the host takes it). Deliver it where
+			// route A fires ITS first frame -- one period after the frame
+			// clock came on -- so the transport start keeps the oracle's
+			// phase; from then on the DSP's own writes are the edges.
+			if(m_frame && m_dspEdgeLatched && m_sample >= m_nextFrame)
+			{
+				m_framePending = true;
+				m_dspEdgeLatched = false;
+			}
+			while(m_sample >= m_nextFrame)
+				m_nextFrame += g_framePeriod;	// only the idle skip's horizon; the edge itself is the DSP's
+		}
 		// The eDMA is told the boundary even when the frame clock is off:
 		// its paced completions are the DSP's clock, not the interrupt's, and
 		// the TCD state is real in every run.
@@ -543,7 +558,7 @@ namespace ot
 				// The DSPs keep running through a skipped idle: book them the
 				// samples the clock jumps (O8).
 				if(auto* c = m_machine.coprocessor(); c && ex > m_sample)
-					c->tickSamples(ex - m_sample);
+					ex = m_sample + c->tickSamples(ex - m_sample);	// a DSP frame edge ends the skip there
 				m_sample = std::max(m_sample, ex);
 				++m_idleSkips;
 				tickTimers();
@@ -817,6 +832,25 @@ namespace ot
 			m_nextFrame = m_sample + g_framePeriod;
 	}
 
+	void Rtos::setFrameFromDsp(const bool _on)
+	{
+		m_frameFromDsp = _on;
+		auto* co = m_machine.coprocessor();
+		if(!co)
+			return;
+		co->setHostWordHook(_on ? std::function<bool(int)>([this](int)
+		{
+			if(!m_frame)
+			{
+				m_dspEdgeLatched = true;		// delivered the moment the frame clock comes on
+				return true;
+			}
+			m_framePending = true;
+			m_nextFrame = m_sample + g_framePeriod;	// the eDMA boundary rule and the idle skip still read it
+			return true;
+		}) : std::function<bool(int)>());
+	}
+
 	uint8_t Rtos::selectBankLive(const uint32_t _bank, const double _ms)
 	{
 		if(runToMainSpin() != Stop::Gate)
@@ -889,8 +923,8 @@ namespace ot
 		m_machine.addWriteWatch(_addr, _addr + _len - 1,
 			[this](const uint32_t _a, const uint8_t _size, const uint32_t _val, const uint32_t _pc)
 			{
-				if(m_memWrites.size() < 20000)
-					m_memWrites.push_back({m_sample, curTcb(), _pc, _a, _val, _size});
+				if(m_memWrites.size() < 2000000)	// ⚠️ was 20,000: a boot-time init filled it before the frames phase began (O9b)
+					m_memWrites.push_back({m_sample, curTcb(), _pc, _a, _val, _size, m_machine.instructions()});
 			});
 	}
 
@@ -922,6 +956,22 @@ namespace ot
 			if(a.vector == g_tickVector)
 				++n;
 		return n;
+	}
+
+	uint32_t Rtos::setMainLevelLive(const uint32_t _level, const double _ms)
+	{
+		if(runToMainSpin() != Stop::Gate)
+			return m_machine.peek32(g_mainGainTable);
+		m_machine.poke32(g_sysMsgScratch, (g_setMainLevelCase << 24) | ((_level & 0x7f) << 16));
+		uint32_t d0 = 0;
+		if(!postMessage(g_sysQueue, g_sysMsgScratch, d0))
+			return m_machine.peek32(g_mainGainTable);
+		const double end = m_sample + _ms * g_sampleHz / 1000.0;
+		while(m_sample < end && m_machine.peek32(g_mainGainTable) == 0)
+			if(!stepOnce())
+				break;
+		runToMainSpin();
+		return m_machine.peek32(g_mainGainTable);
 	}
 
 	bool Rtos::requestCardMount()

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -81,6 +81,8 @@ namespace ot
 	inline constexpr uint32_t g_curPattern      = 0x80000004;
 	inline constexpr uint32_t g_engineBankWrite = 0x40087d44;	// LOAD PROJECT writes PART_PTR from BANK= here
 	inline constexpr uint32_t g_selectBankCase  = 21;			// sys table[20]: "select bank msg[1]"
+	inline constexpr uint32_t g_setMainLevelCase = 4;			// sys table[3]: "set main level msg[1]" (O9b)
+	inline constexpr uint32_t g_mainGainTable   = 0x80003c60;	// 10 longwords, gain:(-1-gain), read per voice by 0x4000cca4
 
 	inline constexpr uint32_t g_fwTransport   = 0x4009b964;	// (arg) transport start/stop; start posts to the UI queue
 	inline constexpr uint32_t g_fwStartTrack  = 0x4009b5c8;	// (track) promote a track to running
@@ -200,12 +202,28 @@ namespace ot
 		// `Rtos(frame=True)` faults on unmapped memory before anything has
 		// primed its auto-map hook), so the from-boot form has no oracle.
 		void setFrame(bool _on);
+		// O9b: the frame edge comes from the DSP's bank-id word (core 0's
+		// host port going non-empty outside a pull) instead of the 16-sample
+		// timer. On hardware the frame handler reads that word with no ready
+		// check, so the interrupt must be what announces it; a free-running
+		// timer read a read-back data word as the bank id at frame 348 of
+		// the first run that carried audio, and the firmware HALTED on it.
+		void setFrameFromDsp(bool _on);
 
 		// Switch the working bank through sys's own case -- the very message
 		// the engine's reset posts with bank 0 (RTOS_FORK.md §7): PART_PTR :=
 		// the bank's blob, the blob is copied into SRAM, the bank byte
 		// follows. Returns the bank byte.
 		uint8_t selectBankLive(uint32_t _bank, double _ms = 500.0);
+		// O9b: sys command 4 = SET MAIN LEVEL (msg[1] = 0..127). Its handler
+		// (case 0x40061e0a) fills the ten-entry main gain table at
+		// 0x80003c60 from the curve at 0x400bcd90 -- the table every voice's
+		// level is multiplied by in the frame builder (0x4000cca4), and the
+		// one thing NEITHER emulator ever wrote: the load does not post it,
+		// so every voice rendered at gain zero. Returns the table's first
+		// entry afterwards (0 = the handler did not fill it; it skips the
+		// fill when bit 0 of 0x8000004a is clear).
+		uint32_t setMainLevelLive(uint32_t _level, double _ms = 200.0);
 
 		// The sequencer's own bank/pattern select, the LOAD PROJECT handler's
 		// LAST step. It writes the sequencer's playing bank/pattern -- the
@@ -250,7 +268,7 @@ namespace ot
 		// address watched it costs one compare.
 		void watchPc(const std::vector<uint32_t>& _addrs);
 
-		struct MemWrite { double sample; uint32_t tcb, pc, addr, val; uint8_t size; };
+		struct MemWrite { double sample; uint32_t tcb, pc, addr, val; uint8_t size; uint64_t instr; };	// instr: the machine's instruction count, the PC watch's clock (O9b)
 		void watchMem(uint32_t _addr, uint32_t _len);
 		const std::vector<MemWrite>& memWrites() const { return m_memWrites; }
 
@@ -463,6 +481,8 @@ namespace ot
 		int m_savedBank = -1;
 		bool m_frame = false;
 		bool m_framePending = false;
+		bool m_frameFromDsp = false;
+		bool m_dspEdgeLatched = false;	// the DSP wrote its bank id while the frame clock was off (it waits at P:0x97 for the host to take it)
 		double m_nextFrame = g_framePeriod;
 		uint64_t m_frameCount = 0;
 		size_t m_seeded = 0;

--- a/tools/ot_emu/v4e.cpp
+++ b/tools/ot_emu/v4e.cpp
@@ -267,11 +267,15 @@ namespace ot::v4e
 
 	namespace
 	{
-		// MACSR bits that matter here (CFPRM 4.1): bit 5 F/I selects fractional
-		// mode, bit 4 S/U selects signed, bit 0 is the product-independent
-		// saturation flag this firmware never sets.
+		// MACSR bits (CFPRM Rev. 3, Table 1-5, and QEMU's cpu.h): bit 7 OMC,
+		// bit 6 S/U, bit 5 F/I, bit 4 R/T. ❌ Until 8 Sep 2026 S/U was taken as
+		// bit 4 here ("bit 4 S/U selects signed"), which is R/T: the frame
+		// builder's two level chains run at MACSR 0xb0 (OMC|F/I|R/T) and 0x60
+		// (S/U|F/I), and the swap read the first as "S/U" and the second as
+		// plain -- so a `movclrl` in the second returned ACC[39:8] where the
+		// chip returns the 16-bit-rounded ACC[39:24] in the LOW word (O9b).
 		constexpr uint32_t g_macsrFractional = 0x20;	// F/I
-		constexpr uint32_t g_macsrSigned     = 0x10;	// S/U
+		constexpr uint32_t g_macsrSigned     = 0x40;	// S/U (integer: 1 = unsigned; fractional: 16-bit rounding on the read-out)
 
 		// One accumulator, 32 bits plus its 8-bit extensions. Musashi's
 		// ColdFire state has no EMAC, so the port keeps its own -- four
@@ -300,15 +304,76 @@ namespace ot::v4e
 
 		uint32_t macsr(Machine&) { return g_emac.macsr; }
 
-		// Reading an accumulator OUT: route A's `get_macf` (fractional: >> 8,
-		// no rounding because MACSR's RT bit is clear in this firmware) and
-		// its integer form (the low longword, no saturation because OMC is
-		// clear too).
+		// Reading an accumulator OUT: the CFPRM's MOVCLR / MOVE-from-ACC
+		// pseudocode (Rev. 3, chapter 6), every branch. ❌ Until 8 Sep 2026
+		// this was route A's `get_macf` minus its S/U branch -- "fractional:
+		// >> 8, no rounding because RT is clear in this firmware, no
+		// saturation because OMC is clear too" -- and that comment was wrong
+		// on both counts for the frame builder's level chain at
+		// 0x4000ccae-0x4000ccfc, which runs with MACSR = 0x60. In FRACTIONAL
+		// mode S/U is not signed/unsigned at all: it selects 16-BIT ROUNDING
+		// on the read-out -- ACC[39:24], rounded by ACC[23:0], into Rx[15:0]
+		// with Rx[31:16] zero. The firmware keeps the LOW words of two such
+		// reads as a voice record's mode:level (`movclrl acc0,d3; swap d3;
+		// movclrl acc1,d2; movew d2,d3`); with a plain >> 8 those words are
+		// 0 and every voice renders at level zero (O9b, the silent output).
+		constexpr uint32_t g_macsrOmc = 0x80, g_macsrRt = 0x10;
 		uint32_t accRead(const uint32_t _n)
 		{
-			if(g_emac.macsr & g_macsrFractional)
-				return static_cast<uint32_t>(g_emac.acc[_n] >> 8);
-			return static_cast<uint32_t>(g_emac.acc[_n]);
+			const auto macsr = g_emac.macsr;
+			const auto acc = g_emac.acc[_n];				// ACC[47:0], sign-extended in an int64
+			if(!(macsr & g_macsrFractional))
+			{
+				if(!(macsr & g_macsrSigned))				// signed integer mode
+				{
+					if(!(macsr & g_macsrOmc))
+						return static_cast<uint32_t>(acc);
+					const auto top = (acc >> 31) & 0x1ffff;		// ACC[47:31]
+					if(top == 0 || top == 0x1ffff)
+						return static_cast<uint32_t>(acc);
+					return (acc >> 47) & 1 ? 0x80000000u : 0x7fffffffu;
+				}
+				if(!(macsr & g_macsrOmc))					// unsigned integer mode
+					return static_cast<uint32_t>(acc);
+				return ((acc >> 32) & 0xffff) == 0 ? static_cast<uint32_t>(acc) : 0xffffffffu;
+			}
+			// signed fractional mode
+			auto saturate32 = [](const int64_t _v) -> uint32_t
+			{
+				const auto top = (_v >> 39) & 0x1ff;			// [47:39]
+				if(top == 0 || top == 0x1ff)
+					return static_cast<uint32_t>(_v >> 8);
+				return (_v >> 47) & 1 ? 0x80000000u : 0x7fffffffu;
+			};
+			if(macsr & g_macsrSigned)
+			{
+				// 16-bit rounding: ACC[39:24] rounded by ACC[23:0] -> Rx[15:0]
+				int64_t v = acc >> 24;							// keeps the sign from [47]
+				const auto rem = acc & 0xffffff;
+				if(rem > 0x800000 || (rem == 0x800000 && (v & 1)))
+					++v;
+				if(macsr & g_macsrOmc)
+				{
+					const auto top = (v >> 15) & 0x1ff;		// [47:39] of the rounded value = v[23:15]
+					if(!(top == 0 || top == 0x1ff))
+						return (v >> 23) & 1 ? 0x8000u : 0x7fffu;
+				}
+				return static_cast<uint32_t>(v & 0xffff);
+			}
+			if(macsr & g_macsrRt)
+			{
+				// 32-bit rounding: ACC[47:8] rounded by ACC[7:0]
+				int64_t v = acc >> 8;
+				const auto rem = acc & 0xff;
+				if(rem > 0x80 || (rem == 0x80 && (v & 1)))
+					++v;
+				if(macsr & g_macsrOmc)
+					return saturate32(v << 8);
+				return static_cast<uint32_t>(v);
+			}
+			if(macsr & g_macsrOmc)
+				return saturate32(acc);
+			return static_cast<uint32_t>(acc >> 8);
 		}
 
 		// ... and writing one IN: route A's `move_mac`.

--- a/tools/ot_emu/v4e.h
+++ b/tools/ot_emu/v4e.h
@@ -20,5 +20,6 @@ namespace ot
 		// The EMAC, split out because it carries its own state and its own
 		// gate (tools/ot_emu/test_emac.cpp).
 		Result emac(Machine& _m, uint32_t _opcode);
+
 	}
 }


### PR DESCRIPTION
## What this is

Milestone O9b of the ColdFire port. `docs/COLDFIRE_PORT.md` O9b has the account; `docs/COLDFIRE_WORKORDER.md` queues O9c (the slot map and the audio comparison, O8's step 5). Two new entries in `CLAUDE.md`'s traps.

**Gate: a THRU track trigged with `--audio-in tones` puts audio on TX0 — passes.** 400 frames, 28 ticks, TX0 slots 1–4 carry the mix on 6,213 of 6,399 frames after the transport start (two stereo pairs, the second 3.7 dB lower).

## The four findings (measured)

1. **The trig does start a voice.** A per-PC coverage diff shows the p-lock applier plus a per-voice EMAC mixer every frame. Its gains come from a voice record whose level is scaled by the main gain table at `0x80003c60`, which only **sys command 4 (SET MAIN LEVEL)** writes — and no emulated load ever posts it. `--main-level 64` posts it after the load. Route A got the same post the same day from the parallel session.
2. **MACSR S/U is bit 6, and in fractional mode it is 16-bit rounding on the accumulator read-out** (CFPRM Rev. 3 ch. 6 MOVCLR pseudocode). The port had S/U as bit 4 and returned `ACC[39:8]` for everything; the firmware's level chain at MACSR `0x60` keeps the low words, which were 0. `accRead` is now the full pseudocode.
3. **The frame interrupt is the DSP's bank word.** The frame handler reads it with no ready check and `halt`s unless it is 0/1; with real audio a data word landed there at frame 348. The port raises the edge from payload A's bank write at P:0x73; `--frame-timer` keeps the old model.
4. **Eleventh vendored dsp56300 defect:** the AGU's modulo pre-decrement from the buffer base underflowed (`x:-(r2)`, r2 = 0, m2 = 0x3f → `0xffffbf`, chip `0x3f`). Sixteen sample writes walked the peripheral registers and enabled TIMER0; its vector in payload B is `move x0,y:(r4)+`, run inline 230,027 times, corrupting a voice count into a 196,608-iteration loop that starved core 0 and killed the output DMA 13 frames after the trig. Fixed in `agu.h`, `tools/dsp56300.patch` regenerated.

## Audit of the AGU fix on the shipped effects

`make check`'s bit-identity gates compare two renders on the same emulator and cannot see this class of change, so the shipping bus render was A/B'd directly: `send_probe --layout RS --wav` with and without the fix is **byte-identical** (529,244 bytes) and its peak/THD/spur lines match. No shipped effect was rendered on the underflow path.

## Gates

- `ctest` 7/7
- O6 with the cores against the stored oracle: 5/5
- M6a with the cores: 8/8
- `make check`: all runnable checks passed
- No build change to `make bus`, so no refhash run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)