### PR TITLE
Route A: .w MAC-with-load words go through the shim too; voice level word agrees with the port (0x01007f00)

### DIFF
--- a/docs/firmware/RTOS_FORK.md
+++ b/docs/firmware/RTOS_FORK.md
@@ -2247,7 +2247,12 @@ after processing). The write path reads the **input-capture ring**
 `0x80005760 + slot·0x100`, 8 slots of 256 bytes, filled by eDMA ch 7 one
 slot per frame (Bryan's §13.3 "channels 1 and 6 as input-capture staging"
 was the neighbouring buffers); slot layout = 16 samples × (L, R) 32-bit
-left-justified with **A/B at +0x80 and C/D at +0**, and the track reads
+left-justified with **A/B at +0x80 and C/D at +0** (the ColdFire's reading:
+the INAB source is the +0x80 pair; the port's O9c found the DSP fills +0
+from the ESAI-in ring's slots and +0x80 from its OUTPUT ring's slots 0/7 —
+a monitor placement some never-posted state enables — so under the port
+only C/D carry the physical inputs today; this driver injects at +0x80
+directly and is unaffected), and the track reads
 slot `(frameclock − (record+20 >> 4)) & 7` (`0x40007578`), eight frames
 behind delivery — the recording lags the live input by **128 samples**
 (buffer[0] = input time 16·(arm frame − 8) + offset, every pass). The
@@ -2381,8 +2386,10 @@ the handler returned; fixed by resuming after the instruction, EMU.md).
 With the level posted, the ten-pass 128 / RLEN 4 run was repeated:
 **T2's FLEX-on-R1 voice never appears in the outbound block at any of the
 ten retrigs** — every slot stays the input thru in all 12,600 frames (the
-same fixture's THRU cross-check gives T1 a live voice record `0x01004001`,
-mode 1 with a non-zero level word, so the level path works). That matches
+same fixture's THRU cross-check gives T1 a live voice record — first read
+`0x01004001`, the port's `0x01007f00` once a `.w` MAC-with-load word the
+native-site scan had skipped was routed through the shim, EMU.md — so the
+level path works and the two emulators agree on it). That matches
 the port's own finding that a staged FLEX sample is read from the card and
 never rendered: the FLEX sample/recorder-buffer playback path is unlocated
 in both emulators (COLDFIRE_PORT O9b/O9c). Until it is found, the played

--- a/docs/firmware/RTOS_FORK.md
+++ b/docs/firmware/RTOS_FORK.md
@@ -2370,6 +2370,28 @@ is always in it."* He offers his sound-on-sound project file.
   length is an exact tempo multiple and at 128 it is not (🟡 a candidate
   only; nothing measured).
 
+**Later the same day — the play side opens a crack.** The ColdFire port
+found why nothing plays under either emulator (COLDFIRE_PORT O9b): every
+voice's level is multiplied by the main gain table at `0x80003c60`, written
+only by sys command 4 (SET MAIN LEVEL), which no load ever posts. Route A
+now posts it after the load (`set_main_level_live`), which exposed a
+fourth harness defect: a forced interrupt taken at IPL 0 livelocked the run
+loop (the INTFRC write was aborted by the burst stop and re-executed after
+the handler returned; fixed by resuming after the instruction, EMU.md).
+With the level posted, the ten-pass 128 / RLEN 4 run was repeated:
+**T2's FLEX-on-R1 voice never appears in the outbound block at any of the
+ten retrigs** — every slot stays the input thru in all 12,600 frames (the
+same fixture's THRU cross-check gives T1 a live voice record `0x01004001`,
+mode 1 with a non-zero level word, so the level path works). That matches
+the port's own finding that a staged FLEX sample is read from the card and
+never rendered: the FLEX sample/recorder-buffer playback path is unlocated
+in both emulators (COLDFIRE_PORT O9b/O9c). Until it is found, the played
+stream across a 128 BPM retrig — the click's remaining half — cannot be
+observed under emulation; the hardware capture is the instrument that can.
+(Rebased onto the regrouped tree 10 Sep 2026: §§10.36–10.46 above were
+written after this paragraph and supersede its "unlocated" — the port
+renders FLEX-from-recorder playback since 10.36.)
+
 Drivers: `tools/scratch/recaudio.py` (`--reg-probe`, `--read-probe`,
 `--field-probe` are the instruments that found the three defects),
 `recaudio_seams.py`, `recaudio_analyse.py`, `make_seam_fixtures.py`

--- a/docs/remixer/EMU.md
+++ b/docs/remixer/EMU.md
@@ -399,7 +399,23 @@ took the NEXT word; (2) the core does not trap on every load form: of the
 them with a made-up effective address, two of them the recorder's mix loop.
 `native_macload_sites` now classifies every pair on the loaded library and
 hooks the accepted ones so they stop before executing and go through the
-shim as if they had trapped. A recorded buffer at unity gain is the test. And Unicorn's `until` address is not
+shim as if they had trapped. A recorded buffer at unity gain is the test.
+
+**A third route-A defect, same day, found by posting SET MAIN LEVEL:** the
+run loop ended a burst from inside the INTFRC write hook, and an
+`emu_stop` there ABORTS the instruction — the write lands but PC stays on
+it. Under IPL 7 that only re-executed an idempotent store; at IPL 0 the
+forced interrupt is delivered at once, its handler clears the bit and
+returns to the same `orl`, which forces again: a livelock in which main
+never ran (SET MAIN LEVEL's handler forces INTC0 source 34, vector 0x62).
+The chip completes the instruction first. All 18 INTFRC writers in the
+image are 6-byte `orl/andl/movel Dn,abs.l`, so `_on_force` now resumes
+after the instruction. And the reason nothing ever played under either
+emulator (COLDFIRE_PORT O9b, found on the port): the per-voice mixer
+multiplies every level by the main gain table at `0x80003c60`, which is
+written only by sys command 4 (SET MAIN LEVEL), which no load posts.
+`Rtos.set_main_level_live(level)` posts it the way select-bank is posted;
+`recaudio.py --main-level` uses it. And Unicorn's `until` address is not
 honoured when the instruction there raises: the trampoline parks on a
 `nop` instead.
 

--- a/docs/remixer/EMU.md
+++ b/docs/remixer/EMU.md
@@ -400,6 +400,13 @@ them with a made-up effective address, two of them the recorder's mix loop.
 `native_macload_sites` now classifies every pair on the loaded library and
 hooks the accepted ones so they stop before executing and go through the
 shim as if they had trapped. A recorded buffer at unity gain is the test.
+The first version of that scan classified only `.l` load forms; the `.w`
+ones (222 words, 87 accepted natively) were found the same evening when
+the port and route A disagreed on a voice's level word — the level chain's
+last instruction `msacw %d4l,%d0l,%a1@(4),%d4,%acc1` (a829 0104) ran
+natively, d4 never loaded, and T1's level read 0x4001 for the port's
+0x7f00. The scan covers both sizes now and the shim's rebuilt plain form
+keeps the U/L half-select bits; both sides store `0x01007f00`.
 
 **A third route-A defect, same day, found by posting SET MAIN LEVEL:** the
 run loop ended a burst from inside the INTFRC write hook, and an

--- a/tools/emu/emu_bringup.py
+++ b/tools/emu/emu_bringup.py
@@ -530,8 +530,11 @@ def native_macload_sites(uc, lo=BASE, hi=0x40098000):
         if (op & 0xF100) != 0xA000 or (op & 0x0030) == 0 or ((op >> 3) & 7) not in (2, 3, 4, 5):
             continue
         ext = int.from_bytes(img[off + 2:off + 4], "big")
-        if not ext & 0x0800:
-            continue
+        # .w forms too (ext bit 11 clear): the level chain's last word,
+        # `msacw %d4l,%d0l,%a1@(4),%d4,%acc1` = a829 0104, is one the core
+        # runs natively and wrongly -- the T1 voice level came out 0x4001
+        # where the port and the arithmetic give 0x7f00 (8 Sep 2026, later;
+        # 222 .w load words in the image, 87 accepted natively).
         if _macload_native(op, ext):
             out.append(lo + off)
     return out
@@ -596,7 +599,8 @@ def _emac_load_shim(uc, r):
     # = a089): Ry in bits 3:0 with bit 3 = A/D, Rx in bits 11:9 with A/D at bit 6,
     # acc bit 0 at bit 7 (straight, unlike the load form)
     plain_op = 0xA000 | ((rx & 7) << 9) | (((rx >> 3) & 1) << 6) | ((acc & 1) << 7) | ry
-    plain_ext = (ext & 0x0F00) | (size_l << 11) | ((acc >> 1) << 4)
+    # ext bits 6-7 are the .w forms' U/L half selects (`%d4u,%d0l`): keep them
+    plain_ext = (ext & 0x0FC0) | (size_l << 11) | ((acc >> 1) << 4)
     try:
         uc.mem_map(TRAMP, 0x3000)
     except UcError:

--- a/tools/emu/emu_rtos.py
+++ b/tools/emu/emu_rtos.py
@@ -878,10 +878,30 @@ class Rtos:
                 if u.base <= a < u.base + 0x20:
                     u.write(a - u.base, size, val, replay=replay)
 
+    INTFRC_REGS = (0xfc048010, 0xfc048014, 0xfc04c010, 0xfc04c014)
+
     def _on_force(self, intc, bits):
         # a reschedule request: end the burst so it is seen within the instruction
         self.forces += 1
         self._force_stop = "force"
+        # emu_stop from inside a memory-write hook ABORTS the instruction: the
+        # write lands but PC stays on it, so it re-executes next burst. For a
+        # force taken under IPL 7 that was harmless (the bit was already set,
+        # nothing re-fired). For a force taken at IPL 0 it is a LIVELOCK: the
+        # interrupt is delivered at once, its handler clears the bit and
+        # returns to the same `orl`, which forces again -- measured 8 Sep 2026
+        # on SET MAIN LEVEL (0x40033ece -> vector 0x62 -> 0x40033ece, for
+        # ever, main never ran). The chip completes the instruction first.
+        # Every INTFRC writer in the image is a 6-byte `orl/andl Dn,abs.l` or
+        # `movel Dn,abs.l` (18 sites, scanned), so resume after it.
+        pc = self.uc.reg_read(eb.UC_M68K_REG_PC) & 0xffffffff
+        op = bytes(self.uc.mem_read(pc, 2))
+        ea = int.from_bytes(self.uc.mem_read(pc + 2, 4), "big")
+        if op in (b"\x81\xb9", b"\xc1\xb9", b"\x23\xc0") and ea in self.INTFRC_REGS:
+            self._force_resume = pc + 6
+        else:
+            self._force_resume = None
+            self._t(f"force from an unrecognised instruction at {pc:#x} ({op.hex()}): re-executing it")
         self.uc.emu_stop()
 
     # -- exception plumbing --------------------------------------------------
@@ -1055,6 +1075,9 @@ class Rtos:
         self.sample += n / self.ips
         self.trap = self.r.trap
         self.pc = self.trap[1] if self.trap else uc.reg_read(eb.UC_M68K_REG_PC)
+        if self._force_stop == "force" and getattr(self, "_force_resume", None):
+            self.pc = self._force_resume            # the INTFRC write completed; do not re-execute it
+            self._force_resume = None
         self.pc_samples[(self._cur(), self.pc)] += 1
         self._tick_timers()
 
@@ -1235,6 +1258,24 @@ class Rtos:
         self.post_message(SYS_QUEUE, SYS_MSG_SCRATCH)
         self.run(ms=ms, until=lambda r: r.uc.mem_read(CUR_BANK, 1)[0] == bank)
         return self.uc.mem_read(CUR_BANK, 1)[0]
+
+    MAIN_GAIN_TABLE = 0x80003c60       # 10 longwords, gain:(0x8000-gain), written ONLY by sys command 4
+
+    def set_main_level_live(self, level=64, ms=500):
+        """SET MAIN LEVEL through sys's own case (command 4, handler
+        0x40061e0a): msg[0] = 4, msg[1] = level 0..127. It fills the main
+        gain table at 0x80003c60 from the curve at 0x400bcd90, and EVERY
+        voice's level is multiplied by that table in the per-frame mixer
+        (0x40004444). Neither emulator's load ever posts it, so until now
+        every voice rendered at gain 0 and no track ever "started" (the
+        ColdFire port's O9b, 8 Sep 2026; route A showed 0 writes to the
+        table too). Post it after the load, as select-bank is. Returns the
+        table's first longword."""
+        self.run(until=lambda r: r.pc == MAIN_SPIN)
+        self.uc.mem_write(SYS_MSG_SCRATCH, bytes([4, level & 0x7f, 0, 0]))
+        self.post_message(SYS_QUEUE, SYS_MSG_SCRATCH)
+        self.run(ms=ms, until=lambda r: r.uc.mem_read(self.MAIN_GAIN_TABLE, 4) != b"\0\0\0\0")
+        return int.from_bytes(self.uc.mem_read(self.MAIN_GAIN_TABLE, 4), "big")
 
     def seq_select_live(self, bank, pattern):
         """The sequencer's own bank/pattern select, `0x400a1030(bank,

--- a/tools/scratch/recaudio.py
+++ b/tools/scratch/recaudio.py
@@ -51,6 +51,7 @@ ap.add_argument("--rec-write-probe", action="store_true", help="watch every writ
 ap.add_argument("--rec-write-window", type=int, nargs=2, default=(0, 10 ** 9), help="frame0 frame1: only log rec-write-probe hits in this frame range (default: all)")
 ap.add_argument("--render-gate-probe", action="store_true", help="watch 0x40007960's silence-vs-render gate (a3@8/a3@16 early exits, a2@0 the zero-fill-vs-fetch flag) -- RTOS_FORK 10.34's 3rd probe")
 ap.add_argument("--blocks", type=int, default=40, help="pool blocks to dump from the row")
+ap.add_argument("--main-level", type=int, default=64, help="SET MAIN LEVEL to post after the load (0 = do not post; without it no voice renders, O9b)")
 ap.add_argument("--field-probe", action="store_true", help="log every write to the track's recorder state record (+36..+83, both banks) with its PC")
 ap.add_argument("--reg-probe", action="store_true", help="log the mix loops' source pointers and gains at loop entry (frames 323..326)")
 ap.add_argument("--read-probe", action="store_true", help="log the write path's source reads (0x40007680..0x40007748) for the first recording frames")
@@ -432,6 +433,8 @@ if not rt.gate_m6a()[0]:
     rt.run(ms=1000, until=lambda x: x.gate_m6a()[0])
 mounted, posted, saved_bank, final_bank, _ = rt.load_project_live("OCTABAM", name, run_ms=20000)
 if final_bank != saved_bank: final_bank = rt.select_bank_live(saved_bank)
+if a.main_level:
+    print(f"main level {a.main_level}: gain table[0] = {rt.set_main_level_live(a.main_level):#x}", flush=True)
 pattern = uc.mem_read(er.CUR_PATTERN, 1)[0]
 rt.seq_select_live(final_bank, pattern); rt.internal_clock()
 rt.frame = True; rt.next_frame = rt.sample + er.FRAME_PERIOD; rt.exact_clock()
@@ -577,4 +580,5 @@ with open(a.out, "wb") as fh:
         rw_ev=rw_ev if a.rec_write_probe else None,
         gate_ev=gate_ev if a.render_gate_probe else None,
         fetch_ev=fetch_ev if a.render_gate_probe else None), fh)
+print(f"voice record 0x80000510 + 48*t, ping 0, after the run: " + " ".join(f"T{t+1}={int.from_bytes(uc.mem_read(0x80000510 + 48 * t, 4), 'big'):#010x}" for t in range(8)))
 print(f"saved {a.out}: {len(audio_out)} audio blocks, {len(blocks)} pool blocks, {len(ev)} events, {len(voice_rec)} voice_rec frames")

--- a/tools/scratch/recaudio_analyse.py
+++ b/tools/scratch/recaudio_analyse.py
@@ -79,17 +79,26 @@ def main(path, show_all=False):
     byf = {}
     for f, s, g, sa, data in ao:
         byf.setdefault(f, []).append((g, sa, struct.unpack(">256I", data)))
-    for e in arms[:3]:
+    # which slots ever deviate from the input thru (a rendering voice shows as content that
+    # is not the counter), and the played values around every arm
+    playing = collections.Counter()
+    for f, s, g, sa, data in ao:
+        w = struct.unpack(">256I", data)
+        for slot in range(8):
+            ls = [s32(w[slot*32 + 2*i]) >> 16 for i in range(16)]
+            if any(abs(ls[i] - ((16*f + i) & 0x7fff)) > 1 for i in range(16)):
+                playing[slot] += 1
+    print(f"outbound block: frames in which a slot is NOT the input thru: {dict(playing)} (of {len(ao)})")
+    for e in arms[:12]:
         f = e["frame"]
-        print(f"-- outbound block, frames {f-1}..{f+3} (values >> 16, minus the input counter 16*frame+i):")
-        for ff in range(f - 1, f + 4):
+        print(f"-- outbound block, frames {f-1}..{f+2} (L >> 16 per slot; input counter would be 16*frame+i):")
+        for ff in range(f - 1, f + 3):
             for g, sa, w in byf.get(ff, []):
                 devs = {}
                 for slot in range(8):
                     ls = [s32(w[slot*32 + 2*i]) >> 16 for i in range(16)]
-                    dev = [ls[i] - ((16*ff + i) & 0xffff) for i in range(16)]
-                    if any(abs(x) > 1 for x in dev): devs[slot] = dev
-                print(f"   f{ff} gpio{g} src {sa:#x}: slot0 L>>16 = {[s32(w[2*i]) >> 16 for i in range(16)]}  deviating slots: {devs}")
+                    if any(abs(ls[i] - ((16*ff + i) & 0x7fff)) > 1 for i in range(16)): devs[slot] = ls
+                print(f"   f{ff}: {devs if devs else 'all slots = input thru'}")
 
 if __name__ == "__main__":
     main(sys.argv[1], "--all" in sys.argv)

--- a/tools/scratch/voiceprobe.py
+++ b/tools/scratch/voiceprobe.py
@@ -9,7 +9,7 @@ of the arm caller 0x40005ff0 with its args.
     .venv/bin/python tools/scratch/voiceprobe.py --project out/_fx2/r4_128 --tree out/_vp
 """
 import argparse, sys, os, struct, collections
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[1])); import toolpath  # noqa: E402,F401  (every tools/ dir on sys.path)
 import emu_rtos as er, emu_card as ec, emu_bringup as eb
 from unicorn.m68k_const import *
 from unicorn import UC_HOOK_CODE, UC_HOOK_MEM_WRITE

--- a/tools/scratch/voiceprobe.py
+++ b/tools/scratch/voiceprobe.py
@@ -1,0 +1,64 @@
+"""O9b, route A: what does a NOTE trig (a play trig on a FLEX track) write, and
+where does it stop? Runs the r4_128 fixture (T2 = FLEX on R1, play trigs at
+steps 2/6/10/14) to just past the first trig at frame 323 and logs, for the
+trig frames, every write into the per-voice records (0x80000110..0x800004ff),
+the per-track records (0x800021d0/0x80001c90 + ping*0xa80, 0x540 bytes each)
+and the FLEX arena record of the track, with the writer's PC; plus every call
+of the arm caller 0x40005ff0 with its args.
+
+    .venv/bin/python tools/scratch/voiceprobe.py --project out/_fx2/r4_128 --tree out/_vp
+"""
+import argparse, sys, os, struct, collections
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+import emu_rtos as er, emu_card as ec, emu_bringup as eb
+from unicorn.m68k_const import *
+from unicorn import UC_HOOK_CODE, UC_HOOK_MEM_WRITE
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--project", required=True); ap.add_argument("--tree", required=True)
+ap.add_argument("--frames", type=int, default=340); ap.add_argument("--from-frame", type=int, default=318)
+ap.add_argument("--track", type=int, default=1, help="0-based track with the play trig (T2)")
+a = ap.parse_args()
+card, name = er.stage_project(a.project, "OCTABAM", "RECT", tree=a.tree)
+r, rt = er.attach(None, card)
+uc = rt.uc
+def rd(u, reg): return u.reg_read(reg) & 0xffffffff
+W = []
+def on_w(u, acc, addr, size, val, x):
+    if rt.frame_count >= a.from_frame and len(W) < 20000:
+        W.append((rt.frame_count, addr, size, val & 0xffffffff, rd(u, UC_M68K_REG_PC)))
+REGIONS = [(0x80000110, 0x80000510), (0x800021d0, 0x800021d0 + 2 * 0xa80), (0x80001c90, 0x80001c90 + 2 * 0xa80),
+           (0x46104d00, 0x46104d40), (0x100b14f0 + 128 * 1096, 0x100b14f0 + 136 * 1096)]   # FLEX arena ids 128..135 (R1..R8)
+for lo, hi in REGIONS:
+    uc.hook_add(UC_HOOK_MEM_WRITE, on_w, begin=lo, end=hi - 1)
+C = []
+def on_call(u, addr, size, x):
+    if rt.frame_count >= a.from_frame and len(C) < 400:
+        sp = rd(u, UC_M68K_REG_A7)
+        C.append((rt.frame_count, addr, struct.unpack(">6I", u.mem_read(sp, 24))))
+for pc in (0x40005ff0, 0x400068e4, 0x40005c7c, 0x40005304):
+    uc.hook_add(UC_HOOK_CODE, on_call, begin=pc, end=pc)
+uc.ctl_flush_tb()
+if not rt.gate_m6a()[0]:
+    rt.run(ms=1000, until=lambda x: x.gate_m6a()[0])
+mounted, posted, saved_bank, final_bank, _ = rt.load_project_live("OCTABAM", name, run_ms=20000)
+if final_bank != saved_bank: final_bank = rt.select_bank_live(saved_bank)
+pattern = uc.mem_read(er.CUR_PATTERN, 1)[0]
+rt.seq_select_live(final_bank, pattern); rt.internal_clock()
+rt.frame = True; rt.next_frame = rt.sample + er.FRAME_PERIOD; rt.exact_clock()
+rt.start_transport_live(); rt.install_trig_log()
+frame0 = rt.frame_count + 1; target = frame0 + a.frames
+rt.run(ms=a.frames * er.FRAME_PERIOD / er.SAMPLE_HZ * 1000.0 * 5 + 2000, until=lambda x: x.frame_count >= target)
+print(f"frames {rt.frame_count - frame0}; live nibble writes {rt.live_nibble_log[:12]}; trig words {rt.trig_words_log[:6]}")
+print("calls (frame, fn, [ret, args...]):")
+for f, pc, st in C:
+    print(f"  f{f} {pc:#x} " + " ".join(f"{x:#x}" for x in st))
+print("writes by (region, pc):")
+byk = collections.Counter()
+for f, ad, sz, v, pc in W:
+    reg = next(lo for lo, hi in REGIONS if lo <= ad < hi)
+    byk[(f"{reg:#x}", f"{pc:#x}")] += 1
+for k, n in sorted(byk.items()): print("  ", k, n)
+print("writes in the trig frames, first 120 (frame addr size val pc):")
+for f, ad, sz, v, pc in [w for w in W if 322 <= w[0] <= 326][:120]:
+    print(f"  f{f} {ad:#x} ({sz}) <- {v:#x}  pc {pc:#x}")


### PR DESCRIPTION
Follow-up to #153, found while resolving a disagreement with the ColdFire port session.

The level chain's last instruction (`msacw %d4l,%d0l,%a1@(4),%d4,%acc1` = a829 0104) is a .w MAC-with-load word Unicorn executes natively with a made-up effective address: d4 never loads, the last product is lost, and T1's voice level read 0x4001 where the port and the arithmetic give 0x7f00. `native_macload_sites` had classified only .l forms; of 222 .w load words in the image, 87 are accepted natively. The scan now covers both sizes and the shim's rebuilt plain form keeps the U/L half-select bits (ext 6-7). Both emulators now store `0x01007f00`.

Gates: M6a oracle 8/8 fields agree (same 34 notes as an unpatched control), M6c 5/5, recording length 0x50c0 and buffer steps unchanged.

Also records in §10.18 the port's O9c finding on the capture block (+0 pair from the ESAI-in ring, +0x80 pair from the output ring's slots 0/7); the recorder oracle injects at +0x80 directly and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)