### PR TITLE
O11: the one-aux return failure reproduced and fixed under the ColdFire port -- r7 is 0x6100 + 0x300*pos, the pin was the harness's model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,6 +342,20 @@ DSP-side "byte-identical" between two cards, run both with `--block-dump`
 and `tools/scratch/blockdump.py diff`: if no host-port block differs, the
 cards did not differ where it matters.
 
+**THE HARNESS'S MODEL OF THE DISPATCHER IS NOT THE DISPATCHER.** `dsp_host`
+handed every effect r7 = 0x6100 + 0x100·(2·pos + fx−1); the stock
+dispatcher bumps r7 THREE times per track (the third unconditional, after
+FX2), so from position 1 on every r7 the harness used was wrong, and two
+modules that pinned a track by its r7 (the one-aux return on T8, the
+track-8 send refusal) matched in the harness and never on the unit — flash
+6's "the return never reaches T8", with `make verify-onebus` green on
+exactly that property. Found 8 Sep 2026 by running the shipping image from
+the card under the ColdFire port (`docs/COLDFIRE_PORT.md` O11). Any module
+logic keyed on a dispatcher fact (r7, r6, X:0x213, instance blocks) is
+measured under the port (`ot_emu --dsp-pcwatch`), never modelled in
+`dsp_host`; and a hardware failure the lock-step harness cannot show goes to
+the port before it goes to a guess.
+
 **A parameter slot can draw a knob and publish nothing.** The page descriptor
 and the DSP-side read are separate mechanisms; `dsp_host` pokes r6 directly, so
 everything looks live locally even when the real unit would publish nothing.

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2343,6 +2343,85 @@ Bump the pin when it merges; nothing to port. dsp56300/dsp56300 issue #5 is
 the AGU modulo pre-decrement defect O9b fixed in `agu.h`; still open
 upstream, our patch stands.
 
+## Milestone O11 — the first hardware failure diagnosed under the port: the one-aux return (8 Sep 2026, branch `coldfire-o11-return`)
+
+`FAILURE_MODES.md` "the one-aux return never reaches T8" (flash 6, tag 20):
+sending AUX produced wet on T1 and T5, the engines' own hosts, and nothing
+on T8; the local gate was green on exactly the property the unit falsified,
+and the cause was guessed as a liveness stamp lost across cores. The port
+runs the shipping remix (`make bus REMIX=bamsep27`) from a card with the
+firmware driving both cores, so it can reproduce the unit.
+
+### ✅ Reproduced, in the read-backs
+
+Fixture: `ot_project.py rigproj` on the cleared RIG backup (every part of
+every bank gets the rig: T1 CHARACTER + DELAY SERVER, T5 MODULATION + REVERB
+SERVER, T8 CHARACTER in BUS mode as the return, SENDs with AUX 30–50), staged
+as a card, a 300 Hz tone on RX0 slot 0 (T2's THRU input, AUX 40), 2,000
+frames. Per-track read-backs (the chain outputs):
+
+| | T1 (delay host) | T5 (reverb host) | T8 (return) |
+|---|---|---|---|
+| port, shipping image | prints wet from frame 500 (−43 dBFS L, −48 R) | prints the reverb from frame 200, rising to −53 | L −26 (the master mix's dry; T8 is the master), R only the reverb rising to −48 |
+| `rig_render` (dsp_host), same part and stem | silent | silent | −58 L/R, the reverb, a tail |
+
+The hosts printing their own wet IS the hardware symptom. A DSP write watch
+on the return's stamp word (`Y:0x360d8`) showed only the clear-on-read
+writes; a PC watch on the station's stamp instruction (`P:0x183b`) never
+fired: the station never stamped.
+
+### ✅ The cause, measured on the dispatcher: r7 has THREE blocks per track
+
+The station pins itself to track 8 by `r7 & 0xff00 == $6700/$6800`. A PC
+watch after its `move r7,a` read **r7 = 0x6a00** for track 8's FX1, every
+frame, init and proc. A PC watch on both `jsr (r2)` sites of the stock
+dispatcher (P:0x4d7 FX1, P:0x50d FX2 on payload A; P:0x2cc/0x302 on B) gave
+the whole map on both cores:
+
+| position | FX1 r7 | FX2 r7 |
+|---|---|---|
+| 0 (T5 / T1) | 0x6100 | 0x6200 |
+| 1 (T6 / T2) | 0x6400 | 0x6500 |
+| 2 (T7 / T3) | 0x6700 | 0x6800 |
+| 3 (T8 / T4) | **0x6a00** | **0x6b00** |
+
+A write watch on the counter `X:0x20a` names the three bumps per track:
+P:0x4b4 (FX1), P:0x4ea (FX2) and **P:0x524, unconditional, after FX2**
+(`move x:>$20a,b / add #>$100,b / move b,x:>$20a` at 0x518–0x524, identical
+in the stock image), reset to 0x6000 at the frame start (P:0x379). So
+**r7 = 0x6100 + 0x300·pos + 0x100·(fx−1)**. The harness had
+`1 + 2·pos + (fx−1)` (dsp_host's r7probe comment; its "track 2 FX2 = 0x6400"
+🟡 reads as position 1's FX1 under the real stride), which is right for
+position 0 only. The return's pin and the send client's track-8 refusal
+(`$6800`) were both derived from that model: they matched in `dsp_host`,
+never on the unit — the gate was green and the unit was wrong for the same
+reason. Not a cross-core race: the reverb host and the return share core 0.
+
+Also seen on the way: the DSP holds THREE copies of the four per-instance
+parameter blocks (X:0x25d, +0x80, +0x100; r6 cycles 0x2c3/0x343/0x3c3 for
+the same instance across frames) — one instance, triple-buffered
+parameters, not three instances.
+
+### ✅ The fix, proven both ways
+
+`character.asm` pins `$6a00/$6b00`; `send_client.asm` refuses `$6b00`;
+`rig_render`, `verify_onebus` and `send_probe` pass `-r7 1 + 3·pos + (fx−1)`;
+dsp_host's comment corrected (patch regenerated). Under the port with the
+rebuilt image: the stamp instruction fires every frame, **T1 and T5 print
+nothing for 2,000 frames, T8 returns** (R = the reverb building; L = the
+master mix's dry plus the reverb, since T8 is the master and `rig_render`
+does not model that routing). `make verify-onebus`: every property holds on
+both cores — and with the r7 model fixed but the old pin it failed 10 of
+25, which is the gate finally seeing what the unit saw. UNFLASHED; it is
+the flash-7 candidate (stamp-defaults before play, as ever).
+
+**What this milestone establishes:** a hardware failure the lock-step
+harness could not show was reproduced and located in one session with no
+flash, from the card, with the firmware's own dispatcher as the instrument.
+The rule it leaves: **any module logic keyed on a dispatcher fact (r7, r6,
+X:0x213, block addresses) is measured under the port, not modelled in
+`dsp_host`.**
+
 ## What is NOT here yet
 
 - **The rest of the peripherals.** The eDMA with its completion-timing rules

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -755,7 +755,17 @@ pool blocks read across the arm: the RECTRIG fixture with `--audio-in tones`
 (`RTOS_FORK.md` §10.16's write path `0x400068e4`). No DSP voice needed to
 RECORD; playing it back does.
 
-## Where the port stands after O10 (8 Sep 2026), and what is left
+### O11 — the one-aux return, diagnosed under the port ✅ DONE (8 Sep 2026, branch `coldfire-o11-return`, stacked on `coldfire-o10`)
+
+`COLDFIRE_PORT.md` O11 / `FAILURE_MODES.md`. The unit's "hosts keep
+printing, nothing on T8" reproduced from the card in the read-backs; cause
+measured on the stock dispatcher: r7 = 0x6100 + 0x300·pos + 0x100·(fx−1)
+(three bumps per track, the third unconditional at P:0x524), so track 8's
+FX1 is $6a00, not the $6700 the return pinned on and the harness modelled.
+Pins and the harness r7 model fixed; port and `make verify-onebus` both
+green. UNFLASHED. Rule: dispatcher facts are measured under the port.
+
+## Where the port stands after O11 (8 Sep 2026), and what is left
 
 The port boots the firmware, mounts the card, loads the project, runs the
 sequencer byte-identical to route A, drives both DSP cores through the host
@@ -770,7 +780,7 @@ with its decider:
 | DIR names RX0 slot 0 "A", the ColdFire capture names slot 2 "A" (O9c vs O10); stable per run, not a rotation | a tone into the unit's input A with a THRU track and the recorder's INAB | one capture |
 | the track record's segment split and tag word (O10) — what the DSP does with them | read payload B's unpack of the 84-word record | RE, no hardware |
 | Bryan's click: the port shows none in any shape because arm and trig round alike; hypothesis = a 2-sample-unit stage on one side | Bryan's project file run AS-IS under the port (read SRC3/AB/CD/LOOP/QREC/timestretch first), then his one-pass test and the odd/even per-pass-walk tempo test (125 vs 130 BPM) on the unit | his file + two captures |
-| the O9c comparison on the shipping image (bus engines, core 0) | `make bus` + the ONEAUX card through the same fixture/fit (`o9d_compare.py`) | one session, no hardware |
+| the O9c comparison on the shipping image (bus engines, core 0) | `make bus` + the ONEAUX card through the same fixture/fit (`o9d_compare.py`) — the rig runs under the port now (O11); the bit comparison of an engine is the remaining step | one session, no hardware |
 
 ## Running it overnight
 

--- a/docs/FAILURE_MODES.md
+++ b/docs/FAILURE_MODES.md
@@ -224,6 +224,20 @@ is a BUS-mode Character pinned to **T8 = payload A / core 0**, while the
 delay host sits on **T1 = payload B / core 1**. Nothing has been measured on
 the unit to distinguish a lost stamp from a return that never publishes.
 
+✅ **CAUSE MEASURED 8 Sep 2026, under the ColdFire port (`COLDFIRE_PORT.md`
+O11), and it is not a cross-core race:** the station pins the return to
+track 8 by testing `r7 & 0xff00` against `$6700/$6800`, the harness's
+two-per-track model of the dispatcher's state block. The stock dispatcher
+bumps its r7 counter THREE times per track (FX1, FX2, and an unconditional
+third at P:0x51e), so on the unit track 8's FX1 runs with **r7 = $6a00**,
+the pin never matches, `ch_nopos` clears the RET level, the station stamps
+nothing, and both hosts keep printing — exactly the symptom, reproduced
+with the firmware driving both cores. Fixed: pin `$6a00/$6b00`; the
+harness's r7 model corrected (rig_render, verify_onebus, send_probe,
+dsp_host's comment); under the port the fixed image returns on T8 with both
+hosts silent for 2,000 frames. UNFLASHED. The reading below stands as the
+history of the wrong guess.
+
 **⚠️ THE LOCAL GATE IS GREEN ON EXACTLY THIS.** `tools/verify_onebus.py`
 asserts "T5 (reverb host) prints nothing while the return is live" and the
 same for T1, and both pass — the property hardware falsifies is the property

--- a/modules/character/character.asm
+++ b/modules/character/character.asm
@@ -371,7 +371,7 @@ ch_sbus:
 ; of the LAST LIVE STAGE's output -- the reverb's if it is running, else the
 ; delay's, else nothing -- resolved below from the engines' liveness stamps.
 ; The RING knob is inert in BUS mode. And the return is PINNED to TRACK 8:
-; dispatch position 3 (r7 $6700/$6800) on payload A only -- a BUS-mode
+; dispatch position 3 on payload A only -- a BUS-mode
 ; station anywhere else, core 1's position 3 (track 4) included, returns
 ; nothing.
         move    x:(r6+$2),x0
@@ -390,10 +390,21 @@ ch_sbus:
         beq     ch_nopos                ; the alias: payload B, never the return
         move    r7,a
         and     #>$ff00,a
-        move    #>$6700,x0
+; ⚠️ r7 is NOT 0x6100 + 0x100 * (2*pos + fx-1). The stock dispatcher bumps
+; its r7 counter THREE times per track (FX1 at P:0x4ae, FX2 at P:0x4e4 and
+; an unconditional third at P:0x51e after FX2), so a track's FX1 is at
+; 0x6100 + 0x300*pos and its FX2 at 0x6200 + 0x300*pos -- measured 8 Sep
+; 2026 on BOTH payloads with the firmware driving the DSP (the ColdFire port,
+; COLDFIRE_PORT.md O11): position 3 is $6a00/$6b00. The old $6700/$6800 was
+; the harness's two-per-track model (dsp_host's r7probe comment), matched
+; ONLY in dsp_host -- which is why verify_onebus was green while the unit
+; never returned (FAILURE_MODES "the one-aux return never reaches T8":
+; the station ran with r7 = $6a00, took ch_nopos, cleared RET, stamped
+; nothing, and both hosts kept printing -- reproduced under the port).
+        move    #>$6a00,x0
         cmp     x0,a
         beq     ch_pos3
-        move    #>$6800,x0
+        move    #>$6b00,x0
         cmp     x0,a
         beq     ch_pos3
 ch_nopos:

--- a/modules/send/send_client.asm
+++ b/modules/send/send_client.asm
@@ -427,7 +427,7 @@ notfirst:
 ; send from it would feed the return back into the bus it returns -- the
 ; master loop that silenced the unit on 6 Sep 2026 (FAILURE_MODES). Refused
 ; by construction, not by discipline: on PAYLOAD A, core 0's position 3
-; (r7 == $6800, the FX2 slot of track 8) contributes nothing and registers
+; (r7 == $6b00, the FX2 slot of track 8) contributes nothing and registers
 ; nothing, whatever its knob says. Payload B's position 3 is track 4 and
 ; sends normally. The payload is told apart by its Y base literal, which
 ; build_bus.py rewrites to $38000 for payload B and leaves at $30000 for A
@@ -437,8 +437,14 @@ notfirst:
         move    #>$38000,x0
         cmp     x0,a
         beq     send_ok                 ; payload B: every position sends
+; ⚠️ r7 = $6200 + $300 * position for an FX2 (three r7 bumps per track in the
+; stock dispatcher, COLDFIRE_PORT.md O11, measured 8 Sep 2026 on both
+; payloads under the firmware). Position 3 is $6b00; the $6800 that stood
+; here was the harness's two-per-track model -- it never matched on the unit,
+; so track 8 was never refused there (unflashed fix, same family as the
+; return's pin).
         move    r7,a
-        move    #>$6800,x0
+        move    #>$6b00,x0
         cmp     x0,a
         beq     send_refused            ; payload A position 3 = track 8
 send_ok:

--- a/tools/dsp_host/dsp_host.cpp
+++ b/tools/dsp_host/dsp_host.cpp
@@ -30,8 +30,17 @@
 //
 //     track 1 FX1 -> alloc 0 (Y:0x1000, 3072 words)  r7 = 0x6100
 //     track 1 FX2 -> alloc 1 (Y:0x4000, 16384 words) r7 = 0x6200   <- measured
-//     track 2 FX1 -> alloc 2 (Y:0x1c00)              r7 = 0x6300
-//     track 2 FX2 -> alloc 3 (Y:0x8000)              r7 = 0x6400   <- measured
+//     track 2 FX1 -> alloc 2 (Y:0x1c00)              r7 = 0x6400   <- 8 Sep 2026: 0x6400, NOT 0x6300
+//     track 2 FX2 -> alloc 3 (Y:0x8000)              r7 = 0x6500   <- 8 Sep 2026: 0x6500, NOT 0x6400
+// ⚠️ r7 is 0x6100 + 0x300*pos + 0x100*(fx-1), THREE blocks per track: the
+// stock dispatcher bumps its r7 counter after FX1 (P:0x4ae), after FX2
+// (P:0x4e4) and a third time, unconditionally, after FX2 (P:0x51e). Measured
+// 8 Sep 2026 on BOTH payloads with the firmware driving the DSP through the
+// ColdFire port (COLDFIRE_PORT.md O11). The two-per-track table this comment
+// carried (r7probe's "track 2 FX2 = 0x6400" reads as position 1's FX1 under
+// the real stride) put every position >= 1 low, and the one-aux return's pin
+// on position 3 matched only in this harness -- never on the unit. Callers
+// (rig_render, verify_onebus, send_probe) pass -r7 1 + 3*pos + (fx-1).
 //
 // so FX2 instance k defaults to alloc index 1+2k and state block 0x6000+(2+2k).
 //

--- a/tools/ot_emu/dsp.cpp
+++ b/tools/ot_emu/dsp.cpp
@@ -800,7 +800,8 @@ namespace ot
 					static_cast<uint32_t>(r.r[0].var & 0xffffff), static_cast<uint32_t>(r.r[4].var & 0xffffff),
 					static_cast<uint32_t>(r.r[6].var & 0xffffff), static_cast<uint32_t>(r.n[4].var & 0xffffff),
 					static_cast<uint32_t>(r.sp.var & 0xff), static_cast<uint32_t>(r.r[2].var & 0xffffff), static_cast<uint32_t>(r.m[2].var & 0xffffff),
-					static_cast<uint32_t>(r.r[1].var & 0xffffff), static_cast<uint32_t>(r.n[1].var & 0xffffff)});
+					static_cast<uint32_t>(r.r[1].var & 0xffffff), static_cast<uint32_t>(r.n[1].var & 0xffffff),
+					static_cast<uint32_t>(r.r[7].var & 0xffffff)});
 			}
 			c.dsp->execInterpreter();
 			c.dsp->doLoopEnd();

--- a/tools/ot_emu/dsp.h
+++ b/tools/ot_emu/dsp.h
@@ -186,7 +186,7 @@ namespace ot
 		struct WatchHit { uint32_t pc, val; uint64_t executed; uint32_t last[4]; uint32_t ddr0, dco0, dsr1, dco1, r4, r6, area, r0; };
 		const std::vector<WatchHit>& writeWatchHits() const { return m_watchHits; }
 		// A PC watch on one core: registers at every arrival (last 24), the DSP side of route A's --watch-pc (O9b).
-		struct PcWatchHit { uint64_t executed; uint32_t a1, a0, b1, b0, x0, x1, y0, y1, r0, r4, r6, n4, sp, r2, m2, r1, n1; };
+		struct PcWatchHit { uint64_t executed; uint32_t a1, a0, b1, b0, x0, x1, y0, y1, r0, r4, r6, n4, sp, r2, m2, r1, n1, r7; };
 		void setPcWatch(const int _core, const uint32_t _pc, const uint64_t _from = 0) { m_pcWatchCore = _core; m_pcWatchPc = _pc; m_pcWatchFrom = _from; m_pcWatchOn = true; }
 		const std::vector<PcWatchHit>& pcWatchHits() const { return m_pcWatchHits; }
 		const std::vector<std::string>& writeMap() const { return m_writeMap; }

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -706,10 +706,10 @@ int main(int _argc, char** _argv)
 		std::printf("dsp        : at the end\n%s", dspPair->report().c_str());
 		if(!dspPcWatch.empty())
 		{
-			std::printf("dsp pcwatch: %s, last %zu arrival(s): executed a1:a0 b1:b0 x0 x1 y0 y1 r0 r4 r6 n4 sp r2 m2 r1 n1\n", dspPcWatch.c_str(), dspPair->pcWatchHits().size());
+			std::printf("dsp pcwatch: %s, last %zu arrival(s): executed a1:a0 b1:b0 x0 x1 y0 y1 r0 r4 r6 n4 sp r2 m2 r1 n1 r7\n", dspPcWatch.c_str(), dspPair->pcWatchHits().size());
 			for(const auto& h : dspPair->pcWatchHits())
-				std::printf("             %llu %06x:%06x %06x:%06x %06x %06x %06x %06x %06x %06x %06x %06x %02x %06x %06x %06x %06x\n", static_cast<unsigned long long>(h.executed),
-					h.a1, h.a0, h.b1, h.b0, h.x0, h.x1, h.y0, h.y1, h.r0, h.r4, h.r6, h.n4, h.sp, h.r2, h.m2, h.r1, h.n1);
+				std::printf("             %llu %06x:%06x %06x:%06x %06x %06x %06x %06x %06x %06x %06x %06x %02x %06x %06x %06x %06x %06x\n", static_cast<unsigned long long>(h.executed),
+					h.a1, h.a0, h.b1, h.b0, h.x0, h.x1, h.y0, h.y1, h.r0, h.r4, h.r6, h.n4, h.sp, h.r2, h.m2, h.r1, h.n1, h.r7);
 		}
 		if(!dspWatch.empty())
 		{

--- a/tools/rig_render.py
+++ b/tools/rig_render.py
@@ -52,6 +52,12 @@ NTRACKS = 8
 # Track -> core. Measured 10 Aug 2026 (marker flash): payload A serves 5-8.
 CORE_OF = {t: (0 if t >= 5 else 1) for t in range(1, NTRACKS + 1)}
 POS_OF = {t: (t - 1) % 4 for t in range(1, NTRACKS + 1)}    # dispatch position on its core
+# r7 (the state block) is 0x6100 + 0x300*pos + 0x100*(fx-1): the stock
+# dispatcher bumps its counter THREE times per track (an unconditional third
+# bump at P:0x51e after FX2). Measured 8 Sep 2026 on both payloads under the
+# firmware (COLDFIRE_PORT.md O11); the old 1 + 2*pos + (fx-1) put every
+# position >= 1 one or more blocks low, and the one-aux return's pin on
+# position 3 matched only here -- never on the unit.
 # Where the per-track audio buffers go in the harness. Hardware runs every
 # track's block at X:0 (the dispatcher copies it in and out); the harness
 # gives each track its own buffer, and puts them ABOVE the loaded modules so
@@ -268,7 +274,7 @@ def main():
                       f"this core dispatches it to SEND (the alias), as the unit does")
             pos = POS_OF[t]
             inst.append(dict(track=t, fx=s.fx, key=s.module.key, core=core,
-                             alloc=2 * pos + (s.fx - 1), r7=1 + 2 * pos + (s.fx - 1),
+                             alloc=2 * pos + (s.fx - 1), r7=1 + 3 * pos + (s.fx - 1),
                              init=ep[0], proc=ep[1], values=s.values,
                              aliased=aliased, stock=s.module.is_stock))
     if not inst:

--- a/tools/scratch/peek_disasm.py
+++ b/tools/scratch/peek_disasm.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Disassemble `--dsp-peek core:P:addr,len` lines out of an ot_emu report
+(the built image's payloads as loaded, not the stock module map).
+  peek_disasm.py REPORT [grep]"""
+import sys, re, pathlib, subprocess, tempfile
+DIS = "vendor/dsp56300/build/source/disassemble/dsp56kDisassemble"
+pat = sys.argv[2] if len(sys.argv) > 2 else None
+for line in open(sys.argv[1]):
+    m = re.match(r"\s*core (\d) P:0x([0-9a-f]+):((?: [0-9a-f]{6})+)", line)
+    if not m: continue
+    core, addr, ws = int(m.group(1)), int(m.group(2), 16), m.group(3).split()
+    blob = b"".join(int(w, 16).to_bytes(3, "little") for w in ws)   # -le: little-endian words
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f: f.write(blob); path = f.name
+    r = subprocess.run([DIS, "-in", path, "-pc", f"{addr:x}", "-le"], capture_output=True, text=True)
+    print(f"; core {core} P:{addr:#07x} ({len(ws)} words)")
+    for l in r.stdout.splitlines():
+        if l[:6].strip() and all(c in "0123456789abcdef" for c in l[:6]) and (pat is None or re.search(pat, l)):
+            print("   " + l)

--- a/tools/send_probe.py
+++ b/tools/send_probe.py
@@ -359,7 +359,7 @@ def run(mem, dur, tail, rev_params, send_params, verbose=False, amp=0.5,
                 f"feed a bus (SEND) or are inserts that process their own "
                 f"track's frames, so there is no accumulator to analyse; "
                 f"render an insert with --direct instead")
-        r7s = ",".join(str(2 + 2 * k) for k, _ in live)
+        r7s = ",".join(str(2 + 3 * k) for k, _ in live)   # FX2 at position k: 0x6200 + 0x300*k (three r7 bumps per track, COLDFIRE_PORT.md O11)
         als = ",".join(str(1 + 2 * k) for k, _ in live)
         # The tone normally reaches the SENDs only, so a SERVER's own track
         # is SILENT and its dry path is never exercised -- MIX=0 renders

--- a/tools/verify_onebus.py
+++ b/tools/verify_onebus.py
@@ -117,7 +117,7 @@ def run(mems, insts, skew=None, tag="r", tone="tone.raw"):
            "-inst", str(len(insts)),
            "-core", ",".join(str(i.core) for i in insts),
            "-alloc", ",".join(str(2 * i.pos + (i.fx - 1)) for i in insts),
-           "-r7", ",".join(str(1 + 2 * i.pos + (i.fx - 1)) for i in insts),
+           "-r7", ",".join(str(1 + 3 * i.pos + (i.fx - 1)) for i in insts),   # three r7 bumps per track (COLDFIRE_PORT.md O11)
            "-audioidx", ",".join(str(k) for k, _ in enumerate(insts)),
            "-audio", "9000",
            "-inmask", str(sum(1 << k for k, i in enumerate(insts) if i.fed)),


### PR DESCRIPTION
Stacked on #158 (`coldfire-o10`); merge that first.

## The failure

`FAILURE_MODES.md` "the one-aux return never reaches T8" (flash 6, tag 20): AUX sends came out of T1 and T5, nothing on T8, with `make verify-onebus` green on that very property. The cause was guessed as a liveness stamp lost across cores.

## Reproduced under the port, from the card

The shipping image (`make bus REMIX=bamsep27`), `rigproj` on the RIG backup, the firmware driving both cores, a tone on T2: **T1 prints the repeats and T5 the reverb** (read-backs), T8 carries only the master mix's dry plus a little reverb on R; `rig_render` on the same part and stem: both hosts silent, T8 = the reverb. A PC watch on the station's stamp instruction never fired.

## The cause, measured on the stock dispatcher (both payloads)

| position | FX1 r7 | FX2 r7 |
|---|---|---|
| 0 | 0x6100 | 0x6200 |
| 1 | 0x6400 | 0x6500 |
| 2 | 0x6700 | 0x6800 |
| 3 | **0x6a00** | **0x6b00** |

The r7 counter (`X:0x20a`) is bumped THREE times per track: after FX1 (P:0x4b4), after FX2 (P:0x4ea) and unconditionally again at P:0x524; reset to 0x6000 per frame. `dsp_host` modelled two per track (its r7probe comment), so the return's pin `$6700/$6800` and the send client's track-8 refusal `$6800` matched only in the harness. Not a cross-core race: the reverb host and the return share core 0.

## The fix, proven both ways

- `character.asm` pins `$6a00/$6b00`; `send_client.asm` refuses `$6b00`.
- `rig_render`, `verify_onebus`, `send_probe`: `-r7 1 + 3*pos + (fx-1)`; `dsp_host.cpp` comment corrected.
- Port, rebuilt image: the stamp fires every frame, **T1 and T5 silent for 2,000 frames, T8 returns**.
- `make verify-onebus`: every property holds on both cores (with the r7 model fixed but the old pin it failed 10 of 25 — the gate finally seeing what the unit saw).

UNFLASHED: flash-7 candidate (stamp-defaults before play).

## Also

`--dsp-pcwatch` now prints r7; `tools/scratch/peek_disasm.py` disassembles `--dsp-peek` P ranges of the LOADED image (the stock module map does not apply to a built one). The DSP triple-buffers the four per-instance parameter blocks. `CLAUDE.md`: dispatcher facts are measured under the port, never modelled in `dsp_host`. `make check` result to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)