### PR TITLE
O13: cycle count under the firmware -- port stopwatch agrees with dsp_host's meter within 2%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,11 @@ DSP_ASM := vendor/dsp56300/build/source/dsp_host/dsp_asm
 # Stamped into the OS version field (max 10 chars) so the unit tells you which
 # build it is running. Bump BUILD every time you flash: a unit whose version
 # string you cannot map back to a commit is a unit you are guessing about.
-BUILD   ?= 79          # the image's version AND the build tag the panel
-                       # shows in every effect name (tools/build_bus.py)
+# BUILD is the image's version AND the build tag the panel shows in every
+# effect name (tools/build_bus.py). No trailing comment on the line: make
+# keeps the spaces before a `#`, and `make image` then splits its recipe
+# (found 9 Sep 2026: the default BUILD produced ".bin: command not found").
+BUILD   ?= 79
 VERSION ?= OCTABAM$(BUILD)
 
 # Which modules the image carries. `make modules` lists what is available;

--- a/docs/CHIP.md
+++ b/docs/CHIP.md
@@ -330,7 +330,10 @@ every run; `tools/rig_render.py` writes `meter.txt`), which is a second
 floor — per block, every instance's real work, inits included — and still
 no stall. For scale: the meter reads BusVerb at ~1,130 instructions/sample
 where the static count is 1,652 words (multi-word instructions count once);
-the same 3,120 wall applies to neither directly. Only the burn sweep measures the ceiling.
+the same 3,120 wall applies to neither directly. The ColdFire port's stopwatch
+(`--dsp-stopwatch`, `COLDFIRE_PORT.md` O13, 9 Sep 2026) reads the firmware's own
+dispatch in the meter's unit and agrees with the meter within 2 % (BusVerb
+1,109/sample under the firmware, 1,130 on the meter). Only the burn sweep measures the ceiling.
 
 **For scale:** the entire BusVerb engine was 758 cycles when the spare was
 measured (~1 133 with the 8-line tank), and 1 392 was room for ~1.8 more complete

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2658,6 +2658,93 @@ Tools: `rig_render --extra '<dsp_host args>'` (e.g. `-dumpy 36000,360d3,f`
 to dump the bus scratch after a render, which is how the two scratches
 were diffed word for word).
 
+## Milestone O13 — the cycle count under the firmware: the port's stopwatch and `dsp_host`'s meter agree within 2 % (9 Sep 2026, branch `port-cycle-meter`)
+
+The question the port could answer that nothing else could: what does the
+firmware's OWN dispatch cost per frame on each core — every effect it
+actually calls, with the knob state the part actually publishes, plus
+whatever it dispatches into an empty slot — in the same unit `dsp_host`'s
+meter reads (`docs/HARNESS.md` "The meter": executed instructions, no
+stall modelled). Two instruments that agree validate the meter as the
+load instrument for the rig; two that disagree mean one is blind.
+
+**The instrument.** `--dsp-stopwatch core:start:stop` — arm at the first
+PC, count instructions executed by that core until the second, one pair
+per arm/stop; prints the count, mean, min, max and the last 24. Semantics
+that matter: a second arrival at `start` before `stop` RE-ARMS (the window
+becomes the last start→stop), and `start == stop` never pairs. So the
+right window for "what does this call cost" is the dispatcher's `jsr` and
+the instruction after it — the callee is everything in between — not a
+guessed whole-dispatcher span: core 0's head at P:0x41e is entered THREE
+times a frame (906 arms per 300 frames against one exit at 0x559), so a
+0x41e→0x559 window read 7,050 per frame for a frame whose calls sum to
+24,654, and core 1's 0x221→0x34e window (1,880 per frame) does not
+contain its effect calls at all. Call sites, from the dispatcher listing in
+O9c: core 0 FX1 `jsr` at P:0x4d7, FX2 at P:0x50d; core 1 FX1 at P:0x2cc,
+FX2 at P:0x302 — four arrivals per frame each, tracks in dispatch order.
+
+**The measurement** (Sam's RIG, `card_oneaux.img`, `mainos_flash7b.bin`,
+300 frames, `--audio-in tones`, the played part's knobs; instructions per
+16-sample frame, every frame identical once the chain is warm):
+
+| core | call | per frame | per sample |
+|---|---|---|---|
+| 0 (T5–T8) | T5 FX1 MODULATION | 480 | 30 |
+| | T5 FX2 **BusVerb** | **17,746** | **1,109** |
+| | T6, T7 FX1 SPECTRUM | 549 each | 34 |
+| | T6, T7 FX2 SEND | 284 each | 18 |
+| | T8 FX1 CHARACTER (BUS station, RET 127) | 4,710 | 294 |
+| | T8 FX2, the empty slot's fallback SEND | 52 | 3 |
+| | **core 0 total** | **24,654** | **1,541** |
+| 1 (T1–T4) | T1 FX1 CHARACTER (live, see below) | 4,665 | 292 |
+| | T1 FX2 **BusDelay** | **7,989** | **499** |
+| | T2–T4 FX1 SPECTRUM | 564 each | 35 |
+| | T2–T4 FX2 SEND | 277 each | 17 |
+| | **core 1 total** | **15,177** | **949** |
+
+✅ measured (`out/o9d/r_swc_*.txt`). The dispatcher's own work between the
+calls is not in the sums; it is bounded by the 1,880 of core 1's
+0x221→0x34e segment and is the same on hardware.
+
+**Against `dsp_host`'s meter for the same rig** (`rig_render --frames 16
+--project proj_oneaux --bank 2 --part 1`, `out/o9d/rig_meter16*.log`):
+
+| core | port, calls summed | `dsp_host` meter, max block | agreement |
+|---|---|---|---|
+| 0 | 24,654 | 24,971 (mean 22,690) | 1.3 % |
+| 1 | 15,177 | 11,126 as rendered; **14,880** with T1's RET forced to 127 | 2 % once the knob state matches |
+
+The core-1 gap was a knob, not a defect in either instrument: CHARACTER
+takes its bypass loop (about 600 a frame) when every knob is neutral,
+including the page-2 side gain at exactly 64, and `dsp_host` drives the
+part's page-2 values into the companion bytes while the port's emulated
+load leaves page 2 unpublished (O9c: the page-2 publish path is the
+`ccpage2` copier) — the peek of T1's FX1 block (`x:0x363`) under the port
+shows six page-1 words of `000000`, low bytes included ✅. So the port
+runs T1's CHARACTER live, which is the worst case and the one the wall
+cares about. (🟡 whether the hardware's load publishes page 2 before the
+first knob touch is the O9c question, unchanged.)
+
+**What this settles.** `dsp_host`'s meter reads the firmware's real load
+to within 2 % when its knob state matches the part's — the effects the
+firmware dispatches, in its order, with the fallback SEND in the empty
+slot, cost what the harness says they cost. The rig's load in meter
+units is core 0 ≈ 1,540 instructions/sample, core 1 ≈ 950. What it does
+NOT settle: the unit is instructions, and the 3,120 wall
+(`docs/CHIP.md` §2) is in `tools/cycle_count.py`'s static words with
+the hardware's stalls on top; the port models no stall either. BusVerb
+reads 1,109 here, 1,130 on the meter, 1,652 static — the same ~0.68
+ratio `HARNESS.md` records — so the port is a third floor in the meter's
+unit, not a ceiling. Only the burn sweep measures the ceiling.
+
+**Reproduce:**
+
+```
+./out/emu/ot_emu --image out/o9d/mainos_flash7b.bin --card out/o9d/card_oneaux.img \
+  --set OCTABAM --project RIG --sequencer --internal-clock --frames 300 --load-ms 20000 \
+  --dsp --main-level 64 --audio-in tones --dsp-stopwatch 0:50d:50e     # core 0 FX2 calls
+```
+
 ## What is NOT here yet
 
 - **The rest of the peripherals.** The eDMA with its completion-timing rules

--- a/docs/COLDFIRE_PORT.md
+++ b/docs/COLDFIRE_PORT.md
@@ -2652,7 +2652,16 @@ identical until frame 641 then −34 dB different — 🟡 that frame is one of
 the port's jittered host frames (a 15-sample frame among 16s; the frame
 edge is the DSP's own bank write, so a heavier core-0 load moves the
 jitter), the port's timing model rather than the bus. `verify_onebus` and
-`make check` green.
+`make check` green. ✅ **Falsifier run (9 Sep 2026):** the baseline and
+the T7-station case re-run at core-interleave quanta 2,000 and 50,000
+(default 64). At BOTH quanta T8's return first differs at sample 10,262 =
+frame 641 — and the BASELINE differs from its own default-quantum run at
+exactly that sample too, with nothing on T7 changed. The difference is
+−144 dBFS rms against a −74 dBFS return, i.e. a few samples one LSB apart.
+So frame 641 is where this run's host-frame phase is decided by the
+interleave, not where a station does anything: any two runs that differ
+in anything diverge there, at the LSB. The bus reading stands; the
+mechanism (the jittered frame) is still the inference.
 
 Tools: `rig_render --extra '<dsp_host args>'` (e.g. `-dumpy 36000,360d3,f`
 to dump the bus scratch after a render, which is how the two scratches

--- a/docs/COLDFIRE_WORKORDER.md
+++ b/docs/COLDFIRE_WORKORDER.md
@@ -775,6 +775,17 @@ once the fixture matches: stereo input (the send client mono-sums L+R;
 slew, delay MDEP 0 (the LFO's phase is history). The bus's cross-core
 mechanism holds under the firmware's ordering of the two cores.
 
+### O13 — the cycle count under the firmware ✅ DONE (9 Sep 2026, branch `port-cycle-meter`)
+
+`COLDFIRE_PORT.md` O13. `--dsp-stopwatch core:start:stop` on the
+dispatcher's four call sites gives every effect's cost per frame under the
+firmware's own dispatch: the RIG costs core 0 24,654 instructions a frame
+(1,541/sample; BusVerb 1,109), core 1 15,177 (949/sample; BusDelay 499).
+`dsp_host`'s meter for the same rig reads 24,971 and 14,880 — within 2 %
+once T1's CHARACTER is in the same (live) state — so the meter is validated
+as the rig's load instrument. Same unit as the meter (instructions, no
+stall), so still a floor against the 3,120 wall, not a ceiling.
+
 ## Where the port stands after O12 (8 Sep 2026), and what is left
 
 The port boots the firmware, mounts the card, loads the project, runs the

--- a/docs/FLASHPLAN.md
+++ b/docs/FLASHPLAN.md
@@ -378,6 +378,14 @@ things, all found by running the shipping image under the ColdFire port
 4. Nothing in the part layout: no re-slot, no stamp needed beyond what
    flash 6 already required. `OCTABAM_ONEAUX` on the card loads as is.
 
+✅ **The image is the tested image (9 Sep 2026):** `REMIX=bamsep27 make
+bus` on `main` (after #166) produces `out/mainos_bus.bin` **byte-identical**
+to `out/o9d/mainos_flash7b.bin`, the file every O12/O13 port measurement
+and the claims sweep ran on (`cmp`, 1,112,560 bytes). ⚠️ `make image`
+itself was broken on the default `BUILD` line (a trailing comment put
+spaces into the version and the recipe split on `.bin`); fixed on the
+O13 branch — bump `BUILD` by editing the number only.
+
 **Pre-flash evidence, under the port (no unit):** Sam's RIG project as
 backed up (master on, T1/T2 THRU on the two input pairs), tones on all
 inputs, 1,500 frames on this image: T1 and T2 pass their inputs (−23.8 /

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -280,7 +280,11 @@ so the STATIC sum is the comparable floor: for this layout **core 0 = 3,005**
 SEND). Core 0 sits 115 under the wall before contention — the same class as
 the tag-91 hang at 3,106. The meter reads about half the static count
 (multi-word instructions count once) and is the per-block, init-inclusive
-shape of the load, not a second calibration.
+shape of the load, not a second calibration. The ColdFire port measured the
+same rig under the firmware's own dispatch (`--dsp-stopwatch` on the four
+call sites, `docs/COLDFIRE_PORT.md` O13, 9 Sep 2026): core 0 24,654 a frame
+against the meter's 24,971, core 1 15,177 against 14,880 once T1's
+CHARACTER is live on both — the meter reads the real load within 2 %.
 
 What it still is not: the ColdFire. Knobs are poked into `r6`, AMP/pan and
 the mixer are a unity sum, samples do not play (stems stand in), and the

--- a/tools/ot_emu/dsp.cpp
+++ b/tools/ot_emu/dsp.cpp
@@ -789,6 +789,16 @@ namespace ot
 					c.timerM[k] = c.dsp->regs().m[k].var & 0xffffff;
 				}
 			}
+			if(m_sw.core == i)
+			{
+				if(pc == m_sw.start) { m_sw.t0 = c.executed; m_sw.armed = true; }
+				else if(pc == m_sw.stop && m_sw.armed)
+				{
+					const uint64_t d = c.executed - m_sw.t0;
+					m_sw.armed = false; ++m_sw.n; m_sw.sum += d; if(d > m_sw.max) m_sw.max = d; if(d < m_sw.min) m_sw.min = d;
+					if(m_sw.last.size() < 4096) m_sw.last.push_back(static_cast<uint32_t>(d));
+				}
+			}
 			if(m_pcWatchOn && i == m_pcWatchCore && pc == m_pcWatchPc && c.executed >= m_pcWatchFrom && !(m_pcWatchFrom && m_pcWatchHits.size() >= 24))
 			{
 				const auto& r = c.dsp->regs();

--- a/tools/ot_emu/dsp.h
+++ b/tools/ot_emu/dsp.h
@@ -188,6 +188,13 @@ namespace ot
 		// A PC watch on one core: registers at every arrival (last 24), the DSP side of route A's --watch-pc (O9b).
 		struct PcWatchHit { uint64_t executed; uint32_t a1, a0, b1, b0, x0, x1, y0, y1, r0, r4, r6, n4, sp, r2, m2, r1, n1, r7; };
 		void setPcWatch(const int _core, const uint32_t _pc, const uint64_t _from = 0) { m_pcWatchCore = _core; m_pcWatchPc = _pc; m_pcWatchFrom = _from; m_pcWatchOn = true; }
+		// O12 cycle meter: instructions executed between two PCs on one core, per
+		// arrival pair (the dispatcher's head to its exit = one frame's DSP work,
+		// in the same unit as dsp_host's meter). Spins outside the pair (the host
+		// wait, the bank wait) are not counted, which is what "busy" failed to do.
+		struct Stopwatch { int core = -1; uint32_t start = 0, stop = 0; uint64_t t0 = 0; bool armed = false; uint64_t n = 0, sum = 0, max = 0, min = ~0ull; std::vector<uint32_t> last; };
+		void setStopwatch(const int _core, const uint32_t _start, const uint32_t _stop) { m_sw.core = _core; m_sw.start = _start; m_sw.stop = _stop; }
+		const Stopwatch& stopwatch() const { return m_sw; }
 		const std::vector<PcWatchHit>& pcWatchHits() const { return m_pcWatchHits; }
 		const std::vector<std::string>& writeMap() const { return m_writeMap; }
 
@@ -226,6 +233,7 @@ namespace ot
 		bool m_pulling = false;
 		bool m_pcWatchOn = false; int m_pcWatchCore = 0; uint32_t m_pcWatchPc = 0; uint64_t m_pcWatchFrom = 0;	// with a `from`, the FIRST 24 arrivals after it are kept
 		std::vector<PcWatchHit> m_pcWatchHits;
+		Stopwatch m_sw;
 		bool m_watchOn = false; int m_watchCore = 0; char m_watchSpace = 'X'; uint32_t m_watchAddr = 0;
 		std::vector<WatchHit> m_watchHits;			// inside pullHalfwords: host-port words are the read-back, not the bank id
 		bool m_hostWordFired = false;	// set by runDue when the hook fired; tickSamples stops its slice on it

--- a/tools/ot_emu/main.cpp
+++ b/tools/ot_emu/main.cpp
@@ -88,6 +88,7 @@ int main(int _argc, char** _argv)
 	std::string audioOut;		// O9: PREFIX -> PREFIX_core<k>.wav, every X-side ESAI TX0 frame (8 slots) the core put out
 	std::string audioIn;		// O9: a WAV onto RX0's slots from the transport start, or "tones"
 	std::string dspPcWatch;		// O9b: core:pc -- registers at the last 24 arrivals at that DSP PC
+	std::string dspStopwatch;	// O12: core:startpc:stoppc -- instructions between the two, per pair (the cycle meter)
 	std::string dspWatch;		// O9b: core:space:addr -- the last 16 writers of one DSP word
 	std::string dspMap;		// O9: per-frame non-zero counts per 4K chunk of both cores' X and Y -> FILE
 	std::string dspWrites;		// O9: per-frame NON-ZERO WRITE counts per 256-word region of both cores' X and Y -> FILE
@@ -148,6 +149,7 @@ int main(int _argc, char** _argv)
 		else if(a == "--dsp-map" && i + 1 < _argc)	dspMap = _argv[++i];
 		else if(a == "--dsp-watch" && i + 1 < _argc)	dspWatch = _argv[++i];
 		else if(a == "--dsp-pcwatch" && i + 1 < _argc)	dspPcWatch = _argv[++i];
+		else if(a == "--dsp-stopwatch" && i + 1 < _argc)	dspStopwatch = _argv[++i];
 		else if(a == "--dsp-writes" && i + 1 < _argc)	dspWrites = _argv[++i];
 		else if(a == "--coverage" && i + 1 < _argc)	coverage = _argv[++i];
 		else if(a == "--main-level" && i + 1 < _argc)	mainLevel = std::atoi(_argv[++i]);
@@ -210,6 +212,12 @@ int main(int _argc, char** _argv)
 		dspPair->setAudioCapture(!audioOut.empty());
 		dspPair->setActivityMap(!dspMap.empty());
 		dspPair->setWriteMap(!dspWrites.empty());
+		if(!dspStopwatch.empty())
+		{
+			int core = 0; unsigned a0 = 0, a1 = 0;
+			if(std::sscanf(dspStopwatch.c_str(), "%d:%x:%x", &core, &a0, &a1) == 3)
+				dspPair->setStopwatch(core, a0, a1);
+		}
 		if(!dspPcWatch.empty())
 		{
 			int core = 0; unsigned pc = 0; unsigned long long from = 0;
@@ -705,6 +713,16 @@ int main(int _argc, char** _argv)
 	if(dspPair)
 	{
 		std::printf("dsp        : at the end\n%s", dspPair->report().c_str());
+		if(!dspStopwatch.empty())
+		{
+			const auto& w = dspPair->stopwatch();
+			std::printf("dsp stopwatch: %s -- %llu pair(s), instructions per pair mean %.0f min %llu max %llu\n", dspStopwatch.c_str(),
+				static_cast<unsigned long long>(w.n), w.n ? static_cast<double>(w.sum) / static_cast<double>(w.n) : 0.0,
+				static_cast<unsigned long long>(w.n ? w.min : 0), static_cast<unsigned long long>(w.max));
+			std::printf("             last 24:");
+			for(size_t k = w.last.size() > 24 ? w.last.size() - 24 : 0; k < w.last.size(); ++k) std::printf(" %u", w.last[k]);
+			std::printf("\n");
+		}
 		if(!dspPcWatch.empty())
 		{
 			std::printf("dsp pcwatch: %s, last %zu arrival(s): executed a1:a0 b1:b0 x0 x1 y0 y1 r0 r4 r6 n4 sp r2 m2 r1 n1 r7\n", dspPcWatch.c_str(), dspPair->pcWatchHits().size());


### PR DESCRIPTION
## Summary
- `ot_emu --dsp-stopwatch core:start:stop`: instructions executed between two PCs, per pair (re-arm semantics documented).
- Measured every effect call of Sam's RIG under the firmware's own dispatch: core 0 24,654 instr/frame (1,541/sample, BusVerb 1,109), core 1 15,177 (949/sample, BusDelay 499).
- `dsp_host`'s meter for the same rig: 24,971 / 14,880 -- within 2% once T1's CHARACTER is in the same state (the port's emulated load leaves page 2 unpublished, so the station runs live there; peeked). The meter is validated as the rig's load instrument; same unit (instructions, no stall), so still a floor against the 3,120 wall.
- Flash 7 pre-flight: `REMIX=bamsep27 make bus` on main is byte-identical to `out/o9d/mainos_flash7b.bin`, the image every port measurement and the claims sweep ran on.
- The T7-station "frame 641" divergence is the port's own: the baseline diverges from itself at the same sample when only `--dsp-quantum` changes, sub-LSB.
- Makefile: `BUILD ?= 79   # comment` put the spaces into VERSION and `make image` split its recipe (`.bin: command not found`). Comment moved above the line; `scripts/refhash.sh` 26/26 bit-identical across the change; `make check` green.
- Docs: COLDFIRE_PORT.md O13 + the falsifier, WORKORDER O13, FLASHPLAN Flash 7, one calibration line each in CHIP.md and HARNESS.md.

## Test plan
- [x] port rebuilt and run with the stopwatch on all four call sites (`out/o9d/r_swc_*.txt`)
- [x] `rig_render --frames 16` with and without `--set T1:RET=127` for the meter side
- [x] `cmp out/mainos_bus.bin out/o9d/mainos_flash7b.bin` after `REMIX=bamsep27 make bus`
- [x] `scripts/refhash.sh save` (Makefile unchanged) then `check` (fixed): ALL 26 CASES BIT-IDENTICAL
- [x] `make check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)