### PR TITLE
RTOS_FORK 10.34: voice-probe finds an empty-voice skeleton, not FLEX audio

### DIFF
--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -3072,3 +3072,82 @@ recorded samples (playback works) or is silent/passthrough (the DSP-side
 voice render for a recorder buffer is the real gap). The pieces upstream of it
 — recorder writes, control record, bind — are now all confirmed present in
 route A.
+
+### 10.34 The 84-word record stays an empty-voice skeleton through pass 2, both ping sides, all four track slots — and route A's own `Edma` class explains why it might have to (9 Sep 2026)
+
+Followed §10.33's own next step: `recaudio.py` gained `--voice-probe`, reading
+the track's 84-word record directly from ColdFire host memory (`0x800021d0`/
+`0x80002c50` payload A, `0x80001c90`/`0x80002710` payload B — `DSP.md`'s
+"four 84-word per-track records" table row) instead of trying to catch it in
+flight over the eDMA hook.
+
+**Addressing confirmed, twice over, before trusting the content.** (1) The
+actual TCD fields captured on this transfer (`out_log`, `ch 0`, `saddr
+0x800021d0`/`0x80001c90`/`0x80002c50`/`0x80002710`) read `nbytes=0x150`
+(336 bytes), `biter&0x1ff=4` — 4 × 336 = 1,344 bytes, exactly "four 84-word
+(0x150-byte) records" back to back, confirming the per-track stride is 336
+bytes = 84 words × 4 bytes, not the wire's 2-halfwords-per-24-bit-word
+count. (2) Reading each word as the top 3 bytes of its 4-byte big-endian
+slot reproduces the documented header magic `0x40000` exactly at word index
+2 of every track slot, on every frame checked — the same value O10 decoded
+from the C++ port's block-dump via the halfword-pair method (`(hi<<8) |
+(lo>>8)`), which is algebraically identical to "top 3 of 4 bytes" for a
+sequential big-endian layout. Both routes agree; the address and byte
+layout are not the open question.
+
+**The content itself never moves.** Captured all four track-slot positions
+on both ping sides, on `g65` (RLEN 16, 65.6 BPM golden, arms at frames
+1/10081) — at frames 1–4 (pass 1 start), 10079–10084 (the pass-2 play trig
+and its immediate neighbourhood), and a periodic sample every 20 frames out
+to 10140: **every position, every frame, decodes to the same near-static
+skeleton** — an empty first header (`count=0, 0, 0x40000, tag=0`), then a
+constant `16, 0, 131064` triple that never forms a valid second header
+(`0x40000` doesn't reland at the expected offset) and never carries a
+16-pair audio payload, with only one word (a tag-like value at index 7)
+drifting slowly and periodically with the pass length. Nothing distinguishes
+pass 1 (buffer empty, expected silence) from pass 2 (buffer full, §10.33's
+bind fires) — the record is byte-for-byte the same shape at both.
+
+**Along the way, a real bug, fixed:** `on_frame_edge` (feeding `rec_fields`
+and now `voice_rec`) is called once per completion of eDMA ch 1, which
+fires **twice per `rt.frame_count` tick** (once per ping/core side) — so
+the existing `a.frames + 64` cap on `rec_fields` was counting *calls*, not
+frames, and silently stopped recording at half the requested frame range. A
+10,150-frame run's capture died at real frame 5,107 with no error printed.
+Fixed by deduping on `frame_count` before appending. This was a pre-existing
+gap in `--field-probe` too, not something the voice-probe introduced — any
+earlier `--field-probe` run past ~half its requested `--frames` should be
+treated as unverified for its back half.
+
+**Why the record may be structurally invisible to route A, not actually
+silent (🟡 inferred, not measured):** `tools/emu_rtos.py`'s `Edma` class
+says so itself — "No data moves (audio is out of route A's scope... M5 ran
+12,000 frames with no DSP at all)". Every completion this class produces is
+a timing event; no bytes cross an eDMA channel. `recaudio.py`'s own counter
+injection exists precisely to patch around this, by hand-writing synthetic
+content into the recorder's *input* read-back ring at 0x80003190 the moment
+the paced chain "completes" — but that patch covers the recorder's input
+side only. If the machine-type-1 (FLEX) handler that assembles the 84-word
+record for a *recorder-buffer* voice reads any DSP-fed state before writing
+its segments (a level, a position, anything that would normally arrive over
+one of the *other* host↔DSP channels this class also never actually moves),
+that input sits at zero forever under route A, and a branch on it could
+make the handler write nothing beyond the header skeleton — indistinguishable,
+from a host-memory read, from the real firmware genuinely not rendering.
+**What would falsify this:** an instruction trace of the 84-word packer's
+FLEX handler (table at `0x400d61d0`, DSP.md §6) on this exact fixture,
+checking whether it reads from any of the read-back addresses (`0x80003190`
+region) `recaudio.py` does NOT inject into, or writes real segment data
+that a mis-parse (not a mis-render) is hiding. That is cheaper than the next
+option and should come first.
+
+**Recommended next step, if the trace doesn't resolve it:** repeat this
+exact check under the C++ port (`tools/ot_emu`), which runs a real DSP and
+already decoded a genuine FLEX voice's audio in the 84-word record for a
+*card-sourced* voice (O10, `COLDFIRE_PORT.md`, validated to −100.2 dB
+against the source WAV) — the same record, the same address family, a
+harness that does not have route A's "no data moves" gap. If a
+recorder-buffer-sourced FLEX voice renders there and not in route A, that
+would confirm route A is instrument-blind here (this project's own pattern:
+`[[octabam-instrument-blindness]]`), not that the firmware fails to play
+the loop.

--- a/tools/scratch/recaudio.py
+++ b/tools/scratch/recaudio.py
@@ -45,6 +45,7 @@ ap.add_argument("--out", required=True)
 ap.add_argument("--inject", default="counter", choices=("counter", "none", "burst"))
 ap.add_argument("--burst-frames", type=int, default=5200, help="burst mode: inject the ramp for this many frames from the start, then silence")
 ap.add_argument("--flex-probe", action="store_true", help="watch the FLEX voice bind 0x4000f450 / caller 0x4000d49e")
+ap.add_argument("--voice-probe", action="store_true", help="capture the track's 84-word record (DSP.md: the voice's audio, both ping sides) every frame")
 ap.add_argument("--blocks", type=int, default=40, help="pool blocks to dump from the row")
 ap.add_argument("--field-probe", action="store_true", help="log every write to the track's recorder state record (+36..+83, both banks) with its PC")
 ap.add_argument("--reg-probe", action="store_true", help="log the mix loops' source pointers and gains at loop entry (frames 323..326)")
@@ -135,14 +136,64 @@ def on_transfer(ch, paced, f):
 rt.edma.on_transfer = on_transfer
 
 # -- per-frame recorder record fields, both banks, the track ------------------
+# ch1 (SPAN_TAG[1]) completes TWICE per rt.frame_count tick (once per ping/core
+# side) -- found 9 Sep 2026 chasing a voice-probe dump that silently stopped at
+# frame 5107 of a 10150-frame run: the a.frames+64 cap was counting CALLS, so it
+# exhausted at half the real frame count. Dedupe by frame_count so the cap is on
+# frames reached, not on_frame_edge invocations.
 rec_fields = []
 def on_frame_edge():
+    if rec_fields and rec_fields[-1][0] == rt.frame_count: return
     if len(rec_fields) >= a.frames + 64: return
     rows = []
     for bank in (0, 1):
         b = REC_STATE + bank * 672 + a.track * 84
         rows.append(bytes(uc.mem_read(b, 84)))
     rec_fields.append((rt.frame_count, rt.sample, rows[0], rows[1]))
+    if a.voice_probe and len(voice_rec) < a.frames + 64:
+        track = a.track + 1
+        core = 0 if track >= 5 else 1
+        base0, base1 = TRACKREC[core]
+        # capture the WHOLE 4-track (1344-byte) block on both ping sides --
+        # not just the assumed pos=(track-1)%4 slot -- the pos->track mapping
+        # is unverified here (this project's r7/track-core mappings have been
+        # backwards before) and is worth checking directly rather than assumed.
+        recs = tuple(bytes(uc.mem_read(base, 84 * 4 * 4)) for base in (base0, base1))
+        voice_rec.append((rt.frame_count, rt.sample) + recs)
+
+# -- the track's 84-word record (DSP.md: "four 84-word per-track records",
+# 0x150 bytes each, ping/pong): the voice's OWN audio -- what O10 (under the
+# port) found the FLEX-render's output actually travels in, as opposed to
+# audio_out (the recorder INPUT block). Read directly from ColdFire host
+# memory: each of the 84 words is a 24-bit value left-justified in a 4-byte
+# big-endian long (top 3 bytes; DSP.md 6/O10's wire-halfword-pair decode of
+# the same bytes gives the identical value, verified by construction).
+TRACKREC = {1: (0x80001c90, 0x80002710), 0: (0x800021d0, 0x80002c50)}
+voice_rec = []          # (frame, sample, ping0_bytes[336], ping1_bytes[336])
+
+def voice_words(raw336):
+    out = []
+    for i in range(0, len(raw336), 4):
+        v = int.from_bytes(raw336[i:i + 3], "big")
+        out.append(v - (1 << 24) if v >= 1 << 23 else v)
+    return out
+
+def voice_segments(rec84):
+    """16 (L,R) pairs from the segmented record (O10: 4-word header (count,0,
+    0x40000,tag) + count pairs; a THRU voice ships two empty headers then the
+    16 pairs, a FLEX voice splits them across several headers)."""
+    pairs = []; i = 0
+    while len(pairs) < 16 and i + 4 <= len(rec84):
+        if rec84[i + 1] == 0 and rec84[i + 2] == 0x40000 and 0 <= rec84[i] <= 16:
+            cnt = rec84[i]; i += 4
+            if cnt:
+                pairs += [(rec84[i + 2 * k], rec84[i + 2 * k + 1]) for k in range(cnt)]
+                i += 2 * cnt
+            continue
+        take = 16 - len(pairs)
+        pairs += [(rec84[i + 2 * k], rec84[i + 2 * k + 1]) for k in range(take)]
+        i += 2 * take
+    return pairs[:16]
 
 # -- inbound (DSP -> host): fill the read-back at the paced chain's completion --
 inj = {"seq": 0, "log": []}
@@ -302,6 +353,30 @@ print(f"trig words: {rt.trig_words_log[:16]}")
 if getattr(a,"flex_probe",False):
     print(f"FLEX bind events: {len(flex_ev)}")
     for e in flex_ev[:30]: print("  ", e[0], "frame", e[1], "regs D0-2,A0-2", e[2], "stack", e[3])
+if a.voice_probe:
+    print(f"voice_rec: {len(voice_rec)} frames captured (track {a.track+1}, ping bases {TRACKREC[0 if a.track+1>=5 else 1]})")
+    # find every play trig (armpost/endpost aren't it -- trig_words_log carries the raw pattern trigs)
+    # and print the record around the frames near each of the arm/end events, both ping sides
+    of_interest = set()
+    for e in ev:                                    # armcall/armpost/endpost
+        for d in range(-1, 4): of_interest.add(e["frame"] + d)
+    for lbl, fr, regs, stk in flex_ev:               # the play-trig FLEX bind (10.33)
+        for d in range(-1, 4): of_interest.add(fr + d)
+    if not of_interest:                              # nothing hooked -- dump the tail
+        of_interest = {fr for fr, *_ in voice_rec[-8:]}
+    of_interest |= {fr for fr, *_ in voice_rec if fr % 20 == 0}   # a periodic sample too
+    for fr, sm, p0, p1 in voice_rec:
+        if fr not in of_interest:
+            continue
+        for tag, raw in (("ping0", p0), ("ping1", p1)):
+            for pos in range(4):
+                slot = raw[pos * 84 * 4: (pos + 1) * 84 * 4]
+                words84 = voice_words(slot)
+                nz = sum(1 for w in words84 if w)
+                if nz <= 4:      # skeleton-only (skip the near-static header noise)
+                    continue
+                segs = voice_segments(words84)
+                print(f"  frame {fr} {tag} pos{pos}: nonzero {nz}/84  segs(L)={[l for l,r in segs]}")
 
 import pickle
 with open(a.out, "wb") as fh:
@@ -310,5 +385,6 @@ with open(a.out, "wb") as fh:
         events=ev, out_log=out_log, inj_log=inj["log"], trig_words=rt.trig_words_log[:200],
         audio_out=[(f, s, g, sa, d) for f, s, g, sa, d in audio_out],
         rec_fields=[(f, s, r0, r1) for f, s, r0, r1 in rec_fields],
-        pool_row=list(row), pool_blocks=blocks, pool_first=pool_w['first'], pool_per_frame=pool_w['per_frame'], rec_setup=rec_setup, snaps=snaps), fh)
-print(f"saved {a.out}: {len(audio_out)} audio blocks, {len(blocks)} pool blocks, {len(ev)} events")
+        pool_row=list(row), pool_blocks=blocks, pool_first=pool_w['first'], pool_per_frame=pool_w['per_frame'], rec_setup=rec_setup, snaps=snaps,
+        voice_rec=voice_rec, flex_ev=flex_ev if getattr(a, "flex_probe", False) else None), fh)
+print(f"saved {a.out}: {len(audio_out)} audio blocks, {len(blocks)} pool blocks, {len(ev)} events, {len(voice_rec)} voice_rec frames")


### PR DESCRIPTION
## Summary
- Adds `--voice-probe` to `tools/scratch/recaudio.py`, reading the track's 84-word per-track record directly from ColdFire host memory (§10.33's next step: does the FLEX voice actually render R1's playback content by pass 2?).
- Addressing/byte-layout confirmed two ways (actual TCD saddr/nbytes/biter fields match DSP.md's documented layout exactly; the decode reproduces the documented `0x40000` header magic) — but the record itself stays a static empty-voice skeleton at all four track slots, both ping sides, through pass 1 and pass 2. No dynamic audio content ever appears.
- Likely explanation, inferred not measured: `emu_rtos.py`'s `Edma` class moves no data at all ("audio is out of route A's scope" per its own docstring) — if the FLEX packer's handler reads any DSP-fed state before writing its segments, that input is stuck at zero under route A regardless of what the real firmware does.
- Also fixes a real bug found along the way: `on_frame_edge` fires twice per `frame_count` (once per ping side), so the existing frame cap was counting calls not frames — a 10,150-frame run's capture silently died at frame 5,107. Deduped by frame_count.
- Full writeup in `docs/RTOS_FORK.md` §10.34, including the recommended next steps (an instruction trace of the FLEX packer handler, then the C++ port which already decoded a card-sourced FLEX voice in O10).

## Test plan
- [x] `python3 -m py_compile tools/scratch/recaudio.py`
- [x] Ran `--voice-probe` (with and without `--flex-probe`) on the `g65` golden self-loop fixture through frame 10150, spanning the pass-2 play trig at frame 10081
- [x] Cross-checked the frame-cap fix by confirming `voice_rec` now covers the full requested frame range (10,150 distinct frames, not 5,107)

This is investigative/diagnostic tooling + a documentation entry, not a firmware or build change — no `make check`/`refhash` implications.