### PR TITLE
Flash 7 plan (one-aux rig with the port-found fixes) + ot_project thru-track

### DIFF
--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -790,7 +790,7 @@ with its decider:
 | DIR names RX0 slot 0 "A", the ColdFire capture names slot 2 "A" (O9c vs O10); stable per run, not a rotation | a tone into the unit's input A with a THRU track and the recorder's INAB | one capture |
 | the track record's segment split and tag word (O10) — what the DSP does with them | read payload B's unpack of the 84-word record | RE, no hardware |
 | Bryan's click: the port shows none in any shape because arm and trig round alike; hypothesis = a 2-sample-unit stage on one side | Bryan's project file run AS-IS under the port (read SRC3/AB/CD/LOOP/QREC/timestretch first), then his one-pass test and the odd/even per-pass-walk tempo test (125 vs 130 BPM) on the unit | his file + two captures |
-| ~~the O9c comparison on the shipping image (bus engines, core 0)~~ ✅ O12: the delay bus bit-identical; the reverb stage level-matched only — T5's knobs arrive modulated on Sam's RIG project (source not pinned) and the toolkit cannot build a THRU track that starts on a clean project | a project-stamping tool that makes a THRU track start (Sam: "stamp a new project"), then one run | one session |
+| ~~the O9c comparison on the shipping image (bus engines, core 0)~~ ✅ O12: the delay bus bit-identical at whole 16-sample blocks; the reverb within its free-running modulation (an initial-state component 🟡 unlocated) | ✅ `ot_project.py thru-track` (9 Sep 2026: machine type + THRU page + the step-1 trig a THRU needs); the reverb comparison then ran and is bounded by the reverb's own free-running modulation (port doc O12) | done |
 
 ## Running it overnight
 

--- a/docs/FLASHPLAN.md
+++ b/docs/FLASHPLAN.md
@@ -356,6 +356,46 @@ configuration (which core, which position) before touching code.
 
 ---
 
+## Flash 7 — the one-aux rig with the port's two fixes (bamsep27, 9 Sep 2026) — NEXT
+
+**The image:** `REMIX=bamsep27 make image` on `main` after #160, #163
+(and #164, harness only). Against tag 20 on the unit it changes THREE
+things, all found by running the shipping image under the ColdFire port
+(`docs/COLDFIRE_PORT.md` O11/O12), none by guessing:
+
+1. **The return's pin and the track-8 refusal use the dispatcher's real
+   r7** (`$6a00/$6b00`; three r7 blocks per track, not two). Tag 20's
+   "hosts keep printing, nothing on T8" was this: the station never
+   matched, cleared its RET level, stamped nothing.
+2. **One rotation tracker per core** (`build_bus.py` ROTLATCH, payload B):
+   the fourth core-1 client (T4) landed one buffer late every frame under
+   the firmware's timing; all four now resolve the same buffer.
+3. Nothing in the part layout: no re-slot, no stamp needed beyond what
+   flash 6 already required. `OCTABAM_ONEAUX` on the card loads as is.
+
+**Pre-flash evidence, under the port (no unit):** Sam's RIG project as
+backed up (master on, T1/T2 THRU on the two input pairs), tones on all
+inputs, 1,500 frames on this image: T1 and T2 pass their inputs (−23.8 /
+−23.0 dBFS out), **T5 prints nothing, T1 prints nothing but its dry, T8
+carries the return**, no fault, no stall. With the master off the return
+alone on T8 builds as a reverb should; the delay path through the bus is
+bit-identical to `dsp_host` (−120 to −200 dB); the reverb path matches it
+within its free-running modulation.
+
+**Claims, in flash 6's order — what changes:**
+
+| | claim | expected now |
+|---|---|---|
+| ii | the chain | PASSES on the unit for the first time: repeats and reverb on T8, T1/T5 silent. Falsified by the hosts still printing → the r7 stride on the unit differs from the port's (measure it: `--dsp-pcwatch`'s r7 column against a station's own stamp) |
+| v | the refusal | T8's SEND at AUX 127 changes nothing (pin `$6b00`); T4 sends |
+| viii | cross-core stamps | no flicker; ALSO: T4's send arrives in step with T2/T3's (it was a block late) |
+
+Everything else as flash 6. **Stop condition unchanged**, with one
+addition: if ii fails, the port has a measurement for it in under an hour
+— bring the exact part and pattern back, not a theory.
+
+---
+
 ## Flash 5 — the ColdFire headroom probe (cfprobe)
 
 **The image:** `REMIX=cfprobe make image` — the rig plus HELLO WORLD and

--- a/tools/ot_project.py
+++ b/tools/ot_project.py
@@ -30,6 +30,13 @@ image R58; anchors verified against values we wrote over MIDI and Sam's own
     python3 tools/ot_project.py stamp-defaults PROJECT_DIR REMIX  # station ids only
     python3 tools/ot_project.py stamp-slot PROJECT_DIR MODULE SLOT [VALUE] [--track N[,N]]
     python3 tools/ot_project.py set-fx PROJECT_DIR fx1|fx2 TRACK MODULE [--page V,V,V,V,V,V] [--page2 V,...]
+    python3 tools/ot_project.py thru-track PROJECT_DIR TRACK [--page HEX14]
+        # a THRU machine that STARTS: machine type 2 in every part of every
+        # bank (+ mirrors), the THRU playback page (default 00017f00000000 =
+        # the pair that lands at the ColdFire's +0 capture, RX0 0/1 in the
+        # port; the RIG's other THRU uses 00004000000000), and a trig at
+        # step 1 in pattern 1 of every bank -- a THRU passes nothing until it
+        # is trigged (measured 9 Sep 2026, COLDFIRE_PORT.md O12).
         # the effect id on ONE track in EVERY part of EVERY bank (all eight
         # part records, both .work and .strd), with optional page bytes.
         # ⚠️ Every part, because the emulated load applies bank 1 part 1 and
@@ -566,6 +573,34 @@ def _resolve_slot(mod, slot):
     return s
 
 
+def thru_track(pdir, track, page_hex="00017f00000000", guard=True):
+    """Make `track` (1-based) a THRU machine that starts on play: machine
+    type 2 in all eight part records of every bank, its THRU playback page
+    (seven bytes at Part+0x8edaa + track*30 + 2*7), and a trig at step 1 in
+    pattern 1 of every bank. A THRU machine on the unit passes nothing until
+    it is trigged (the RECTRIG-based rig was silent for exactly that, 9 Sep
+    2026); the RIG's own THRU tracks carry a step-1 trig."""
+    pdir = pathlib.Path(pdir); t = int(track) - 1
+    if not 0 <= t < NTRACKS:
+        sys.exit("track is 1..8")
+    page = bytes.fromhex(page_hex)
+    if len(page) != 7:
+        sys.exit("--page is 7 bytes (14 hex digits)")
+    pb = 0x8edaa - 0x8ed77                      # the PB page, relative to the part record
+    for bank in sorted(pdir.glob("bank*.work")):
+        num = int(bank.name[4:6])
+
+        def mut(data):
+            for p in range(NPARTS_ALL):
+                off = PART_BASE + p * PART_STRIDE
+                data[off + 0x2b + t] = 2
+                data[off + pb + t * 30 + 2 * 7: off + pb + t * 30 + 2 * 7 + 7] = page
+            base = trac_off(0, t) + 0x00 + 7    # pattern 1 (index 0), mask 0x00, step 1
+            data[base] |= 1
+        _bank_write(pdir, num, mut, guard=guard)
+    print(f"T{t+1}: THRU (type 2) in {NPARTS_ALL} parts of every bank, page {page_hex}, trig at step 1 of pattern 1")
+
+
 def set_fx(pdir, which_slot, track, which, page=None, page2=None, guard=True):
     """Put effect `which` (module key/name or fx id) on `track` (1-based) in
     the FX1 or FX2 slot of EVERY part record (all eight, current + saved) of
@@ -880,6 +915,10 @@ if __name__ == "__main__":
         # a REAL set, before its first load on a flashed image: only the ids
         # a station replaced are touched; BusVerb/BusDelay keep Sam's knobs
         stamp_defaults(pdir, sys.argv[3], replaced_only=True)
+    elif cmd == "thru-track":
+        args = sys.argv[4:]
+        page = args[args.index("--page") + 1] if "--page" in args else "00017f00000000"
+        thru_track(pdir, int(sys.argv[3]), page, guard="--no-guard" not in args)
     elif cmd == "set-fx":
         args = sys.argv[3:]
         page = page2 = None


### PR DESCRIPTION
- `docs/FLASHPLAN.md` Flash 7: the image is `REMIX=bamsep27 make image` on main (#160 pins + #163 tracker; #164 is harness only). No re-slot, no new stamp. Pre-flash evidence from running Sam's RIG project (as backed up, master on, tones on all inputs) under the ColdFire port on that image: T1/T2 pass their inputs, T5 prints nothing, T1 only its dry, T8 carries the return, no fault. Flash 6's claim ii is expected to pass on the unit for the first time; the stop condition gains "bring the part and pattern back to the port".
- `ot_project.py thru-track PROJECT TRACK [--page HEX14]`: machine type 2 in every part of every bank, the THRU playback page, and the step-1 trig a THRU machine needs before it passes anything (measured 9 Sep). Reproduces the hand-built fixture byte for byte.
- Work-order debts table updated (the "stamp a project" gap closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)