### PR TITLE
Bus: one rotation tracker per core -- the accumulators' race fixed, gated under the port

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2532,9 +2532,10 @@ So half of a frame's senders deposit into buffer N and half into buffer
 N+1. The delay reads the accumulator on the same core with the same phase
 each block and is bit-exact regardless; the reverb, the only cross-core
 reader, gets a frame's deposits split across two of its "two back" reads —
-a persistent residual with a matched envelope, exactly what was measured,
-and the mechanism behind FAILURE_MODES' "cross-core bus glitch — the
-accumulators' race 🟡". `XBUS.md`'s rule ("clients never read the shared
+a persistent residual with a matched envelope — ❌ this link is retracted
+below: fixing the split leaves the reverb residual untouched; the split IS
+the mechanism behind FAILURE_MODES' "cross-core bus glitch — the
+accumulators' race 🟡" (T4 + delay MODE 1). `XBUS.md`'s rule ("clients never read the shared
 rotation word directly; each core tracks the rotation privately, advancing
 once per block") is not what the one-aux code does: the send client,
 both engines and the return all read `y:$36000` at their own block time.
@@ -2550,6 +2551,40 @@ between the cores. The port is the gate: after the fix the reverb path
 must come out bit-identical like the delay path. 🟡 Whether the unit's
 serving order lands the flip mid-frame exactly as the port's does is
 hardware's to say; that it lands mid-frame at all is enough to split.
+
+### ✅ The fix: one rotation tracker per core (9 Sep 2026, branch `bus-private-rotation`)
+
+Measured first, with `--dsp-pcwatch` on the RESOLVED write offset
+(`x:(r7+$69)` as each client consumes it): under the old per-instance
+tracking core 1's four clients resolved **3/1 per frame** — three on
+buffer N, the fourth (T4, the last dispatched) on N+1 — every frame. ⚠️
+Correction to the paragraph above: with T2 the only sender in the reverb
+fixture, its deposits landed consistently, so the split did NOT cause the
+reverb residual (which survives the fix, below); the split is the standing
+"T4 + delay MODE 1" hardware residual, T4 being that fourth client.
+
+The fix is in `build_bus.py`'s ROTLATCH body for payload B: the design's
+tracker (advance one step per frame; keep it when the shared word reads
+one step behind, i.e. a pre-flip read; snap otherwise) is kept, but ONE
+per core in a bus-scratch word only core 1 writes (`+0xc6`), advanced by
+position 0's FX2 (r7 == `$6200`, the rig's delay host) and checked by every
+client against the shared word. Measured after: **all four core-1 clients
+resolve the same buffer every frame** (0x30 ×4, 0x00 ×4, 0x10 ×4, 0x20 ×4).
+
+A first version latched the shared word as READ at position 0 and the
+port killed it within the hour: a pre-flip read puts the whole core one
+buffer BEHIND core 0, and its "two back" read is then exactly the buffer
+core 0's housekeeper is clearing (`R+1 ≡ R−3`): the delay path went
+SILENT under the port and `verify_onebus` lost its skew identity. So the
+four-deep scheme tolerates no cross-core offset at all — both cores must
+resolve the post-flip value — which is precisely what the tracker's
+asymmetric keep provides and a latch does not.
+
+Gates: `make verify-onebus` every property on both cores, skew identity
+included; `REMIX=bamsep27 make check` exit 0; the port's delay path
+bit-exact in the steady windows (−120 to −200 dB, lag now −21); the
+reverb path unchanged at −13 dB — still open, and now demonstrably NOT the
+rotation. UNFLASHED, alongside the O11 pins.
 
 Tools: `rig_render --extra '<dsp_host args>'` (e.g. `-dumpy 36000,360d3,f`
 to dump the bus scratch after a render, which is how the two scratches

--- a/docs/FAILURE_MODES.md
+++ b/docs/FAILURE_MODES.md
@@ -168,7 +168,7 @@ SysEx app). Factory rescue: `downloads/extracted/OCTATRACK_OS1.40C.syx`.
 
 ---
 
-## Cross-core bus glitch — the accumulators' race 🟡 → ✅ MECHANISM MEASURED under the port, 9 Sep 2026: core 0's housekeeping flips the rotation word in the middle of core 1's frame and every client reads the word directly, so a frame's sends split across two buffers; the reverb (the cross-core reader) gets them a block late/split. `COLDFIRE_PORT.md` O12. Fix = a per-core rotation (module change), unbuilt.
+## Cross-core bus glitch — the accumulators' race 🟡 → ✅ MECHANISM MEASURED under the port, 9 Sep 2026: core 0's housekeeping flips the rotation word in the middle of core 1's frame and every client reads the word directly, so a frame's sends split across two buffers; the reverb (the cross-core reader) gets them a block late/split. `COLDFIRE_PORT.md` O12. ✅ FIXED 9 Sep 2026 (branch `bus-private-rotation`, UNFLASHED): one rotation tracker per core (`build_bus.py` ROTLATCH, payload B), every core-1 client resolves the same buffer per frame under the port; verify-onebus and make check green.
 
 **Symptom.** A tear, stutter or hash on wet audio that crosses cores; often
 smeared into a reverb tail so it is hard to localise.

--- a/docs/XBUS.md
+++ b/docs/XBUS.md
@@ -110,7 +110,9 @@ defects below burned in:
 
 - **Clients never read the shared rotation word directly.** Each core tracks
   the rotation privately, advancing once per block, so all clients on a core
-  agree — a core-1 client that read the shared word at its own dispatch time
+  agree (✅ 9 Sep 2026: this was per INSTANCE until then, and the ColdFire port
+  showed core 1's fourth client on the wrong buffer every frame; it is now ONE
+  tracker per core, `build_bus.py` ROTLATCH) — a core-1 client that read the shared word at its own dispatch time
   would straddle core 0's flip and land contributions in a dead buffer on
   random blocks.
 - **The tracked rotation is seeded at `init`, and is NOT self-healing.**

--- a/tools/build_bus.py
+++ b/tools/build_bus.py
@@ -2347,22 +2347,61 @@ mkgo:""",
             # housekeeps) -- so it takes payload B's body wherever it sits.
             as_b = (tag == "B") or (DEV and name == "DELAY SERVER")
             if as_b:
+                # 9 Sep 2026 (COLDFIRE_PORT.md O12): the per-INSTANCE tracking
+                # above this comment's history still left core 1's four clients
+                # resolving a 3/1 split every frame under the firmware's real
+                # timing (three on buffer N, the fourth -- T4 -- on N+1; the
+                # port's --dsp-pcwatch on the resolved offset), which is the
+                # standing "T4 + delay MODE 1" residual. A core needs ONE
+                # rotation per frame, so: the frame's position-0 calls (the
+                # dispatcher's track counter X:0x418 is 0 for them, bumped by
+                # 0x20 after each track's FX2 -- measured on both payloads)
+                # ... a first version latched the shared word as READ at position 0
+                # and the port killed it inside an hour: a pre-flip read puts the
+                # whole core one buffer BEHIND core 0, and its 'two back' read is
+                # then the very buffer core 0 is clearing (silence, and the gate's
+                # skew identity gone). So the design's tracker stays -- advance
+                # one step per frame, keep it on a pre-flip read (T == R+1), snap
+                # otherwise -- but ONE per core, in a bus-scratch word only core
+                # 1 writes (+0xc6, free): position 0's FX2 (the rig's delay host,
+                # r7 == $6200) advances it once a frame, every client checks it
+                # against the shared word and uses it. Every core-1 client then
+                # resolves the same buffer for a frame, whatever its dispatch
+                # slot's phase against the flip.
+                _latch = _rot + 0xc6
                 body = "\n".join([
-                    "        move    x:(r7+$67),a        ; ROTLATCH: payload B",
+                    "        move    x:(r7+$67),a        ; ROTLATCH: payload B, ONE tracker per core",
                     "        tst     a",
                     "        bne     rotdone             ; not the block's first call",
-                    f"        move    x:(r7+${slot:02x}),a",
-                    "        add     #>$10,a             ; advance exactly one step",
-                    "        and     #>$30,a             ; per block, mod 4",
-                    "        move    a,x1                ; x1 = S'",
-                    f"        move    y:>${_rot:x},a         ; the shared rotation, ONCE",
-                    "        move    a,x0                ; x0 = R, the snap target",
+                    "        move    r7,a",
+                    "        move    #>$6200,x0",
+                    "        cmp     x0,a                ; position 0's FX2 (the rig's delay host)",
+                    "        bne     rotchk              ; advances the core's tracker once a frame",
+                    f"        move    y:>${_latch:x},a",
+                    "        add     #>$10,a             ; T' = T + one step",
+                    "        and     #>$30,a",
+                    "        move    a1,x0",
+                    "        move    x0,a                ; A2-clean",
+                    f"        move    a,y:>${_latch:x}",
+                    "rotchk:",
+                    f"        move    y:>${_latch:x},a",
+                    "        move    a,x1                ; x1 = T, the core's tracked rotation",
+                    f"        move    y:>${_rot:x},a         ; R, the shared word (pre- or post-flip)",
+                    "        and     #>$30,a",
+                    "        move    a1,x0",
+                    "        move    x0,a                ; x0 = R",
+                    "        cmp     x1,a",
+                    "        beq     rotuse              ; T == R: aligned, use T",
                     "        add     #>$10,a",
-                    "        and     #>$30,a             ; a = R + one step",
-                    "        move    a,y0",
-                    "        move    x1,a                ; a = S'",
-                    "        cmp     y0,a                ; S' == R+step: a pre-flip",
-                    "        tne     x0,a                ; read, so KEEP S'. else snap",
+                    "        and     #>$30,a",
+                    "        move    a1,y0               ; y0 = R + one step",
+                    "        move    x1,a",
+                    "        cmp     y0,a",
+                    "        beq     rotuse              ; T == R+1: a pre-flip read, keep T",
+                    "        move    x0,a                ; anything else: T is stale, snap to R",
+                    f"        move    a,y:>${_latch:x}",
+                    "rotuse:",
+                    f"        move    y:>${_latch:x},a",
                     f"        move    a,x:(r7+${slot:02x})",
                     "rotdone:",
                     f"        move    x:(r7+${slot:02x}),a"])


### PR DESCRIPTION
## What was measured

With the ColdFire port driving both cores from the card, a PC watch on the RESOLVED write offset each bus client consumes showed core 1's four clients resolving **3/1 every frame** — three on buffer N, the fourth (T4, the last dispatched) on N+1. That is the standing "T4 + delay MODE 1" residual and FAILURE_MODES' "accumulators' race 🟡". The per-instance rotation tracking (`build_bus.py` ROTLATCH, payload B) kept each client's own tracker, and the last one diverged.

## The fix

The design's tracker stays (advance one step per frame; keep it when the shared word reads one step behind = a pre-flip read; snap otherwise) but there is now ONE per core, in a bus-scratch word only core 1 writes (+0xc6), advanced by position 0's FX2 (the rig's delay host, r7 == $6200) and checked by every client. Measured after: all four core-1 clients resolve the same buffer every frame.

A first version that simply latched the shared word as read at position 0 failed inside the hour under the port: a pre-flip read put the whole core one buffer behind core 0, whose "two back" read is exactly the buffer core 0's housekeeper clears — the delay path went silent and `verify_onebus` lost its skew identity. The four-deep scheme tolerates no cross-core offset; the tracker's asymmetric keep is what makes it work. Recorded in the port doc.

## Gates

- `make verify-onebus`: every property on both cores, skew identity included.
- `REMIX=bamsep27 make check`: exit 0.
- Port: delay path bit-exact against `dsp_host` in the steady windows (−120 to −200 dB).
- Port: the reverb path is unchanged at −13 dB — the split was not its cause; that residual stays open and the earlier doc sentence linking them is retracted in the doc.

UNFLASHED, alongside the O11 pins (#160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)