### PR TITLE
O10: FLEX playback renders sample-exact under the port, and Bryan's recorder loop is seam-free at the voice tap in every fixture -- the click is outside the port's model

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2221,7 +2221,12 @@ RX0 slot 2. 🟡 The DSP's DIR path called slot 0 "A" (O9c); the two names
 disagree by two slots, which is the receive ring's phase against the ESAI
 slot counter (the same rotation O9c found on the transmit side). The
 ColdFire's naming is what the recorder uses: **INAB records the +0x80 pair
-= RX0 slot 2/3 in the port.** `--audio-in tones` (500·(k+1) Hz on slot k)
+= RX0 slot 2/3 in the port.** ✅ Stable, not a rotation: three runs with
+different load lengths (20.0/20.5/21.0 s) all land the slot-2 tone in the
++0x80 pair — the receive ring's phase is fixed where the transmit side's
+rotates (O9c), so the two-slot offset between the DSP's DIR naming and the
+ColdFire's capture naming is a fixed fact of the port, 🟡 unmeasured on the
+unit. `--audio-in tones` (500·(k+1) Hz on slot k)
 sidesteps the question: the recorded frequency says which slot was taken.
 
 ### ✅ The track record's audio is a list of segments (corrects O9d's "words 8..38")

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2277,6 +2277,7 @@ card, `--audio-in tones` (500·(k+1) Hz on RX0 slot k), `--main-level 64`,
 | RLEN MAX, 128 BPM, play trigs on the REC steps (his test 3) | −104.4 dB rms, max 0.00 % |
 | RLEN 4, 120 BPM (his clean control) | −104.4 dB, 0.00 % (pass = 22,050) |
 | RLEN 4, 128 BPM, `--self`: play trigs on T1, the recording track | −104.4 dB, 0.00 % (T1 plays and records a 1500 Hz tone; INAB records the inputs, not its own output) |
+| RLEN 4, 128 BPM, play trigs OFF the record steps (4/8/12/16 against REC at 2/6/10/14) | −104.4 dB, 0.00 % from the first trig at step 4 (`r4_128_off`) |
 
 And the read-back tap (the chain OUTPUT, T2's slot of core 1's 256-word
 read-back, `o10_continuity.py --readback`) on the 8-bar run: −69 dBFS (the
@@ -2292,11 +2293,32 @@ in both emulators — `--pit-clock`, recorded in O8; the 0x8c jitter is real
 but the port's frame-lock is idealised), the DSP-side retrigger of a FLEX
 voice on a buffer being written (the port's DSP runs the real code, but its
 ESAI/DMA phase against the ColdFire frame is the port's), and any hardware
-path outside the host port. The falsifier for "seam-free by construction"
-is a fixture where the play grid and the arm grid differ — a play trig NOT
-on a REC step, or RLEN MAX (the next arm is the end), or the sound-on-sound
-shape (`--self`: T1 records what it plays) — three of which are queued in
-this milestone.
+path outside the host port. All four falsifiers the port can run — a play trig NOT on a REC step, RLEN
+MAX, the sound-on-sound shape, the 120 control — came back continuous: with
+both mechanisms on the same sample grid the played stream is the input
+delayed by the arm-to-trig offset, and that offset never changes. Bryan's
+click therefore needs the two to ROUND DIFFERENTLY on the unit (the pass is
+20,671.875 samples at 128 BPM — a fraction; at 120 it is 22,050 exactly,
+which is why 120 is clean), 🟡 inferred from the arithmetic, and the port
+cannot show which side rounds which way because it rounds both the same.
+
+✅ **Measured, the port's own timing of the two:** the play trig's sub-frame
+nibble (`FW_LIVE_NIBBLE`) is `f` for passes 1–8 (frames 322, 1614, …, 9366),
+`e` for passes 9–16 (10658 …), `d` for 17–24 (20994 …) — one sample earlier
+every eight passes, in lockstep with the arm offset route A measured
+(15 ×8 then 14, §10.16.5). Both derive from the frame builder's event
+arithmetic, so in the port they cannot drift apart. 🟡 **What would make the
+unit click on exactly Bryan's pattern:** a stage on one side that works in
+2-sample units (stereo pairs). At 120 BPM a pass is 1,378 frames + 2
+samples, so the nibble walks by two per pass and a 2-sample stage tracks it
+exactly — clean; at 128 it walks by ONE every eight passes, which a 2-sample
+stage cannot follow — one click per eight passes, i.e. every two bars,
+starting at the ninth pass (Bryan: "~6th repeat" onset, clicks at RLEN 4,
+16 and MAX alike, 120 clean). Hardware falsifier that costs one capture: a
+tempo whose pass fraction walks by an ODD number of samples per pass but
+not every eight (e.g. 125 BPM: 21,168 samples/pass exactly = clean
+predicted; 130: 20,353.85 → walks; the prediction is click iff the
+per-pass walk is odd), against a tempo with an even walk.
 
 ## What is NOT here yet
 

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -1591,7 +1591,7 @@ running and the poked trig firing at frame 344:
 | the RIG as staged (T1 THRU, master track on), tones in | a THRU track passing the inputs, tracks 1–4 → core 1 → ColdFire → core 0 |
 | the same, `MASTER_TRACK=0` | the master track was the gate |
 | T5 THRU with a trig in A01 step 2, tones in, master on and off | a THRU on the ESAI core itself, no inter-core hop |
-| T1 FLEX on slot 1 with `KICK.WAV` staged (`stage_card.py --audio`), `TSMODE=0` | the ColdFire rendering a sample into the 512-word block |
+| T1 FLEX on slot 1 with `KICK.WAV` staged (`stage_card.py --audio`), `TSMODE=0` | the ColdFire rendering a sample into the 512-word block — ❌ the WRONG block (it is the forwarded read-backs); the sample goes into the track's 84-word record and, with the main level posted, it renders sample-exact (O10) |
 
 What the instruments say about where it stops:
 
@@ -2185,6 +2185,104 @@ Instrument rule added to the port: **a DSP-side "byte-identical" between
 two cards is not evidence until the host-port dump shows the cards differed
 on the way in.** Three O9c retractions rode on skipping that check.
 
+## Milestone O10 — FLEX playback renders, sample-exact; the recorder loop under the port (8 Sep 2026, branch `coldfire-o10`)
+
+### ✅ "A FLEX voice never renders in either emulator" is retracted for the port
+
+O9 staged `KICK.WAV` on T1's FLEX slot and watched the 512-word block to
+core 0 and the read-backs; O9b/O9c repeated "the FLEX loader is unlocated".
+Both watched the wrong block, and O9's run had no main level (O9b's root
+cause A). The audio of a voice — THRU or FLEX — travels in the track's
+84-word record (O9d). Fixture: the RIG with T1 = machine type 1 (FLEX) on
+slot 1 in banks 1–2, all parts and mirrors, T1 FX1/FX2 = SEND, the kick
+(`scripts/make_test_audio.py kick`, 16-bit mono) staged at slot 1's own
+card path, `--poke-trig 2 --main-level 64`, no audio in:
+
+- T1's record carries audio from frame 1 (the pattern's own step-1 trig),
+  0 dBFS peak, retriggered at the poked trig (the kick restarts at record
+  sample 5,528 = frame 345.5 for a trig at 344); the read-back and TX0 ring
+  words 2–5 (both channels, a centred voice) carry it.
+- With the slot's `TSMODE=0` the record IS the file: `kick.wav << 8`,
+  residual **−100.2 dB**, k = 1.000, lag −16 samples (one frame). With the
+  RIG's `TSMODE=2` (timestretch) the fit is −3.9 dB — grains, as expected.
+
+So the ColdFire's sample renderer runs under the port from the card, sample
+for sample; the card read (176 sectors) O9 saw was the load doing its job.
+
+### ✅ The capture pairs, measured from the ch 7 blocks (corrects O9c)
+
+Each ch 7 block is one page of the ColdFire's input-capture ring
+(`0x80005460 + page·0x100`, 64 words): **+0 = the C/D pair, +0x80 = the A/B
+pair**, 16 × (L,R) each, exactly RTOS_FORK §10.18's layout. A tone on RX0
+slot 2 lands at **+0x80 (A/B, L)**; on slot 0 at **+0 (C/D, L)**. O9c's
+"+0x80 is fed from TX0 ring words 0/7 and never written" is ❌ retracted —
+it is written, from the ESAI-in ring, and carries what the DSP calls
+RX0 slot 2. 🟡 The DSP's DIR path called slot 0 "A" (O9c); the two names
+disagree by two slots, which is the receive ring's phase against the ESAI
+slot counter (the same rotation O9c found on the transmit side). The
+ColdFire's naming is what the recorder uses: **INAB records the +0x80 pair
+= RX0 slot 2/3 in the port.** `--audio-in tones` (500·(k+1) Hz on slot k)
+sidesteps the question: the recorded frequency says which slot was taken.
+
+### ✅ The track record's audio is a list of segments (corrects O9d's "words 8..38")
+
+Decoded from the FLEX run (`tools/scratch/o10_recloop.py record_audio`):
+an 84-word track record carries **16 stereo pairs in segments**, each a
+4-word header `(count, 0, 0x40000, tag)` followed by `count` (L,R) pairs. A
+THRU voice ships two empty headers then the 16 pairs at words 8–39 (what
+O9d read); a FLEX voice ships `(15 pairs)(1 pair)`, `(14)(2)`, `(13)(3)`,
+`(12)(4)`, `(11)(5)` — the split walks one sample per frame with the first
+header's count (0x0f, 0x0e, …) and the tag word steps `0x040000 +
+n·0x400000`. 🟡 What the split means (a source-position/interpolation
+boundary the DSP consumes) is not decoded; what is measured is that parsing
+the segments gives the voice's audio sample-exact (the kick fit above, and
+the −104 dB below), and reading a fixed window does not — two "seams" were
+found and retracted inside an hour before the parse (frame-periodic
+residuals against a fitted sine are the tell).
+
+### ✅ Bryan's 128 BPM / RLEN 4 loop under the port: sample-continuous for 32 passes
+
+Fixture = route A's own (`tools/scratch/make_seam_fixtures.py` → `r4_128`:
+16-step 1X A01, T1 = recorder trigs REC1/INAB at steps 2/6/10/14, RLEN 4,
+T2 = FLEX on R1 with play trigs at the same steps, 128 BPM), staged as a
+card, `--audio-in tones` (500·(k+1) Hz on RX0 slot k), `--main-level 64`,
+8 bars = 42,000 frames (≈45 min wall), `--block-dump`.
+
+- The recorder records **input A = the 1500 Hz tone on RX0 slot 2** (the
+  +0x80 capture pair), and T2 plays R1 from the first play trig at step 2
+  (record sample 5,056 = frame 316; the trig write is at frame 322) at
+  −20 dBFS, the input's own level. Play trigs land every 20,672 samples.
+- **One sine, fitted on passes 2–8, fits all 32 passes to −104.4 dB rms
+  (24-bit rounding), maximum deviation 0.0% at every sample** — through
+  every pass boundary and every retrigger, pass 9, 17 and 25 included.
+  `o10_seam.py` (residual phase of the tone) and a per-sample residual at
+  each trig agree. The voice's audio that reaches the DSP has no seam.
+- This is CONSISTENT with route A's recording-level finding (§10.16.5: the
+  ninth arm lands on the eighth recording's last sample), not against it:
+  the play trigs walk the same fractional step grid as the arms
+  (4 steps = 20,671.875 samples → 20,672 ×7 then 20,671), so a recording that
+  starts one input sample early is also played one sample early, and the
+  stream stays continuous. On this grid, at this tempo, with play trigs on
+  the arm steps, there is no click by construction.
+- 🟡 TX0 in this run sits at −75 dBFS (the RECTRIG project's levels) with a
+  −18 dB residual against one sine in every pass alike — an instrument
+  limit at that level (the O9c ring-rotation capture, the output stage), not
+  a seam; the DSP chain's continuity was proven on the THRU comparison at
+  normal levels. The voice tap is the decisive one here.
+
+**So the port does not reproduce Bryan's click at 128 / RLEN 4 with play
+trigs on the record steps.** What the port cannot see, and where the click
+can still live: the unit's own trig-to-arm timing (the RTOS tick is 2× off
+in both emulators — `--pit-clock`, recorded in O8; the 0x8c jitter is real
+but the port's frame-lock is idealised), the DSP-side retrigger of a FLEX
+voice on a buffer being written (the port's DSP runs the real code, but its
+ESAI/DMA phase against the ColdFire frame is the port's), and any hardware
+path outside the host port. The falsifier for "seam-free by construction"
+is a fixture where the play grid and the arm grid differ — a play trig NOT
+on a REC step, or RLEN MAX (the next arm is the end), or the sound-on-sound
+shape (`--self`: T1 records what it plays) — three of which are queued in
+this milestone.
+
 ## What is NOT here yet
 
 - **The rest of the peripherals.** The eDMA with its completion-timing rules
@@ -2202,8 +2300,8 @@ on the way in.** Three O9c retractions rode on skipping that check.
   64-word block per core, with one 64-word block read back.
 - **Audio out.** ~~The ESAI path is untraced.~~ ~~Traced in O9: input proven,
   output silent because no track ever starts.~~ O9b: THRU tracks pass the
-  inputs to TX0 through the whole chain. FLEX playback (the sample loader)
-  is the open half.
+  inputs to TX0 through the whole chain. ~~FLEX playback (the sample loader)
+  is the open half.~~ ✅ O10: FLEX playback renders, sample-exact.
 
 ## The oracle, made concrete (7 Sep 2026)
 

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2270,6 +2270,21 @@ card, `--audio-in tones` (500·(k+1) Hz on RX0 slot k), `--main-level 64`,
   a seam; the DSP chain's continuity was proven on the THRU comparison at
   normal levels. The voice tap is the decisive one here.
 
+### ✅ Three more of Bryan's shapes, four bars each, same result
+
+| fixture (`make_seam_fixtures.py`, 4 bars = 21,000 frames) | voice tap, one sine over every pass |
+|---|---|
+| RLEN MAX, 128 BPM, play trigs on the REC steps (his test 3) | −104.4 dB rms, max 0.00 % |
+| RLEN 4, 120 BPM (his clean control) | −104.4 dB, 0.00 % (pass = 22,050) |
+| RLEN 4, 128 BPM, `--self`: play trigs on T1, the recording track | −104.4 dB, 0.00 % (T1 plays and records a 1500 Hz tone; INAB records the inputs, not its own output) |
+
+And the read-back tap (the chain OUTPUT, T2's slot of core 1's 256-word
+read-back, `o10_continuity.py --readback`) on the 8-bar run: −69 dBFS (the
+RECTRIG part's own T2 level, 49 dB under the voice), residual −56 dB rms
+and 0.5–0.7 % max **in every pass alike** — the DSP's arithmetic floor at
+that level, nothing localised at any trig or boundary. 🟡 A fixture with
+T2's level raised would put that floor at −100 dB; not done here.
+
 **So the port does not reproduce Bryan's click at 128 / RLEN 4 with play
 trigs on the record steps.** What the port cannot see, and where the click
 can still live: the unit's own trig-to-arm timing (the RTOS tick is 2× off

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2320,6 +2320,18 @@ not every eight (e.g. 125 BPM: 21,168 samples/pass exactly = clean
 predicted; 130: 20,353.85 → walks; the prediction is click iff the
 per-pass walk is odd), against a tempo with an even walk.
 
+### Upstream check (8 Sep 2026, after a prior-art note from a parallel session)
+
+joelanders/mc68k-md-mm PR #5 ("Expose shared HI08 command acceptance and
+receive status", open, based on our pin 4a6d0d1) adds optional callbacks so
+CVR HC follows DSP acceptance. The port already does exactly that on its own
+side — `dsp.cpp` clears HC/HCP from the dsp56300 interrupt-taken hook (O8,
+measured) and does not use mc68k's HI08 acceptance path — so the PR neither
+changes what the port relies on nor duplicates code the port would drop.
+Bump the pin when it merges; nothing to port. dsp56300/dsp56300 issue #5 is
+the AGU modulo pre-decrement defect O9b fixed in `agu.h`; still open
+upstream, our patch stands.
+
 ## What is NOT here yet
 
 - **The rest of the peripherals.** The eDMA with its completion-timing rules

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2283,8 +2283,14 @@ And the read-back tap (the chain OUTPUT, T2's slot of core 1's 256-word
 read-back, `o10_continuity.py --readback`) on the 8-bar run: −69 dBFS (the
 RECTRIG part's own T2 level, 49 dB under the voice), residual −56 dB rms
 and 0.5–0.7 % max **in every pass alike** — the DSP's arithmetic floor at
-that level, nothing localised at any trig or boundary. 🟡 A fixture with
-T2's level raised would put that floor at −100 dB; not done here.
+that level, nothing localised at any trig or boundary. ✅ Done: with T2's AMP VOL at 127 (the AMP page is the six bytes BEFORE
+the track's FX1 row in `ot_project`'s P1_OFF layout — lane flat 12..17; the
+`+0x1b` "level" byte did nothing to the read-back) the read-back rises to
+−57.1 dBFS and the residual against one sine is −58.9 dB rms, **broadband**
+(every harmonic below −100 dB relative: it is T2's FX1 FILTER's own
+low-level noise, not distortion) and **proportional to the signal**, with a
+single-sample −0.5 % dip (−103 dBFS absolute) at each retrigger and no phase
+step anywhere. The DSP side of a retrigger is clean to that level.
 
 **So the port does not reproduce Bryan's click at 128 / RLEN 4 with play
 trigs on the record steps.** What the port cannot see, and where the click

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -755,6 +755,23 @@ pool blocks read across the arm: the RECTRIG fixture with `--audio-in tones`
 (`RTOS_FORK.md` §10.16's write path `0x400068e4`). No DSP voice needed to
 RECORD; playing it back does.
 
+## Where the port stands after O10 (8 Sep 2026), and what is left
+
+The port boots the firmware, mounts the card, loads the project, runs the
+sequencer byte-identical to route A, drives both DSP cores through the host
+port, takes ESAI audio in, plays FLEX samples sample-exact, records through
+the recorder, and renders a THRU track's FX chain bit-identical to
+`dsp_host`. The queue above is done. What remains is fidelity debt, each
+with its decider:
+
+| debt | decider | cost |
+|---|---|---|
+| RTOS tick = PIT on the CPU clock (5 ms) where the RM says bus clock (10 ms); every wall-clock number in the records is 2× out if so (`CHIP.md` §1) | a hardware tick measurement (an LED blink / a UI timeout on video), or a firmware constant that only fits one | one capture |
+| DIR names RX0 slot 0 "A", the ColdFire capture names slot 2 "A" (O9c vs O10); stable per run, not a rotation | a tone into the unit's input A with a THRU track and the recorder's INAB | one capture |
+| the track record's segment split and tag word (O10) — what the DSP does with them | read payload B's unpack of the 84-word record | RE, no hardware |
+| Bryan's click: the port shows none in any shape because arm and trig round alike; hypothesis = a 2-sample-unit stage on one side | Bryan's project file run AS-IS under the port (read SRC3/AB/CD/LOOP/QREC/timestretch first), then his one-pass test and the odd/even per-pass-walk tempo test (125 vs 130 BPM) on the unit | his file + two captures |
+| the O9c comparison on the shipping image (bus engines, core 0) | `make bus` + the ONEAUX card through the same fixture/fit (`o9d_compare.py`) | one session, no hardware |
+
 ## Running it overnight
 
 One session per milestone, in a terminal left open:

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -726,7 +726,27 @@ write map for the DSP side once the ColdFire sends anything. **Falsifier for
 (it does — it is Sam's rig), so this is a fidelity gap, not firmware
 behaviour; the question is which peripheral or flag the voice start waits on.
 
-### O10 — the recorder with real input *(after O9b or in parallel; Opus)*
+### O10 — FLEX playback + the recorder loop under the port ✅ DONE (8 Sep 2026, branch `coldfire-o10`) — the port does NOT reproduce the click
+
+`COLDFIRE_PORT.md` O10. ❌ "a FLEX voice never renders in either emulator"
+is retracted for the port: the voice's audio is in the 84-word track
+record (a list of `(count,0,0x40000,tag)` segments — parse it, do not
+window it), and a FLEX slot plays sample-exact (`kick.wav<<8`, −100 dB,
+TSMODE 0). The capture pairs are measured (RX0 slot 2 → the ColdFire's A/B
+at +0x80). Bryan's fixtures (route A's `make_seam_fixtures.py`, staged as
+cards, `--audio-in tones`): 128/RLEN 4 for 32 passes, 128/MAX, 120/RLEN 4
+and the `--self` shape are ALL one continuous sine to −104 dB at the voice
+tap — the play trigs and the arms share the fractional step grid, so the
+recording-level −1 seam route A found never reaches the played stream.
+Analysers: `tools/scratch/o10_recloop.py`, `o10_continuity.py`,
+`o10_seam.py`, `o10_phase.py`. **Open:** where the hardware click lives is
+outside what the port models (its trig/arm timing is idealised; the RTOS
+tick is 2× off in both emulators; the DSP/ESAI phase is the port's). The
+one falsifier the port can still run is a fixture whose play grid differs
+from the arm grid (`r4_128_off`, play trigs at 4/8/12/16) — result in the
+port doc.
+
+### ~~O10 — the recorder with real input~~ *(the original entry)*
 
 The inputs reach the ColdFire's capture buffers now. Bryan's click
 (`octabam-seam-patch-falsified`) wants content injected at the source and the

--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -2337,6 +2337,39 @@ model is the candidate again — its 128/4 prediction was "seams from pass
 Two questions for him cost nothing: does the click STOP after about a
 minute, and what was trigged on the flex in the MAX test.
 
+**Both answered (Bryan T, 8 Sep 2026, evening, via Sam):** *"REC trigs and
+PLAY trigs on the same steps. I usually have both on 1, but tested
+2/6/10/14. Clicking definitely does not stop. Once it is in the buffer it
+is always in it."* He offers his sound-on-sound project file.
+
+- ✅ **The flex IS retrigged, and on the same step the recorder arms, in
+  every test including MAX.** The "flex not retrigged at all in test 3"
+  escape above is closed: the reader is not free-running, so the play
+  retrig arrives on the same step as the arm and the two heads start the
+  pass together (d ≈ 0, ±the order in which the two trigs are serviced).
+- 🟡 **"Does not stop" cannot separate the two candidates in HIS patch.**
+  Sound-on-sound re-records the buffer's own playback (his wording — "once
+  it is in the buffer" — says the feedback exists; the SRC3/INAB settings
+  that make it so are in the project file, not yet seen). Any play-side
+  discontinuity the first band pass produces is captured into the next
+  layer and plays for as long as the feedback holds it, so the band
+  model's "seams 5–123, then clean" would ALSO sound like it never stops.
+  The discriminator is a recording with **no live writer**: record ONE
+  pass at 128/RLEN 4, remove the REC trig, keep the PLAY trig every 4
+  steps — clicks or not; then remove the PLAY trig too (LOOP on, free
+  loop) — clicks or not. Clean/clicks/clean splits recording content from
+  the retrig from the loop point. **Asked, 8 Sep 2026 (evening, via
+  Sam); answer pending.**
+- **The project file is the fixture.** The port now renders a FLEX voice
+  sample-exactly from the card (COLDFIRE_PORT O10), so his project loads
+  as-is (`ot_emu`, `emu_card`) and the recorder loop under the port can
+  run his exact patch — SRC3, AB/CD, LOOP, QREC and the recorder buffer's
+  timestretch attribute included — with a known tone in and the played
+  output watched at the retrig, which is the half route A could not see.
+  The timestretch attribute is worth reading first: at 120 the buffer
+  length is an exact tempo multiple and at 128 it is not (🟡 a candidate
+  only; nothing measured).
+
 Drivers: `tools/scratch/recaudio.py` (`--reg-probe`, `--read-probe`,
 `--field-probe` are the instruments that found the three defects),
 `recaudio_seams.py`, `recaudio_analyse.py`, `make_seam_fixtures.py`

--- a/tools/scratch/o10_continuity.py
+++ b/tools/scratch/o10_continuity.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""One-sine continuity test for a recorded-and-replayed tone (O10).
+  o10_continuity.py [--readback] DUMP TRACK FREQ [pass_len=20672] [fit_lo=25000] [fit_hi=160000]
+--readback tests the core's read-back slot (the chain output) instead of the voice's record audio.
+Fits A sin + B cos at FREQ on samples fit_lo..fit_hi of the track's audio and
+reports, per pass, the rms residual and the largest deviation (% of the
+tone's amplitude) against that ONE sine: a seam (dropped/duplicated sample)
+is a permanent phase step, a retrigger glitch a local spike; -100 dB is
+24-bit rounding, i.e. sample-continuous.
+"""
+import sys, math, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import blockdump as bd, o10_recloop as rl
+
+def main():
+    rb = sys.argv[1] == '--readback'; a = sys.argv[2:] if rb else sys.argv[1:]
+    dump, track, f = a[0], int(a[1]), float(a[2])
+    L = int(a[3]) if len(a) > 3 else 20672
+    lo = int(a[4]) if len(a) > 4 else 25000
+    hi = int(a[5]) if len(a) > 5 else 160000
+    c = bd.classes(bd.read(dump))
+    x = rl.readback_audio(c, track) if rb else rl.track_audio(c, track)
+    first = next((i for i, v in enumerate(x) if v), None)
+    if first is None: print(f"T{track}: silent"); return
+    w = 2 * math.pi * f / 44100
+    saa = sbb = sab = sa = sb = 0.0
+    for n in range(lo, min(hi, len(x))):
+        a = math.sin(w * n); b = math.cos(w * n); v = x[n]
+        saa += a * a; sbb += b * b; sab += a * b; sa += a * v; sb += b * v
+    det = saa * sbb - sab * sab; A = (sa * sbb - sb * sab) / det; B = (saa * sb - sab * sa) / det
+    amp = math.hypot(A, B)
+    print(f"T{track}: audio from sample {first}; one sine at {f:.0f} Hz fitted on {lo}..{hi}: {20 * math.log10(amp / 8388608):.1f} dBFS")
+    for p in range(len(x) // L):
+        seg = range(p * L, (p + 1) * L)
+        if seg.stop <= first: continue
+        r = [abs(x[n] - (A * math.sin(w * n) + B * math.cos(w * n))) / amp for n in seg if n >= first + 200]
+        if not r: continue
+        i = max(range(len(r)), key=lambda k: r[k]); rm = math.sqrt(sum(v * v for v in r) / len(r))
+        flag = "" if r[i] < 0.005 else "   <-- deviates"
+        print(f"  pass {p + 1:2d} ({seg.start:7d}..): rms {20 * math.log10(rm) if rm else -200:7.1f} dB, max {100 * r[i]:6.2f}% at {seg.start + i + (first + 200 - seg.start if seg.start < first + 200 else 0)}{flag}")
+
+if __name__ == '__main__':
+    main()

--- a/tools/scratch/o10_phase.py
+++ b/tools/scratch/o10_phase.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Seam/click detector for a recorded-and-replayed TONE: the instantaneous
+phase of a known frequency, from a sliding DFT, must advance linearly; a
+dropped sample is a +360/period degree jump, a duplicated one the negative,
+a level step shows in the magnitude. Prints every window-to-window phase jump
+above `thresh` degrees (after removing the expected advance).
+  o10_phase.py DUMP TRACK FREQ_HZ [win=64] [thresh=4]
+  o10_phase.py --wav FILE.wav CHANNEL FREQ_HZ [win=64] [thresh=4]   (e.g. --audio-out's ring word 2)
+"""
+import sys, math, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import blockdump as bd, o10_recloop as rl
+
+def read_wav_channel(path, ch):
+    import wave
+    w = wave.open(path, 'rb'); n = w.getnframes(); nch = w.getnchannels(); sw = w.getsampwidth(); raw = w.readframes(n)
+    return [int.from_bytes(raw[(i * nch + ch) * sw:(i * nch + ch + 1) * sw], 'little', signed=True) << (24 - 8 * sw) for i in range(n)]
+
+def main():
+    if sys.argv[1] == '--wav':
+        path, track, f = sys.argv[2], int(sys.argv[3]), float(sys.argv[4]); args = sys.argv[5:]
+    else:
+        path, track, f = sys.argv[1], int(sys.argv[2]), float(sys.argv[3]); args = sys.argv[4:]
+    win = int(args[0]) if len(args) > 0 else 64
+    thresh = float(args[1]) if len(args) > 1 else 4.0
+    if sys.argv[1] == '--wav':
+        x = read_wav_channel(path, track)
+    else:
+        c = bd.classes(bd.read(path)); x = rl.track_audio(c, track)
+    period = 44100 / f
+    w = 2 * math.pi * f / 44100
+    cos = [math.cos(w * i) for i in range(win)]; sin = [math.sin(w * i) for i in range(win)]
+    prev = None; hops = 0; first = None; jumps = []
+    for s in range(0, len(x) - win, win // 2):
+        seg = x[s:s + win]
+        re = sum(v * cs for v, cs in zip(seg, cos)); im = sum(v * sn for v, sn in zip(seg, sin))
+        mag = 2 * math.hypot(re, im) / win
+        if mag < 8388608 * 1e-4:
+            prev = None; continue
+        ph = math.degrees(math.atan2(re, im))
+        if first is None: first = s
+        if prev is not None:
+            pmag, pph, ps = prev
+            expect = pph - math.degrees(w * (s - ps))          # phase of the tone referenced to the window start
+            d = (ph - expect + 180) % 360 - 180
+            if abs(d) > thresh:
+                jumps.append((s, d, 20 * math.log10(mag / pmag) if pmag else 0))
+        prev = (mag, ph, s)
+    print(f"T{track} {f:.0f} Hz (period {period:.2f} samples = {360 / period:.1f} deg/sample): audio from sample {first}, "
+          f"{len(jumps)} phase jump(s) > {thresh} deg in {win}-sample windows")
+    for s, d, dl in jumps[:40]:
+        print(f"   sample {s:7d} (frame {s / 16:8.1f}, pass {s / 20672:6.3f}): {d:+6.1f} deg = {d / (360 / period):+.2f} samples, level {dl:+.1f} dB")
+
+if __name__ == '__main__':
+    main()

--- a/tools/scratch/o10_recloop.py
+++ b/tools/scratch/o10_recloop.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""O10: the recorder loop under the port -- what T2 plays back from R1.
+
+  o10_recloop.py DUMP [bpm] [rlen_steps]
+Extracts T2's chain input (its 84-word record audio: what the FLEX voice plays)
+and prints, per sequencer step, the level and the dominant frequency (from
+zero crossings; `--audio-in tones` puts 500*(k+1) Hz on RX0 slot k, so the
+frequency says WHICH input pair the recorder captured), then the largest
+sample-to-sample jump in each pass relative to the tone's own slope -- a seam
+click shows as a jump far above the slope (Bryan's 128/RLEN4 case: PR #157's
+follow-on, RTOS_FORK 10.18).
+"""
+import sys, math, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import blockdump as bd
+
+def words(w):
+    out = []
+    for i in range(0, len(w), 2):
+        v = (w[i] << 8) | (w[i + 1] >> 8); out.append(v - (1 << 24) if v >= 1 << 23 else v)
+    return out
+
+def record_audio(rec, right=False):
+    """One 84-word track record -> its 16 audio samples (L, or R).
+    Measured 8 Sep 2026 (O9d/O10): the record is a sequence of SEGMENTS, each
+    a 4-word header (count, 0, 0x40000, tag) followed by `count` stereo pairs,
+    16 pairs in all -- a THRU voice ships two empty headers then 16 pairs; a
+    FLEX voice ships e.g. (15 pairs)(1 pair), (14)(2), ... the split moving one
+    sample per frame with the header's first word. Parsed, not assumed: a
+    wrong layout shows as a frame-periodic glitch against a fitted sine."""
+    o = 1 if right else 0
+    pairs = []; i = 0
+    while len(pairs) < 16 and i + 4 <= len(rec):
+        if rec[i + 1] == 0 and rec[i + 2] == 0x40000 and 0 <= rec[i] <= 16:
+            cnt = rec[i]; i += 4
+            if cnt:
+                pairs += [rec[i + 2 * k + o] for k in range(cnt)]; i += 2 * cnt
+            continue
+        take = 16 - len(pairs)
+        pairs += [rec[i + 2 * k + o] for k in range(take)]; i += 2 * take
+    return pairs[:16]
+
+def track_audio(c, track, right=False):
+    core = 0 if track >= 5 else 1; pos = (track - 1) % 4
+    addrs = {1: (0x80001c90, 0x80002710), 0: (0x800021d0, 0x80002c50)}[core]
+    rec = sorted(sum((c.get(('>', 0, core, a), []) for a in addrs), []))
+    out = []
+    for _, w in rec:
+        ws = words(w); out += record_audio(ws[pos * 84:(pos + 1) * 84], right)
+    return out
+
+def db(x): return 20 * math.log10(x / 8388608) if x > 0 else -200
+
+def main():
+    dump = sys.argv[1]; bpm = float(sys.argv[2]) if len(sys.argv) > 2 else 128.0
+    rlen = int(sys.argv[3]) if len(sys.argv) > 3 else 4
+    step = 60.0 / bpm / 4 * 44100                     # samples per 16th step
+    c = bd.classes(bd.read(dump))
+    for t in (1, 2):
+        x = track_audio(c, t)
+        print(f"T{t}: {len(x)} samples ({len(x) / step:.1f} steps of {step:.1f})")
+        rows = []
+        for s in range(int(len(x) / step)):
+            seg = x[int(s * step): int((s + 1) * step)]
+            if not seg: continue
+            rms = math.sqrt(sum(v * v for v in seg) / len(seg))
+            zc = sum(1 for i in range(1, len(seg)) if (seg[i - 1] < 0) != (seg[i] < 0))
+            f = zc / 2 / (len(seg) / 44100)
+            rows.append((s + 1, db(rms), f))
+        print("   step: level dBFS / dominant Hz  " + "  ".join(f"{s}:{l:.0f}/{f:.0f}" for s, l, f in rows))
+        # seams: largest jump per RLEN-step pass, relative to the median slope of that pass
+        if any(l > -60 for _, l, _ in rows):
+            for p in range(int(len(x) / (step * rlen))):
+                a, b = int(p * step * rlen), int((p + 1) * step * rlen)
+                seg = x[a:b]
+                d = [abs(seg[i] - seg[i - 1]) for i in range(1, len(seg))]
+                if not d or max(seg, key=abs) == 0: continue
+                med = sorted(d)[len(d) // 2] or 1
+                i = max(range(len(d)), key=lambda k: d[k])
+                print(f"   pass {p + 1} (samples {a}..{b}): max jump {d[i]} at +{i + 1} = {d[i] / med:.1f}x the median slope")
+
+if __name__ == '__main__':
+    main()

--- a/tools/scratch/o10_recloop.py
+++ b/tools/scratch/o10_recloop.py
@@ -49,6 +49,17 @@ def track_audio(c, track, right=False):
         ws = words(w); out += record_audio(ws[pos * 84:(pos + 1) * 84], right)
     return out
 
+def readback_audio(c, track, right=False):
+    """The track's slot of its core's 256-halfword read-back: the per-track
+    chain OUTPUT before the master mix (32 words per track, (L,R) pairs)."""
+    core = 0 if track >= 5 else 1; pos = (track - 1) % 4; o = 1 if right else 0
+    addrs = {1: (0x80003190, 0x80003590), 0: (0x80003390, 0x80003790)}[core]
+    rb = sorted(sum((c.get(('<', 1, core, a), []) for a in addrs), []))
+    out = []
+    for _, w in rb:
+        ws = words(w); out += ws[pos * 32 + o: pos * 32 + 32: 2]
+    return out
+
 def db(x): return 20 * math.log10(x / 8388608) if x > 0 else -200
 
 def main():

--- a/tools/scratch/o10_seam.py
+++ b/tools/scratch/o10_seam.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Residual phase of a recorded-and-replayed tone against a perfect tone:
+phase(s) - w*s, unwrapped in small hops, so a dropped input sample is a
+permanent +360/period step, a duplicated one -period step, and a playback
+rate error a ramp. Prints the residual at each pass boundary and the largest
+single hop inside each pass.
+  o10_seam.py DUMP TRACK FREQ [pass_len=20672] [win=128]
+  o10_seam.py --wav FILE CH FREQ [pass_len] [win]
+"""
+import sys, math, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import blockdump as bd, o10_recloop as rl, o10_phase as ph
+
+def main():
+    wav = sys.argv[1] == '--wav'; a = sys.argv[2:] if wav else sys.argv[1:]
+    src, trk, f = a[0], int(a[1]), float(a[2])
+    L = int(a[3]) if len(a) > 3 else 20672; win = int(a[4]) if len(a) > 4 else 128
+    x = ph.read_wav_channel(src, trk) if wav else rl.track_audio(bd.classes(bd.read(src)), trk)
+    w = 2 * math.pi * f / 44100; period = 44100 / f
+    cos = [math.cos(w * i) for i in range(win)]; sin = [math.sin(w * i) for i in range(win)]
+    res = {}; prev = None; acc = 0.0; start = None
+    for s in range(0, len(x) - win, win // 2):
+        seg = x[s:s + win]; re = sum(v * c for v, c in zip(seg, cos)); im = sum(v * c for v, c in zip(seg, sin))
+        mag = 2 * math.hypot(re, im) / win
+        if mag < 8388608 * 1e-4: prev = None; continue
+        r = (math.degrees(math.atan2(re, im)) - math.degrees(w * s)) % 360   # residual vs a tone starting at sample 0
+        if prev is not None:
+            acc += (r - prev + 180) % 360 - 180
+        elif start is None:
+            start = s
+        prev = r; res[s] = acc
+    if not res: print("no tone"); return
+    print(f"{'pass':>4} {'start':>9} {'residual at start':>18} {'at end':>8} {'max hop in pass':>16}  (deg; one sample = {360 / period:.1f} deg; audio from {start})")
+    keys = sorted(res)
+    for p in range(len(x) // L):
+        ks = [k for k in keys if p * L <= k < (p + 1) * L]
+        if len(ks) < 4: continue
+        hops = [(res[ks[i]] - res[ks[i - 1]], ks[i]) for i in range(1, len(ks))]
+        h, at = max(hops, key=lambda t: abs(t[0]))
+        print(f"{p + 1:4d} {p * L:9d} {res[ks[0]]:18.1f} {res[ks[-1]]:8.1f} {h:+9.1f} at {at:7d}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What this is

The next ColdFire-port milestone after #157. Two results, one retraction, one hypothesis.

## Measured (docs/COLDFIRE_PORT.md, Milestone O10)

- ❌ **"A FLEX voice never renders in either emulator" is retracted for the port.** Earlier sessions watched the 512-word block (the forwarded read-backs); a voice's audio travels in its 84-word track record. With the kick staged at the slot's own path and the main level posted, T1 FLEX plays it **sample-exact**: `kick.wav << 8`, residual −100.2 dB, one frame of lag (TSMODE 0; TSMODE 2 = timestretch grains).
- **The track record's audio is a list of segments** `(count, 0, 0x40000, tag)` + `count` stereo pairs, 16 pairs total: THRU ships two empty headers then the pairs; FLEX ships (15)(1), (14)(2)… walking one per frame. `o10_recloop.record_audio` parses it; a fixed window produced two false seams before the parse (frame-periodic residuals against a fitted sine are the tell).
- **Capture pairs:** a tone on RX0 slot 2 lands in the ColdFire's A/B pair (+0x80), slot 0 in C/D (+0) — O9c's "+0x80 is never written" retracted. The recorder's INAB source is reachable in the port.
- **Bryan's loop under the port** (route A's `make_seam_fixtures.py` cards, `--audio-in tones`, `o10_continuity.py`): 128/RLEN 4 for 32 passes, 128/MAX, 120/RLEN 4, the `--self` shape and play trigs OFF the record steps are **all one continuous 1500 Hz sine to −104.4 dB rms (24-bit rounding) at the voice tap**, through every retrigger. The play-trig nibble walks one sample per eight passes (f/e/d) in lockstep with the arm offset route A measured, so the two cannot drift apart in the port; the played stream is the input delayed by a constant.
- Read-back tap (the chain output) with T2's AMP VOL at 127: −57 dBFS, residual −59 dB broadband (FILTER's low-level noise, harmonics < −100 dB), a one-sample −0.5 % dip per retrigger, no phase step. The `+0x1b` level byte does not scale the chain; the AMP page sits six bytes before the track's FX1 row. TX0 at −75 dBFS is not usable as a tap (ring capture).
- The receive slot→capture-pair mapping is stable across runs (no RX-side rotation).
- Upstream check: mc68k PR #5 does not overlap the port's own HC clearing; dsp56300 issue #5 = our agu.h fix.
- Also carries the parallel session's RTOS_FORK §10.18 note with Bryan's answers (REC+PLAY on the same steps in every test; his project file is coming and is the fixture to run as-is).

**So the port does not reproduce the click.** 🟡 Hypothesis with a one-capture hardware falsifier: a 2-sample-unit stage on one side (120 BPM walks 2 samples/pass = tracked = clean; 128 walks 1 sample per 8 passes = one click per two bars from the ninth pass — Bryan's pattern). Prediction: click iff the per-pass walk is odd (125 BPM clean, 130 clicks).

## Tools

`tools/scratch/o10_recloop.py` (segment parser, per-step table), `o10_continuity.py` (one-sine per-pass test, `--readback`), `o10_seam.py`, `o10_phase.py`. Fixtures under `out/o9d/`.

## Gates

ctest unchanged (no emulator code changed this PR — instruments are Python over `--block-dump`). Nothing flashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
