### PR TITLE
Harness: whole 16-sample blocks in dsp_host (-frames 16) -- the frame nibble is the dispatcher's split; the reverb residual explained as free-running modulation

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2551,6 +2551,44 @@ must come out bit-identical like the delay path. 🟡 Whether the unit's
 serving order lands the flip mid-frame exactly as the port's does is
 hardware's to say; that it lands mid-frame at all is enough to split.
 
+### ✅ The harness ran 15-sample blocks; the unit runs 16 (9 Sep 2026, branch `harness-whole-block`)
+
+Chasing the reverb residual through the dispatcher: `dsp_host` seeds the
+frame-context word `x:(x:0x415+0x1e)` with a "frames" nibble and capped it
+at 15 ("the & 0xf in setup"). Under the firmware that nibble is the
+track's SPLIT: at every unsplit dispatch `x:$20c = 0` and `x:$20d = 16`
+(peeked), the a=0 sub-block call is skipped and the a=1 call runs 16
+samples. `dsp_host` seeded 15, took `x:$20c` (=15) as the count, and so
+every harness render since the harness existed processed **15 samples per
+block** — self-consistent, but 16/15 on every per-block rate (an LFO
+advanced once per block, a per-block ramp) and a sub-frame offset on every
+bus latency (the −36 / −34 / −21 lags above: four bus stages at one sample
+each). `dsp_host -frames 16` now seeds the nibble as 0 and takes the a=1
+call's count (`x:$20d`) when `x:$20c` is 0; at the legacy 15 nothing
+changes (the bit-identity gates stand). `rig_render --frames 16`.
+
+| at 16-sample blocks (`--frames 16`) | lag | residual |
+|---|---|---|
+| the delay path (kick, one client, MDEP 0) | **−16 = exactly one frame** | −120 to −200 dB per steady window |
+| the reverb path, modulators live | −14 | −14 dB |
+| the reverb path, allpass modulator frozen (test build) | −16 | −16 dB early → −31 dB late |
+
+**The reverb residual is not a defect the port can name.** Its output is
+statistically the harness's (levels within 0.1 dB, L/R correlation 0.545
+vs 0.541; L↔L −14 dB, cross-channel −2 dB, so no swap) and it is
+FREE-RUNNING: the same kick 1,000 samples later gives a tail −22 dB
+different from the earlier tail time-shifted — the fixed-depth allpass
+modulator (`$200000`, "never zero" by design) runs on its own phase, and
+`dsp_host` meets the input at a different phase than the port. Freezing it
+in a test build halves the residual and leaves a component that DECAYS
+with the tail (−16 dB at 0.1 s, −31 dB at 0.5 s): an initial-state
+difference at the kick's arrival, 🟡 unlocated (candidates: a per-block
+counter or warm-up artefact the port's thousands of load frames leave
+differently from the harness's 256-block warm-up; the tank's persistent
+one-pole states). Everything static about the reverb — input, parameters,
+bus timing, block length, channels — is now proven equal; what is left is
+its own history.
+
 Tools: `rig_render --extra '<dsp_host args>'` (e.g. `-dumpy 36000,360d3,f`
 to dump the bus scratch after a render, which is how the two scratches
 were diffed word for word).

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -1,3 +1,5 @@
+> ⚠️ **9 Sep 2026: `dsp_host`'s default block is 15 samples; the unit's is 16.** The frame-context nibble the harness seeds is the dispatcher's SPLIT, not a length (0 = a whole 16-sample block, measured under the ColdFire port). Renders at the default are self-consistent and every bit-identity gate is pinned to them, but every per-block rate is 16/15 of the unit's and every bus latency carries a sub-frame offset. `dsp_host -frames 16` / `rig_render --frames 16` run whole blocks exactly as the firmware does (the delay bus then lands at exactly one frame of lag against the port). `docs/COLDFIRE_PORT.md` O12.
+
 # The harness — hearing and measuring the effects without hardware
 
 Flash cycles are expensive: every hardware test is a manual firmware write.

--- a/tools/dsp_host/dsp_host.cpp
+++ b/tools/dsp_host/dsp_host.cpp
@@ -607,9 +607,16 @@ int main(int argc, char** argv) {
                     c, C.ctx.setupLo, C.ctx.setupHi, C.ctx.loop, C.ctx.exit);
         // It reads the frame count out of x:(x:0x415 + 0x1e) as (w >> 8) & 0xf, so
         // seed that first. The count is capped at 15 frames by the & 0xf.
-        if (a.frames > 15) { std::printf("frames capped to 15 (the & 0xf in setup)\n"); a.frames = 15; }
+        // 9 Sep 2026 (COLDFIRE_PORT.md O12): under the firmware that nibble is
+        // the track's SPLIT, and 0 means a whole 16-sample block (x:$20c = 0,
+        // x:$20d = 16 at every unsplit dispatch, measured with the ColdFire
+        // port); the cap at 15 had every harness render processing 15 samples
+        // per block where the unit does 16, which is 16/15 on every per-block
+        // rate (BusVerb's allpass modulator, any per-block LFO). -frames 16
+        // seeds the field as 0 and moves 16 samples per block.
+        if (a.frames > 16) { std::printf("frames capped to 16 (a whole block)\n"); a.frames = 16; }
         const TWord blkA = C.mem->get(MemArea_X, 0x415);
-        C.mem->set(MemArea_X, blkA + 0x1e, (static_cast<TWord>(a.frames) << 8) | a.flags);
+        C.mem->set(MemArea_X, blkA + 0x1e, (static_cast<TWord>(a.frames & 0xf) << 8) | a.flags);
         std::printf("core %d: seeded x:0x%05x+0x1e = frames %d\n", c, blkA, a.frames);
 
         runRange(*C.dsp, C.ctx.setupLo, C.ctx.setupHi);
@@ -618,7 +625,13 @@ int main(int argc, char** argv) {
 
         C.ctlA = C.mem->get(MemArea_X, 0x419);
         C.ctlB = C.mem->get(MemArea_X, 0x208);
-        C.cnt  = C.mem->get(MemArea_X, 0x20c);
+        // The per-block sample count is the a=0 sub-block's (x:$20c) when the
+        // frame is split, else the a=1 call's (x:$20d): the stock dispatcher
+        // skips the a=0 call at x:$20c == 0 and makes the a=1 call with n7 =
+        // x:$20d = 16 (COLDFIRE_PORT.md O12, measured under the firmware).
+        // At the legacy -frames 15 this still reads 15, so every existing
+        // bit-identity gate is untouched; at -frames 16 it reads 16.
+        C.cnt  = C.mem->get(MemArea_X, 0x20c) ? C.mem->get(MemArea_X, 0x20c) : C.mem->get(MemArea_X, 0x20d);
         std::printf("core %d: context: x:0x419=0x%05x  x:0x208=0x%05x  x:0x20c=%u (frames)  "
                     "x:0x20d=%u  x:0x20e=%u\n", c, C.ctlA, C.ctlB, C.cnt,
                     C.mem->get(MemArea_X, 0x20d), C.mem->get(MemArea_X, 0x20e));

--- a/tools/rig_render.py
+++ b/tools/rig_render.py
@@ -225,6 +225,7 @@ def main():
     ap.add_argument("--out", default="out/rig")
     ap.add_argument("--keep", action="store_true", help="keep the raw files")
     ap.add_argument("-v", "--verbose", action="store_true")
+    ap.add_argument("--frames", type=int, default=FRAMES, help="samples per dsp_host block (15 = the harness default; 16 = the firmware's frame)")
     ap.add_argument("--extra", default="", help="extra dsp_host arguments, e.g. '-dumpy 36000,360d3,file' (the bus scratch after the render)")
     a = ap.parse_args()
 
@@ -298,9 +299,10 @@ def main():
     if n_src == 0:
         die("no stems and no --seconds: nothing to render")
     pad = send_probe.WARMUP_BLOCKS * FRAMES        # the engines stay dry for 256 calls
+    FR = a.frames
     total = pad + n_src + int(a.tail * SR)
-    blocks = -(-total // FRAMES)
-    n = blocks * FRAMES
+    blocks = -(-total // FR)
+    n = blocks * FR
 
     tag = os.getpid()
     raws = {}
@@ -326,7 +328,7 @@ def main():
            "-audioidx", ",".join(str(i["track"] - 1) for i in inst),
            "-audio", f"{AUDIO_BASE:x}",
            "-in", ",".join(str(raws.get(i["track"], silent)) for i in inst),
-           "-frames", str(FRAMES), "-blocks", str(blocks),
+           "-frames", str(FR), "-blocks", str(blocks),
            "-out", str(out), "-meter", str(outdir / "meter.txt")]
     for i in inst:
         cmd += ["-params", ",".join(map(str, i["values"]))]
@@ -342,7 +344,7 @@ def main():
               f"alloc {i['alloc']} r7 {i['r7']} init P:0x{i['init']:05x} "
               f"params {' '.join(map(str, i['values']))}"
               f"{'   <- SEND alias' if i['aliased'] else ''}")
-    print(f"{blocks} blocks x {FRAMES} frames ({n / SR:.1f} s incl. {pad / SR:.1f} s warm-up), "
+    print(f"{blocks} blocks x {FR} frames ({n / SR:.1f} s incl. {pad / SR:.1f} s warm-up), "
           f"stems on {sorted(stems) or 'none'}")
     r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
     if a.verbose:


### PR DESCRIPTION
Independent of #163 (touches only dsp_host, rig_render and docs).

## Finding

`dsp_host` seeds `x:(x:0x415+0x1e)` with a "frames" nibble and capped it at 15. Under the firmware that nibble is the track's SPLIT: at every unsplit dispatch `x:$20c = 0`, `x:$20d = 16`, the a=0 call is skipped and the a=1 call runs 16 samples (measured with the ColdFire port). The harness took `x:$20c` as the count, so every render to date processed **15 samples per block** — self-consistent, but 16/15 on every per-block rate and a sub-frame offset on every bus latency (the −36/−34/−21 lags seen in O12).

## Change

- `dsp_host -frames 16` seeds the nibble as 0 and takes the a=1 call's count (`x:$20d`) when `x:$20c` is 0. At the legacy 15 nothing changes: every bit-identity gate stands.
- `rig_render --frames 16`; `--extra` passes raw `dsp_host` args (e.g. `-dumpy` for the bus scratch).
- Delay bus at 16 against the port: **lag exactly −16 (one frame), −120 to −200 dB per steady window.**

## The reverb residual, closed as "not a defect"

Levels within 0.1 dB, L/R correlation 0.545 vs 0.541, no channel swap. The port's reverb is free-running: the same kick 1,000 samples later gives a tail −22 dB different from the earlier one time-shifted — its fixed-depth allpass modulator ("never zero" by design) runs on its own phase, which `dsp_host` meets differently. Frozen in a test build, half the residual goes and the rest decays with the tail (−16 dB early → −31 dB late): an initial-state difference at the kick's arrival, unlocated, recorded as 🟡 in the port doc.

`make check` result in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)