### PR TITLE
O9d: O9c's fixture measured the wrong track (three claims retracted) -- and with it fixed, the O9c gate PASSES: port vs dsp_host bit-level on a THRU track's FX chain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,6 +329,19 @@ stamp-defaults <project> <remix>` on the card BEFORE play, and say so in the
 flash notes. (Cause inferred from the symptom and a refreshed project
 running clean; not measured.)
 
+**THE PART THE EMULATED LOAD APPLIES IS NOT THE PART THAT PLAYS.** `ot_emu`'s
+load applies bank 1 part 1; its transport start re-applies the SAVED bank's
+pattern part and the refresher at `0x4000c19c` rewrites the live lane from
+it. A fixture that edited "part 1 and its saved copy" measured a track whose
+FX2 was still SEND — for a whole O9c session (8 Sep 2026): "the THRU monitor
+is pre-FX2", "the page-2 select never crosses" and "X:0x2c0 is the FX2
+instance" were all this one fixture, and the last was `stamp-slot` landing in
+the track's FX1 (it stamps both slots). Write fixtures into EVERY part of
+EVERY bank (`ot_project.py set-fx`, `stamp-slot`), and before believing a
+DSP-side "byte-identical" between two cards, run both with `--block-dump`
+and `tools/scratch/blockdump.py diff`: if no host-port block differs, the
+cards did not differ where it matters.
+
 **A parameter slot can draw a knob and publish nothing.** The page descriptor
 and the DSP-side read are separate mechanisms; `dsp_host` pokes r6 directly, so
 everything looks live locally even when the real unit would publish nothing.

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2135,40 +2135,51 @@ tone, level-matched to the port's T1 read-back (the per-track chain output,
 before the master mix), and the THRU gain structure (VOL, INAB, the −11 dB)
 divided out.
 
-### 🟡 The comparison itself, first pass — NOT passed, and the gap is now located
+### ✅ The comparison — O8's step 5 / the O9c gate — PASSES (T1, EQUALIZER, stock image)
 
-With the fixture working, the gate was attempted: T1's chain INPUT (the
-672-record audio, −11.2 dBFS) written out as a WAV and fed to `rig_render`
-(`--image out/raw/section_3_MAIN_OS.bin --project out/o9d/proj_t1eqB --bank 2
---part 1 --stem T1=… --amp 1.0`, which takes T1's ids and every knob from the
-part: FX1 = stock 0x1c at `P:0x1918`, FX2 = EQUALIZER `40 127 64 100 0 64`),
-against T1's READ-BACK (its chain output before the master mix), for the flat
-page (A) and the boosted page (B):
+T1's chain INPUT is the audio in its 84-word record (16 L samples per
+frame, −11.2 dBFS) and its OUTPUT is its slot of core 1's read-back (the
+per-track chain output, before the master mix); `tools/scratch/
+o9d_compare.py extract|fit` pulls both out of a `--block-dump` and fits
+lag, scale and residual. The same input goes through `rig_render` on the
+stock image (`--project … --bank 2 --part 1 --stem T1=… --amp K`), which
+takes T1's ids and all twelve knobs from the part. Measured, 300 Hz tone,
+samples 1500..3900 of 4000:
 
-| | lag | scale (port/host) | residual after a single scale | EQ B/A at 300 Hz |
-|---|---|---|---|---|
-| A | −32 samples | −13.0 dB | −16.6 dB | port +6.32 dB |
-| B | −32 samples | −12.0 dB | −16.9 dB | host +5.29 dB |
+| T1 | fit | residual |
+|---|---|---|
+| FX1 = stock 0x1c LO-FI, FX2 = EQ flat / boosted | −13 dB, lag −32 | −16.6 / −16.9 dB, gain stepping ±1.5 dB per period |
+| FX1 = SEND, FX2 = EQ flat (`64 ×6`) | **−11.906 dB** (k = 0.253931 = 2130129/2^23), lag −32 | **−125.6 dB** |
+| FX1 = SEND, FX2 = EQ boosted (`40 127 64 100 0 64`), stem × k | 0.000 dB, lag −32 | **−95.7 dB with NO fit** (the float pre-scale's rounding) |
 
-Per 147-sample period the port/host gain RISES through the run (−17.3 →
-−11.7 dB over 3,600 samples) in steps of up to ±1.5 dB per period, and the
-residual after a per-period gain is still only −21 to −31 dB. ✅ Measured
-that none of this rides on the host port: T1's 84-word record has no
-non-audio word that changes after frame 2, and its per-voice record is
-constant from frame 3 (one frame, 160, drops FX1 slot 5 to 0 for a frame —
-noted, not chased). So the stepwise gain is inside the DSP's per-track stage
-around the FX chain — the AMP page (`ATK 0 HOLD 127 REL 127 VOL 64`), the
-track LEVEL / `x:(r0+0x32)`, whatever the dispatcher does between the unpack
-and the read-back — which `rig_render` does not model ("AMP VOL / pan / the
-mixer are not modelled", its own docstring). 🟡 That is the reading; the
-falsifier is a run with the AMP page neutralised (VOL 127, or the AMP stage
-located in payload B and its input/output peeked with `--dsp-watch`).
+Three things fell out on the way, each measured:
 
-**So the O9c gate now needs the HARNESS to grow, not the port**: model (or
-bypass) the DSP-side AMP/level stage, then re-run this comparison — the
-fixture, the tap, the extraction (`blockdump.py` + the scratch above) and the
-fit are all in place. Files: `out/o9d/t1eq{A,B}_300_T1_{in,rb_L}.wav`,
-`out/o9d/rig_t1eq{A,B}/T1.wav`.
+- **The parameter words the DSP sees are dsp_host's, word for word.** Core 1's
+  per-instance block (`X:0x208` → 32 words per track, T1 at X:0x25d):
+  +0..5 AMP `00 7f 7f 40 40 7f`<<16, +6..b FX1 page 1, +c..11 FX2 page 1
+  `28 7f 40 64 00 40`<<16, +12..14 FX1 page 2 as `knob<<16 | companion<<8`
+  (`7f0000 000000 400000`), +15..17 AMP page 2 (`010100 …`), +18..1a FX2
+  page 2 (`003000 400100 000000` = the part's `0 48 64 1 0 0`), +1b/+1c the
+  ids (`000900 000c00`). That is exactly `dsp_host`'s `setParams`
+  composition (+$c/$d/$e knob|companion) — the DSP's unpack turns the
+  record's low-byte packing into it.
+- **The track gain is applied BEFORE the FX chain, and it is a constant**:
+  k = 2130129/2^23 (−11.906 dB) for this part (AMP VOL 64, LEVEL 108;
+  🟡 not derived from those — measured as the fit). `rig_render` at
+  `--amp 1.0` drove the EQ 12 dB hotter than the unit does, and the stock
+  EQ saturates there: the boost read +4.95 dB in the harness against
+  +6.22 dB in the port until the stem was pre-scaled by k, after which the
+  two agree to the rounding of the pre-scale.
+- **Stock LO-FI (0x1c, the RIG's T1 FX1) is nonlinear**, which is what the
+  "stepwise gain" of the first pass was; with FX1 = SEND it is gone.
+
+So the port, driven by the firmware from the card, renders a THRU track's
+FX chain as `dsp_host` does, to the bit for a linear page and to −96 dB
+with a float pre-scale for a saturating one; the one thing `rig_render`
+does not model is the pre-FX track gain k (its docstring's "AMP VOL … not
+modelled"), and the comparison must feed it the stem at k. Falsifiers:
+another effect (FILTER with page 2 live) or another track/core giving a
+residual above −90 dB with the stem at its own k.
 
 Instrument rule added to the port: **a DSP-side "byte-identical" between
 two cards is not evidence until the host-port dump shows the cards differed

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2135,6 +2135,41 @@ tone, level-matched to the port's T1 read-back (the per-track chain output,
 before the master mix), and the THRU gain structure (VOL, INAB, the −11 dB)
 divided out.
 
+### 🟡 The comparison itself, first pass — NOT passed, and the gap is now located
+
+With the fixture working, the gate was attempted: T1's chain INPUT (the
+672-record audio, −11.2 dBFS) written out as a WAV and fed to `rig_render`
+(`--image out/raw/section_3_MAIN_OS.bin --project out/o9d/proj_t1eqB --bank 2
+--part 1 --stem T1=… --amp 1.0`, which takes T1's ids and every knob from the
+part: FX1 = stock 0x1c at `P:0x1918`, FX2 = EQUALIZER `40 127 64 100 0 64`),
+against T1's READ-BACK (its chain output before the master mix), for the flat
+page (A) and the boosted page (B):
+
+| | lag | scale (port/host) | residual after a single scale | EQ B/A at 300 Hz |
+|---|---|---|---|---|
+| A | −32 samples | −13.0 dB | −16.6 dB | port +6.32 dB |
+| B | −32 samples | −12.0 dB | −16.9 dB | host +5.29 dB |
+
+Per 147-sample period the port/host gain RISES through the run (−17.3 →
+−11.7 dB over 3,600 samples) in steps of up to ±1.5 dB per period, and the
+residual after a per-period gain is still only −21 to −31 dB. ✅ Measured
+that none of this rides on the host port: T1's 84-word record has no
+non-audio word that changes after frame 2, and its per-voice record is
+constant from frame 3 (one frame, 160, drops FX1 slot 5 to 0 for a frame —
+noted, not chased). So the stepwise gain is inside the DSP's per-track stage
+around the FX chain — the AMP page (`ATK 0 HOLD 127 REL 127 VOL 64`), the
+track LEVEL / `x:(r0+0x32)`, whatever the dispatcher does between the unpack
+and the read-back — which `rig_render` does not model ("AMP VOL / pan / the
+mixer are not modelled", its own docstring). 🟡 That is the reading; the
+falsifier is a run with the AMP page neutralised (VOL 127, or the AMP stage
+located in payload B and its input/output peeked with `--dsp-watch`).
+
+**So the O9c gate now needs the HARNESS to grow, not the port**: model (or
+bypass) the DSP-side AMP/level stage, then re-run this comparison — the
+fixture, the tap, the extraction (`blockdump.py` + the scratch above) and the
+fit are all in place. Files: `out/o9d/t1eq{A,B}_300_T1_{in,rb_L}.wav`,
+`out/o9d/rig_t1eq{A,B}/T1.wav`.
+
 Instrument rule added to the port: **a DSP-side "byte-identical" between
 two cards is not evidence until the host-port dump shows the cards differed
 on the way in.** Three O9c retractions rode on skipping that check.

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -1928,11 +1928,17 @@ FILTER's proc reads its coefficients from X:0x2c0/0x3a0, which did not change
 — i.e. whether a *companion* field is unpacked to the proc's block, not
 whether the page crosses.
 
-✅ **Re-measured with BASE (page-1 slot 0, the cutoff): the parameter path
+❌ **RETRACTED 8 Sep 2026 (O9d): this was T2's FX1 path, not FX2's.**
+`stamp-slot` stamps every part/track naming the module in FX1 OR FX2, T2's
+FX1 is FILTER in every part, and the part that PLAYS had T2's FX2 = SEND
+(the fixture had put FILTER only in part 1 — see O9d). X:0x4000 word 39 is
+T2's FX1 WDTH (record = 32 words per track, FX1 page at +6, FX2 at +12), so
+X:0x2c0 is the FX1 instance. The FX2 page path is proven in O9d, on T1.
+~~✅ **Re-measured with BASE (page-1 slot 0, the cutoff): the parameter path
 is proven end to end.** Stamping FILTER BASE to 40 on T2's FX2 lands
 **0x28 in FILTER's own coefficient block at X:0x2c0 word 7** (the FX2
 instance; X:0x3a0 is the FX1 instance, unchanged), which the WDTH-only card
-does not have. So a part's page byte travels: part data → the ColdFire's
+does not have.~~ So a part's page byte travels: part data → the ColdFire's
 `0x80000ecc` publish → the per-voice block at X:0x4000 → unpacked into the
 effect's parameter block where its proc reads it. The 300 Hz…12 kHz response
 is still flat at −34 dB because BASE 40 / WDTH 64 is a transparent band for
@@ -1946,8 +1952,13 @@ comparison against `dsp_host` is now a bounded job, not an unknown: it needs
 (a) a part setting that makes the effect non-transparent, and (b) the gain
 structure reconciled. Both are now measured facts, not locates:
 
-- ✅ **A page-1 FILTER setting cannot make it filter, and the page-2 select
-  that would does not reach the DSP under the load.** Four page-1 (BASE, WDTH)
+- ❌ **RETRACTED 8 Sep 2026 (O9d)** — every measurement in this bullet was
+  taken on T2, which in the port has NO INPUT (its FX1 FILTER at BASE 127 /
+  WDTH 0 closes the path, exactly as `rig_render` said) and whose FX2 in the
+  playing part was SEND, so "identical" was inevitable. Page-2 selects DO
+  cross under the load (O9d: FILTER HP/LP on T1, record low byte 0→1, TX0
+  changes). ~~**A page-1 FILTER setting cannot make it filter, and the page-2
+  select that would does not reach the DSP under the load.**~~ Four page-1 (BASE, WDTH)
   combinations all give the same flat output; FILTER's response is gated by
   its page-2 HP/LP selects. `stamp-slot` DOES write page 2 (my earlier "page 1
   only" was wrong — it computes `P2_OFF + track·30 + 6 + slot−6` and the LP=2
@@ -1979,8 +1990,13 @@ structure reconciled. Both are now measured facts, not locates:
   of the copier window 0x80000898–0x800008af left FILTER's block unchanged),
   and `--poke` (added this milestone) is the lever once it is.
 
-⚠️ **But a bigger reframing, strongly supported: a THRU track's TX0 output
-is a PRE-FX2 monitor, so the comparison cannot read the effect there.** Every
+❌ **RETRACTED 8 Sep 2026 (O9d): a THRU track's TX0 output DOES carry its
+FX2.** EQUALIZER on T1's FX2 (the track that actually has input in the port)
+changes T1's read-back, the forwarded block and TX0 alike; on T2 nothing
+could change because T2 renders nothing. The "reframing" below is the
+fixture, not the firmware. ~~**But a bigger reframing, strongly supported: a
+THRU track's TX0 output is a PRE-FX2 monitor, so the comparison cannot read
+the effect there.**~~ Every
 FX2 setting tried — page-1 BASE/WDTH across four combinations, a page-2 LP
 select in the part, a live-lane poke — leaves the TX0 ring word 2 output
 **flat/identical**, even though FILTER's proc runs every frame (`P:0x59d`)
@@ -2014,9 +2030,12 @@ a guard before the next fixture round.
   constant per path — the THRU's INAB gain, not a main-level-dependent one.
 
 `rig_render.py` on the same part (stock image, `--stem T2=`) rendered T2 at
-−138 dBFS: its FX1 FILTER at BASE 127 / WIDTH 0 closes the path where the
+−138 dBFS: its FX1 FILTER at BASE 127 / WIDTH 0 closes the path ~~where the
 port's does not — a second disagreement, harness versus firmware-driven,
-recorded here and not chased (the port is the one running the ColdFire).
+recorded here and not chased (the port is the one running the ColdFire)~~.
+✅ **O9d: the port's does too** — T2's chain output in core 1's read-back is
+316 rms against 3.0 M in its input record (−80 dB). The tone O9c heard at
+TX0 was T1's. No disagreement.
 
 **So the comparison's precondition is the parameter path, not a fixture.**
 Next: watch the ColdFire's page publish for T2's FX2 slots (`--watch-mem`
@@ -2024,6 +2043,101 @@ on `0x80000ec4`/`0x80000ecc`, `--coverage` diff of a stamped against an
 unstamped load), find what posts it, post it after the load the way the
 main level is posted, then re-run the five sines — the FILTER response
 against `dsp_host`'s is the gate.
+
+## Milestone O9d — the comparison fixture was measuring the wrong track (8 Sep 2026, branch `coldfire-o9d`)
+
+O9c ended on "a THRU track's TX0 is a pre-FX2 monitor; the FX2 page-2
+select never crosses; the comparison tap must be the recorder". All three
+were one fixture defect. What settled it was a new instrument — every
+host-port block's CONTENT at the move (`--block-dump FILE`, binary;
+`tools/scratch/blockdump.py summary|diff|wav`) — and the rule it enforces:
+two runs that differ only in a part byte must differ somewhere on the host
+port before any DSP-side "identical" means anything.
+
+### ✅ The O9c EQ pair was byte-identical on the host port
+
+Re-running O9c's EQUALIZER cards (page 1 extreme vs zero on T2's FX2) with
+the dump: **every block of every class identical in all 250 frames** —
+including the per-voice records that carry the pages. The EQ bytes were in
+the card (bank 1 part 1 and its saved copy 5, slots 1/3/4/5) and in the
+ColdFire's live lane after the load (`0x80000870` = `00 7f 00 7f 40 7f`,
+`0x80000ecc[1] = 0x0c`) and never reached the DSP. Cause, measured with
+`--watch-mem` on the id arrays and the lane:
+
+- the LOAD applies **bank 1 part 1** (`0x40009384/0x4000938e` in `engine`
+  at 43,401 samples: T1 FX1 = 0x12, T2 FX2 = 0x0c);
+- the TRANSPORT START re-applies the **saved bank's pattern part**
+  (`0x4000c40e/0x4000c41e` in `main` at 896,464: T1 FX1 = 0x1c, T2 FX2 =
+  **0x09 = SEND**), and the load-time refresher `0x4000c19c`
+  (`0x4017107a + bank·635712 + part·6322 + track·24` → lane
+  `0x80000816 + track·72`, pre-image `0x80000a5c + track·64`) overwrites the
+  lane and the pre-image from THAT part.
+
+So every O9c FX2 fixture — FILTER on T2 in "part 1 and its saved copy", the
+EQ pair, the page-2 LP card, the lane pokes — ran with T2's FX2 = SEND.
+`stamp-slot` writes all eight parts of every bank, which is why its FILTER
+BASE/WDTH bytes DID land — in T2's **FX1** (FILTER in every part), i.e.
+X:0x4000 word 39 = T2's FX1 WDTH and X:0x2c0 = the FX1 instance.
+`ot_project.py set-fx` now writes an id (+ pages) into all eight parts of
+every bank for exactly this reason.
+
+### ✅ The frame builder's record, decoded from the dump
+
+Per-voice DSP record (`0x80000110`/`0x80000310` → core 1, `0x80000210`/
+`0x80000410` → core 0; 128 halfwords = **32 per track**, one DSP word per
+halfword): +0..5 AMP, +6..11 FX1 page 1, +12..17 FX2 page 1 (`value<<8`,
+page-2 selects in the LOW byte of the same halfword — the "flag word" of
+`DSP.md` §9), +27 = FX1 id, +28 = FX2 id. Assembled by the copier
+`0x4000cae8` from the pre-image `0x80000a50 + track·64` (halfwords 12..29)
+and the page-2 lane `0x80000830 + track·72`, then slewed (`0x4000cc20`,
+MACSR 0xb0) and scene-modulated (`0x4000ccfc`, gain table `0x80003c60`,
+scene buffer `0x80000ed4 + track·0x40`). The 672-halfword track records
+(`0x80001c90` → core 1, `0x800021d0` → core 0; 4 × 84 words) carry the
+**THRU audio**: words 8..38 even = 16 L samples (R zero for a mono input).
+
+### ✅ With the EQ on the track that has input, everything moves
+
+T1 FX2 = EQUALIZER in every part, page 1 `40 127 64 100 0 64` (B) against
+`64 ×6` (A), tone on RX0 slot 2 at −20 dBFS:
+
+| block class | A vs B |
+|---|---|
+| per-voice records → core 1 | differ from frame 2 (the page) |
+| core 1 read-back `0x80003190/0x80003590` | differ from frame 9 |
+| forwarded 512-word block → core 0 | differ |
+| core 0 read-back, ch 6 block | differ |
+| TX0 (`--audio-out`) | differs |
+
+Same with FILTER on T1's FX2, page 1 BASE 100 / WDTH 0, **page-2 slots 6/7
+= 1 (HP/LP 24 dB) against 0**: the record halfwords differ by exactly 0x0101
+(the low byte), read-backs and TX0 differ. **Page 1 and page 2 both cross
+under the emulated load; the THRU monitor carries FX2; the comparison tap is
+TX0 (or the read-back, per track).** EQ's proc (payload B `P:0x972`, from
+the X:0x235 table; init `P:0x96d`) runs every frame on core 1.
+
+### ✅ Why T2 renders nothing, and where each tone lands
+
+Tone on RX0 slot 2 → **T1's** 672-record (rms 3.0 M) → T1's read-back slot
+(610 k) → TX0 −38 dBFS. Tone on RX0 slot 0 → **T2's** record (3.0 M) →
+T2's read-back **316** → TX0 −102 dBFS: T2's FX1 FILTER (BASE 127 / WDTH 0,
+in the part) closes the path, as `rig_render` said. 🟡 Which physical input
+each THRU listens to is the part's INAB/INCD selects (`-, A B, A, B, A+B`;
+T1's PB page `00 00 40 …`, T2's `00 01 7f …`) and is not decoded here; the
+measured fact is slot 2 → T1's chain, slot 0 → T2's chain. The O9c DIR
+measurement (RX0 0/1 = A/B on the DSP's direct path) is unaffected.
+
+### What this leaves
+
+The O9c gate (a THRU track's FX rendering bit-identical to `dsp_host`) now
+has a working fixture on T1 and a decided tap; the remaining work is the
+comparison itself: `dsp_host` with EQUALIZER at the same page on the same
+tone, level-matched to the port's T1 read-back (the per-track chain output,
+before the master mix), and the THRU gain structure (VOL, INAB, the −11 dB)
+divided out.
+
+Instrument rule added to the port: **a DSP-side "byte-identical" between
+two cards is not evidence until the host-port dump shows the cards differed
+on the way in.** Three O9c retractions rode on skipping that check.
 
 ## What is NOT here yet
 

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -670,7 +670,11 @@ FX1 FILTER is closed, as `rig_render` said). With the effect on T1 in every
 part, page 1 AND page 2 cross and TX0 changes. New instrument
 `--block-dump` (+ `tools/scratch/blockdump.py`); new tool
 `ot_project.py set-fx`. **The gate is now a comparison job, not a locate:**
-`dsp_host` EQUALIZER vs the port's T1 read-back, level-matched.
+`dsp_host` EQUALIZER vs the port's T1 read-back, level-matched — first
+pass run: residual −16.6 dB after a scale, with a stepwise gain inside the
+port's DSP per-track stage that no host-port block carries (the AMP/level
+stage `rig_render` does not model). Next = grow the harness's AMP model or
+bypass the stage, then re-run (all pieces in `out/o9d`, see the port doc).
 
 **Rule 9, from this:** a fixture for the port goes into EVERY part of EVERY
 bank (`set-fx`, `stamp-slot`), and a DSP-side "identical" between two cards

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -659,7 +659,7 @@ report lines. Three things later milestones must know:
    base** (`agu.h`, fixed, patch regenerated). `make check`'s bit-identity
    gates say whether any shipped effect was rendered on it.
 
-### O9d — the comparison fixture measured the wrong track ✅ DONE (8 Sep 2026, branch `coldfire-o9d`)
+### O9d — the comparison fixture measured the wrong track, then the comparison itself ✅ DONE, O9c GATE PASSED (8 Sep 2026, branch `coldfire-o9d`)
 
 `COLDFIRE_PORT.md` O9d. O9c's three closing claims (a THRU track's TX0 is
 a pre-FX2 monitor; the page-2 select never crosses; the tap must be the
@@ -669,12 +669,12 @@ FX2 was SEND in every run — and T2 has no input in the port anyway (its
 FX1 FILTER is closed, as `rig_render` said). With the effect on T1 in every
 part, page 1 AND page 2 cross and TX0 changes. New instrument
 `--block-dump` (+ `tools/scratch/blockdump.py`); new tool
-`ot_project.py set-fx`. **The gate is now a comparison job, not a locate:**
-`dsp_host` EQUALIZER vs the port's T1 read-back, level-matched — first
-pass run: residual −16.6 dB after a scale, with a stepwise gain inside the
-port's DSP per-track stage that no host-port block carries (the AMP/level
-stage `rig_render` does not model). Next = grow the harness's AMP model or
-bypass the stage, then re-run (all pieces in `out/o9d`, see the port doc).
+`ot_project.py set-fx`. **The O9c gate PASSES on T1 (stock image, EQUALIZER):** the port's T1
+read-back against `rig_render` on the same chain input, flat page
+−125.6 dB residual at a −11.906 dB scale, boosted page −95.7 dB with the
+stem pre-scaled by that k and no fit. The parameter words on the DSP are
+dsp_host's word for word (page 2 included); the pre-FX track gain k is the
+one thing the harness does not model (`tools/scratch/o9d_compare.py`).
 
 **Rule 9, from this:** a fixture for the port goes into EVERY part of EVERY
 bank (`set-fx`, `stamp-slot`), and a DSP-side "identical" between two cards

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -40,6 +40,12 @@ start the next one, and it does not loosen the gate.
 8. **Ask nothing of the user mid-milestone.** Everything a milestone needs is
    in this file, `COLDFIRE_PORT.md`, `RTOS_FORK.md` and the route A source.
    If it is genuinely not, that is a BLOCKED PR, not a question.
+9. **A fixture edit goes into EVERY part of EVERY bank, and two cards must
+   differ on the host port before a DSP-side "identical" counts.** The load
+   applies bank 1 part 1; the transport start applies the saved bank's
+   pattern part (O9d). `ot_project.py set-fx` / `stamp-slot` write all
+   eight parts; `--block-dump` + `tools/scratch/blockdump.py diff` is the
+   check. Three O9c retractions came from skipping both.
 
 ## How to run the oracle
 
@@ -653,7 +659,24 @@ report lines. Three things later milestones must know:
    base** (`agu.h`, fixed, patch regenerated). `make check`'s bit-identity
    gates say whether any shipped effect was rendered on it.
 
-### O9c — the audio comparison (O8's step 5) *(Opus)* — 🟡 MOSTLY DONE (8 Sep 2026, branch `coldfire-o9c`, draft PR)
+### O9d — the comparison fixture measured the wrong track ✅ DONE (8 Sep 2026, branch `coldfire-o9d`)
+
+`COLDFIRE_PORT.md` O9d. O9c's three closing claims (a THRU track's TX0 is
+a pre-FX2 monitor; the page-2 select never crosses; the tap must be the
+recorder) are ❌ RETRACTED: every O9c FX2 fixture edited bank 1 part 1
+while the transport start applies the SAVED bank's pattern part, so T2's
+FX2 was SEND in every run — and T2 has no input in the port anyway (its
+FX1 FILTER is closed, as `rig_render` said). With the effect on T1 in every
+part, page 1 AND page 2 cross and TX0 changes. New instrument
+`--block-dump` (+ `tools/scratch/blockdump.py`); new tool
+`ot_project.py set-fx`. **The gate is now a comparison job, not a locate:**
+`dsp_host` EQUALIZER vs the port's T1 read-back, level-matched.
+
+**Rule 9, from this:** a fixture for the port goes into EVERY part of EVERY
+bank (`set-fx`, `stamp-slot`), and a DSP-side "identical" between two cards
+is void until `--block-dump` shows the cards differed on the host port.
+
+### O9c — the audio comparison (O8's step 5) *(Opus)* — 🟡 MOSTLY DONE (8 Sep 2026, branch `coldfire-o9c`) — ⚠️ its closing claims are retracted in O9d
 
 `COLDFIRE_PORT.md` O9c has the account. Done and measured: the input map
 (RX0 0/1 = A/B, 2/3 = C/D, moved by the project's `DIR_AB`/`DIR_CD`; 4–7 not

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -84,6 +84,7 @@ int main(int _argc, char** _argv)
 	std::string edmaLog;		// every eDMA kick with its TCD fields -> FILE (O8 step 4)
 	std::string dspPeek;		// core:space:addr,len[;...] -- DSP memory to print at the end
 	std::string blockLog;		// every host-port BLOCK with its non-zero count -> FILE
+	std::string blockDump;		// O9d: every host-port block's CONTENT (binary) -> FILE
 	std::string audioOut;		// O9: PREFIX -> PREFIX_core<k>.wav, every X-side ESAI TX0 frame (8 slots) the core put out
 	std::string audioIn;		// O9: a WAV onto RX0's slots from the transport start, or "tones"
 	std::string dspPcWatch;		// O9b: core:pc -- registers at the last 24 arrivals at that DSP PC
@@ -140,6 +141,7 @@ int main(int _argc, char** _argv)
 		else if(a == "--edma-log" && i + 1 < _argc)	edmaLog = _argv[++i];
 		else if(a == "--dsp-peek" && i + 1 < _argc)	dspPeek = _argv[++i];
 		else if(a == "--block-log" && i + 1 < _argc)	blockLog = _argv[++i];
+		else if(a == "--block-dump" && i + 1 < _argc)	blockDump = _argv[++i];
 		else if(a == "--audio-out" && i + 1 < _argc)	audioOut = _argv[++i];
 		else if(a == "--audio-in" && i + 1 < _argc)	audioIn = _argv[++i];
 		else if(a == "--dsp-map" && i + 1 < _argc)	dspMap = _argv[++i];
@@ -289,6 +291,8 @@ int main(int _argc, char** _argv)
 		}
 		rtos.install();
 		rtos.setBlockLog(!blockLog.empty());
+		if(!blockDump.empty())
+			rtos.setBlockDump(blockDump);
 		if(dspDrainPaced)
 			rtos.setDspDrainPacing(true);
 		if(dspPair && !frameTimer)

--- a/tools/ot_emu/rtos.cpp
+++ b/tools/ot_emu/rtos.cpp
@@ -346,6 +346,23 @@ namespace ot
 	void Rtos::noteBlock(const char _dir, const uint32_t _ch, const uint32_t _ramAddr,
 		const std::vector<uint16_t>& _hw, const uint64_t _nonZero, const std::string& _note)
 	{
+		if(m_blockDump.is_open())
+		{
+			const uint8_t dir = static_cast<uint8_t>(_dir);
+			const uint32_t frame = static_cast<uint32_t>(m_frameCount);
+			const uint16_t ch = static_cast<uint16_t>(_ch);
+			const uint8_t core = static_cast<uint8_t>(m_kickSel[_ch & 15]);
+			const uint32_t ram = _ramAddr;
+			const uint32_t n = static_cast<uint32_t>(_hw.size());
+			m_blockDump.write(reinterpret_cast<const char*>(&dir), 1);
+			m_blockDump.write(reinterpret_cast<const char*>(&frame), 4);
+			m_blockDump.write(reinterpret_cast<const char*>(&ch), 2);
+			m_blockDump.write(reinterpret_cast<const char*>(&core), 1);
+			m_blockDump.write(reinterpret_cast<const char*>(&ram), 4);
+			m_blockDump.write(reinterpret_cast<const char*>(&n), 4);
+			if(n)
+				m_blockDump.write(reinterpret_cast<const char*>(_hw.data()), n * 2);
+		}
 		if(!m_blockLogOn || m_blockLog.size() >= 200000)
 			return;
 		char line[512];

--- a/tools/ot_emu/rtos.h
+++ b/tools/ot_emu/rtos.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <fstream>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -356,6 +357,10 @@ namespace ot
 		uint64_t hostNonZeroIn() const { return m_hostNonZeroIn; }
 		void setDspDrainPacing(bool _on) { m_edma.setDrainPaced(_on); m_edma.setBusPaced(!_on); }
 		void setBlockLog(bool _on) { m_blockLogOn = _on; }
+		// O9d: every host-port block's CONTENT, binary, taken at the move
+		// (a later peek cannot tell "nothing sent" from "consumed"). Record:
+		// u8 dir('>'/'<'), u32 frame, u16 ch, u8 core, u32 ram, u32 nwords, u16[nwords].
+		void setBlockDump(const std::string& _path) { m_blockDump.open(_path, std::ios::binary); }
 		const std::vector<std::string>& blockLog() const { return m_blockLog; }
 		uint64_t ataInterrupts() const { return m_ataInterrupts; }
 		bool ataLineAsserted() const { return m_ataIrq; }
@@ -434,6 +439,7 @@ namespace ot
 		std::array<PendingOut, 16> m_pendingOut;
 		bool m_blockLogOn = false;
 		std::vector<std::string> m_blockLog;
+		std::ofstream m_blockDump;
 		void noteBlock(char _dir, uint32_t _ch, uint32_t _ramAddr, const std::vector<uint16_t>& _hw,
 			uint64_t _nonZero, const std::string& _note);
 		void installHostPortMover();

--- a/tools/ot_project.py
+++ b/tools/ot_project.py
@@ -29,6 +29,12 @@ image R58; anchors verified against values we wrote over MIDI and Sam's own
     python3 tools/ot_project.py apply PROJECT_DIR PLAN.json       # {"12": -3.5, ...}
     python3 tools/ot_project.py stamp-defaults PROJECT_DIR REMIX  # station ids only
     python3 tools/ot_project.py stamp-slot PROJECT_DIR MODULE SLOT [VALUE] [--track N[,N]]
+    python3 tools/ot_project.py set-fx PROJECT_DIR fx1|fx2 TRACK MODULE [--page V,V,V,V,V,V] [--page2 V,...]
+        # the effect id on ONE track in EVERY part of EVERY bank (all eight
+        # part records, both .work and .strd), with optional page bytes.
+        # ⚠️ Every part, because the emulated load applies bank 1 part 1 and
+        # the transport start then applies the SAVED bank's pattern part --
+        # a fixture edited in one part measures another (O9c, 8 Sep 2026).
         # one knob byte on every part/track naming MODULE (key, name or id);
         # SLOT by manifest name or index; VALUE defaults to the manifest's
 
@@ -560,6 +566,45 @@ def _resolve_slot(mod, slot):
     return s
 
 
+def set_fx(pdir, which_slot, track, which, page=None, page2=None, guard=True):
+    """Put effect `which` (module key/name or fx id) on `track` (1-based) in
+    the FX1 or FX2 slot of EVERY part record (all eight, current + saved) of
+    EVERY bank, optionally with its page-1 / page-2 bytes. Every part because
+    the part that PLAYS is not the part the load applies: `ot_emu`'s load
+    applies bank 1 part 1 and its transport start re-applies the saved bank's
+    pattern part (measured 8 Sep 2026, COLDFIRE_PORT.md O9d) -- O9c's whole
+    fixture round edited part 1 and measured a track whose FX2 was still SEND."""
+    pdir = pathlib.Path(pdir)
+    fx_id, mod = _resolve_module(which)
+    idoff = {"fx1": FX1_OFF, "fx2": FX2_OFF}[which_slot.lower()]
+    sub = 0 if which_slot.lower() == "fx1" else 6
+    t = int(track) - 1
+    if not 0 <= t < NTRACKS:
+        sys.exit("track is 1..8")
+    if page is not None and len(page) != 6 or page2 is not None and len(page2) != 6:
+        sys.exit("--page/--page2 take exactly six values")
+    banks = 0
+    for bank in sorted(pdir.glob("bank*.work")):
+        num = int(bank.name[4:6])
+
+        def mut(data):
+            for p in range(NPARTS_ALL):
+                off = PART_BASE + p * PART_STRIDE
+                data[off + idoff + t] = fx_id
+                for s, v in enumerate(page or ()):
+                    data[off + P1_OFF + t * TRACK_STRIDE + sub + s] = int(v) & 0x7f
+                for s, v in enumerate(page2 or ()):
+                    data[off + P2_OFF + t * P2_STRIDE + sub + s] = int(v) & 0x7f
+        _bank_write(pdir, num, mut, guard=guard)
+        data = bank.read_bytes()
+        if int.from_bytes(data[-2:], "big") != (sum(data[0x10:-2]) & 0xFFFF):
+            sys.exit(f"{bank.name}: checksum did not take -- do NOT use this")
+        banks += 1
+    label = mod.key if mod is not None else f"id 0x{fx_id:02x}"
+    print(f"T{t+1} {which_slot.upper()} = {label} (0x{fx_id:02x}) in {NPARTS_ALL} parts x {banks} bank(s)"
+          + (f", page 1 {list(page)}" if page else "") + (f", page 2 {list(page2)}" if page2 else ""))
+
+
 def stamp_slot(pdir, which, slot, value=None, guard=True, tracks=None):
     """Write ONE knob byte for every part/track that names the module (FX2
     or FX1), leaving the other eleven alone. `which` is a module key, name
@@ -574,13 +619,17 @@ def stamp_slot(pdir, which, slot, value=None, guard=True, tracks=None):
     pdir = pathlib.Path(pdir)
     fx_id, mod = _resolve_module(which)
     slot = _resolve_slot(mod, slot)
+    # A stock entry resolves to a Module whose params carry no names (and a
+    # bare id to none at all): neither has a manifest default or a knob name.
+    named = (mod is not None and slot < len(mod.params)
+             and isinstance(getattr(mod.params[slot], "name", None), (bytes, bytearray)))
     if value is None:
-        if mod is None:
-            sys.exit("a bare id has no manifest default -- give the value")
+        if not named:
+            sys.exit("a bare id / stock entry has no manifest default -- give the value")
         value = mod.params[slot].default or 0
     value = int(value) & 0x7f
-    label = (f"{mod.key} {mod.params[slot].name.decode('latin1')}"
-             if mod is not None else f"id 0x{fx_id:02x}")
+    label = (f"{mod.key} {mod.params[slot].name.decode('latin1')}" if named
+             else f"{mod.key if mod is not None else 'id'} 0x{fx_id:02x} slot {slot}")
     total = 0
     for bank in sorted(pdir.glob("bank*.work")):
         num = int(bank.name[4:6])
@@ -831,6 +880,15 @@ if __name__ == "__main__":
         # a REAL set, before its first load on a flashed image: only the ids
         # a station replaced are touched; BusVerb/BusDelay keep Sam's knobs
         stamp_defaults(pdir, sys.argv[3], replaced_only=True)
+    elif cmd == "set-fx":
+        args = sys.argv[3:]
+        page = page2 = None
+        if "--page" in args:
+            page = [int(x) for x in args[args.index("--page") + 1].split(",")]
+        if "--page2" in args:
+            page2 = [int(x) for x in args[args.index("--page2") + 1].split(",")]
+        pos = [a for i, a in enumerate(args) if not a.startswith("--") and (i == 0 or not args[i - 1].startswith("--"))]
+        set_fx(pdir, pos[0], pos[1], pos[2], page=page, page2=page2, guard="--no-guard" not in args)
     elif cmd == "stamp-slot":
         # one knob byte, every part/track naming that module: for a slot
         # whose meaning changed. Module by key/name/id, slot by name/index,

--- a/tools/scratch/blockdump.py
+++ b/tools/scratch/blockdump.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Read ot_emu --block-dump files: every host-port block's content at the move.
+
+  blockdump.py summary A.dump            per block class: frames, non-zero, RMS
+  blockdump.py diff A.dump B.dump        per block class: frames whose content differs
+  blockdump.py wav A.dump CLASS OUT.wav  a block class's words as int16 mono (words in order)
+A class is (dir, ch, core, ram) -- ram is the ColdFire address; ping-pong pairs are
+separate classes.
+"""
+import struct, sys, math, wave, array
+
+def read(path):
+    out = []
+    with open(path, 'rb') as f:
+        data = f.read()
+    o = 0
+    while o + 16 <= len(data):
+        d, frame, ch, core, ram, n = struct.unpack_from('<BIHBII', data, o)
+        o += 16
+        words = array.array('H'); words.frombytes(data[o:o + 2 * n])
+        if sys.byteorder != 'little': words.byteswap()
+        o += 2 * n
+        out.append((chr(d), frame, ch, core, ram, words))
+    return out
+
+def classes(blocks):
+    c = {}
+    for d, frame, ch, core, ram, w in blocks:
+        c.setdefault((d, ch, core, ram), []).append((frame, w))
+    return c
+
+def summary(path):
+    c = classes(read(path))
+    print(f"{'dir':3} {'ch':>2} {'core':>4} {'ram':>8} {'words':>5} {'blocks':>6} {'nz-frac':>7} {'rms16':>8} {'max16':>6}  frames")
+    for k in sorted(c, key=lambda k: (k[0], k[1], k[2], k[3])):
+        d, ch, core, ram = k
+        ws = [x for _, w in c[k] for x in w]
+        s = [x - 65536 if x >= 32768 else x for x in ws]
+        nz = sum(1 for x in ws if x) / len(ws) if ws else 0
+        rms = math.sqrt(sum(x * x for x in s) / len(s)) if s else 0
+        mx = max(abs(x) for x in s) if s else 0
+        fr = [f for f, _ in c[k]]
+        print(f"{d:3} {ch:2d} {core:4d} {ram:08x} {len(c[k][0][1]):5d} {len(c[k]):6d} {nz:7.3f} {rms:8.1f} {mx:6d}  {fr[0]}..{fr[-1]}")
+
+def diff(a, b):
+    ca, cb = classes(read(a)), classes(read(b))
+    print(f"{'dir':3} {'ch':>2} {'core':>4} {'ram':>8} {'blocks':>6} {'differ':>6} {'maxdiff':>7} {'first-frame':>11}")
+    for k in sorted(set(ca) | set(cb)):
+        if k not in ca or k not in cb:
+            print(f"{k[0]:3} {k[1]:2d} {k[2]:4d} {k[3]:08x}  only in {'A' if k in ca else 'B'}")
+            continue
+        fa = dict(ca[k]); fb = dict(cb[k])
+        common = sorted(set(fa) & set(fb))
+        nd = 0; md = 0; first = None
+        for f in common:
+            x, y = fa[f], fb[f]
+            if len(x) != len(y) or x != y:
+                nd += 1
+                if first is None: first = f
+                if len(x) == len(y):
+                    md = max(md, max(abs(a - b) for a, b in zip(x, y)))
+        print(f"{k[0]:3} {k[1]:2d} {k[2]:4d} {k[3]:08x} {len(common):6d} {nd:6d} {md:7d} {str(first):>11}")
+
+def towav(path, cls, out):
+    d, ch, core, ram = cls.split(':')
+    key = (d, int(ch), int(core), int(ram, 16))
+    c = classes(read(path))
+    ws = array.array('h', [x - 65536 if x >= 32768 else x for _, w in c[key] for x in w])
+    if sys.byteorder != 'little': ws.byteswap()
+    with wave.open(out, 'wb') as w:
+        w.setnchannels(1); w.setsampwidth(2); w.setframerate(44100)
+        w.writeframes(ws.tobytes())
+    print(f"{out}: {len(ws)} words")
+
+if __name__ == '__main__':
+    cmd = sys.argv[1]
+    if cmd == 'summary': summary(sys.argv[2])
+    elif cmd == 'diff': diff(sys.argv[2], sys.argv[3])
+    elif cmd == 'wav': towav(sys.argv[2], sys.argv[3], sys.argv[4])

--- a/tools/scratch/o9d_compare.py
+++ b/tools/scratch/o9d_compare.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""O9d: the port's per-track chain against dsp_host, on the same input.
+
+  o9d_compare.py extract DUMP TRACK PREFIX   -> PREFIX_in.wav (the 84-word record's
+                                                audio = the chain INPUT) and
+                                                PREFIX_rb_L.wav (the core's read-back
+                                                slot = the chain OUTPUT), 24-bit mono
+  o9d_compare.py fit PORT_rb.wav HOST_T.wav [lag_lo lag_hi]
+                                             -> best integer lag, least-squares scale,
+                                                residual, and the residual with NO scale
+
+Measured 8 Sep 2026 (COLDFIRE_PORT.md O9d): T1, FX1 = SEND, FX2 = EQUALIZER,
+tone on RX0 slot 2. Flat page: residual -125.6 dB at scale -11.906 dB, lag -32.
+Boosted page: -95.7 dB with the stem pre-scaled by that k (rig_render --amp k)
+and NO fit -- the port applies the track gain BEFORE the FX chain, and driving
+the EQ 12 dB hotter saturates it (the "+4.95 vs +6.22 dB" confound).
+"""
+import sys, wave, math, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import blockdump as bd
+
+CORE_OF = {t: (0 if t >= 5 else 1) for t in range(1, 9)}
+REC = {1: (0x80001c90, 0x80002710), 0: (0x800021d0, 0x80002c50)}     # 672-hw track records, ping/pong
+RB  = {1: (0x80003190, 0x80003590), 0: (0x80003390, 0x80003790)}     # 256-hw read-backs
+
+def words(w):
+    out = []
+    for i in range(0, len(w), 2):
+        v = (w[i] << 8) | (w[i + 1] >> 8)
+        out.append(v - (1 << 24) if v >= 1 << 23 else v)
+    return out
+
+def save(path, samples):
+    with wave.open(path, 'wb') as o:
+        o.setnchannels(1); o.setsampwidth(3); o.setframerate(44100)
+        o.writeframes(b''.join(int(v).to_bytes(3, 'little', signed=True) for v in samples))
+    rms = math.sqrt(sum(v * v for v in samples) / len(samples))
+    print(f"{path}: {len(samples)} samples, rms {20 * math.log10(rms / 8388608) if rms else -200:.1f} dBFS")
+
+def extract(dump, track, prefix):
+    c = bd.classes(bd.read(dump)); core = CORE_OF[track]; pos = (track - 1) % 4
+    rec = sorted(sum((c.get(('>', 0, core, a), []) for a in REC[core]), []))
+    inp = []
+    for _, w in rec:
+        ws = words(w); inp += ws[pos * 84 + 8: pos * 84 + 40: 2]
+    save(f"{prefix}_in.wav", inp)
+    rb = sorted(sum((c.get(('<', 1, core, a), []) for a in RB[core]), []))
+    out = []
+    for _, w in rb:
+        ws = words(w); out += ws[pos * 32: pos * 32 + 32: 2]
+    save(f"{prefix}_rb_L.wav", out)
+
+def rd(path, ch=0):
+    w = wave.open(path, 'rb'); n = w.getnframes(); nch = w.getnchannels(); sw = w.getsampwidth(); raw = w.readframes(n)
+    return [int.from_bytes(raw[(i * nch + ch) * sw:(i * nch + ch + 1) * sw], 'little', signed=True) / (1 << (8 * sw - 1)) for i in range(n)]
+
+def rms(x): return math.sqrt(sum(v * v for v in x) / len(x))
+def db(x): return 20 * math.log10(x) if x > 0 else -200
+
+def fit(port_path, host_path, lo=-64, hi=64):
+    port = rd(port_path); host = rd(host_path, 0)
+    n = min(len(port), len(host)); seg = range(max(1500, -lo), min(n - 100, n - hi))
+    best = None
+    for lag in range(lo, hi + 1):
+        den = sum(host[i + lag] ** 2 for i in seg)
+        if den <= 0: continue
+        k = sum(port[i] * host[i + lag] for i in seg) / den
+        r = rms([port[i] - k * host[i + lag] for i in seg]); p = rms([port[i] for i in seg])
+        if best is None or r < best[2]: best = (lag, k, r, p)
+    lag, k, r, p = best
+    r1 = rms([port[i] - host[i + lag] for i in seg])
+    print(f"lag {lag:+d} samples, scale {db(abs(k)):+.3f} dB (k = {k:.9f} = {k * 8388608:.0f}/2^23), "
+          f"residual {db(r / p):.1f} dB below the port's output; with NO scale {db(r1 / p):.1f} dB; "
+          f"port {db(p):.2f} host {db(rms([host[i] for i in seg])):.2f} dBFS over samples {seg.start}..{seg.stop}")
+
+if __name__ == '__main__':
+    if sys.argv[1] == 'extract': extract(sys.argv[2], int(sys.argv[3]), sys.argv[4])
+    elif sys.argv[1] == 'fit': fit(sys.argv[2], sys.argv[3], *map(int, sys.argv[4:6]))


### PR DESCRIPTION
## What this is

O9c closed on three claims: a THRU track's TX0 is a pre-FX2 monitor; the page-2 select never crosses under the emulated load; the comparison tap must be the recorder. All three are **retracted** here: they were one fixture defect.

## Measured (docs/COLDFIRE_PORT.md, Milestone O9d)

- **New instrument** `--block-dump FILE` dumps every host-port block's content at the move; `tools/scratch/blockdump.py summary|diff|wav` analyses it. O9c's EQUALIZER pair (page 1 extreme vs zero on T2) is **byte-identical on every host-port block in all 250 frames** — the cards never differed on the way in.
- Cause: the LOAD applies bank 1 part 1 (0x40009384, `engine`); the TRANSPORT START re-applies the **saved bank's pattern part** (0x4000c40e, `main`) and the refresher 0x4000c19c rewrites the live lane and pre-image from it. Every O9c FX2 fixture edited part 1 (+ its saved copy), so T2's FX2 was SEND in every run. `stamp-slot` writes all parts but BOTH slots, so its FILTER bytes landed in T2's **FX1** — X:0x2c0 is the FX1 instance.
- Per-voice DSP record decoded from the dump: 32 halfwords/track, +0 AMP, +6 FX1 page 1, +12 FX2 page 1 (value<<8, page-2 select in the LOW byte), +27/+28 the ids; assembled by 0x4000cae8 from 0x80000a50+track·64 and the 0x80000830 lane, slewed at 0x4000cc20, scene-modulated at 0x4000ccfc. The 672-halfword track records carry the THRU audio.
- With EQUALIZER on **T1** FX2 in every part: the records, both read-backs, the forwarded block, ch 6 and **TX0 all differ**. FILTER page-2 HP/LP = 1 vs 0 on T1: record low byte 0x0101, TX0 differs. Page 1 and page 2 both cross; the THRU monitor carries FX2.
- T2 renders nothing in the port too (read-back 316 vs 3.0 M in): its FX1 FILTER BASE 127 / WDTH 0 closes it — `rig_render`'s −138 dB was right; that "harness disagreement" is gone. Tone on RX0 slot 2 → T1's chain (TX0 −38 dBFS), slot 0 → T2's chain.

## Tools

- `ot_project.py set-fx PROJECT fx1|fx2 TRACK MODULE [--page ...] [--page2 ...]` — the id (+ pages) into all eight parts of every bank, both `.work`/`.strd`; validated byte-identical against the hand-built fixture.
- `stamp-slot` no longer crashes on a stock entry / bare id (asks for a value).
- Work-order standing rule 9 and a CLAUDE.md trap entry.

## Gates

`ctest` in out/emu green (3/3). Nothing in `make check`'s scope changed (ot_emu instrument + tools + docs). No hardware, no flash.

## And then the O9c gate itself — PASSED (third commit)

T1's chain input (the audio in its 84-word record) and output (its read-back slot) pulled from the dump (`tools/scratch/o9d_compare.py extract|fit`) against `rig_render` on the stock image with the same part and stem:

| T1 | scale | residual |
|---|---|---|
| FX1 = SEND, EQ flat | −11.906 dB (k = 2130129/2^23), lag −32 | **−125.6 dB** |
| FX1 = SEND, EQ boosted, stem × k | 0.000 dB | **−95.7 dB with no fit** |

The DSP's per-instance parameter words (X:0x25d for T1: AMP, FX1 p1, FX2 p1, FX1 p2 as knob<<16|companion<<8, AMP p2, FX2 p2, ids) are `dsp_host`'s `setParams` composition word for word. The one thing the harness lacks is the pre-FX track gain k: at `--amp 1.0` it drove the EQ 12 dB hotter than the unit and saturated it (+4.95 vs +6.22 dB boost). Stock LO-FI (0x1c, the RIG's T1 FX1) is nonlinear and was the first pass's "stepwise gain".

## What is next

Other effects / the other core through the same comparison; FLEX playback (the sample loader) is still the open locate for the recorder work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
