### PR TITLE
O12b: the accumulators' race measured under the port -- the rotation word flips mid-way through core 1's frame and every client reads it directly; the reverb path pays

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2510,6 +2510,47 @@ stamp a fresh project** — `ot_project` can set a machine type and a PB
 page but not whatever else makes a THRU track start; that is the next
 tool, and with it the reverb comparison is one run.
 
+### ✅ Found: the rotation word flips in the middle of core 1's frame, and the clients read it directly (9 Sep 2026)
+
+With the reverb path still −13 dB off on the clean project (T2 trigged
+at step 1 — a THRU machine on the unit passes nothing until it is trigged,
+which is why the RECTRIG-based rig had been silent; T5's words exact;
+the port deterministic across interleaves), the cross-core read was
+instrumented directly:
+
+- `--dsp-watch 0:Y:36000`: core 0's housekeeping (P:0x8fd, in the reverb
+  host's block) flips the shared rotation word once per frame, 0x30 → 0x00
+  → 0x10 → 0x20, spacing 66,546 / 66,574 instructions.
+- `--dsp-pcwatch 1:623` (the send client's `move y:>$36000,a` + `and #>$30`,
+  every bus client on core 1 runs it per block): **within one core-1 frame
+  the four clients see 0x30, 0x30, 0x00, 0x00** — the flip lands between
+  the second and third client, every frame, at the firmware's own serving
+  order (the port's interleave quantum does not move it: 1, 64, 1,000 and
+  100,000 give bit-identical output).
+
+So half of a frame's senders deposit into buffer N and half into buffer
+N+1. The delay reads the accumulator on the same core with the same phase
+each block and is bit-exact regardless; the reverb, the only cross-core
+reader, gets a frame's deposits split across two of its "two back" reads —
+a persistent residual with a matched envelope, exactly what was measured,
+and the mechanism behind FAILURE_MODES' "cross-core bus glitch — the
+accumulators' race 🟡". `XBUS.md`'s rule ("clients never read the shared
+rotation word directly; each core tracks the rotation privately, advancing
+once per block") is not what the one-aux code does: the send client,
+both engines and the return all read `y:$36000` at their own block time.
+`dsp_host` in lock-step flips the word between whole core frames and can
+never split one.
+
+**The fix is a module change, not a port one:** a rotation each core
+derives from its own frame count (the dispatcher's per-frame counter at
+`x:$41c`/`x:$41e`, if it is one — measured below) or latched once per core
+per frame, so every client on a core writes the same buffer for a given
+frame; the four-deep buffers already absorb a constant one-block offset
+between the cores. The port is the gate: after the fix the reverb path
+must come out bit-identical like the delay path. 🟡 Whether the unit's
+serving order lands the flip mid-frame exactly as the port's does is
+hardware's to say; that it lands mid-frame at all is enough to split.
+
 Tools: `rig_render --extra '<dsp_host args>'` (e.g. `-dumpy 36000,360d3,f`
 to dump the bus scratch after a render, which is how the two scratches
 were diffed word for word).

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2474,6 +2474,42 @@ here either; 🟡 the port's core interleave is still not the chip's timing
 reverb stage was not bit-compared (its allpass modulation is history, like
 MDEP); its level matched within 1 dB in the both-engines run.
 
+### 🟡 The reverb stage: level-matched, not bit-compared, and why (8 Sep 2026, later)
+
+Same fixture with the reverb instead of the delay (T1's FX2 = SEND, one
+client, MOD 0): the port's return is **deterministic** — identical to
+−200 dB across load lengths and across core-interleave quanta of 1, 64,
+1,000 and 100,000 instructions (`--dsp-quantum`, added for this; the delay
+fixture is likewise quantum-independent) — so it is NOT a cross-core race.
+Against `dsp_host` it is −7.5 dB residual with the envelope within ±3 dB
+per window and one extra frame of lag (52 = 36 + 16: the reverb's
+accumulator read crosses cores, one more block back).
+
+The difference is in what T5's engine is GIVEN, not in the engine: the
+DSP's per-instance block for T5 carries FX1 slots 2 and 5 and FX2 slot 2
+as fractional, time-varying values (`0x321a`, `0x3f`, `0x28ad`) where the
+part holds 0, 0, 0 — on Sam's RIG project. Ruled out by measurement:
+the scene crossfader (poked to 0 at `0x460d16c8`: unchanged), the track's
+LFO depths (zeroed in the part: unchanged), the pattern (the PATTERN= key
+did not move the port off pattern 0 — 🟡 the loader's pattern source is
+not that key). The pre-image `0x80000a50` for T5's FX2 slot 2 is written
+0x7f00 by the load, 0 by the refresher and 0x6400 by the slew packer
+(`0x4000d688`) at the transport start, none of them 0x28ad — the modulated
+value enters between the pre-image and the block, i.e. in the frame
+builder's slew/scene stage (`0x4000cc20`/`0x4000ccfc`, O9d), from per-track
+state this project carries and the toolkit cannot yet read or clear.
+
+The alternative fixture — the rig on the RECTRIG backup, which has none
+of that (T5's words come out exact: `28 30 00 00 00 00`, `00 40 00 64 40
+7f`) — cannot hear anything: its T2, set to THRU with the RIG's THRU page
+bytes copied in, never gets the transport-start write (only tracks 0 and
+5 do), so it renders silence. ✅ Sam: T1 and T2 are THRU on his projects
+(drums and synths in), which is why the RIG-based fixture hears and the
+RECTRIG-based one does not. **Toolkit gap (the way through, per Sam):
+stamp a fresh project** — `ot_project` can set a machine type and a PB
+page but not whatever else makes a THRU track start; that is the next
+tool, and with it the reverb comparison is one run.
+
 Tools: `rig_render --extra '<dsp_host args>'` (e.g. `-dumpy 36000,360d3,f`
 to dump the bus scratch after a render, which is how the two scratches
 were diffed word for word).

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -790,7 +790,7 @@ with its decider:
 | DIR names RX0 slot 0 "A", the ColdFire capture names slot 2 "A" (O9c vs O10); stable per run, not a rotation | a tone into the unit's input A with a THRU track and the recorder's INAB | one capture |
 | the track record's segment split and tag word (O10) — what the DSP does with them | read payload B's unpack of the 84-word record | RE, no hardware |
 | Bryan's click: the port shows none in any shape because arm and trig round alike; hypothesis = a 2-sample-unit stage on one side | Bryan's project file run AS-IS under the port (read SRC3/AB/CD/LOOP/QREC/timestretch first), then his one-pass test and the odd/even per-pass-walk tempo test (125 vs 130 BPM) on the unit | his file + two captures |
-| ~~the O9c comparison on the shipping image (bus engines, core 0)~~ ✅ O12: the delay bus bit-identical; the reverb stage level-matched only (its allpass modulation is history) | a reverb fixture with its modulation off, if one exists | small |
+| ~~the O9c comparison on the shipping image (bus engines, core 0)~~ ✅ O12: the delay bus bit-identical; the reverb stage level-matched only — T5's knobs arrive modulated on Sam's RIG project (source not pinned) and the toolkit cannot build a THRU track that starts on a clean project | a project-stamping tool that makes a THRU track start (Sam: "stamp a new project"), then one run | one session |
 
 ## Running it overnight
 

--- a/docs/FAILURE_MODES.md
+++ b/docs/FAILURE_MODES.md
@@ -168,7 +168,7 @@ SysEx app). Factory rescue: `downloads/extracted/OCTATRACK_OS1.40C.syx`.
 
 ---
 
-## Cross-core bus glitch — the accumulators' race 🟡
+## Cross-core bus glitch — the accumulators' race 🟡 → ✅ MECHANISM MEASURED under the port, 9 Sep 2026: core 0's housekeeping flips the rotation word in the middle of core 1's frame and every client reads the word directly, so a frame's sends split across two buffers; the reverb (the cross-core reader) gets them a block late/split. `COLDFIRE_PORT.md` O12. Fix = a per-core rotation (module change), unbuilt.
 
 **Symptom.** A tear, stutter or hash on wet audio that crosses cores; often
 smeared into a reverb tail so it is hard to localise.

--- a/tools/ot_emu/dsp.cpp
+++ b/tools/ot_emu/dsp.cpp
@@ -708,6 +708,8 @@ namespace ot
 	// the output DMA ran out un-re-armed, and the audio died 38 frames after
 	// the first trig. Hardware runs the cores in parallel; a small quantum
 	// is the nearest thing.
+	double DspPair::g_quantum = 64.0;
+
 	bool DspPair::stepCore(const int _i, const double _limit)
 	{
 		Core& c = *m_cores[_i];

--- a/tools/ot_emu/dsp.h
+++ b/tools/ot_emu/dsp.h
@@ -193,7 +193,7 @@ namespace ot
 
 		// Run both cores up to the due count now (the ticks only book it),
 		// interleaved in quanta of g_quantum instructions (O9b).
-		static constexpr double g_quantum = 64.0;
+		static double g_quantum;		// O12: --dsp-quantum N (default 64); huge = each core runs its whole due span in turn
 		void runDue();
 		bool stepCore(int _i, double _limit);
 		// Run ONE core until `_ready` or `_budget` instructions (the read-back

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -138,6 +138,7 @@ int main(int _argc, char** _argv)
 		else if(a == "--dsp-no-idle")			dspNoIdle = true;
 		else if(a == "--dsp-drain-paced")		dspDrainPaced = true;
 		else if(a == "--dsp-verbose")			dspVerbose = true;
+		else if(a == "--dsp-quantum" && i + 1 < _argc)	ot::DspPair::g_quantum = std::atof(_argv[++i]);	// O12: the core interleave quantum (instructions)
 		else if(a == "--edma-log" && i + 1 < _argc)	edmaLog = _argv[++i];
 		else if(a == "--dsp-peek" && i + 1 < _argc)	dspPeek = _argv[++i];
 		else if(a == "--block-log" && i + 1 < _argc)	blockLog = _argv[++i];


### PR DESCRIPTION
Follow-on to #161. Two commits.

## What was chased

The reverb-only return under the port sat −7 to −13 dB off `dsp_host` with a matched envelope, while the delay path was bit-identical (−120 to −200 dB). Ruled out by measurement: the auto-gain (count 1, reciprocal 1.0), the engine's parameter words, the tempo, the bus scratch, the core interleave (`--dsp-quantum` 1/64/1,000/100,000: bit-identical output — not a race in the port's interleave), the scene crossfader, the track LFO depths, the pattern. On Sam's RIG project T5's knobs additionally arrive modulated from per-track state the toolkit cannot edit; the clean fixture is the rig on the RECTRIG backup with T2 trigged at step 1 (a THRU machine passes nothing until trigged).

## What was found

- `--dsp-watch 0:Y:36000`: core 0's housekeeping flips the shared rotation word once per frame.
- `--dsp-pcwatch 1:623`: **within one core-1 frame the four bus clients read 0x30, 0x30, 0x00, 0x00** — the flip lands between the second and third client at the firmware's own serving order.

So half of a frame's sends go into buffer N and half into N+1. The delay reads on the same core with the same phase and is exact; the reverb is the only cross-core reader and gets a frame's deposits split across two "two back" reads. This is FAILURE_MODES' "cross-core bus glitch — the accumulators' race 🟡", now with its mechanism, and it contradicts XBUS.md's rule that clients never read the rotation word directly: the send client, both engines and the return all do.

## The fix (not built here)

A rotation each core derives privately (its own frame count, or a once-per-frame latch by the first participant) so every client on a core writes the same buffer per frame; the four-deep buffers already absorb a constant one-block offset between the cores. The dispatcher's `x:$41c` counter is 0 at the call and cannot serve. The port is the gate: after the fix the reverb path must come out bit-identical like the delay path. Touches the shipping bus modules — your call before I build it.

Also here: `--dsp-quantum N` knob; the THRU-needs-a-trig fact; the toolkit gap for stamping a THRU-capable project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)