### PR TITLE
flex-seekbind A/B: same-buffer FLEX re-bind as a DSP seek, not a new note (RTOS_FORK 10.49, port-gated, unflashed)

### DIFF
--- a/docs/firmware/RTOS_FORK.md
+++ b/docs/firmware/RTOS_FORK.md
@@ -4238,3 +4238,39 @@ clusters were overload. (3) One freeze of the unit on 81 while switching
 the rec trig to one-shot with T1 muted — observed once, cause unknown,
 not reproduced. (4) `hw_flash7`'s Mac MIDI clock ran the unit at 127.1
 BPM; internal clock for every count, MIDI only for mutes/solos.
+
+### 10.51 OCTABAM82 (A + counter hold) on hardware: no restart, no seam, the voice free-runs behind the write head — clean for 90 s; a whole-bar jump is not something this instrument could see (12 Sep 2026 — measured on the unit, drift question open)
+
+Same project, same rig, same morning as §10.50, FX off, tone amp 0.05,
+internal clock. `out/hw/softretrig/seekB_128.wav` (60 s) and
+`seekB_128_long.wav` (90 s): level flat at 2.06e7 rms throughout; **bar
+fold 1.3× / 1.5× (nothing per bar; 80 was 48×, 81 was 7×); single events
+0 in 30 bars, then 1 in 46 bars** — the one at 46.37 s is a 1–2-sample
+impulse with a phase step of −0.07 samples and amplitude ratio 1.000, a
+dropout blip, not a seam. `judge.py` verdict on both: no per-bar event.
+
+**What 82 does that 81 does not.** The tone-kill discriminator: on 80 and
+81 the output dies with the input and, one bar later, 140 ms of the tone
+that was still in the buffer's first blocks plays back — the voice
+restarts from the buffer start every bar. On 82 (`seekB_128_kill2.wav`)
+the output dies at the kill and **nothing comes back**: the voice does
+not restart at the bar. With the per-bind counter (+0x90) held, the
+re-bind is a no-op for the DSP; the read head free-runs behind the write
+head and the bar boundary is nothing to it. That is the "do not move the
+read pointer at all" of §10.50, arrived at by the cheaper lever.
+
+**What this instrument cannot see.** At 128 BPM the bar (82,687.5
+samples) is exactly 1875.0 periods of the 1 kHz tone, so a jump of a
+whole bar — the free-running read head crossing the re-armed write head
+and the voice flipping to one-bar-old material — produces NO phase step
+and NO residual. The seam and the restart were visible because they are
+fractions of a period. The two heads' loop lengths differ by the
+half-sample truncation, so they drift by up to half a sample per bar;
+whether they ever cross depends on how far the read head trails the
+write head (unmeasured). 90 s = 48 bars ≤ 24 samples of drift. Open:
+(a) Sam's ear on real material over minutes; (b) the burst-train source
+(`hw_flash7.py --source burst`) for 5 minutes — a bar-jump shows as a
+burst 1.875 s late; (c) the golden tempo (65.6) and RLEN 4 / Bryan's
+128/RLEN4 for the seam family's other members. Until (a)–(b), 82 is
+"clean on every instrument that could see the previous failure",
+not "fixed".

--- a/docs/firmware/RTOS_FORK.md
+++ b/docs/firmware/RTOS_FORK.md
@@ -4121,3 +4121,43 @@ not bar-periodic — spacings 0.09–1.2 s, clusters up to 2,400 samples —
 because GAPTEST.WAV is not a pure sine, so the tone-calibrated detector does
 not apply. The control has to be a pure 1 kHz loop of 82,687 samples; only
 then is the burst count comparable to `cond_b_128`.)
+
+### 10.49 Seek-not-note candidates built and port-gated; OCTABAM81 (lever A) is the morning's flash (10 Sep 2026, late — measured in the port, unflashed)
+
+Two caves for §10.48's hypothesis, built through the real planter:
+`modules/flex-seekbind` (lever A: hooked on the bind tail's same-sample test
+`0x4000f8cc`; when the bind's own slot/type/generation verdict holds, take the
+same-sample continuation with result 1, skipping the position compare that
+turns the re-bind into a new note) and `modules/flex-seekbind-ctr` (lever B,
+paired: on that same path do not bump the voice's per-bind counter `+0x90`).
+Remixes `seekA` → `OCTATRACK_OCTABAM81.bin`, `seekB` → `OCTABAM82.bin`.
+
+**Gate 1 — does stock already take the seek path?** No, and the answer is
+better than yes/no: on `n128fix` (record once, play every bar) the stock
+tail's verdict at `0x4000f912` for the T2 voice is, bind by bind, NEW, SEEK,
+NEW, SEEK, NEW — it ALTERNATES with the half-sample truncation. The position
+compare in the tail passes on the bars where the trig lands on the wrap and
+fails on the bars where it lands a sample off, so every other bar is a new
+note to the DSP. (This is also the port's self-loop burst period of
+§10.48, every other bar; hardware bursts every bar — the port and the unit
+disagree on exactly the compare's inputs, which is what cfprobe should read.)
+**A and B: 5 of 5 binds take the seek path** (cave entered 5×, compare path
+0×, "different" path only on the initial note). **Gate 2 — does the DSP see
+a difference?** Yes: from the first bar stock would have restarted (bar 3),
+every DSP read-back frame differs from stock (−0.1 dB rms, content differs
+on every frame after), while the ColdFire feed is unchanged. **Gate 3 —
+regression:** feed stationarity −1/0/−1 as stock, no fault, 21,000 frames.
+**What the port cannot say:** its own read-back burst at each bar (5–7
+samples, the feed's one-sample shift smoothed by the DSP) is identical for
+stock, A and B, and the unit's 15–50-sample transient never appears in it.
+So the port has done all it can: A is well-formed, changes the DSP-facing
+event exactly as intended, and changes what the DSP then does. Whether that
+is the click is the morning's ten-minute count.
+
+**Morning order.** Flash OCTABAM81 (A). Record-once loop, 128 BPM, 60 s,
+`out/hw/softretrig/cap.sh`: baseline is 30 bursts. Zero or a clear drop →
+A is the fix (then the golden and the self-loop checks). Unchanged → the
+DSP restart is not message-driven: skip B, lever C (a fade at voice start
+in the DSP payload). Changed but not gone → OCTABAM82 (B). Either way, the
+cfprobe read of the tail's compare inputs on the unit tells why the unit
+takes the new-note path every bar where the port alternates.

--- a/docs/firmware/RTOS_FORK.md
+++ b/docs/firmware/RTOS_FORK.md
@@ -4274,3 +4274,45 @@ burst 1.875 s late; (c) the golden tempo (65.6) and RLEN 4 / Bryan's
 128/RLEN4 for the seam family's other members. Until (a)–(b), 82 is
 "clean on every instrument that could see the previous failure",
 not "fixed".
+
+### 10.52 82's residual, found under the threshold: a −26 dB, 1 ms scuff every OTHER bar that beats over ~37 s, absent at the golden tempo — the half-sample truncation's last trace, and the next lever is the recorder's length arithmetic (12 Sep 2026 — measured on the unit)
+
+Sam, by ear on 82 at 128: "the clicks get quieter over time until they
+disappear, then it repeats." §10.51's fold (1.5×) had averaged it away.
+Per-bar maximum of the one-period residual over the 90 s take
+(`seekB_128_long.wav`), at a fixed bar phase (244 ms on that take's
+grid): **odd bars 1.7, 2.2, 2.2, 1.5, 1.1, 1.5, 2.1, 2.3, 1.8, 1.1, …,
+2.3, 2.0, 1.4, 1.1× the floor; even bars 1.0–1.1× throughout.** Every
+other bar, rising and fading with a period of ~10 odd bars ≈ 20 bars ≈
+37 s. At 2× a 2.67 % floor it is ~5 % of the tone amplitude for ~1 ms,
+−26 dB re the tone; the phase step across it is −0.05 samples on every
+bar (the frequency estimate's constant drift, i.e. zero) and the
+amplitude ratio 1.000 — **not a timing seam, a scuff**. Alternate bars is
+the 82,687/82,688 signature; the 37 s beat is a slow drift between the
+read head and whatever it slides past.
+
+**Golden control, same image, same rig:** 65.6 BPM, 60 s
+(`seekB_65.6.wav`), 15 bars: **the loudest 1 ms bin in the whole take is
+1.1× the floor**, per-bar maxima at random phases, fold 1.1×. Nothing.
+The residual exists only where the bar is not an integer number of
+samples.
+
+**Standing, 12 Sep:**
+
+| image | 128 BPM (non-golden) | 65.6 BPM (golden) |
+|---|---|---|
+| 80 (stock re-bind) | restart hash 140 % + −3.6-sample jump, every bar | clean (§10.39) |
+| 81 (lever A) | no hash; ±1.5-sample alternating seam, every bar | — |
+| 82 (A + counter hold) | no hash, no seam; −26 dB 1 ms scuff every other bar, beating ~37 s | clean, 1.1× floor |
+
+82 is the image to keep testing on; its residual is ~30 dB below where
+this started and the seam family is out of it. What remains is owned by
+the recorder's length alternation, not the bind: the next lever is the
+length converter / block walk (`recorder-seam`'s territory — that patch
+was judged against the restart-dominated click and falsified for the
+wrong reason; re-score it, or its successor, on 82 with `gaps.py` and the
+per-bar-max view, non-golden only). Instrument for it: `gaps.py`, per-bar
+maximum, ≥ 60 s takes (the beat is 37 s long), FX off, internal clock,
+tone amp 0.05; a fixed bar grid; the 1 kHz tone is blind to whole-bar
+jumps at 128 (1875.0 periods per bar), so the burst-train source stays on
+the list for the drift question.

--- a/docs/firmware/RTOS_FORK.md
+++ b/docs/firmware/RTOS_FORK.md
@@ -4161,3 +4161,80 @@ DSP restart is not message-driven: skip B, lever C (a fade at voice start
 in the DSP payload). Changed but not gone → OCTABAM82 (B). Either way, the
 cfprobe read of the tail's compare inputs on the unit tells why the unit
 takes the new-note path every bar where the port alternates.
+
+### 10.50 OCTABAM81 on hardware: lever A removes the restart transient and leaves a pure alternating ±1.5-sample seam — Bryan's click reduced to its timing step (12 Sep 2026 — measured on the unit)
+
+**The flash.** `out/OCTATRACK_OCTABAM81.bin` re-proven first: rebuilt from
+`flex-seekbind` @5d8c73d in a clean worktree, bit-identical to the 10 Sep
+image (sha256 `e27e320e…`), `make check REMIX=seekA` green. Sam's self-loop
+project (T1 = FLEX, REC trig every bar + PLAY trig every bar on the same
+track, recorder source INAB, RLEN 16, 128 BPM, internal clock, FX off),
+`tools/tone` 1 kHz into A/B, `tools/rec` from the MicroBook. Captures in
+`out/hw/softretrig/`: `seekA_128c_kill.wav` (81, FX off, 16 s of tone),
+`seekA_128b.wav` (81, FX on, 60 s), `base80_128.wav` (OCTABAM80 re-flashed
+the same morning, FX off, 60 s — the same-day baseline).
+
+**The instrument had to change first.** `bursts.py`'s second-difference
+count reported 0 on 81 while Sam heard "little gaps" every bar; the
+detector keys on HF energy and a timing step has none. `gaps.py` predicts
+each sample from one tone period earlier (fractional delay, period from
+the FFT peak) — any stationary periodic waveform cancels, harmonics and
+all; a step or a hole is a spike — and folds the residual on the 1.875 s
+bar grid. It finds all 30 of `cond_b_128`'s clicks (10 Sep) and the 31 of
+`soft_128`, then measures the tone's phase before and after each event.
+(`judge.py` is the front end; its floor gate was calibrated on the
+record-once fixture, 0.22 % of rms, and a self-loop sits at ~3 % on both
+images — the gate is per-fixture, fixed in the script.)
+
+**The result, same floor on both images:**
+
+| image | per-bar event (bar fold) | shape | tone phase step across it | amplitude after/before |
+|---|---|---|---|---|
+| 80 (`base80_128`) | 48× | 150–350 samples, residual peaks at 140 % of the tone amplitude — hash, then a sine-shaped ramp | **−3.6 samples** (−3.2…−3.8, 10 events) | 0.97–1.04 |
+| 81 (`seekA_128c`) | 7× | ~44 samples (one period), residual ≤ 30 %, raw never above 100 % — no hash | **alternating −1.96 / +1.18 samples**, bar by bar, 8 of 8 | 1.000 |
+
+Lever A does what it was built to do: the DSP no longer restarts the
+voice at the bar (no chirp, no hash, no amplitude event), and what remains
+is a pure timing step whose sign alternates — the half-sample-truncation
+family §10.42 measured in the port on the record-once fixture (−1/0
+alternating), here on hardware on the self-loop at about ±1.5. Bryan's
+"click" on this geometry was two things stacked: the restart transient
+(gone) and the seam (still there, now audible on its own as a "little
+gap"). §10.49's "partial → OCTABAM82" applies; expectation for B is low
+(the +0x90 counter is not obviously the seek's target position). The next
+real lever is the position the seek lands on versus where the voice is —
+on a self-loop the ideal bar boundary is "do not move the read pointer at
+all". The FX-on capture (`seekA_128b`) shows the same-sized steps but
+non-alternating and with amplitude ratios 0.81–1.24: the reverb smears
+them (the §10.44-era rule, "a reverb cannot show you a discontinuity");
+FX off for every capture from now on.
+
+**Port side (same morning, flashed bytes this time).** The 10.49 gates ran
+on `mainos_seekA.bin` with the cave at `0x400d24d0`; the flashed image
+places it at `0x400d7200` (same 24 bytes, different cave placement, tempo
+cave moved too). Re-run on the self-loop fixture (`n128self_card.img`,
+`--pre-roll 200`, watches on the cave and the three exits): the initial
+note takes the stock "different" path, and **binds 2–5 all take the seek
+exit** — the slot/type/generation verdict at `(55,sp)` HOLDS across a
+re-record. This retracts §10.48's explanation of the softretrig failure
+("new generation each bind, so sp@55 is false"): the generation is not
+bumped by the self-loop's re-arm. Stock on the same fixture alternates
+SAME/NEW/SAME/NEW (return 0 at binds 2 and 4, 0x100 at 3 and 5), the
+§10.49 pattern. The ColdFire position `a2@(88)` advances by exactly
+0x142ff = 82,687 per bar; stock's `d3` is 1 or 2, so its compare fails
+every other bar. Per-bar RMS of the read-back and the main mix is flat on
+both images (nothing dies) — the port still cannot show the seam's size or
+the transient, only the message path.
+
+**A morning of wrong turns, recorded so they are not repeated.** (1) T1
+was taken for a THRU track because the output died the instant the tone
+was killed; it is the self-loop itself, reading the ring a hair from the
+write head, and a bar later it played the 140 ms of old tone left at the
+buffer start. "Mute T1 → silence" on both 81 and 80 measured nothing.
+(2) The 10 Sep `seekA_128.wav` was not a dud from two summed tone
+processes: the unit's input chain was ~17 dB hotter than at 03:23 (amp
+0.3 clipped orange; 0.05 is right now), so its 7.5× level and 231 junk
+clusters were overload. (3) One freeze of the unit on 81 while switching
+the rec trig to one-shot with T1 muted — observed once, cause unknown,
+not reproduced. (4) `hw_flash7`'s Mac MIDI clock ran the unit at 127.1
+BPM; internal clock for every count, MIDI only for mutes/solos.

--- a/modules/flex-seekbind-ctr/manifest.py
+++ b/modules/flex-seekbind-ctr/manifest.py
@@ -1,0 +1,26 @@
+"""FLEX seek-bind, counter half -- pair with FLEX SEEK BIND (RTOS_FORK 10.48
+lever B). On a same-sample re-bind leave the per-voice counter (+0x90) alone
+so the frame builder does not re-send the voice as new; the +0x98 store is
+always replayed. Hook 0x4000f834 (addql #1,(144,a2) / movel a0,(152,a2)).
+Unflashed."""
+
+from remix.schema import CavePatch, Kind, Module
+
+MODULE = Module(
+    name="flex-seekbind-ctr",
+    key="FLEX SEEK BIND CTR",
+    kind=Kind.CF_PATCH,
+    doc="ColdFire cave: on a same-sample FLEX re-bind, do not bump the voice's "
+        "per-bind counter (pairs with FLEX SEEK BIND).",
+    cf_patches=(
+        CavePatch(
+            label="seek-bind counter cave",
+            cave_addr=None,
+            pinned=bytes.fromhex("4a2f003b660452aa0090254800984e75"),
+            source="modules/flex-seekbind-ctr/seekbind_ctr.s",
+            hook_addr=0x4000f834,
+            hook_stock=bytes.fromhex("52aa0090" "25480098"),
+            report_note=" (same-sample re-bind keeps +0x90)",
+        ),
+    ),
+)

--- a/modules/flex-seekbind-ctr/seekbind_ctr.s
+++ b/modules/flex-seekbind-ctr/seekbind_ctr.s
@@ -1,0 +1,10 @@
+| FLEX seek-bind B (second cave, paired with A) -- hooked on the bind's
+| per-voice counter bump (0x4000f834: addql #1,(144,a2) / movel a0,(152,a2),
+| 8 bytes). On a same-sample re-bind leave the counter alone so the frame
+| builder does not re-send the voice as new; always replay the store.
+        .text
+seekB:  tstb    (59,%sp)
+        bnes    same
+        addql   #1,(144,%a2)
+same:   movel   %a0,(152,%a2)
+        rts

--- a/modules/flex-seekbind/manifest.py
+++ b/modules/flex-seekbind/manifest.py
@@ -1,0 +1,38 @@
+"""FLEX seek-bind -- a same-buffer FLEX re-bind tells the DSP "seek", not
+"new note" (RTOS_FORK 10.48 hypothesis, 10 Sep 2026; unflashed, port gates
+in 10.49).
+
+The bind (0x4000f450) decides at its tail whether a re-bind is the same
+sample (return 0) or a new one (return 0x100) from its own slot/type/
+generation verdict (sp@55) AND a position compare against a settings field
+(0x4000f8cc..0x4000f8ea). On a recorder-buffer voice re-trigged every bar the
+verdict holds but the compare plausibly fails, so every bar is a new note and
+the DSP restarts the voice -- the chirp-then-click of 10.48. This cave, hooked
+on the verdict test, takes the same-sample continuation with result 1 whenever
+the verdict holds and the stock "different" path otherwise. The position reset
+and everything else stay stock.
+"""
+
+from remix.schema import CavePatch, Kind, Module
+
+HOOK = 0x4000f8cc
+HOOK_STOCK = bytes.fromhex("4a2f0037" "6718")       # tstb (55,sp) / beqs 0x4000f8ea
+
+MODULE = Module(
+    name="flex-seekbind",
+    key="FLEX SEEK BIND",
+    kind=Kind.CF_PATCH,
+    doc="ColdFire cave: a same-slot/type/generation FLEX re-bind takes the bind's "
+        "same-sample path (DSP seek) instead of becoming a new note.",
+    cf_patches=(
+        CavePatch(
+            label="seek-bind cave",
+            cave_addr=None,
+            pinned=bytes.fromhex("4a2f003b670a7001588f4ef94000f8ec588f4ef94000f8ea"),
+            source="modules/flex-seekbind/seekbind.s",
+            hook_addr=HOOK,
+            hook_stock=HOOK_STOCK,
+            report_note=" (same-sample re-bind -> seek path)",
+        ),
+    ),
+)

--- a/modules/flex-seekbind/seekbind.s
+++ b/modules/flex-seekbind/seekbind.s
@@ -1,0 +1,13 @@
+| FLEX seek-bind A -- hooked on the bind tail's same-sample test (0x4000f8cc:
+| tstb (55,sp) / beqs 0x4000f8ea, 6 bytes). Same slot/type/generation ->
+| take the SAME-SAMPLE continuation with result 1, skipping the position
+| compare that turns a recorder-buffer re-bind into a new note. Otherwise
+| the stock "different" path. Entry: (sp) = return, bind's sp@55 = (59,sp).
+        .text
+seekA:  tstb    (59,%sp)
+        beqs    diff
+        moveq   #1,%d0
+        addql   #4,%sp
+        jmp     0x4000f8ec
+diff:   addql   #4,%sp
+        jmp     0x4000f8ea

--- a/remixes/seekA.py
+++ b/remixes/seekA.py
@@ -1,0 +1,10 @@
+"""seekA -- bus + the FLEX seek-bind cave (lever A). Hardware test image for RTOS_FORK 10.48/10.49; unflashed."""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="seekA",
+    doc="bus + the FLEX seek-bind cave (lever A).",
+    modules=("REVERB SERVER", "DELAY SERVER", "SEND", "TEMPO SYNC", "FLEX SEEK BIND"),
+    fallback="SEND",
+)

--- a/remixes/seekB.py
+++ b/remixes/seekB.py
@@ -1,0 +1,10 @@
+"""seekB -- bus + seek-bind + its counter half (lever B). Hardware test image for RTOS_FORK 10.48/10.49; unflashed."""
+
+from remix.schema import Remix
+
+REMIX = Remix(
+    name="seekB",
+    doc="bus + seek-bind + its counter half (lever B).",
+    modules=("REVERB SERVER", "DELAY SERVER", "SEND", "TEMPO SYNC", "FLEX SEEK BIND", "FLEX SEEK BIND CTR"),
+    fallback="SEND",
+)


### PR DESCRIPTION
Two caves for the 10.48 hypothesis that the click is the DSP restarting a voice at every re-bind of a recorder-buffer FLEX voice.

- `modules/flex-seekbind` (A): on the bind's same-sample verdict, take the seek continuation, skipping the position compare that makes the re-bind a new note.
- `modules/flex-seekbind-ctr` (B): pair, holds the per-bind counter on that path.
- Remixes `seekA` → OCTABAM81, `seekB` → OCTABAM82 (images built, in `out/`).

Port gates (10.49): stock's verdict alternates NEW/SEEK per bar with the half-sample truncation; A/B make 5 of 5 re-binds seeks; DSP read-back differs from stock from the first converted bar; feed stationarity unchanged. The port cannot show the unit's 15–50-sample transient, so the judge is the hardware burst count on the record-once loop (baseline 30/min). Do not merge before that count; this PR is the record of the candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)