### PR TITLE
Bus: flash 6's claims under the port -- a wrong-track BUS station silenced the return (fixed); iii/iv/v/viii pass

### DIFF
--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2623,6 +2623,37 @@ one-pole states). Everything static about the reverb — input, parameters,
 bus timing, block length, channels — is now proven equal; what is left is
 its own history.
 
+### ✅ Flash 6's remaining claims, run under the port (9 Sep 2026, branch `bus-claims-under-port`)
+
+The master-off rig, T2 sending, the flash-7 image, one project variant per
+claim (`set-fx`/`stamp-slot`), 1,200 frames each, T8's read-back as the
+return:
+
+| claim | fixture | result |
+|---|---|---|
+| iii, neither engine | T1 and T5 FX2 = NONE | T8 peak 0: digital silence, not garbage ✅ |
+| iv, delay MIX 0 | | the reverb of the DRY sends: same onset, −44 dBFS against the repeats-only −58 ✅ |
+| iv, reverb MIX 64 | | repeats under the tail: a different, non-silent return ✅ |
+| v, the refusal | SEND on T8's FX2, AUX 127 | T8's return **bit-identical** to the baseline ✅ |
+| vii, a BUS-mode station on T4 | | T4 returns nothing ✅ — **and T8's return went SILENT from its first sample** ❌ |
+| vii, the same on T7 | | T7 returns nothing ✅ — **T8 silent** ❌ |
+| viii, 6,000 frames | | no block under −90 dBFS after frame 1,000; the return's slow ±5 dB wander is the modulated tank on a pure tone ✅ |
+
+**The vii defect:** the engines' liveness stamps are clear-on-read with a
+single reader by design, and a BUS-mode station on ANY track ran the
+reads — a station that failed the pin returned nothing, exactly as flash
+6's claim asked, while stealing the stamps from the real return on T8,
+which then saw nothing live. `verify_onebus` checks "returns nothing from
+T4/T7" and "T8 returns" as separate cases and never both at once. Fixed in
+`character.asm`: a station whose RET level is 0 (not track 8, or the knob
+down) skips the stamp reads and the RETV/RETD stamps. Re-run: T8's return
+bit-identical to the baseline with the station on T4; with it on T7
+identical until frame 641 then −34 dB different — 🟡 that frame is one of
+the port's jittered host frames (a 15-sample frame among 16s; the frame
+edge is the DSP's own bank write, so a heavier core-0 load moves the
+jitter), the port's timing model rather than the bus. `verify_onebus` and
+`make check` green.
+
 Tools: `rig_render --extra '<dsp_host args>'` (e.g. `-dumpy 36000,360d3,f`
 to dump the bus scratch after a render, which is how the two scratches
 were diffed word for word).

--- a/docs/FLASHPLAN.md
+++ b/docs/FLASHPLAN.md
@@ -348,6 +348,7 @@ forced to 0 in code — gated).
 | v | the refusal | put SEND on T8's FX2 with AUX 127: nothing changes; the same on T4: it sends | T8 audible in the return (the position pin is wrong) |
 | vi | stations silent | a station on any track with its old send bytes (a tag-17 part, unstamped, on a scratch copy) sends nothing | a station's track in the reverb with its AUX at 0 |
 | vii | the return pin | a BUS-mode Character on T7 or T4: returns nothing; on T8: returns | a return from T7 or T4 |
+| vii-b | a wrong-track station does not kill the return | a BUS-mode Character on T4 AND the T8 return together: T8 still returns (✅ 9 Sep 2026 under the port after the fix; before it T8 went silent) | T8 silent with a BUS station elsewhere |
 | viii | cross-core stamps | play for minutes: no flicker of the return, no host print creeping back | the return dropping out and back (a stamp lost > 3 blocks) |
 
 **Stop condition:** any of ii–iv failing on the unit after passing
@@ -370,7 +371,11 @@ things, all found by running the shipping image under the ColdFire port
 2. **One rotation tracker per core** (`build_bus.py` ROTLATCH, payload B):
    the fourth core-1 client (T4) landed one buffer late every frame under
    the firmware's timing; all four now resolve the same buffer.
-3. Nothing in the part layout: no re-slot, no stamp needed beyond what
+3. **A BUS-mode station off track 8 no longer silences the return** (it
+   stole the engines' clear-on-read liveness stamps; `character.asm` now
+   touches them only with a RET level up). Found by running flash 6's own
+   claim vii under the port with T8 present.
+4. Nothing in the part layout: no re-slot, no stamp needed beyond what
    flash 6 already required. `OCTABAM_ONEAUX` on the card loads as is.
 
 **Pre-flash evidence, under the port (no unit):** Sam's RIG project as

--- a/modules/character/character.asm
+++ b/modules/character/character.asm
@@ -444,6 +444,19 @@ ch_sdone:
         move    a,r5                    ; DELAY output [read]
         move    #>$ffffff,m4
         move    #>$ffffff,m5
+; ---- ONLY THE RETURN READS THE STAMPS (9 Sep 2026, found under the port) --
+; The engines' liveness words are clear-on-read, single reader by design. A
+; BUS-mode station on any OTHER track (T4, T7 -- flash 6's claim vii only
+; asked that it return nothing, and it does) was still running this block,
+; stealing the stamps before T8's return read them: with such a station in
+; the part the REAL return went silent from its first sample (the port,
+; COLDFIRE_PORT.md O12; the local gate never tried both at once). A station
+; whose RET level is 0 -- not track 8, or the knob down -- has no business
+; here: skip the reads AND the RETV/RETD stamps below. (The engines then
+; keep printing, which is what a return at 0 means.)
+        move    x:(r7+$3e),a
+        tst     a
+        beq     ch_ndl                  ; no return level: touch nothing
 ; ---- which stage is live? (one-aux rig, 7 Sep 2026) ---------------------
 ; Each engine stamps its own word every block it processes (y:$9c4 reverb,
 ; y:$9c5 delay); this reads and clears them (single writer, single reader)

--- a/tools/scratch/o12_claims.py
+++ b/tools/scratch/o12_claims.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Flash 6's remaining claims, read off the port's block dumps (COLDFIRE_PORT.md O12).
+  o12_claims.py            (expects out/o9d/cl_{nm,none,dmix0,rmix64,t8send,t4ret,t7ret,long}.dump)"""
+import sys, math, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import blockdump as bd, o10_recloop as rl
+def db(v): return 20*math.log10(v/8388608) if v>0 else -200
+def rms(x): return math.sqrt(sum(v*v for v in x)/len(x)) if x else 0
+def load(name): return bd.classes(bd.read(f'out/o9d/cl_{name}.dump'))
+def rb(c,t,lo,hi,right=False): return rl.readback_audio(c,t,right)[lo*16:hi*16]
+def same(a,b): return all(x==y for x,y in zip(a,b)) and len(a)==len(b)
+nm=load('nm'); base8=rb(nm,8,0,1200); base8r=rb(nm,8,0,1200,True)
+print(f"baseline (T2 sends, master off): T8 return {db(rms(base8[6400:])):.1f} dBFS (frames 400-1200); hosts T1 {db(rms(rb(nm,1,400,1200))):.1f} T5 {db(rms(rb(nm,5,400,1200))):.1f}")
+c=load('none'); y=rb(c,8,0,1200); print(f"iii  NONE on T1 and T5: T8 peak {max(abs(v) for v in y)} (0 = digital silence, not garbage) -> {'PASS' if max(abs(v) for v in y)==0 else 'FAIL'}")
+c=load('dmix0'); y=rb(c,8,0,1200); on=next((i for i,v in enumerate(y) if v),None); onb=next((i for i,v in enumerate(base8) if v),None)
+print(f"iv   delay MIX 0: T8 {db(rms(y[6400:])):.1f} dBFS, onset sample {on} vs baseline {onb} (the reverb of the DRY sends: later onset, no repeats) -> {'PASS' if on and onb and on>onb+100 else 'CHECK'}")
+c=load('rmix64'); y=rb(c,8,0,1200); print(f"iv   reverb MIX 64: T8 {db(rms(y[6400:])):.1f} dBFS vs baseline {db(rms(base8[6400:])):.1f} (repeats under the tail: different, not silent) -> {'PASS' if not same(y,base8) and rms(y[6400:])>0 else 'FAIL'}")
+c=load('t8send'); y=rb(c,8,0,1200); print(f"v    SEND on T8 FX2 at AUX 127: T8 return bit-identical to baseline -> {'PASS' if same(y,base8) else 'FAIL (differs)'}")
+for v,t in (('t4ret',4),('t7ret',7)):
+    c=load(v); yt=rb(c,t,0,1200); y8=rb(c,8,0,1200)
+    print(f"vii  BUS-mode station on T{t}: T{t} out peak {max(abs(x) for x in yt)} (0 = returns nothing), T8 still returns {'identically' if same(y8,base8) else 'DIFFERENTLY'} -> {'PASS' if max(abs(x) for x in yt)==0 and same(y8,base8) else 'FAIL'}")
+c=load('long'); y=rl.readback_audio(c,8); n=len(y)//16
+lv=[db(rms(y[f*16:(f+250)*16])) for f in range(500,n-250,250)]
+print(f"viii long run ({n} frames): T8 return per 250 frames from 500: min {min(lv):.1f} max {max(lv):.1f} dBFS (flat = no flicker/dropout) -> {'PASS' if max(lv)-min(lv)<1.0 else 'CHECK'}")
+print("   ", ' '.join(f"{v:.1f}" for v in lv))


### PR DESCRIPTION
Flash 6 had eight claims; the port had exercised two. This runs the rest with the firmware driving both cores on the flash-7 image, one project variant per claim (`tools/scratch/o12_claims.py`).

| claim | result |
|---|---|
| iii neither engine | digital silence on T8, not garbage ✅ |
| iv delay MIX 0 / reverb MIX 64 | the reverb of the dry sends / repeats under the tail ✅ |
| v SEND on T8 at AUX 127 | T8's return bit-identical to baseline ✅ |
| vii BUS station on T4 or T7 | returns nothing ✅ — **but T8's real return went silent from its first sample** ❌ |
| viii 6,000 frames | no block under −90 dBFS; the slow wander is the modulated tank on a pure tone ✅ |

**The vii defect and fix.** The engines' liveness stamps are clear-on-read with one reader by design; a BUS-mode station on any track ran the reads, returning nothing itself (claim vii as written) while stealing the stamps from T8. `verify_onebus` tests "T4 returns nothing" and "T8 returns" in separate renders. `character.asm` now skips the stamp reads and the RETV/RETD stamps when its RET level is 0 (not track 8, or the knob down). After: T8 bit-identical to baseline with a station on T4; with one on T7 identical until a jittered host frame then −34 dB different (the port's frame-edge model, recorded 🟡). `make verify-onebus` green; `make check` result in a comment. Flash plan: claim vii-b added, the fix listed for flash 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)