### PR TITLE
RTOS_FORK 10.39: Bryan's click confirmed on hardware in the audio domain, with exact timing

### DIFF
--- a/docs/RTOS_FORK.md
+++ b/docs/RTOS_FORK.md
@@ -3417,3 +3417,54 @@ alternative explanation that mattered. Sam's ear caught what no check in
 §10.36/§10.37 was built to catch. **A positive result needs the same
 skepticism as a null one, especially when it's the answer you were hoping
 for.**
+
+### 10.39 The click, on hardware, in the audio domain: clean at golden, a real burst at every non-golden wrap, exactly 1.875 s apart (9 Sep 2026)
+
+§10.38 left the play side genuinely open and asked for a hardware
+recording with documented conditions — the existing `out/hw/flash7/loop_*`
+captures had no test-condition metadata to trust. Sam ran it live: unit on
+internal clock, self-loop armed (REC+PLAY on the same track, RLEN 16, same
+geometry as `g65`/`n128`), tempo switched by hand on the device between
+takes; `tools/tone` fed a continuous 1 kHz sine into inputs A/B through the
+MicroBook while `tools/rec` captured 60 s at a time (both already compiled
+from earlier sessions — no new tooling needed).
+
+**128 BPM (non-golden), 57 s analysed (t=3–60 s, skipping the tone's own
+ramp-in):** the same sample-to-sample jump metric used on the emulator
+renders finds **115 outlier samples, clustered into distinct bursts of
+several large jumps within a few samples of each other** (a real short
+transient, not one glitched sample) — **recurring at 4.180 s, 6.055 s,
+7.930 s, 9.805 s, 11.681 s, 13.556 s, 15.431 s, 17.306 s, … every 1.875 s**,
+which is 82,687.5 samples at 44.1 kHz — **exactly** the ideal non-golden
+pass length at 128 BPM / RLEN 16 that route A (§10.32) and this session's
+port work both derived. One cluster at every single pass boundary, not
+every other. A 0.6 s clip cut around the burst at 6.055 s
+(`out/hw_click_clip.wav`) — Sam confirmed by ear: **"yes"**, this is the
+click.
+
+**65.6 BPM (golden), same method, same 57 s window (~15+ passes):** **zero**
+outliers. Confirmed by ear as clean too.
+
+**What this is:** the first time in this project that Bryan's click has
+been captured, in the audio domain, on hardware, with fully documented
+test conditions, AND with its recurrence period matching a specific
+arithmetic prediction to the millisecond — not inferred from recorded
+sample positions (§10.16–10.32) and not a description relayed secondhand
+(§10.18, §10.29–10.31). Golden-clean / non-golden-clicks is no longer
+resting on any one leg (route A's arithmetic, one earlier ear test under
+confounds, or this) — it now has three independent legs, and this is the
+cleanest of them.
+
+**What doesn't yet match the emulator.** §10.38's isolated fixture (T2
+plays R1, never armed — the fixture built to rule out the monitor-passthrough
+confound) found its own periodic anomaly on `n128_iso`, but at HALF this
+rate — every OTHER wrap (165,375 samples), not every wrap — and Sam's ear
+called its character "a second tone comes in", not a click, and flagged it
+as "not even close" to the real hardware sound. Two mismatches to close,
+not one: the PERIOD (every wrap vs every other) and the CHARACTER (a burst
+transient vs a sustained second tone). Next: reproduce this exact hardware
+result — clean golden, a burst at every non-golden wrap — in the emulator,
+using this recording as the ground truth to match against rather than
+`o10_recloop.py`'s per-pass jump metric alone (which is tuned for a smooth
+sine and may itself be why the emulator's every-wrap bursts, if present,
+weren't being counted the same way hardware's are).

--- a/tools/scratch/make_isolated_flex_fixtures.py
+++ b/tools/scratch/make_isolated_flex_fixtures.py
@@ -1,0 +1,52 @@
+"""Build isolated FLEX-playback fixtures: T1 records (armed, RLEN 16, single
+REC1 trig at step 1), T2 plays R1 back and is NEVER armed -- so T2's own
+rendered output cannot contain a live input-monitor passthrough by
+construction (RTOS_FORK 10.38's own retraction: every self-loop fixture used
+since 10.16 has the record and play roles on the SAME armed track, which is
+exactly where a monitor and real buffer playback are indistinguishable).
+
+Same geometry as g65/n128 (RLEN 16, single REC1+play trig at step 1, 1X 16
+steps) but split across two tracks, at both the golden and non-golden tempo.
+
+    .venv/bin/python tools/scratch/make_isolated_flex_fixtures.py out/_iso
+"""
+import argparse, pathlib, shutil, sys
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import ot_project as o
+
+SRC = pathlib.Path.home() / "octa/backups/RECTRIG_20260906_step9"
+FIX = {"g65_iso": "65.6", "n128_iso": "128.0"}
+
+def build(root):
+    root = pathlib.Path(root); root.mkdir(parents=True, exist_ok=True)
+    for name, bpm in FIX.items():
+        d = root / name
+        if d.exists(): shutil.rmtree(d)
+        shutil.copytree(SRC, d, ignore=shutil.ignore_patterns("._*"))
+
+        def clear_t1_t2(data):
+            for track in (0, 1):
+                for mask in (0x00, 0x20, 0x28, 0x30):
+                    base = o.trac_off(0, track) + mask
+                    for k in range(8):
+                        data[base + k] = 0
+        o._bank_write(d, 1, clear_t1_t2, guard=False)
+
+        o.set_machine_type(d, 1, 1, 1, 1, guard=False)      # T1 FLEX
+        o.set_track_slot(d, 1, 1, 1, 129, "flex")           # T1 on R1 (its own recorder buffer)
+        o.set_machine_type(d, 1, 1, 2, 1, guard=False)      # T2 FLEX
+        o.set_track_slot(d, 1, 1, 2, 129, "flex")           # T2 ALSO on R1 -- plays T1's buffer, never armed
+
+        o.set_pattern_trig(d, 1, 0, 0, 1, 0x20, guard=False)   # T1 step1: REC1 (INAB) -- the only trig T1 gets
+        o.set_pattern_trig(d, 1, 0, 1, 1, 0x00, guard=False)   # T2 step1: PLAY -- the only trig T2 gets
+
+        o.set_pattern_scale(d, 1, 0, 16, "1X", guard=False)
+        o.set_recorder_setup(d, 1, 1, 0, "RLEN", 15, guard=False)   # RLEN 15 = display 16, matches g65/n128
+        o.set_tempo(d, bpm)
+        print(f"== {d}  (T1 records+arms, T2 plays R1, never armed, {bpm} BPM)")
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("root", nargs="?", default="out/_iso")
+    a = ap.parse_args()
+    build(a.root)


### PR DESCRIPTION
## Summary
Sam ran a live hardware capture with fully documented test conditions (unit on internal clock, self-loop armed, RLEN 16, tempo switched by hand between takes) — a continuous 1 kHz tone into inputs A/B via `tools/tone` through the MicroBook, captured with `tools/rec` (both already compiled from earlier sessions).

- **128 BPM (non-golden), 57s analysed:** 115 outlier samples in the sample-to-sample jump metric, clustering into real burst transients that recur at **exactly 1.875s intervals** (82,687.5 samples) — the ideal non-golden pass length at RLEN 16 that route A (§10.32) and this session's port work both independently derived. One burst at every single pass boundary. A 0.6s clip cut around one burst — confirmed by ear.
- **65.6 BPM (golden), identical method, same window (~15+ passes):** zero outliers. Confirmed clean by ear too.

This is the first time the click has been captured in the audio domain, on hardware, with documented conditions and millisecond-precision timing confirmation — a third independent leg for golden-clean/non-golden-clicks (after route A's arithmetic and one earlier confounded ear test), and much the cleanest of the three.

`docs/RTOS_FORK.md` §10.39 has the full writeup, including two open mismatches against the emulator's own isolated-fixture finding (§10.38) that still need closing: the emulator showed the anomaly at half the rate (every other wrap, not every wrap) with a different character (a sustained second tone, not a burst transient).

Also adds `tools/scratch/make_isolated_flex_fixtures.py`, used to build the T2-plays-R1-never-armed fixtures referenced in §10.38/§10.39 (T2 is never armed, so it structurally cannot produce a monitor-passthrough artifact).

## Test plan
- N/A — hardware capture + analysis, documented in the doc; recordings live under `out/hw_capture_*.wav` (gitignored).