### PR TITLE
Every community mod in one image: the scenes-kits bridge, schema.Override, the combo remixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,6 +419,17 @@ all oracle failures.
 hash.** Register discipline in a boot stub is not checkable by anything but
 the port: `verify_dram_boot` watches the loader's entry and its `fatal` hang.
 
+**TWO BUILDS ON ONE MACHINE CORRUPTED EACH OTHER THROUGH FIXED `/tmp`
+NAMES (10 Sep 2026).** `build_bus.assemble()` wrote `/tmp/build_bus_src.asm`,
+`.bin` and `.sym` by fixed name, so two sessions' `make check` — or the
+selftest's per-remix builds beside anyone else's build — read each other's
+assembler output: "STREAMZ overruns the region (2883 > 2724 words)",
+"selprobe dsp_asm exit 1", a different remix each time, on a clean checkout
+too. Found by a peer session. Scratch is `tempfile.mkdtemp` per process now
+(`verify_hello` likewise). A failure that moves between remixes across runs
+is a shared-scratch race before it is anything else; and a `make check`
+result taken while another build was running is not a result.
+
 **The report is API, and it prints paths.** Moving a tool changed the build
 report (the hints name `tools/harness/send_probe.py`), which refhash
 correctly flagged with every artifact identical. Re-save only after proving

--- a/PLAN.md
+++ b/PLAN.md
@@ -107,12 +107,17 @@ port on 9 Sep 2026 unless marked.
    he can compare against his own build on his own unit), then `octakit`
    (her runtime through our loader; she has the project-migration test
    set). Bump `BUILD`, stamp projects, `docs/remixer/FLASHING.md`.
-2. **Detour chaining** for the two stock routines three authors hook:
-   `apply_part` entry `0x40009094` (midi-scenes, octakit, octamax) and the
-   scene-parameter writer `0x40052ae8` (octakit, octamax). Until then
-   Octakit and midi-scenes are mutually exclusive — and note the second
-   reason: Parts versus Kits. His code addresses the Part window; hers
-   replaces it. A Kits-aware midi-scenes is his and Sam's to write.
+2. **Shared sites — BRIDGED (10 Sep 2026), unflashed.** `modules/scenes-kits`
+   chains MIDI SCENES and Octakit at `apply_part` (`0x40009094`) and CC→page
+   2 in front of her MIDI CC dispatch (`0x400d64a0`), through
+   `schema.Override`; the `mods` / `rig-mods` / `mutables-mods` remixes
+   carry everything. Measured under the port: every `apply_part` in a
+   project load runs the whole chain, nobody's fatal. His hooks keep their
+   meaning under Kits because her active path applies the stock Part
+   window (she wraps stock's body, she does not replace it). **Open:** his
+   Part save/reload menu hooks against her LOAD/SAVE KIT menus — the
+   Kits-aware half that is his and hers; the scene-parameter writer
+   `0x40052ae8` (octakit, octamax) when octamax returns.
 3. **octabam's DRAM home is the arena reserve — DONE locally (10 Sep
    2026), unflashed.** The top window had a measured neighbour (the
    engine task's sector bounce buffer lands there at project load, inside

--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ the local ColdFire emulator. `docs/remixer/REMIXER.md` is its manual.
 
 | remix | contains | why |
 |---|---|---|
-| **`ported`** | MIDI SCENES + LOFI AMF FIX | every community mod known to coexist, together — the pick-and-choose proof |
+| **`mods`** | **every community firmware mod in one image**: MIDI SCENES + Octakit + the LO-FI AMF fix + CC→page 2, bridged by `scenes-kits` | the "all the mods" image; no effects of ours |
+| **`rig-mods`** / **`mutables-mods`** | the rig, or the insert card, plus every mod | effects plus the mods (the rig omits the LO-FI fix: its CHARACTER station replaces LO-FI) |
+| **`scenes`** / **`kits`** | one family of mods, no effects: MIDI SCENES + LO-FI fix + CC→page 2, or Octakit + LO-FI fix | for someone who wants scenes but not Kits, or Kits but not scenes |
+| **`rig-scenes`** / **`rig-kits`**, **`mutables-scenes`** / **`mutables-kits`** | the rig or the insert card with one family | same, with effects |
+| **`ported`** | MIDI SCENES + LOFI AMF FIX | the pick-and-choose proof: two authors' ports in one image |
 | **`octakit`** / **`octakit-fix`** | Em's Octakit, alone / with the LO-FI fix | her mod through this pipeline; must reproduce her identities |
 | **`midi-scenes`** | MIDI SCENES alone | his mod through this pipeline |
 | **`bamsep26`** (default) | the bus rig: both engines, send, stations, tempo sync, menu shortcut | what goes on Sam's unit |
@@ -72,11 +76,13 @@ the local ColdFire emulator. `docs/remixer/REMIXER.md` is its manual.
 | **`mutables`** | five inserts | a card of stacking effects, no servers |
 | **`hello`** / **`hello-dram`** | one module each | the reference minimal builds |
 
-⚠️ **OCTAKIT and MIDI SCENES cannot share an image yet** — both hook the
-same stock routine (`apply_part`, `0x40009094`), and beyond the hook his
-code addresses the Part window that hers replaces. The build refuses the
-pair by name; detour chaining and a Kits-aware scenes port are the two
-halves of the fix (`PLAN.md`).
+**OCTAKIT and MIDI SCENES share an image through a bridge.** Both hook the
+same stock routine (`apply_part`, `0x40009094`) and both want the MIDI CC
+dispatch; `modules/scenes-kits` chains them — his pre-work, then her
+engine load; our CC cave, then her handler, then stock — and the build
+refuses the pair *without* it. What the bridge does not settle is his Part
+save/reload menu hooks against her Kit menus: unmeasured, and the next
+thing to look at with both authors (`modules/scenes-kits/README.md`).
 
 ## How it works, in one screen
 

--- a/docs/remixer/PLACEMENT.md
+++ b/docs/remixer/PLACEMENT.md
@@ -273,6 +273,27 @@ and that every window reads back equal to its linked image — except the
 bytes a runtime writes about itself once its hooks run, which are counted
 and printed.
 
+## Shared sites: the bridge (10 Sep 2026)
+
+Two stock sites are claimed by more than one mod, and until today the
+ledger's only answer was to refuse the pair. `modules/scenes-kits` is the
+first **bridge**: a stub that does what both hooks did, in an order that
+respects each one's protocol, declared through `schema.Override` so the
+build skips the overridden detour or recipe write and hands the stub the
+skipped claim's target as a link-time symbol (`CHAIN_APPLY_NEXT`,
+`CC_NEXT`). Sites, protocols and the guard her boot-time path forces are
+in `modules/scenes-kits/README.md`.
+
+✅ **Measured under the port** (`mods` image — MIDI SCENES + Octakit + the
+LO-FI fix + CC→page 2 — on the static-sample card, boot → LOAD PROJECT →
+400 frames): six `apply_part` calls, and every one went site → bridge stub
+→ her entry → her trampoline (stock's body); her fatal 0×, the loader's
+fatal 0×; once her lifecycle was active his `pack` ran (2×, one from his
+`bank_sw` path) and his `after` 1×; her window and ours read back as
+their own state words only. Not measured: MIDI CCs through the chained
+dispatch (the port has no MIDI in), his Part save/reload menu hooks
+against her Kit menus, hardware.
+
 ## What is still open
 
 - **More than 10 MB** is the same mechanism with a bigger

--- a/modules/ccpage2/cc_page2.s
+++ b/modules/ccpage2/cc_page2.s
@@ -26,7 +26,10 @@
 | slot2 order) patched by the build; a select's over-count value would be the
 | stored index that stalls the sequencer, so the clamp is mandatory.
 
-        .set    STOCK,    0x4000e79c   | stock CC handler (tail-called)
+| CC_NEXT is where anything but 62-67 goes: the stock CC handler
+| (0x4000e79c), or -- when Octakit is in the image and the scenes-kits
+| bridge chains this cave in front of her CC dispatch -- her handler. The
+| build defines it (CavePatch.defsyms; schema.Override); it is not set here.
         .set    P1WRITE,  0x40054cd8   | stock page-1 writer (canary, CC 67 only)
         .set    MAPBUILD, 0x40001854   | fills the channel->track map
         .set    MAPGLOB,  0x46104cf4   | long stock loads to d3 before MAPBUILD
@@ -67,7 +70,7 @@ CAVE:   movel   %sp@(4),%a0            | a0 = msg {status, cc, value}
         cmpl    %d0,%d1                | 5 - (cc-62); carry if 5 < (cc-62)
         bcs.s   tostk                  | not 62..67 (also catches cc < 62)
         bra.s   mine
-tostk:  jmp     STOCK                  | tail-call stock, argument intact
+tostk:  jmp     (CC_NEXT).l            | tail-call the next handler, argument intact
 
 mine:   lea     %sp@(-28),%sp
         movem.l %d2-%d7/%a2,%sp@

--- a/modules/ccpage2/manifest.py
+++ b/modules/ccpage2/manifest.py
@@ -107,6 +107,11 @@ MODULE = Module(
         reference=legacy_bytes,         # the build holds the linked source
                                         # against the hand-patched form, at
                                         # whatever address it floats to
+        # Where CCs other than 62-67 go. Stock's handler -- unless a bridge
+        # (modules/scenes-kits) overrides it to Octakit's, in which case the
+        # build defines CC_NEXT as hers and skips the oracle above (the
+        # bytes then legitimately differ by that one address).
+        defsyms=(("CC_NEXT", STOCK_CC),),
         emit=emit,
         report_note=" (CC 62-67 reach FX2 page 2)",
     ),),

--- a/modules/scenes-kits/README.md
+++ b/modules/scenes-kits/README.md
@@ -1,0 +1,72 @@
+# Scenes + Kits: the bridge
+
+The module that lets MIDI SCENES (bkkbrls-del), Octakit (Em) and CC→page 2
+share one image. `Kind.CF_PATCH`: one DRAM unit (`chains.s`), one detour,
+three `Override`s. Nothing of its own to use; it exists so the other three
+compose.
+
+## The two shared sites
+
+**`apply_part` entry, `0x40009094`.** His `apply` wrapper and her
+`engine-part-load` write both rewrite the same eight bytes. His did: save
+the caller's return address into `apply_ret`, return through `after`
+(which unpacks the new part's scene locks), `jsr pack` (which packs the
+outgoing part's), replay the displaced prologue, jump into the routine.
+Hers: `jmp gk_stock_engine_part_load_and_publish`, whose active path
+replays the same prologue, runs the **stock body** through her trampoline,
+and publishes the Kit bookkeeping around it. So the bridge stub is his
+pre-work followed by a jump into her entry — never a second replay:
+
+```
+chain_apply_part:
+        tst.l   (__gk_lifecycle_state).l      | 0 = active
+        bne.s   1f
+        move.l  (%sp),(apply_ret).l
+        move.l  #after,(%sp)
+        jsr     (pack).l
+1:      jmp     (CHAIN_APPLY_NEXT).l          | her entry
+```
+
+The guard is hers to respect: while her lifecycle state is not active
+(boot-time part loads) she chooses her path by comparing the **stock
+caller's** return address on the stack against known sites, and anything
+else is her fatal. So the swap only happens once she is active; before
+that the site is hers alone, and his boot-time unpack of the first part's
+locks is skipped (the next apply does it).
+
+Why his hooks still mean something under Kits: her active path applies
+the stock Part window (his `pack`/`unpack` address it through
+`0x46c82456`). She wraps it; she does not replace it.
+
+**The MIDI CC dispatch entry, `0x400d64a0`.** Her recipe installs
+`gk_stock_midi_control_parameter`; CC→page 2 repoints the entry to its
+cave. The cave keeps the entry; its fall-through symbol `CC_NEXT` becomes
+her handler (the build defines it from her skipped write), and hers falls
+through to stock's as before. Order: CCs 62–67 ours, then hers, then
+stock's.
+
+## How the build does it — `schema.Override`
+
+An Override says "my claim at this site stands in for that module's": the
+build skips the overridden detour or recipe write, and when the override
+names a `defsym`, defines it as the target the skipped write carried (a
+`jmp abs.l`'s address or a 4-byte pointer) for every unit and cave it
+links. The ledger owns the site to the bridge and still refuses MIDI
+SCENES + OCTAKIT in a remix that does not carry it. The `octakit` remix
+alone is unchanged: overrides only apply when the bridge is selected.
+
+## Measured vs inferred
+
+- ✅ The `mods`, `rig-mods` and `mutables-mods` remixes build; `make check`
+  green; the octakit-alone identities untouched.
+- ✅ Under the ColdFire port with a project of static samples (boot → LOAD
+  PROJECT → play): the numbers are in `docs/remixer/PLACEMENT.md`; the
+  claim is that every `apply_part` during the load goes stub → her entry,
+  her fatal never runs, and in the active state his `after` runs once per
+  apply.
+- 🟡 **Not measured**: hardware; MIDI CCs through the chained dispatch
+  (the port has no MIDI input); his Part *save/reload* menu hooks
+  (`0x4002dd12`, `0x4002dd56`, `0x4005e05a`) against her LOAD/SAVE KIT
+  menus — they detour stock menu actions her UI may not route through.
+  That is the Kits-aware work that remains his and hers; this bridge makes
+  the image buildable and the apply path coherent.

--- a/modules/scenes-kits/chains.s
+++ b/modules/scenes-kits/chains.s
@@ -1,0 +1,27 @@
+| SCENES KITS -- the bridge that lets MIDI SCENES and Octakit share the
+| one stock instruction they both hook: the entry of apply_part
+| (0x40009094). Linked into the platform runtime beside his units, so
+| his symbols resolve directly; hers arrive as link-time values.
+|
+| His wrapper (midisc code2.s `apply`) did: save the caller's return
+| address into apply_ret, put `after` on the stack in its place, jsr pack,
+| replay the two displaced prologue instructions, jmp 0x4000909c. Her
+| entry (gk_stock_engine_part_load_and_publish) replays that prologue
+| itself, runs stock's body through her trampoline and publishes -- so the
+| chain is his pre-work, then a jump into her entry, never a second replay.
+|
+| One rule of hers to respect: while her lifecycle state is not "active"
+| (boot-time part loads) she decides her path by comparing the STOCK
+| caller's return address on the stack against known sites, and anything
+| else is her fatal. So the return-address swap only happens once she is
+| active; before that the site is hers alone, and his boot-time unpack of
+| the first part's locks is skipped (the next apply does it).
+        .text
+        .global chain_apply_part
+chain_apply_part:
+        tst.l   (__gk_lifecycle_state).l      | 0 = active
+        bne.s   1f
+        move.l  (%sp),(apply_ret).l           | his: keep the caller for `after`
+        move.l  #after,(%sp)                  | ... and return through `after` (unpack)
+        jsr     (pack).l                      | his: pack the outgoing part's locks
+1:      jmp     (CHAIN_APPLY_NEXT).l          | hers: prologue, stock body, publish, rts

--- a/modules/scenes-kits/manifest.py
+++ b/modules/scenes-kits/manifest.py
@@ -1,0 +1,58 @@
+"""SCENES KITS -- the bridge: MIDI SCENES, Octakit and CC PAGE 2 in one image.
+
+Three mods, two shared sites, and until 10 Sep 2026 the ledger refused
+every pair (Sam: "rather than make them exclusive can we be brutal and
+make them all work?"). This module carries the stubs that let them share:
+
+  * apply_part entry (0x40009094): his wrapper and her engine-load both
+    rewrite it. `chains.s` does his pre-work (save the caller into
+    apply_ret, return through `after`, `jsr pack`) and jumps into her
+    entry, which replays the displaced prologue and runs stock's body
+    through her trampoline. His hooks keep their meaning under Kits
+    because her active path still applies the STOCK Part window (the
+    structure his pack/unpack address through 0x46c82456); she wraps it,
+    she does not replace it. While her lifecycle state is not active (boot)
+    the site is hers alone -- she inspects the stock caller's return
+    address there, and his swap would trip her fatal.
+  * the MIDI CC dispatch entry (0x400d64a0): her recipe installs her
+    handler, CC PAGE 2 repoints it to its cave. The cave keeps the entry;
+    its fall-through (CC_NEXT) becomes her handler instead of stock's, and
+    hers falls through to stock as before. CCs 62-67 are ours, then hers,
+    then stock's.
+
+Both are declared as Overrides (schema.Override): the build skips his
+detour and her two recipe writes at those sites, writes the bridge's own
+detour at apply_part, and defines CHAIN_APPLY_NEXT / CC_NEXT as the targets
+her writes carried. The ledger owns the sites to this module; a remix
+carrying both MIDI SCENES and OCTAKIT without it is still refused.
+
+MEASURED (port): see docs/remixer/PLACEMENT.md and this README. NOT
+measured: hardware. Kits semantics beyond the apply path -- his Part
+save/reload menu hooks against her LOAD/SAVE KIT menus -- are the open
+question this bridge does not answer; it makes the image buildable and
+the apply path coherent, no more.
+"""
+
+from remix.schema import Detour, Kind, Linked, Module, Override
+
+H = bytes.fromhex
+
+MODULE = Module(
+    name="scenes-kits",
+    key="SCENES KITS",
+    kind=Kind.CF_PATCH,
+    doc="The bridge that lets MIDI SCENES, Octakit and CC PAGE 2 share one "
+        "image (apply_part and the CC dispatch chained).",
+    linked=(Linked("chains", "modules/scenes-kits/chains.s", dram=True),),
+    detours=(
+        Detour(0x40009094, H("4fefff9848d77cfc"), "chains", "chain_apply_part",
+               "apply_part: his pack + after, then her engine load", pad_to=8),
+    ),
+    overrides=(
+        Override(0x40009094, "MIDI SCENES"),
+        Override(0x40009094, "OCTAKIT", write="engine-part-load",
+                 defsym="CHAIN_APPLY_NEXT"),
+        Override(0x400D64A0, "OCTAKIT",
+                 write="midi-control-parameter-000-at-400d64a0", defsym="CC_NEXT"),
+    ),
+)

--- a/remixes/kits.py
+++ b/remixes/kits.py
@@ -1,0 +1,24 @@
+"""KITS -- every firmware mod that composes with Octakit, no effects.
+
+The "just the mods" image of the Octakit family: 256 Kits per Project
+(Em) and the LO-FI AMF fix (Bryan T). Two mods cannot join: MIDI SCENES
+hooks the same stock routine and addresses the Part window Octakit
+replaces (its family is `scenes`), and CC PAGE 2 repoints the MIDI
+control-parameter dispatch entry at 0x400d64a0 that her recipe rewrites
+(seven `midi-control-parameter` writes -- her own CC handling). CC to
+page 2 under Octakit would have to live inside her runtime; the ledger
+refuses the pair until then. Nothing of octabam's DSP is placed.
+⚠️ Octakit migrates a project's Parts into Kits on load; back up projects
+first, and know that going back to stock may lose Kit data (her warning).
+Unflashed.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="kits",
+    doc="All the firmware mods of the Octakit family, no effects: 256 Kits "
+        "and the LO-FI AMF fix.",
+    modules=("OCTAKIT", "LOFI AMF FIX"),
+    fallback="NONE",
+)

--- a/remixes/mods.py
+++ b/remixes/mods.py
@@ -1,0 +1,21 @@
+"""MODS -- every community firmware mod in one image, no effects.
+
+MIDI SCENES (bkkbrls-del), Octakit (Em), the LO-FI AMF fix (Bryan T) and
+CC to page 2 (octabam), bridged by SCENES KITS so the two shared stock
+sites carry all of them: apply_part runs his pack/after around her
+engine load, and the CC dispatch runs our cave, then hers, then stock's.
+Nothing of octabam's DSP is placed. ⚠️ Octakit migrates Parts into Kits
+on load: back up projects first. ⚠️ The apply path is measured under the
+port; his Part save/reload menu hooks against her Kit menus are not (see
+modules/scenes-kits). Unflashed.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="mods",
+    doc="Every community firmware mod in one image: MIDI SCENES + Octakit + "
+        "the LO-FI AMF fix + CC to page 2, bridged.",
+    modules=("MIDI SCENES", "OCTAKIT", "LOFI AMF FIX", "CC PAGE 2", "SCENES KITS"),
+    fallback="NONE",
+)

--- a/remixes/mutables-kits.py
+++ b/remixes/mutables-kits.py
@@ -1,0 +1,19 @@
+"""MUTABLES-KITS -- the insert card plus the Octakit family.
+
+The five MI-flavoured inserts (WarpFold, Ripple, Rungs, Streamz, BodeShift)
+with 256 Kits per Project and the LO-FI AMF fix. No CC to page 2: it
+repoints the MIDI control-parameter dispatch entry Octakit's own recipe
+rewrites (see `kits`). No bus, so unimplemented ids fall back to the
+firmware's own NONE. ⚠️ Octakit migrates Parts into Kits on load: back up
+projects first. Unflashed.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="mutables-kits",
+    doc="Five MI inserts + Octakit + the LO-FI AMF fix.",
+    modules=("WARPFOLD", "RIPPLE", "RUNGS", "STREAMZ", "BODESHIFT",
+             "OCTAKIT", "LOFI AMF FIX"),
+    fallback="NONE",
+)

--- a/remixes/mutables-mods.py
+++ b/remixes/mutables-mods.py
@@ -1,0 +1,17 @@
+"""MUTABLES-MODS -- the insert card plus every community firmware mod.
+
+The five MI-flavoured inserts with MIDI SCENES, Octakit, the LO-FI AMF fix
+and CC to page 2, bridged by SCENES KITS. No bus, so unimplemented ids
+fall back to the firmware's own NONE. ⚠️ Octakit migrates Parts into Kits
+on load: back up projects first. Unflashed.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="mutables-mods",
+    doc="Five MI inserts + every community firmware mod, bridged.",
+    modules=("WARPFOLD", "RIPPLE", "RUNGS", "STREAMZ", "BODESHIFT",
+             "MIDI SCENES", "OCTAKIT", "LOFI AMF FIX", "CC PAGE 2", "SCENES KITS"),
+    fallback="NONE",
+)

--- a/remixes/mutables-scenes.py
+++ b/remixes/mutables-scenes.py
@@ -1,0 +1,17 @@
+"""MUTABLES-SCENES -- the insert card plus the MIDI SCENES family.
+
+The five MI-flavoured inserts (WarpFold, Ripple, Rungs, Streamz, BodeShift)
+with MIDI scene locks, the LO-FI AMF fix and CC to page 2. No bus, so
+unimplemented ids fall back to the firmware's own NONE. The inserts are
+verified by local render and never flashed; so are the mods. Unflashed.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="mutables-scenes",
+    doc="Five MI inserts + MIDI SCENES + the LO-FI AMF fix + CC to page 2.",
+    modules=("WARPFOLD", "RIPPLE", "RUNGS", "STREAMZ", "BODESHIFT",
+             "MIDI SCENES", "LOFI AMF FIX", "CC PAGE 2"),
+    fallback="NONE",
+)

--- a/remixes/rig-kits.py
+++ b/remixes/rig-kits.py
@@ -1,0 +1,24 @@
+"""RIG-KITS -- the bus rig (bamsep26) plus Octakit.
+
+The rig with Em's 256 Kits per Project instead of Parts. Not here, on
+purpose: the LO-FI AMF fix (the CHARACTER station replaces LO-FI) and CC
+to page 2 (it repoints the MIDI control-parameter dispatch entry Octakit's
+own recipe rewrites -- see `kits`). ⚠️ Two things nobody has measured:
+Octakit migrates Parts into Kits on load, and the rig's hosts are reached
+through the project's part bytes (`ot_project.py stamp-defaults`) --
+whether those survive her migration unchanged is the first thing to check
+on a unit, with a backed-up project. Unflashed.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="rig-kits",
+    doc="The rig + Octakit.",
+    modules=("REVERB SERVER", "DELAY SERVER", "SEND", "DELAY",
+             "SPECTRUM", "CHARACTER", "MODULATION",
+             "TEMPO SYNC", "MENU SHORTCUT",
+             "OCTAKIT"),
+    fallback="SEND",
+    fx1=("SPECTRUM", "CHARACTER", "MODULATION"),
+)

--- a/remixes/rig-mods.py
+++ b/remixes/rig-mods.py
@@ -1,0 +1,22 @@
+"""RIG-MODS -- the bus rig (bamsep26) plus every community firmware mod.
+
+The rig with MIDI SCENES, Octakit and CC to page 2, bridged by SCENES
+KITS. No LO-FI AMF fix: the CHARACTER station replaces LO-FI. ⚠️ Unmeasured
+on top of `mods`' caveats: the rig's hosts are reached through the
+project's part bytes (`ot_project.py stamp-defaults`); whether those
+survive Octakit's Parts->Kits migration is the first thing to check on a
+unit, with a backed-up project. Unflashed.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="rig-mods",
+    doc="The rig + MIDI SCENES + Octakit + CC to page 2, bridged.",
+    modules=("REVERB SERVER", "DELAY SERVER", "SEND", "DELAY",
+             "SPECTRUM", "CHARACTER", "MODULATION",
+             "TEMPO SYNC", "MENU SHORTCUT",
+             "MIDI SCENES", "OCTAKIT", "CC PAGE 2", "SCENES KITS"),
+    fallback="SEND",
+    fx1=("SPECTRUM", "CHARACTER", "MODULATION"),
+)

--- a/remixes/rig-scenes.py
+++ b/remixes/rig-scenes.py
@@ -1,0 +1,22 @@
+"""RIG-SCENES -- the bus rig (bamsep26) plus MIDI SCENES and CC to page 2.
+
+Everything the rig is -- BusVerb + BusDelay on the one aux bus, the three
+stations, the stock delay, tempo sync, the menu shortcut -- with
+bkkbrls-del's MIDI scene locks and octabam's CC->page 2 on top. The LO-FI
+AMF fix is NOT here on purpose: the CHARACTER station replaces LO-FI, so
+its code is harvested and there is nothing to fix. Unflashed; the rig
+itself is on the unit (flash 7), the scenes are not.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="rig-scenes",
+    doc="The rig + MIDI SCENES + CC to page 2.",
+    modules=("REVERB SERVER", "DELAY SERVER", "SEND", "DELAY",
+             "SPECTRUM", "CHARACTER", "MODULATION",
+             "TEMPO SYNC", "MENU SHORTCUT",
+             "MIDI SCENES", "CC PAGE 2"),
+    fallback="SEND",
+    fx1=("SPECTRUM", "CHARACTER", "MODULATION"),
+)

--- a/remixes/scenes.py
+++ b/remixes/scenes.py
@@ -1,0 +1,20 @@
+"""SCENES -- every firmware mod that composes with MIDI SCENES, no effects.
+
+The "just the mods" image for someone who wants the unit's own effects and
+the community's firmware changes: MIDI-driven scene locks (bkkbrls-del),
+the LO-FI AMF fix (Bryan T) and MIDI CC reaching page-2 knobs (octabam).
+Octakit is the one mod that cannot join -- it hooks the same stock routine
+and replaces the Part window his code addresses -- so its family is
+`kits`. Nothing of octabam's DSP is placed: every stock effect stays, the
+chooser is stock's. Unflashed.
+"""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="scenes",
+    doc="All the firmware mods of the MIDI SCENES family, no effects: scenes "
+        "over MIDI, the LO-FI AMF fix, CC to page 2.",
+    modules=("MIDI SCENES", "LOFI AMF FIX", "CC PAGE 2"),
+    fallback="NONE",
+)

--- a/tools/build/build_bus.py
+++ b/tools/build/build_bus.py
@@ -88,7 +88,7 @@ code: payload B's placed P words carry 0x38000 five times and 0x30000 zero
 times. The old docstring here claimed "exactly one occurrence", which was
 never true for the XBUS path.
 """
-import dataclasses, hashlib, os, pathlib, re, subprocess, sys
+import dataclasses, hashlib, json, os, pathlib, re, subprocess, sys
 
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[1])); import toolpath  # noqa: E402,F401  (every tools/ dir on sys.path)
 from dsp_modmap import BASE, IMG, PAYLOADS, modules  # noqa: E402
@@ -838,18 +838,30 @@ def _dev_hooks(key, src):
     return src
 
 
+# ⚠️ PER-PROCESS SCRATCH. Until 10 Sep 2026 this wrote /tmp/build_bus_src.asm,
+# .bin and .sym by fixed name, so two builds on one machine -- two sessions'
+# `make check`, or the selftest's per-remix builds beside another -- read
+# each other's output: one side saw "seamtest overrun 2783 > 2724", the other
+# "selprobe dsp_asm exit 1", each on a different remix each time, and a
+# clean checkout showed the same moving failures (found by a peer session).
+_SCRATCH = None
+
+
 def assemble(src_text, org):
-    tmp = pathlib.Path("/tmp/build_bus_src.asm")
+    global _SCRATCH
+    if _SCRATCH is None:
+        import tempfile
+        _SCRATCH = pathlib.Path(tempfile.mkdtemp(prefix="build_bus."))
+    tmp, binf, symf = (_SCRATCH / n for n in ("src.asm", "out.bin", "out.sym"))
     tmp.write_text(src_text)
     subprocess.run([str(DIS), "-in", str(tmp), "-org", f"{org:x}",
-                    "-out", "/tmp/build_bus.bin", "-sym", "/tmp/build_bus.sym"],
+                    "-out", str(binf), "-sym", str(symf)],
                    check=True, capture_output=True)
-    blob = pathlib.Path("/tmp/build_bus.bin").read_bytes()
+    blob = binf.read_bytes()
     words = [blob[i] | (blob[i + 1] << 8) | (blob[i + 2] << 16)
              for i in range(0, len(blob), 3)]
     syms = dict((k, int(v, 16)) for k, v in
-                (l.split() for l in
-                 pathlib.Path("/tmp/build_bus.sym").read_text().split("\n") if l))
+                (l.split() for l in symf.read_text().split("\n") if l))
     return words, syms["init"], syms["proc"]
 
 
@@ -1218,6 +1230,48 @@ def main():
     # instructions -- isolates the hook mechanism from the stores (R48/R49
     # killed the voices on the unit; docs/firmware/DSP.md 6c-i).
     _plan = []
+    # ---- overrides (schema.Override): a bridge stands in at a shared site --
+    # Collected before anything is written: which detours to skip, which
+    # recipe writes to skip, and the continuation symbols the bridge's stub
+    # and any overridden cave link against -- the TARGET the skipped write
+    # carried (a `jmp abs.l`'s address, or a 4-byte pointer entry).
+    _ovr_detours: set[tuple[int, str]] = set()          # (site, module key)
+    _ovr_writes: dict[str, set[str]] = {}               # module key -> write names
+    _defsym_ovr: dict[str, int] = {}                    # symbol -> target
+    for _k in REMIX.modules:
+        for _o in getattr(remix_modules()[_k], "overrides", ()):
+            if _o.module not in REMIX.modules:
+                sys.exit(f"{_k} overrides {_o.module} at 0x{_o.site:08x}, which this "
+                         f"remix does not carry -- nothing to bridge; drop {_k}")
+            if _o.write is None:
+                _ovr_detours.add((_o.site, _o.module))
+                continue
+            _ovr_writes.setdefault(_o.module, set()).add(_o.write)
+            if _o.defsym:
+                _rt = getattr(remix_modules()[_o.module], "runtime", None)
+                if _rt is None:
+                    sys.exit(f"{_k}: override names write {_o.write!r} of {_o.module}, "
+                             f"which has no runtime recipe")
+                _spec = json.loads(pathlib.Path(_rt.recipe).read_text())
+                _data = None
+                for _p in _spec["patches"]:
+                    if _p["name"] == _o.write:
+                        _wl = [w for w in _p["writes"]
+                               if _spec["format"]["os_load_address"] + w["offset"] == _o.site]
+                        if _wl:
+                            _data = bytes.fromhex(_wl[0]["data"])
+                if _data is None:
+                    sys.exit(f"{_k}: {_o.module} has no write {_o.write!r} at 0x{_o.site:08x}")
+                if _data[:2] == b"\x4e\xf9" and len(_data) >= 6:
+                    _defsym_ovr[_o.defsym] = int.from_bytes(_data[2:6], "big")   # jmp abs.l
+                elif len(_data) == 4:
+                    _defsym_ovr[_o.defsym] = int.from_bytes(_data, "big")       # a pointer
+                else:
+                    sys.exit(f"{_k}: cannot read a target out of {_o.module}'s write "
+                             f"{_o.write!r} ({_data.hex()}) -- not a jmp abs.l or a pointer")
+                print(f"  {_k}: {_o.defsym} = 0x{_defsym_ovr[_o.defsym]:08x} "
+                      f"({_o.module}'s {_o.write} at 0x{_o.site:08x}, bridged)")
+
     for _c in _caves:
         _b = _c.pinned
         if _replay and _c.hook_addr is not None:
@@ -1295,13 +1349,22 @@ def main():
         # is written, as it always was.
         _legacy_emit = _c.emit is not None and len(_b) > 0
         if _c.source and not _replay and _toolchain and not _legacy_emit:
+            # A bridge may redefine one of this cave's defsyms (CC_NEXT):
+            # the linked bytes then differ from the ratified form by exactly
+            # that address, so the oracle is set aside for it and said so.
+            _bridged = [n for n, _v in _c.defsyms if n in _defsym_ovr]
+            _cdefs = tuple((n, _defsym_ovr.get(n, v)) for n, v in _c.defsyms)
             _lb, _lsyms, _lglob = _link(
                 _c.source, _c.cave_addr, _c.cpu,
                 pathlib.Path("out/linked/caves") / re.sub(r"\W+", "_", _c.label),
-                sections=(".text",), defsyms=tuple(_c.defsyms) + tuple(_exports.items()))
+                sections=(".text",), defsyms=_cdefs + tuple(_exports.items()))
             _exports.update(_lglob)
             _ref = (_c.reference(_c.cave_addr) if _c.reference is not None
                     else _c.pinned if _c.emit is None else _b)
+            if _bridged:
+                print(f"  {_c.label}: {', '.join(f'{n} -> 0x{_defsym_ovr[n]:08x}' for n in _bridged)}"
+                      f" (bridged; the ratified-bytes oracle is set aside for this cave)")
+                _ref = b""
             if _ref and _lb != _ref:
                 sys.exit(f"{_c.source} linked at 0x{_c.cave_addr:08x} no longer "
                          f"matches the bytes the manifest ratifies ({len(_lb)} vs "
@@ -1383,7 +1446,8 @@ def main():
         # A runtime whose recipe writes the arena geometry (Octakit's four)
         # declares them in its ArenaReserve; the build computes those
         # literals from EVERY reservation in the remix (1e) instead.
-        _skip = tuple(getattr(getattr(_m, "arena", None), "recipe_writes", ()))
+        _skip = tuple(getattr(getattr(_m, "arena", None), "recipe_writes", ())) + \
+            tuple(_ovr_writes.get(_m.key, ()))                 # bridged (schema.Override)
         _writes, _append, _info = runtime_build.build(_rt, IMG.read_bytes(), _work, _exts,
                                                       skip=_skip)
         _sym[_m.key] = _info["symbols"]
@@ -1503,7 +1567,7 @@ def main():
         from remix import platform_build
         _pappend, _psyms, _boot, _pnames = platform_build.build(
             [(_m.key, _u) for _m, _u in _dram], _payloads, pathlib.Path("out/platform"),
-            reserve=_reserve)
+            reserve=_reserve, defsyms=_defsym_ovr)
         for _m, _u in _dram:
             _sym[_u.label] = _psyms          # detours name units; one table serves all
         _exports.update(_psyms)
@@ -1549,6 +1613,10 @@ def main():
 
     for _m, _d in [(remix_modules()[_k], _d) for _k in REMIX.modules
                    for _d in getattr(remix_modules()[_k], "detours", ())]:
+        if (_d.site, _m.key) in _ovr_detours:
+            print(f"  {_m.key}: detour at 0x{_d.site:08x} bridged -- another module's stub "
+                  f"stands in for it")
+            continue
         _got = bytes(img[_d.site - BASE:_d.site - BASE + len(_d.expect)])
         if _got != _d.expect:
             sys.exit(f"{_m.key} detour {_d.note or _d.symbol} at 0x{_d.site:08x} finds "

--- a/tools/remix/ledger.py
+++ b/tools/remix/ledger.py
@@ -134,6 +134,24 @@ def check(selected) -> list[str]:
     # build's own free-space check covers the real extent); a floating one
     # is skipped like a floating cave. Detour sites are hook sites. Table
     # refs and Pokes are fixed rewrites, checked as pokes below.
+    # ---- overrides (schema.Override): a bridge's claim stands in ---------
+    # The overridden module's detour or recipe write at that site is not a
+    # claim any more; the bridge's own detour is. A bridge naming a module
+    # the remix does not carry is refused: there is nothing to bridge.
+    keys = {m.key for m in selected}
+    overridden_detours: set[tuple[int, str]] = set()      # (site, module key)
+    overridden_writes: set[tuple[str, str]] = set()       # (module key, write name)
+    for m in selected:
+        for o in getattr(m, "overrides", ()):
+            if o.module not in keys:
+                clash("override", m.name, f"(no {o.module})",
+                      f"0x{o.site:08x} -- it bridges {o.module}, which this remix "
+                      f"does not carry")
+            if o.write is None:
+                overridden_detours.add((o.site, o.module))
+            else:
+                overridden_writes.add((o.module, o.write))
+
     for m in selected:
         for u in getattr(m, "linked", ()):
             if u.cave_addr is None:
@@ -145,6 +163,8 @@ def check(selected) -> list[str]:
                           f"0x{u.cave_addr:08x}")
             caves.append((u.cave_addr, 6, m.name, f"linked unit {u.label}"))
         for d in getattr(m, "detours", ()):
+            if (d.site, m.key) in overridden_detours:
+                continue                 # a bridge's stub stands in for it
             if d.site in hooks:
                 clash("hook site", hooks[d.site], m.name,
                       f"0x{d.site:08x} -- the second jmp overwrites the first")
@@ -156,11 +176,18 @@ def check(selected) -> list[str]:
                 pokes.append((addr, 4, m.name, f"table ref ({t.label})"))
         for p in getattr(m, "pokes", ()):
             pokes.append((p.addr, len(p.expect), m.name, f"poke {p.note or hex(p.addr)}"))
+    # A FLOATING emit cave's poke ADDRESSES do not depend on where the cave
+    # lands -- only the values written do -- so it is evaluated at a probe
+    # address purely to learn its sites. Until 10 Sep 2026 it was skipped,
+    # and the matrix said Octakit and CC PAGE 2 compose while the build
+    # refused them: both rewrite the MIDI control-parameter dispatch entry
+    # at 0x400d64a0 (her seven midi-control-parameter writes, its repoint).
+    PROBE_ADDR = 0x400D7000
     for m in selected:
         for c in m.cf_patches:
-            if c.emit is None or c.cave_addr is None:
+            if c.emit is None:
                 continue
-            _, cpokes = c.emit(c.cave_addr)
+            _, cpokes = c.emit(c.cave_addr if c.cave_addr is not None else PROBE_ADDR)
             for pa, expect, _write in cpokes:
                 span = (pa, len(expect), m.name, c.label)
                 for start, length, owner, label in caves:
@@ -214,9 +241,10 @@ def check(selected) -> list[str]:
 
     for m in runtimes:
         skip = set(getattr(getattr(m, "arena", None), "recipe_writes", ()))
+        skip |= {w for k, w in overridden_writes if k == m.key}
         for start, length, label in runtime_write_spans(m):
             if label in skip:
-                continue                 # computed by the build (arena geometry)
+                continue                 # computed by the build (arena geometry), or bridged
             for cstart, clength, owner, clabel in caves:
                 if _overlap(cstart, clength, start, length):
                     clash("ColdFire cave", f"{owner}'s {clabel}",

--- a/tools/remix/platform_build.py
+++ b/tools/remix/platform_build.py
@@ -76,13 +76,15 @@ def link_runtime(units, work: pathlib.Path, defsyms: dict, base: int) -> tuple[b
     return raw.read_bytes(), _nm(elf, work)
 
 
-def build(units, payloads, work: pathlib.Path, reserve=None):
+def build(units, payloads, work: pathlib.Path, reserve=None, defsyms=None):
     """units: [(module key, Linked)] with dram=True, in link order.
     payloads: [dict(name, blob, stage, dst, rawlen, rhash, backup)] for
     payloads built elsewhere (Octakit): `blob` = signature + GKA3 stream.
     reserve: (base, size) of the arena reserve the runtime lives in;
-    required when there are units. Returns (append bytes, symbols of the
-    octabam runtime, boot poke, payload names) and writes LAYOUT."""
+    required when there are units. defsyms: extra {name: value} for the
+    link (a bridge's continuation targets, schema.Override). Returns
+    (append bytes, symbols of the octabam runtime, boot poke, payload
+    names) and writes LAYOUT."""
     import json
     work = work.resolve()
     work.mkdir(parents=True, exist_ok=True)
@@ -97,6 +99,7 @@ def build(units, payloads, work: pathlib.Path, reserve=None):
         defs = {}
         for p in payloads:
             defs.update(p.get("symbols", {}))
+        defs.update(defsyms or {})
         raw, symbols = link_runtime(units, work / "runtime", defs, base)
         packed = runtime_build.PACKED_MAGIC + len(raw).to_bytes(4, "big") + \
             runtime_build.pack(raw, MAX_CANDIDATES)

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -679,6 +679,30 @@ class ArenaReserve:
 
 
 @dataclass(frozen=True)
+class Override:
+    """This module's own claim at `site` stands in for another module's --
+    the way two mods that hook one stock instruction get to share it.
+
+    A BRIDGE module (modules/scenes-kits is the first) carries a stub that
+    does what both hooks did, in an order that respects each one's
+    protocol, and declares an Override per claim it replaces: `module` is
+    the other module's key, `write` the name of its Runtime recipe write
+    at that site (None for a Detour). The build then skips the overridden
+    detour or write and, when `defsym` is given, defines that symbol for
+    every unit and cave it links as the overridden claim's TARGET -- the
+    address a `jmp abs.l` write jumped to, or the pointer a 4-byte table
+    write installed -- so the stub knows where to continue. The ledger
+    treats the site as the bridge's; the overridden module must be in the
+    remix, or the override is refused.
+    """
+
+    site: int
+    module: str
+    write: str | None = None
+    defsym: str | None = None
+
+
+@dataclass(frozen=True)
 class RuntimeExt:
     """Sources linked INTO another module's loader-appended runtime.
 
@@ -743,6 +767,9 @@ class Module:
     # (schema.ArenaReserve). DRAM units need none: the platform reserves
     # its own (arena.PLATFORM_PAGES) whenever a remix carries any.
     arena: ArenaReserve | None = None
+    # Claims of OTHER modules this module's own stand in for
+    # (schema.Override) -- a bridge chaining two mods' hooks at one site.
+    overrides: tuple[Override, ...] = ()
     # Which slot carries the MODE select, and what each of its positions
     # renames and re-defaults. Empty for a single-engine module.
     mode_slot: int | None = None

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -478,6 +478,20 @@ def main():
              "stations": ("FILTER", "SPATIALIZER", "EQUALIZER", "PHASER",
                           "FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
                           "DARK REV", "COMPRESSOR", "LO-FI", "DJ EQ",
+                          "COMB FILTER"),
+             # the rig plus a community family (10 Sep 2026): the same
+             # stations, so the same thirteen; the mods place no DSP words.
+             "rig-scenes": ("FILTER", "SPATIALIZER", "EQUALIZER", "PHASER",
+                            "FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
+                            "DARK REV", "COMPRESSOR", "LO-FI", "DJ EQ",
+                            "COMB FILTER"),
+             "rig-kits": ("FILTER", "SPATIALIZER", "EQUALIZER", "PHASER",
+                          "FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
+                          "DARK REV", "COMPRESSOR", "LO-FI", "DJ EQ",
+                          "COMB FILTER"),
+             "rig-mods": ("FILTER", "SPATIALIZER", "EQUALIZER", "PHASER",
+                          "FLANGER", "CHORUS", "PLATE REV", "SPRING REV",
+                          "DARK REV", "COMPRESSOR", "LO-FI", "DJ EQ",
                           "COMB FILTER")}
     for _n in registry.remix_names():
         _r = registry.remix(_n)

--- a/tools/verify/verify_ccpage2.py
+++ b/tools/verify/verify_ccpage2.py
@@ -64,7 +64,13 @@ def check_source_matches(m):
             o, e, b = (pathlib.Path(d) / n for n in ("cc.o", "cc.elf", "cc.bin"))
             subprocess.run(["m68k-elf-as", "-mcpu=5407", "-o", str(o),
                             str(ROOT / "modules/ccpage2/cc_page2.s")], check=True)
-            subprocess.run(["m68k-elf-ld", f"-Ttext=0x{addr:x}", "-o", str(e), str(o)], check=True)
+            # The cave's fall-through is a link-time symbol (CC_NEXT) so a
+            # bridge can chain it in front of Octakit's CC handler; the
+            # manifest's default is stock's handler, and that is what the
+            # ratified bytes carry.
+            subprocess.run(["m68k-elf-ld", f"-Ttext=0x{addr:x}",
+                            *[f"--defsym={n}=0x{v:x}" for n, v in m.MODULE.cf_patches[0].defsyms],
+                            "-o", str(e), str(o)], check=True)
             subprocess.run(["m68k-elf-objcopy", "-O", "binary", "-j", ".text",
                             str(e), str(b)], check=True)
             linked = b.read_bytes()

--- a/tools/verify/verify_hello.py
+++ b/tools/verify/verify_hello.py
@@ -61,14 +61,17 @@ if (init, proc) == send_probe.entry_points(MEM, SEND.menu.fx2_id):
 # full-scale bipolar ramp, exact endpoints
 ramp = [int(round(-8388607 + (2 * 8388607) * i / (N - 1))) for i in range(N)]
 assert min(ramp) == -8388607 and max(ramp) == 8388607
-pathlib.Path("/tmp/ramp.raw").write_bytes(b"".join(struct.pack("<i", s) for s in ramp))
+import tempfile
+SCRATCH = pathlib.Path(tempfile.mkdtemp(prefix="verify_hello."))   # per process: two runs must not share /tmp names
+RAMP = SCRATCH / "ramp.raw"
+RAMP.write_bytes(b"".join(struct.pack("<i", s) for s in ramp))
 
 def render(gain):
-    out = f"/tmp/hello_g{gain}.raw"
+    out = str(SCRATCH / f"hello_g{gain}.raw")
     cmd = [HOST, "-mem", MEM, "-init", f"{init:x}", "-proc", f"{proc:x}",
            "-inst", "1", "-r7", "2", "-alloc", "1", "-inmask", "1",
            "-frames", str(FRAMES), "-blocks", str(N // FRAMES),
-           "-in", "/tmp/ramp.raw", "-out", out,
+           "-in", str(RAMP), "-out", out,
            "-params", ",".join(str(gain if i == GAIN_SLOT else 0)
                                 for i in range(NSLOTS))]
     r = subprocess.run(cmd, capture_output=True, text=True)


### PR DESCRIPTION
Sam: "rather than make them exclusive can we be brutal and make them all
work?" Two stock sites were claimed by more than one mod; the ledger's
only answer was to refuse the pair.

- schema.Override(site, module, write, defsym): a bridge module's own
  claim at a site stands in for another module's. The build skips the
  overridden detour or recipe write and defines the skipped write's
  target (a jmp abs.l's address, or a 4-byte pointer) as a link-time
  symbol for every unit and cave it links; the ledger owns the site to
  the bridge and still refuses the pair without it.
- modules/scenes-kits: chains MIDI SCENES and Octakit at apply_part
  (0x40009094) -- his pre-work (apply_ret, return through `after`, jsr
  pack), then a jump into her gk_stock_engine_part_load_and_publish,
  which replays the displaced prologue and runs STOCK's body through her
  trampoline (so his Part-window hooks keep their meaning under Kits);
  the swap only once her lifecycle is active, because her boot-time path
  inspects the stock caller's return address. CC PAGE 2's cave takes its
  fall-through from CC_NEXT, which the bridge points at her
  gk_stock_midi_control_parameter; hers falls through to stock's.
- Measured under the ColdFire port (mods image, static-sample card, boot
  -> LOAD PROJECT -> 400 frames): six apply_parts, every one site -> stub
  -> her entry -> her trampoline; her fatal 0x, the loader's 0x; his pack
  2x (one via bank_sw), after 1x once active.
- Remixes: mods, rig-mods, mutables-mods (everything, bridged) and the
  single-family scenes/kits, rig-scenes/rig-kits, mutables-scenes/
  mutables-kits. The rig omits the LO-FI fix (CHARACTER replaces LO-FI);
  the kits family omits CC PAGE 2 without the bridge (Octakit owns the
  CC dispatch).
- Ledger: a floating emit cave's pokes are now seen (evaluated at a probe
  address) -- the matrix had said Octakit + CC PAGE 2 compose while the
  build refused them.
- build_bus.assemble and verify_hello use per-process scratch
  (tempfile.mkdtemp): fixed /tmp names let two builds on one machine
  corrupt each other (found by a peer session; CLAUDE.md trap).
- selftest: the rig combos give up the same thirteen stock effects the
  rig does; verify_ccpage2 links with the manifest's defsyms.

Gates: make check green for mods, rig-mods, mutables-mods, scenes, kits,
rig-scenes, rig-kits, mutables-scenes, mutables-kits, ported, octakit,
midi-scenes, bamsep26, hello; refhash 26/26 bit-identical. Unflashed.
Not measured: MIDI CCs through the chained dispatch (no MIDI in under the
port); his Part save/reload menu hooks against her Kit menus; hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)