### PR TITLE
O12: the AUX bus under the firmware is bit-identical to dsp_host once the fixture matches (send mono-sum, knob slew, MDEP 0)

### DIFF
--- a/docs/BUS.md
+++ b/docs/BUS.md
@@ -508,6 +508,8 @@ with IN; SEND-fed returns never had it, so the return level is unchanged —
 but a render of the host's own material (`render_reverb` with AUX 64)
 prints 6 dB lower than v8 did.
 
+**✅ 8 Sep 2026, under the ColdFire port (`COLDFIRE_PORT.md` O12):** with the firmware driving both cores from the card, the send → delay → return path is bit-identical to `dsp_host` (−120 to −200 dB per window) at a 36-sample offset; no flicker, no missing repeats. The port's core interleave is still not the chip's timing, so hardware keeps the last word — but the mechanism survives a real two-core ordering.
+
 **What only hardware can show.** The stamps and the chain buffer cross
 cores under the chip's timing, not the emulator's; the position-3 pin and
 the refusal are measured in the emulator's instance model (r7 = $6200 +

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2422,6 +2422,62 @@ The rule it leaves: **any module logic keyed on a dispatcher fact (r7, r6,
 X:0x213, block addresses) is measured under the port, not modelled in
 `dsp_host`.**
 
+## Milestone O12 — the bus itself under the firmware: bit-identical to `dsp_host` (8 Sep 2026, branch `coldfire-o12-bus`)
+
+O9c's gate, on the shipping rig's AUX bus instead of a THRU insert: T2 sends
+AUX into the delay host on core 1, the return station on core 0 reads the
+last live stage. Fixture: the one-aux rig (`rigproj`, image
+`bamsep27` with the O11 pins), `MASTER_TRACK=0` so T8's read-back is the
+return alone, `rig_render` fed T2's own chain input (the 84-word record's
+audio) at the port's pre-FX gain k = 0.253931 (O9d). Three fixture facts
+had to be learned first, each measured:
+
+- **The send client mono-sums the block** (`x:(r0)` + `x:(r0+1)`, `asr #1`)
+  before scaling by AUX. `dsp_host` writes a mono stem into BOTH channels;
+  the port's THRU with a tone on one input is left-only, so every send
+  deposited 6 dB less. With the tone on both inputs of T2's pair the
+  steady-state return matched to 0.0 dB (−29.7 / −29.7 dBFS).
+- **The ColdFire slews the knobs** (the 160-frame marker slew), so a send's
+  AUX ramps from 0 after the transport start; `dsp_host` has the value from
+  block 0. Under a steady tone the port's return simply runs ~4,000 samples
+  behind the harness's envelope. A probe that starts after the slew (the
+  kick from sample 4,000) removes it.
+- **The delay's modulation LFO is history.** With MDEP 48 the repeats
+  wander ±30 samples window to window between the two (the LFO's phase
+  after thousands of frames of load versus block 0). MDEP 0 for the gate.
+
+Not the cause, each checked on the way: the tempo (`--tempo 120` changed
+nothing), the auto-gain (the delay reads count 1 and reciprocal 1.0 under
+the port, PC-watched at `P:0x79e/0x7a8`; with one client both sides have
+counts 1,1,1,0), the parameters (T1's DELAY SERVER page 1 and 2 words on
+the DSP equal `rig_render`'s), the bus scratch (rotation, reciprocal table,
+counts identical; the buffers 8 dB lower = the mono-sum above).
+
+**Result, kick on both inputs after the slew, one client, MDEP 0:**
+
+| | lag | scale | residual |
+|---|---|---|---|
+| T2's chain (SPECTRUM + SEND) | −32 | 0.000 dB | **−131 dB** |
+| the return, samples 7,000–17,500 (the repeats) | −36 | 0.000 dB | **−120 to −200 dB** per window |
+| the return, whole run | −36 | −0.04 dB | −23 dB (the onset window and the render's end edge) |
+
+The 36 = the 32-sample record pipeline (O9d) + 4: four block-latency stages
+on the bus (send→accumulator, accumulator→delay, delay→chain, chain→return,
+each "two buffers back") at the firmware's 16-sample frame against
+`dsp_host`'s 15-sample block. The bus's cross-core mechanism — the rotation
+each core tracks privately, the four-deep buffers, the liveness stamps, the
+chain buffer — produces the same words under the firmware's real ordering
+of the two cores as under lock-step. BUS.md's "what only hardware can show"
+(a return that flickers, repeats missing from the reverb) does not show
+here either; 🟡 the port's core interleave is still not the chip's timing
+(O8), so this is the strongest local statement, not a hardware one. The
+reverb stage was not bit-compared (its allpass modulation is history, like
+MDEP); its level matched within 1 dB in the both-engines run.
+
+Tools: `rig_render --extra '<dsp_host args>'` (e.g. `-dumpy 36000,360d3,f`
+to dump the bus scratch after a render, which is how the two scratches
+were diffed word for word).
+
 ## What is NOT here yet
 
 - **The rest of the peripherals.** The eDMA with its completion-timing rules

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -765,7 +765,17 @@ FX1 is $6a00, not the $6700 the return pinned on and the harness modelled.
 Pins and the harness r7 model fixed; port and `make verify-onebus` both
 green. UNFLASHED. Rule: dispatcher facts are measured under the port.
 
-## Where the port stands after O11 (8 Sep 2026), and what is left
+### O12 — the AUX bus under the firmware ✅ DONE (8 Sep 2026, branch `coldfire-o12-bus`)
+
+`COLDFIRE_PORT.md` O12. The one-aux rig's bus (T2 send → delay on core 1 →
+return on core 0) renders bit-identical to `dsp_host` (−120 to −200 dB per
+window, lag 36 = the record pipeline + four bus stages at 16 vs 15 samples)
+once the fixture matches: stereo input (the send client mono-sums L+R;
+`dsp_host` dual-monos a stem), the probe after the ColdFire's 160-frame knob
+slew, delay MDEP 0 (the LFO's phase is history). The bus's cross-core
+mechanism holds under the firmware's ordering of the two cores.
+
+## Where the port stands after O12 (8 Sep 2026), and what is left
 
 The port boots the firmware, mounts the card, loads the project, runs the
 sequencer byte-identical to route A, drives both DSP cores through the host
@@ -780,7 +790,7 @@ with its decider:
 | DIR names RX0 slot 0 "A", the ColdFire capture names slot 2 "A" (O9c vs O10); stable per run, not a rotation | a tone into the unit's input A with a THRU track and the recorder's INAB | one capture |
 | the track record's segment split and tag word (O10) — what the DSP does with them | read payload B's unpack of the 84-word record | RE, no hardware |
 | Bryan's click: the port shows none in any shape because arm and trig round alike; hypothesis = a 2-sample-unit stage on one side | Bryan's project file run AS-IS under the port (read SRC3/AB/CD/LOOP/QREC/timestretch first), then his one-pass test and the odd/even per-pass-walk tempo test (125 vs 130 BPM) on the unit | his file + two captures |
-| the O9c comparison on the shipping image (bus engines, core 0) | `make bus` + the ONEAUX card through the same fixture/fit (`o9d_compare.py`) — the rig runs under the port now (O11); the bit comparison of an engine is the remaining step | one session, no hardware |
+| ~~the O9c comparison on the shipping image (bus engines, core 0)~~ ✅ O12: the delay bus bit-identical; the reverb stage level-matched only (its allpass modulation is history) | a reverb fixture with its modulation off, if one exists | small |
 
 ## Running it overnight
 

--- a/tools/rig_render.py
+++ b/tools/rig_render.py
@@ -225,6 +225,7 @@ def main():
     ap.add_argument("--out", default="out/rig")
     ap.add_argument("--keep", action="store_true", help="keep the raw files")
     ap.add_argument("-v", "--verbose", action="store_true")
+    ap.add_argument("--extra", default="", help="extra dsp_host arguments, e.g. '-dumpy 36000,360d3,file' (the bus scratch after the render)")
     a = ap.parse_args()
 
     image = pathlib.Path(a.image)
@@ -333,6 +334,8 @@ def main():
         cmd += ["-tempo", str(a.tempo)]
     if a.skew is not None:
         cmd += ["-skew", str(a.skew)]
+    if a.extra:
+        cmd += a.extra.split()
     print("tracks:")
     for i in inst:
         print(f"  T{i['track']} FX{i['fx']} {i['key']:14s} core {i['core']} "


### PR DESCRIPTION
The O9c gate on the shipping rig's bus instead of a THRU insert: T2 sends AUX into the delay host on core 1, the return station on core 0 reads the last live stage, the firmware driving both cores from the card (O11's image).

## Result (kick on both inputs after the knob slew, one client, delay MDEP 0)

| | lag | scale | residual |
|---|---|---|---|
| T2's chain (SPECTRUM + SEND) | −32 | 0.000 dB | −131 dB |
| the return, the repeats (samples 7,000–17,500) | −36 | 0.000 dB | −120 to −200 dB per window |

36 = the 32-sample record pipeline + four bus stages ("two buffers back" each) at the firmware's 16-sample frame vs `dsp_host`'s 15-sample block. The cross-core mechanism (private rotations, four-deep buffers, stamps, chain buffer) produces the same words under the firmware's real ordering of the cores.

## Three fixture facts, each measured

- **The send client mono-sums L+R** before scaling by AUX; `dsp_host` writes a mono stem into both channels, the port's one-input THRU is left-only → every send 6 dB low until the tone is on both inputs (then 0.0 dB match).
- **The ColdFire slews knobs** over 160 frames from the transport start; the probe must start after it.
- **The delay's modulation LFO is history**: MDEP 48 wanders ±30 samples between the two; MDEP 0 for the gate.

Checked and equal: tempo, auto-gain (count 1, reciprocal 1.0, PC-watched), the engine's page-1/2 words, the bus scratch (rotation, counts, reciprocal table). The reverb stage was level-matched (~1 dB), not bit-compared (allpass modulation is history too).

`rig_render --extra` passes raw `dsp_host` args (`-dumpy 36000,360d3,f` dumps the bus scratch for a word-for-word diff). BUS.md's "what only hardware can show" updated; the port's interleave is still not the chip's timing, so hardware keeps the last word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)