### PR TITLE
Sample-save path, the DSP read-back block, and the 8-track-to-card proposition

### DIFF
--- a/docs/WSL.md
+++ b/docs/WSL.md
@@ -1,0 +1,101 @@
+# Getting started on WSL
+
+The build is bash + Makefile + CMake and does not run on native Windows. It
+runs unchanged inside WSL2. Verified on Ubuntu 26.04.1, 3 Sep 2026.
+
+## Dependencies
+
+A working **WSL2** Ubuntu shell ([install
+guide](https://learn.microsoft.com/windows/wsl/install)) — WSL 2, not WSL 1.
+Then, inside it:
+
+```bash
+sudo apt update
+sudo apt install -y build-essential cmake git curl unzip xxd binutils \
+                    binutils-m68k-linux-gnu \
+                    python3 python3-numpy binwalk radare2 pulseaudio-utils
+mkdir -p ~/.local/bin
+ln -sf "$(command -v m68k-linux-gnu-objdump)" ~/.local/bin/m68k-elf-objdump
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.local/bin/env
+```
+
+- **`binwalk` and `radare2` must go in before `make setup`.** The setup script
+  installs them with Homebrew otherwise (`scripts/setup.sh:27`); with them
+  already on PATH it skips that branch and never needs brew.
+- **`binutils-m68k-linux-gnu` is not optional, and skipping brew is exactly why
+  it is easy to miss.** `scripts/disasm.sh emac` shells out to
+  `m68k-elf-objdump`, the only correct ColdFire decoder here. On the macOS
+  route it arrives with `m68k-elf-gcc` from Homebrew (`scripts/setup.sh:31`),
+  which this route never runs. Without it `scripts/disasm.sh emac` exits with
+  "m68k-elf-objdump not found", and the only disassembler left is r2, **which
+  silently invents code on this CPU**: 6,757 instructions below `0x40098000`
+  that it cannot decode, 4,543 of them longer than two bytes, so the stream
+  desynchronises. The Ubuntu package ships the same decoder under a different
+  name, hence the symlink. Check it before trusting any disassembly:
+
+  ```bash
+  scripts/disasm.sh emac 0x40003664 8      # must print msacl, not "invalid"
+  ```
+
+  That span is the delay's EMAC loop, and `scripts/disasm.sh`'s own header
+  states the expected output, so it is a real gate and not a smoke test.
+- **`uv`** provisions `.venv` for the remixer. Without it `make remix` will not
+  start and three checks in `make verify` silently `[SKIP]`.
+- **`pulseaudio-utils`** is for audio — see *Changes needed*.
+
+## Steps
+
+Clone into the Linux filesystem, **not** `/mnt/c` — over the 9p bridge the
+CMake build is slow, and a Windows-side clone loses the exec bit and can carry
+CRLF endings that bash chokes on.
+
+```bash
+git clone https://github.com/sambanks/octabam.git ~/octabam
+cd ~/octabam
+
+make setup        # toolchain: assembler, emulator, firmware tool (~5 min)
+make os           # your own copy of Elektron's OS 1.40C
+make recon        # -> out/raw/section_3_MAIN_OS.bin
+make bus          # -> out/mainos_bus.bin
+make check        # the floor: build + cycle budget + verification
+```
+
+For the remixer:
+
+```bash
+make emu-setup    # uv sync --extra emu
+make remix
+```
+
+Run `make remix` from **Windows Terminal** on the Ubuntu profile — it is a
+Textual TUI and wants a real terminal.
+
+Reach the tree from Windows at `\\wsl$\Ubuntu\home\<user>\octabam` — useful for
+playing rendered wavs, and for copying a built image to a CF card, which is a
+plain file copy from Explorer. VS Code: use the **WSL** extension.
+
+## Changes needed
+
+**One.** The remixer plays audio with `afplay`, which is macOS-only
+(`tools/remix/app.py:2646`), so `r` renders but you hear nothing. WSLg already
+runs a PulseAudio server wired to Windows audio; point `afplay` at it:
+
+```bash
+sudo tee /usr/local/bin/afplay >/dev/null <<'SH'
+#!/bin/sh
+exec paplay "$@"
+SH
+sudo chmod +x /usr/local/bin/afplay
+```
+
+`exec` matters: the remixer stops playback by killing that pid, and without it
+you kill the wrapper while the sound plays on. No restart needed — `afplay` is
+looked up at play time.
+
+Nothing else in the repo needs changing.
+
+---
+
+Not covered here: flashing. `docs/FLASHING.md` is the guide, and none of it has
+been done from a Windows host.

--- a/docs/WSL.md
+++ b/docs/WSL.md
@@ -1,12 +1,13 @@
 # Getting started on WSL
 
 The build is bash + Makefile + CMake and does not run on native Windows. It
-runs unchanged inside WSL2. Verified on Ubuntu 26.04.1, 3 Sep 2026.
+runs inside WSL2. The steps below were verified on Ubuntu 26.04.1 on
+3 Sep 2026; the *Limits* section says what has changed since.
 
 ## Dependencies
 
 A working **WSL2** Ubuntu shell ([install
-guide](https://learn.microsoft.com/windows/wsl/install)) — WSL 2, not WSL 1.
+guide](https://learn.microsoft.com/windows/wsl/install)). WSL 2, not WSL 1.
 Then, inside it:
 
 ```bash
@@ -14,15 +15,14 @@ sudo apt update
 sudo apt install -y build-essential cmake git curl unzip xxd binutils \
                     binutils-m68k-linux-gnu \
                     python3 python3-numpy binwalk radare2 pulseaudio-utils
-mkdir -p ~/.local/bin
-ln -sf "$(command -v m68k-linux-gnu-objdump)" ~/.local/bin/m68k-elf-objdump
+sudo ln -sf "$(command -v m68k-linux-gnu-objdump)" /usr/local/bin/m68k-elf-objdump
 curl -LsSf https://astral.sh/uv/install.sh | sh
 source $HOME/.local/bin/env
 ```
 
 - **`binwalk` and `radare2` must go in before `make setup`.** The setup script
   installs them with Homebrew otherwise (`scripts/setup.sh:27`); with them
-  already on PATH it skips that branch and never needs brew.
+  already on PATH it skips that branch.
 - **`binutils-m68k-linux-gnu` is not optional, and skipping brew is exactly why
   it is easy to miss.** `scripts/disasm.sh emac` shells out to
   `m68k-elf-objdump`, the only correct ColdFire decoder here. On the macOS
@@ -40,13 +40,18 @@ source $HOME/.local/bin/env
 
   That span is the delay's EMAC loop, and `scripts/disasm.sh`'s own header
   states the expected output, so it is a real gate and not a smoke test.
+- **The symlink goes in `/usr/local/bin`, not `~/.local/bin`.** `~/.local/bin`
+  is on PATH only in login shells. A script run as
+  `wsl.exe -d Ubuntu -- bash script.sh` from Windows is not a login shell,
+  does not see it, and hits the gate above even though the interactive shell
+  passed it (observed 10 Sep 2026).
 - **`uv`** provisions `.venv` for the remixer. Without it `make remix` will not
   start and three checks in `make verify` silently `[SKIP]`.
-- **`pulseaudio-utils`** is for audio — see *Changes needed*.
+- **`pulseaudio-utils`** is for audio. See *Changes needed*.
 
 ## Steps
 
-Clone into the Linux filesystem, **not** `/mnt/c` — over the 9p bridge the
+Clone into the Linux filesystem, **not** `/mnt/c`. Over the 9p bridge the
 CMake build is slow, and a Windows-side clone loses the exec bit and can carry
 CRLF endings that bash chokes on.
 
@@ -68,12 +73,33 @@ make emu-setup    # uv sync --extra emu
 make remix
 ```
 
-Run `make remix` from **Windows Terminal** on the Ubuntu profile — it is a
+Run `make remix` from **Windows Terminal** on the Ubuntu profile. It is a
 Textual TUI and wants a real terminal.
 
-Reach the tree from Windows at `\\wsl$\Ubuntu\home\<user>\octabam` — useful for
-playing rendered wavs, and for copying a built image to a CF card, which is a
-plain file copy from Explorer. VS Code: use the **WSL** extension.
+Reach the tree from Windows at `\\wsl$\Ubuntu\home\<user>\octabam`. That is
+useful for playing rendered wavs, and for copying a built image to a CF card,
+which is a plain file copy from Explorer. VS Code: use the **WSL** extension.
+
+## Limits
+
+The steps above were verified against the tree of 3 Sep 2026. Since
+9 Sep 2026 the build treats the m68k cross-toolchain as a first-class
+dependency, and this route does not provide it:
+
+- `scripts/setup.sh:31` now requires `m68k-elf-gcc` and adds it to the
+  Homebrew list when it is missing, so on a machine without brew `make setup`
+  stops at `brew install` with `brew: command not found`.
+- Every remix with linked ColdFire units (octakit, midi-scenes, hello-dram,
+  scenes-kits) needs `m68k-elf-as`, `ld`, `objcopy` and `nm`, and
+  `tools/build/build_bus.py:1494` refuses without them. `make check` runs the
+  selftest over every remix, so it fails on this route.
+
+`binutils-m68k-linux-gnu` ships those four under the `m68k-linux-gnu-`
+prefix, but whether symlinking them as `m68k-elf-*` satisfies the build,
+and whether an `.s` re-assembled that way still matches its author's bytes,
+has not been tried. Until it is, this route is proven for **disassembly**
+(`scripts/disasm.sh emac`) and for the tree state of 3 Sep; treat
+`make setup` and `make check` here as unverified.
 
 ## Changes needed
 
@@ -90,12 +116,12 @@ sudo chmod +x /usr/local/bin/afplay
 ```
 
 `exec` matters: the remixer stops playback by killing that pid, and without it
-you kill the wrapper while the sound plays on. No restart needed — `afplay` is
-looked up at play time.
+you kill the wrapper while the sound plays on. No restart needed, because
+`afplay` is looked up at play time.
 
-Nothing else in the repo needs changing.
+Beyond the toolchain gap in *Limits*, nothing else in the repo needs changing.
 
 ---
 
-Not covered here: flashing. `docs/FLASHING.md` is the guide, and none of it has
-been done from a Windows host.
+Not covered here: flashing. `docs/remixer/FLASHING.md` is the guide, and none
+of it has been done from a Windows host.

--- a/docs/firmware/COLDFIRE_PORT.md
+++ b/docs/firmware/COLDFIRE_PORT.md
@@ -2012,7 +2012,9 @@ Two different inserts, extreme settings, no change at TX0: a THRU track's TX0
 monitor does not carry FX2 output. The parameter path (page 1 proven, page 2
 = the ccpage2 lane) stands; what O9c had wrong was where to listen. 🟡 Next:
 the FX2 output goes to the recording / bus path — read the DSP-side read-back
-source (`X:0x400` → `0x80003190`) with a recorder armed, or use a machine
+source (`X:0x4600`/`X:0x2600` → `0x80003190`; ❌ was "`X:0x400`", retracted
+10 Sep 2026 in `DSP.md`, "The read-back block is four per-track post-FX2
+blocks") with a recorder armed, or use a machine
 that plays into FX2 (the FLEX loader). Both tie O9c's comparison to the
 recorder path, i.e. to the same DSP-in-the-loop work Bryan's click needs.
 

--- a/docs/firmware/DSP.md
+++ b/docs/firmware/DSP.md
@@ -789,7 +789,7 @@ destination (`0x6000 | X address`) and the count in halfwords (two per
 | `0x800021d0` (A) / `0x80001c90` (B) + ping·`0xa80` | 336 | `X:0x080` | **four 84-word per-track records** (`0x150` bytes each) |
 | `0x80000110` / `0x80000210` + ping·`0x200` | 64 | `X:0x000` | four 16-word per-voice records |
 | `0x80005460` + slot·`0x80` | 32 | `X:0x800` | a sample-slot record, on demand |
-| `0x80003190` + ping·`0x400` | 256 | ← `X:0x400` | read-back (DSP → CPU) — ❌ half the story: ✅ measured 8 Sep 2026 (`COLDFIRE_PORT.md` O9), core 1's read-back lands here and core 0's at `+0x200`, and the ColdFire then sends the 512 words FROM `0x80003190` TO core 0 every frame (eDMA ch 0); 🟡 the two cores' track mixes, forwarded to the core that owns the ESAI |
+| `0x80003190` + ping·`0x400` | 256 | ← `X:0x4600` / `X:0x2600` (❌ was "`X:0x400`", see below) | read-back (DSP → CPU) — ❌ half the story: ✅ measured 8 Sep 2026 (`COLDFIRE_PORT.md` O9), core 1's read-back lands here and core 0's at `+0x200`, and the ColdFire then sends the 512 words FROM `0x80003190` TO core 0 every frame (eDMA ch 0); ✅ **four per-track post-FX2 blocks of 64 words**, not a mix (read 10 Sep 2026, below) |
 | `0x80005460..0x80005e60`, page-stepped | 128 | ← | ✅ the eight ESAI input slots × 16 samples (eDMA ch 7; proven by content, O9) |
 
 The 336-word block is assembled by the packer at `0x4000d3fc`–`0x4000d55e`:
@@ -798,6 +798,51 @@ for each of 8 tracks it calls the machine-type handler from the table at
 `0x80001c80`. The 72-word staging block the DSP copies out of `X:0x30000`
 (§5) is the 84-word record after the DSP's unpack; the packer also steps a
 second per-track cursor by `0x48` = 72.
+
+### The read-back block is four per-track post-FX2 blocks, not a mix
+
+✅ Read 10 Sep 2026 from `out/dsp/payload_A.asm` and `payload_B.asm`
+(`tools/dsp_disasm_all.py`, the vendored dsp56300 disassembler, 0 undecodable
+instructions). Every address below is in payload A; payload B has the same
+code 0x20b words lower.
+
+The dispatcher at `P:0x54`/`P:0x64` loads `r5 = X:0x4600` (bank A) or
+`X:0x2600` (bank B) and saves it at `X:0x206` (`P:0x8c`). That is the
+address the ColdFire's "DMA a block OUT" command names as `0x6600`
+(`COLDFIRE_PORT.md`, the host command table: `0x6600 | 0x2000` bank bits
+masked). ❌ The "`X:0x400`" this table carried was never located and is
+retracted; `X:0x415`–`0x41f` are the dispatcher's own variables and sit
+inside that range.
+
+The per-track loop fills it. Right after the FX2 call (`jsr (r2)` at
+`P:0x50d`, handler from the table at `X:0x235 + id`), `P:0x50e`–`0x514`
+loads `r0 = X:0x206`, `r1 = 0`, `n1 = 1`, `r3 = X:0x419` (the track record)
+and calls the copy at **`P:0x55a`**. Its source `X:0x000` is the track's
+audio block, the same `r0 = 0` the dispatcher hands every effect
+(`CLAUDE.md`, the harness trap). It reads 16 interleaved L/R samples and
+writes each 24-bit sample as **two words** (`mpy` by `0x8000` and by `0x80`,
+then `a` and `b0` stored), so one track is 16 × 2 × 2 = **64 words** per
+frame, which is exactly the `add #>$40` the loop applies to `X:0x206` at
+`P:0x52b` before the next track. Four tracks per core × 64 = the 256 words
+the ColdFire reads. The 16-bit host port carries one DSP word per cycle, so
+the split is how a 24-bit sample survives the crossing.
+
+So the block the ColdFire holds at `0x80003190` (core 1, tracks 1–4) and
+`0x80003390` (core 0, tracks 5–8) is **every track's post-FX2 audio, 16
+samples per frame, 24-bit, per track** — the full 8-track stem set, every
+frame. 🟡 Whether the track LEVEL and the ColdFire-side delay are applied
+before or after this point is not read here; the delay's frame routine
+`0x400031a0` consumes this block and the ColdFire sends the processed 512
+words back to core 0 at `X:0x4400` (`RTOS_FORK.md` §10.16.2). Falsifier for
+the reading: run the port with the DSP frame engine on from boot, a known
+signal on one track and an audible FX2, and dump the 64 words; they must be
+that signal after FX2 and nothing else.
+
+The port's "P:0x55a called three times a frame" (`COLDFIRE_PORT.md`, the
+ESAI section) counts the three calls at `P:0x2df`/`0x2e2`/`0x2e6`, which
+copy the ESAI rings into the block's upper 256 words. The per-track call at
+`P:0x514` is a fourth site, inside the loop, once per track; 🟡 it was not
+reached in that run because no track was playing through FX2.
 
 **What consumes the tempo inside the packer's handlers** — three sites, all
 turning tempo into a *rate*, none copying it:

--- a/docs/firmware/DSP.md
+++ b/docs/firmware/DSP.md
@@ -802,9 +802,12 @@ second per-track cursor by `0x48` = 72.
 ### The read-back block is four per-track post-FX2 blocks, not a mix
 
 ✅ Read 10 Sep 2026 from `out/dsp/payload_A.asm` and `payload_B.asm`
-(`tools/dsp_disasm_all.py`, the vendored dsp56300 disassembler, 0 undecodable
-instructions). Every address below is in payload A; payload B has the same
-code 0x20b words lower.
+(`tools/build/dsp_disasm_all.py`, the vendored dsp56300 disassembler, 0
+undecodable instructions). Every address below is in payload A. Payload B
+has the same dispatcher sites at `P:0x5f`/`P:0x68` (the `r5` loads) and
+`P:0x74` (the save to `X:0x206`), and the same per-track loop and copy
+0x20b words lower: `P:0x303` for `P:0x50e`, `P:0x309` for `P:0x514`,
+`P:0x34f` for `P:0x55a`.
 
 The dispatcher at `P:0x54`/`P:0x64` loads `r5 = X:0x4600` (bank A) or
 `X:0x2600` (bank B) and saves it at `X:0x206` (`P:0x8c`). That is the

--- a/docs/firmware/SAMPLE_SAVE.md
+++ b/docs/firmware/SAMPLE_SAVE.md
@@ -162,6 +162,25 @@ That is 512 frames at 24 bit stereo, 768 at 16 bit stereo, 1,024 at 24 bit
 mono. ❌ An earlier note here said "3,072 sample chunks". That was the r2
 misreading, and it is wrong: 3,072 is bytes.
 
+⚠️ **objdump prints that instruction as `remul`, which reads as a remainder.
+It is a divide, and the value is the quotient.** The encoding `4c44 6006` is
+ambiguous: `m68k-linux-gnu-as -mcpu=5407` assembles both `divu.l %d4,%d6` and
+`remul %d4,%d6,%d6` to exactly those bytes, because the destination and
+remainder registers are the same register, and binutils simply prefers the
+`remul` spelling when disassembling. Two independent reasons the quotient is
+the correct reading:
+
+- `A` is always 2, 3, 4 or 6, and 3,072 is divisible by all four. A remainder
+  would be 0 in every configuration, the frame count would be 0, and the loop
+  would abort with `-51` before writing a single sample. The unit saves
+  samples, so it is not the remainder.
+- The quotient is the only value that makes the surrounding code meaningful:
+  it is compared against the contiguous run and the remaining count to pick a
+  chunk size.
+
+Same family as the traps in `CLAUDE.md`: legal encoding, plausible-looking
+output, wrong meaning. Assemble the candidates when a mnemonic surprises you.
+
 Each pass:
 
 1. `0x4009499c(slotId, position, 1)` returns a pointer in `d0` and the

--- a/docs/firmware/SAMPLE_SAVE.md
+++ b/docs/firmware/SAMPLE_SAVE.md
@@ -1,0 +1,278 @@
+# How a recording becomes a `.wav` on the card
+
+The firmware writes WAV files itself. This page is the save path: the
+routine that emits the header, the loop that streams the audio out of the
+sample pool, the file API underneath, and the clock that names the file.
+
+**Method.** Read from `out/raw/section_3_MAIN_OS.bin`, SHA-256
+`164f31224bf61181e3f50e7dec40df9afcae5b16dbf6e4c0d0cc5e986af0a84e`, load base
+`0x40000400`. Disassembled with `scripts/disasm.sh emac`, that is
+`objdump -m m68k:cfv4e`.
+
+⚠️ **Do not read this region with r2.** `scripts/disasm.sh` records why:
+6,757 instructions below `0x40098000` that r2 cannot decode, 4,543 of them
+longer than two bytes, so the stream desynchronises and invents plausible
+code. An earlier reading of this same routine with r2 got the staging buffer
+wrong by a factor of the block size, and turned a `mulsl` and a `remul` into
+`invalid`. Every claim below was re-derived with cfv4e.
+
+Confidence markers as in `CHIP.md`: ✅ measured, 🟡 inferred with a falsifier
+stated, ❌ retracted.
+
+---
+
+## 0. Why this page exists
+
+Two independent projects list this path as unmapped. `docs/history/COVERAGE.md`
+here, and octamax's `COVERAGE.md`, both record that no WAV writer and no
+sample-save path had been located. Both were wrong. The writer is at
+`0x40020f04` and it has always been in the image.
+
+The practical consequence: **writing audio to the card is not new machinery.**
+Anything that wants to put samples on the card can call what is already there.
+
+---
+
+## 1. The path, end to end
+
+✅ All addresses below are measured, unless a row says otherwise.
+
+| step | address | what happens |
+|---|---|---|
+| build the path | `0x40013a08` (sprintf) | formats `%s/AUDIO/%s.wav` (`0x400b3a85`) or `../AUDIO/%s.wav` (`0x400b3a11`); project directory from `0x40025230` |
+| open for write | `0x40016864` | mode string `"w"` at `0x400b328b`, I/O buffer `0x460263e0`, buffer size `0x10000` |
+| write header and audio | **`0x40020f04`** | the subject of this page |
+| close | `0x4001677c` | |
+
+The one call site of the writer is `0x40084e46`, inside the save routine that
+opens the file 34 bytes earlier at `0x40084e24`. That routine passes the
+**trim points**, not the whole slot:
+
+```
+d0 = state@(266)          start sample
+d1 = state@(270) - d0     sample count
+a4 = state@(2)            slot id
+wav_write(handle, d0, d1, a4)
+```
+
+So a save writes the trimmed region of the slot, not its full contents.
+
+---
+
+## 2. The writer `0x40020f04`
+
+✅ Signature, from the prologue and the caller:
+
+```
+long wav_write(void *handle,      sp@(48)   open file object
+               long  startSample, sp@(52)
+               long  sampleCount, sp@(56)
+               long  slotId)      sp@(60)
+```
+
+✅ Two guards, both taken before anything is written:
+
+| guard | address | effect |
+|---|---|---|
+| `0x46105408` must be non-zero | `0x40020f1c` | returns `-2` |
+| `slotId` must be `<= 135` | `0x40020f26` (`cmpal #135,%a4`) | returns `-2` |
+
+**135 is `0x87`, the last recorder buffer.** `EXTERNAL.md` §6 records that
+recorder buffers are object ids 128 to 135 in the same arena as the sample
+slots. This writer accepts them. It is not restricted to sample slots.
+
+✅ The slot's control record is `0x46c922c4 + slotId * 44`, which is the same
+base and stride `EXTERNAL.md` gives for the state arena. Two flag bits in the
+first word of that record drive the whole format:
+
+| bit | clear | set |
+|---|---|---|
+| 0 | mono, 1 channel | stereo, 2 channels |
+| 1 | 24 bit, 3 bytes per sample | 16 bit, 2 bytes per sample |
+
+Bit 1 is read twice, once for the byte count at `0x40020f48` and once for the
+`bits` field at `0x40020ff6`, and the two agree. That internal consistency is
+why the mapping is marked measured rather than inferred.
+
+✅ Return codes: `1` success, `-2` a guard failed, `-51` a chunk of zero
+length was computed, or the negative value the write primitive returned.
+
+---
+
+## 3. The 44 byte header
+
+✅ Built in a scratch buffer at `0x46c2d980`, then written in one call. The
+CPU is big endian and RIFF is little endian, so every numeric field goes
+through `byterev.l` first. `byterev` is ColdFire ISA_C, opcode `0x02C0 | reg`.
+Neither r2 nor binutils `m68k:cfv4e` decodes it; objdump prints `.short 0x02c0`.
+It is decoded here by hand, and the little endian requirement makes the
+reading certain.
+
+Let `A` be the block align, that is bytes per sample times channels. Let `D`
+be `sampleCount * A`, the audio byte count. Let `P` be `D & 1`, the RIFF pad.
+
+| offset | size | content |
+|---|---|---|
+| `+0x00` | 4 | `RIFF` |
+| `+0x04` | 4 | `D + P + 44` |
+| `+0x08` | 4 | `WAVE` |
+| `+0x0c` | 4 | `fmt ` |
+| `+0x10` | 4 | 16 |
+| `+0x14` | 2 | 1, PCM |
+| `+0x16` | 2 | channels |
+| `+0x18` | 4 | 44100 |
+| `+0x1c` | 4 | `44100 * A`, byte rate |
+| `+0x20` | 2 | `A`, block align |
+| `+0x22` | 2 | 24 or 16, bits per sample |
+| `+0x24` | 4 | `data` |
+| `+0x28` | 4 | `D + P` |
+
+Total 44 bytes, `0x2c`, matching the `pea 0x2c` at `0x40021026`.
+
+The sample rate is the literal `44100` at `0x40020fca` and `0x40020fd8`. It is
+not read from the slot. ✅
+
+### 🟡 The RIFF size field looks eight bytes too large
+
+The RIFF specification puts the total file size minus 8 in the field at
+`+0x04`. Here that is `D + P + 36`. The firmware computes `D + P + 44`, at
+`0x40020f78`, as `lea %a0@(2c,%d1:l),%a0` with `a0` holding `P` and `d1`
+holding `D`. Nothing is appended after the pad byte, so there is no extra
+chunk to account for the difference.
+
+Either the firmware writes a value 8 too large, which most decoders ignore
+because they trust the `data` chunk size, or the `lea` is being misread.
+
+**Falsifier, and it needs no tools:** take any `.wav` the Octatrack saved,
+read bytes 4 to 7 as a little endian integer, and compare with the file size
+minus 8. If they differ by 8, the firmware is off by 8.
+
+---
+
+## 4. The audio loop
+
+✅ The same `0x46c2d980` scratch buffer is reused as a **3,072 byte** staging
+area. The count of sample frames that fit is computed once, at `0x4002105a`:
+
+```
+d6 = 3072 / A          remul %d4,%d6,%d6
+```
+
+That is 512 frames at 24 bit stereo, 768 at 16 bit stereo, 1,024 at 24 bit
+mono. ❌ An earlier note here said "3,072 sample chunks". That was the r2
+misreading, and it is wrong: 3,072 is bytes.
+
+Each pass:
+
+1. `0x4009499c(slotId, position, 1)` returns a pointer in `d0` and the
+   contiguous run available at that position in `d1`. ✅ This is the pool page
+   walk. It has exactly two callers, this loop and `0x4008e4f4`, and it
+   branches on `slotId - 128 <= 7`, that is on whether the slot is a recorder
+   buffer.
+2. The frame count for this pass is `min(d6, d1, remaining)`. A result of zero
+   aborts with `-51`.
+3. The converter runs, chosen by the 16 bit flag at `0x40021042`:
+   `0x40097b54` for 16 bit, `0x40097f8c` for 24 bit. It is called as
+   `(dest, src, valueCount, 1)` where `valueCount` is frames shifted left by
+   the stereo bit.
+4. The write primitive `0x400166b8` writes `frames * A` bytes.
+5. `remaining -= frames`, `position += frames`.
+
+After the loop, a single zero byte is written if `P` is 1, at `0x400210cc`.
+That is the RIFF pad, and it is correct.
+
+**Why this matters for anything that streams to the card:** the loop is
+already page aware and already chunked. It walks a block chained pool, it
+never assumes the audio is contiguous, and it writes in bounded pieces.
+
+---
+
+## 5. The file API underneath
+
+✅ Corroborated by two other projects that traced it independently, which is
+stronger evidence than either alone.
+
+| routine | address | named by |
+|---|---|---|
+| open | `0x40016864` | ems-octakit `runtime/abi.inc`, octamax `NOTES.md` |
+| read | `0x40016564` | both |
+| seek | `0x4001660c` | ems-octakit |
+| write | `0x400166b8` | both |
+| close | `0x4001677c` | both |
+| project directory | `0x40025230` | both |
+| sprintf | `0x40013a08` | octamax |
+
+Mode strings: `"w"` at `0x400b328b`, `"r"` at `0x400b3289`.
+
+octamax also reports two working patches that create files on the card from a
+detour using this API, so the write side is proven in practice and not only in
+disassembly.
+
+---
+
+## 6. The recording auto-name, and the clock
+
+Recordings are named `YYMMDD-HHMM`. Two recordings saved in the same minute
+collide, and the user has to rename one by hand. This section is why.
+
+✅ The name builder is `0x400819fc`. It formats
+`%02d%02d%02d-%02d%02d` (`0x400b77bb`, referenced from this one site only)
+into a buffer at `0x460faab4`.
+
+It reads the clock through two helpers:
+
+- `0x4001c4d8(index)` reads one field. It is an I2C transaction against the
+  peripheral registers `0xfc05c02c`, `0xfc05c034` and `0xfc05c038`, polling
+  until a status nibble reads 2. ✅
+- `0x4001c31c(value)` converts BCD to binary, as
+  `(v >> 4) * 10 + (v & 15)`. ✅ So the clock returns BCD.
+
+### The field map
+
+✅ Measured, by comparing the name builder against its sibling at
+`0x40081968`, 148 bytes earlier, which formats
+`%04d-%02d-%02d %02d:%02d:%02d` (`0x400b779d`) and therefore prints seconds.
+
+| index | field | used by the timestamp `0x40081968` | used by the name `0x400819fc` |
+|---|---|---|---|
+| 1 | second | yes | **no** |
+| 2 | minute | yes | yes |
+| 3 | hour | yes | yes |
+| 4 | 🟡 day of week | no | no |
+| 5 | day of month | yes | yes |
+| 6 | month | yes | yes |
+| 7 | year, plus 2000 | yes | yes |
+
+Index 4 is skipped by both routines. Day of week is the one calendar field
+neither a filename nor a timestamp needs, which is the reading, but nothing
+here reads it, so it is inferred. Falsifier: call `0x4001c4d8(4)` and compare
+against a known date.
+
+Index 0 is never read by either routine and is unidentified.
+
+**So the collision is not a missing capability.** Seconds are available at
+index 1, and the sibling routine 148 bytes away already reads them. The name
+builder simply does not ask.
+
+---
+
+## 7. What is not known
+
+- **The writer has not been executed.** Everything above is a static read with
+  a correct decoder. Running it means driving SAVE SAMPLE under `tools/emu/`
+  route A and watching for the `0x400166b8` call with length `0x2c` from
+  `0x40021032`. Falsifier: if no 44 byte write precedes the audio chunks, the
+  header builder is not what it looks like.
+- **The converters `0x40097b54` and `0x40097f8c` are not disassembled.** Their
+  argument shape is known from the call site, their internals are not.
+- **The FAT layer is still unmapped.** `0x40016864` and `0x400166b8` are used
+  as black boxes here, exactly as `COVERAGE.md` says. File creation, directory
+  entries and cluster allocation are all behind them.
+- **`0x46105408`, the guard word, is unidentified.** It gates the whole writer.
+- **The reader is a separate routine at `0x400210fc`**, called from the static
+  and flex loaders `0x40093b14` and `0x40096710`. It parses `RIFF`, `WAVE`,
+  `fmt `, `data`, `cue ` and `smpl` at `0x400213ec` onward. Not covered here.
+- **Card write throughput has never been measured**, in this project or in
+  any of the three others surveyed. Every figure that exists is a sector count
+  from an emulator. Nothing on this page should be read as a statement about
+  how fast the card can be written.

--- a/docs/firmware/SAMPLE_SAVE.md
+++ b/docs/firmware/SAMPLE_SAVE.md
@@ -267,7 +267,7 @@ It reads the clock through two helpers:
 | 4 | 🟡 day of week | no | no |
 | 5 | day of month | yes | yes |
 | 6 | month | yes | yes |
-| 7 | year, plus 2000 | yes | yes |
+| 7 | year, two digits (the timestamp routine adds 2000 at `0x400819d0` before its `%04d`; the name builder passes it as read) | yes | yes |
 
 Index 4 is skipped by both routines. Day of week is the one calendar field
 neither a filename nor a timestamp needs, which is the reading, but nothing

--- a/docs/firmware/SAMPLE_SAVE.md
+++ b/docs/firmware/SAMPLE_SAVE.md
@@ -288,9 +288,12 @@ builder simply does not ask.
   as black boxes here, exactly as `COVERAGE.md` says. File creation, directory
   entries and cluster allocation are all behind them.
 - **`0x46105408`, the guard word, is unidentified.** It gates the whole writer.
-- **The reader is a separate routine at `0x400210fc`**, called from the static
-  and flex loaders `0x40093b14` and `0x40096710`. It parses `RIFF`, `WAVE`,
-  `fmt `, `data`, `cue ` and `smpl` at `0x400213ec` onward. Not covered here.
+- **The reader is a separate routine at `0x400210fc`**, with two call sites,
+  `jsr` at `0x40093b12` and at `0x4009670e`. ✅ Both verified. 🟡 Those sit
+  inside what octamax names the static loader `0x40093980` and the flex loader
+  `0x40096548`, but the function boundaries were not checked here. The reader
+  parses `RIFF`, `WAVE`, `fmt `, `data`, `cue ` and `smpl` from `0x400213ec`
+  onward. Not covered here.
 - **Card write throughput has never been measured**, in this project or in
   any of the three others surveyed. Every figure that exists is a sector count
   from an emulator. Nothing on this page should be read as a statement about

--- a/docs/firmware/SAMPLE_SAVE.md
+++ b/docs/firmware/SAMPLE_SAVE.md
@@ -103,10 +103,17 @@ length was computed, or the negative value the write primitive returned.
 
 ✅ Built in a scratch buffer at `0x46c2d980`, then written in one call. The
 CPU is big endian and RIFF is little endian, so every numeric field goes
-through `byterev.l` first. `byterev` is ColdFire ISA_C, opcode `0x02C0 | reg`.
-Neither r2 nor binutils `m68k:cfv4e` decodes it; objdump prints `.short 0x02c0`.
-It is decoded here by hand, and the little endian requirement makes the
-reading certain.
+through `byterev.l` first. `byterev` is ColdFire ISA_A+ (the assembler
+accepts it from `-march=isaaplus` on; ❌ an earlier version of this page said
+ISA_C), opcode `0x02C0 | reg`. Under the `m68k:cfv4e` profile that
+`scripts/disasm.sh emac` uses, objdump prints it as `.short 0x02c0`, and r2
+does not decode it at all. The `m68k:isa-aplus` and `m68k:isa-c` profiles do
+print `byterev %d0`, but they drop the EMAC instructions: under either, the
+`msacl` gate at `0x40003664` comes out as `btst` and `.short` (checked
+10 Sep 2026). No single profile decodes both, so this page reads the header
+builder under `cfv4e` and decodes the `.short 0x02c0` words by hand; the
+little endian requirement makes the reading certain. To see `byterev` spelled
+out, re-run the span under `-m m68k:isa-aplus` and ignore its EMAC output.
 
 Let `A` be the block align, that is bytes per sample times channels. Let `D`
 be `sampleCount * A`, the audio byte count. Let `P` be `D & 1`, the RIFF pad.

--- a/docs/history/COVERAGE.md
+++ b/docs/history/COVERAGE.md
@@ -34,7 +34,7 @@ container? data inside the MAIN OS that `FUN_40001d4c` receives as `param_1`?).
 | OS format & update (8.5.2, ch.18) | ✅ | ELUP/ELEK/aPLib, checksum, validation, ATA write, MIDI upgrade. Complete |
 | Kernel / RTOS / scheduler | ✅ | Context switch, priority queues, PIT, TRAP #0. Missing: task list, allocator |
 | ATA/CF storage | ✅ | ATA stack (PIO/DMA), driver+vtable, registers. Missing: FAT layer (vtable `_DAT_46c82xxx`) |
-| File hierarchy: Sets/Projects/Audio Pool (ch.4,7,8) | 🟡 | Project settings serialization found; the rest missing (banks/parts/samples on disk) |
+| File hierarchy: Sets/Projects/Audio Pool (ch.4,7,8) | 🟡 | Project settings serialization found. **The sample-save path is no longer missing** — the firmware's own WAV writer is `0x40020f04`, documented in `docs/firmware/SAMPLE_SAVE.md`, along with the buffered file API it sits on and the auto-name clock. Still missing: banks/parts on disk, and the WAV reader `0x400210fc` |
 | Audio engine (voices) | 🟡 | Data model (voice `0x800049d8`, mailboxes), frame builder, handoff to the DSP. Missing: voice parameter computation, envelopes, amp modulator |
 | Sample playback: FLEX vs STATIC | ⬜ | FLEX=RAM, STATIC=stream from CF. Not decompiled |
 | **Timestretch** (NORMAL/BEAT) | ⬜ | On the DSP (separate binary) |

--- a/docs/proposals/MULTITRACK_TO_CARD.md
+++ b/docs/proposals/MULTITRACK_TO_CARD.md
@@ -145,8 +145,12 @@ and let a background task drain the ring to eight files.
 - Leaves the eight recorders free for the user.
 - Needs a DRAM placement for the ring. `PLAN.md` item 6, measuring
   `0x46000000` to `0x47502c10` with samples loaded and the recorder running,
-  is the prerequisite. A ring of 4 MiB holds 1.5 seconds of card stall at
-  24-bit, which is the budget a slow card gets before samples drop.
+  is the prerequisite. The ring holds the raw 1,024-byte frames, so the
+  per-frame hook stays a memcpy and the packing to 24-bit happens in the
+  drainer. At 2.82 MB/s a ring of 4 MiB holds 1.5 seconds of card stall,
+  which is the budget a slow card gets before samples drop. Packing before
+  the ring instead would stretch the same 4 MiB to 2.0 seconds at the cost
+  of work inside the frame.
 
 Why C over B: the audio is already sitting in DRAM in the shape we want, so
 the capture is a memcpy, and nothing we add touches the pool's bookkeeping.

--- a/docs/proposals/MULTITRACK_TO_CARD.md
+++ b/docs/proposals/MULTITRACK_TO_CARD.md
@@ -1,0 +1,219 @@
+# Writing all eight tracks to the card while playing
+
+A technical proposition. It says what the firmware already does, what the
+numbers are, what nobody has measured, and the order in which to measure it.
+It is not a build plan and nothing here is on `PLAN.md`.
+
+Confidence markers as in `docs/firmware/CHIP.md`: ✅ measured, 🟡 inferred with
+a falsifier stated, ❌ retracted. Where a number is arithmetic on measured
+inputs it says so.
+
+---
+
+## 1. The wish, in one sentence
+
+Record the eight tracks' post-effects outputs to eight files on the
+CompactFlash card, continuously, while the sequencer plays, without stopping
+for a save.
+
+Related wishes from the same thread, not covered here: a routing matrix to
+the recorder buffers, and recording sources other than the track outputs.
+
+---
+
+## 2. What the firmware already does
+
+Everything in this section is in the stock OS today. None of it is new code.
+
+### 2.1 The eight post-FX2 track outputs reach the ColdFire every frame
+
+✅ `docs/firmware/DSP.md`, the frame table and the section after it (read
+10 Sep 2026 from both DSP payloads). After each track's FX2 runs, the DSP
+copies that track's 16-sample block into a read-back buffer, 64 words per
+track. The ColdFire's DMA fetches the buffer every frame:
+
+| DRAM address | tracks | size per frame |
+|---|---|---|
+| `0x80003190` | 1 to 4 | 256 words |
+| `0x80003390` | 5 to 8 | 256 words |
+
+Each sample is 24-bit, carried as two 16-bit words because the host port is
+16 bits wide. So the ColdFire holds a complete 8-track stem set, 16 samples
+deep, every 363 µs. Nothing on the DSP has to change to capture it.
+
+🟡 Not yet read: whether the track LEVEL knob and the ColdFire-side delay are
+applied before or after this point. The ColdFire's delay routine consumes
+this block and sends the processed result back to the DSP, so the point just
+before that send-back is the post-delay tap. Falsifier: sweep LEVEL and the
+delay on one track and dump the 64 words; if they do not change, the tap is
+upstream of both.
+
+### 2.2 The recorders can already capture per track
+
+✅ `docs/firmware/PARAM_PAGES.md`, hardware-confirmed by Bryan T on
+2 Sep 2026. A track recorder's SRC3 source offers `-, T1…T8, MAIN, CUE`. Eight
+recorders with SRC3 set to T1 through T8 is an 8-track capture with no
+modification at all.
+
+🟡 The recorder's mixer reads three sources with independent gain ramps.
+INAB and INCD come from the input-capture ring at `0x80005760`; SRC3 set to a
+track comes from the read-back block in 2.1. This reconciles the two
+`RTOS_FORK.md` entries that name different sources for "the recorder's audio":
+they describe different sources of the same mixer. Falsifier: a recorder with
+SRC3 = T1 and INAB = INCD = off must reproduce the T1 block of 2.1 sample for
+sample.
+
+### 2.3 The firmware writes WAV files itself
+
+✅ `docs/firmware/SAMPLE_SAVE.md`. The writer at `0x40020f04` builds a 44-byte
+header, walks the sample pool in 3,072-byte pieces, converts through the
+16-bit or 24-bit converter, and writes through a 64 KB buffered file API.
+It accepts recorder buffers as sources. The file API underneath has been used
+from a detour to create files on the card, on hardware, by octamax.
+
+### 2.4 Card I/O does not stop audio
+
+✅ octamax validated a bank load from the card while the sequencer ran. The
+storage stack is asynchronous: a command queue, an interrupt per sector, an
+RTOS event on completion. The discipline the firmware already follows is
+buffer in DRAM, flush later.
+
+---
+
+## 3. The numbers
+
+All arithmetic on measured inputs. Frame = 16 samples at 44,100 Hz, so
+2,756.25 frames per second.
+
+| quantity | value |
+|---|---|
+| raw stem data in DRAM, 8 tracks | 1,024 bytes per frame, 2.82 MB/s |
+| on card, 8 tracks, stereo, 24-bit | 2,116,800 B/s, 2.02 MiB/s, 121 MiB per minute |
+| on card, 8 tracks, stereo, 16-bit | 1,411,200 B/s, 1.35 MiB/s, 81 MiB per minute |
+| sectors per second at 24-bit | 4,134, one sector interrupt every 242 µs |
+| sample pool | 14,602 blocks × 6,144 B = 85.56 MiB |
+| pool split eight ways, 24-bit stereo, no samples loaded | 42 seconds per track |
+
+Two conclusions follow without any further measurement:
+
+- **Capacity, not bandwidth, is why this cannot be done with the stock
+  recorders alone.** Forty-two seconds of eight tracks fills the RAM the
+  samples also need. Streaming exists to make the card the store, not the RAM.
+- **The card must sustain about 2 MiB/s for as long as the song lasts.** The
+  ATA specification's PIO mode 4 ceiling is 16.7 MB/s. That is a
+  specification figure. What this driver reaches, through an interrupt per
+  512-byte sector on a 264 MHz ColdFire that is also running the sequencer,
+  the recorder mixer and the delay, is **unmeasured** (section 5).
+
+---
+
+## 4. Three ways to do it
+
+### A. Stock, offline
+
+Eight recorders, SRC3 = T1 to T8, record, then save each buffer with the
+stock writer. Works today by hand. Limits: 42 seconds, and eight manual
+saves. Worth stating because it is the baseline every other option is
+measured against, and because it is the fixture for measurement 2 in
+section 5.
+
+### B. Stream the stock recorders
+
+Keep A's recorders recording in a loop. A background task walks each
+recorder's block chain behind the write position, appends drained blocks to
+eight open files, and returns the blocks to the pool.
+
+- Reuses: the recorder mixer, the pool page walk `0x4009499c`, both
+  converters, the writer's header and chunk loop, the file API.
+- New: the drainer task, block recycling behind the write head, a header
+  fix-up at stop (seek exists at `0x4001660c`).
+- Risk: the pool's block rows are the recorder's own bookkeeping. Recycling a
+  block the recorder still owns is a corruption with no error message.
+  The loop point is a hard cut inside the frame, which the drainer must not
+  straddle.
+
+### C. Tap the read-back block directly (recommended)
+
+Hook the frame path at the point where the ColdFire has both cores' blocks
+in DRAM. Copy 1,024 bytes per frame into a ring of our own, pack to 24-bit,
+and let a background task drain the ring to eight files.
+
+- Reuses: the file API, the writer's header layout, the 16-bit and 24-bit
+  converters if their argument shape fits, the DRAM platform's detour and
+  runtime mechanism (`docs/remixer/PLACEMENT.md`).
+- New: one per-frame copy, one ring, one drainer task, one header fix-up.
+- Leaves the eight recorders free for the user.
+- Needs a DRAM placement for the ring. `PLAN.md` item 6, measuring
+  `0x46000000` to `0x47502c10` with samples loaded and the recorder running,
+  is the prerequisite. A ring of 4 MiB holds 1.5 seconds of card stall at
+  24-bit, which is the budget a slow card gets before samples drop.
+
+Why C over B: the audio is already sitting in DRAM in the shape we want, so
+the capture is a memcpy, and nothing we add touches the pool's bookkeeping.
+B becomes the fallback only if the read-back block turns out to be upstream
+of something the wish needs, such as the delay.
+
+Either way the file side is the same: eight WAV files, header written with
+placeholder sizes, sizes patched at stop. A single 16-channel file is a
+variant of the same writer, not a different design.
+
+---
+
+## 5. What must be measured, in order
+
+Each item names the instrument, the cost, and what would falsify the
+proposition. Do not skip 1; it is the one number that decides whether this
+is real.
+
+1. **Card write throughput, on hardware.** One flash. A detour at a menu
+   hook writes 32 MiB through `0x400166b8` in 64 KB pieces while the
+   sequencer plays, and reports frames elapsed and whether audio dropped.
+   octamax's file-creating detour is the template. Falsifier: under about
+   2.5 MiB/s sustained, streaming eight 24-bit tracks is not real on this
+   card path, and the proposition drops to 16-bit or to fewer tracks.
+   Nothing in any of the four repos measures this today. Do not estimate it.
+
+2. **The read-back block's content.** Port or hardware, no flash needed on
+   the port. Set up option A's fixture, put a known signal on T1 with an
+   audible FX2, and dump the 64 words at `0x80003190`. Falsifier: anything
+   other than T1 after FX2. On the port this needs the DSP frame engine
+   running from boot; in every run so far the block has been zero because
+   the port started the DSP cold at transport start
+   (`docs/firmware/RTOS_FORK.md` §10.16).
+
+3. **The tap's position relative to LEVEL and the delay.** Same fixture,
+   sweep both. Decides where in the frame routine the hook goes.
+
+4. **DRAM for the ring.** `PLAN.md` item 6, unchanged.
+
+5. **ColdFire headroom.** No figure exists. The port counts about 64k
+   instructions per frame under emulation, but that is the emulator's
+   count, not a cycle budget. Measurement 1 gives the first real data
+   point: whether the sequencer dropped audio while the card was busy.
+
+6. **Execute the stock writer under the port.** `SAMPLE_SAVE.md` item 1.
+   Confirms the header builder before its layout is copied.
+
+7. **The RIFF size field.** Needs no tools. Read bytes 4 to 7 of any `.wav`
+   the unit saved and compare with the file size minus 8. If they differ by
+   8, the stock writer is off by 8 and ours should not copy the mistake.
+
+---
+
+## 6. What this is not
+
+- Not a change to the DSP. The stems are already delivered.
+- Not a change to the recorders. Option C does not touch them.
+- Not on `PLAN.md`. The remixer's work order stands; this is a survey for the
+  people who asked.
+- Not a claim that it works. Nothing has been built, flashed or timed.
+  Measurement 1 is where that starts.
+
+---
+
+## 7. Questions back to the thread
+
+- Eight stereo files, eight mono pairs, or one 16-channel file?
+- 24-bit or 16-bit? The difference is a third of the card bandwidth.
+- Should recording start and stop with the sequencer, or with a key?
+- Which cards do people use? Measurement 1 has to run on each.


### PR DESCRIPTION
## What this branch adds

Documentation only. No module, no build change, nothing flashed.

**`docs/firmware/SAMPLE_SAVE.md` (new).** The firmware's own WAV writer at `0x40020f04`: the 44-byte header, the 3,072-byte staging loop, the file API underneath, and the clock behind the `YYMMDD-HHMM` auto-name. `COVERAGE.md` said no sample-save path had been located; it had always been in the image. Every claim is read with `objdump -m m68k:cfv4e`, with the r2 misreadings retracted beside the correct values (3,072 is bytes, not samples; `remul` here is the quotient; the reader's call sites are the `jsr` addresses).

**`docs/firmware/DSP.md`.** The read-back block the ColdFire fetches every frame is not a mix at `X:0x400`. It is four per-track post-FX2 blocks of 64 words at `X:0x4600`/`X:0x2600`, filled by the copy at `P:0x55a` right after the FX2 `jsr`. So `0x80003190` and `0x80003390` hold every track's post-FX2 audio, 16 samples per frame, 24-bit, per track. Retraction propagated to `COLDFIRE_PORT.md`.

**`docs/proposals/MULTITRACK_TO_CARD.md` (new).** The survey the sample-save work was started for: writing all eight tracks to the card while playing. What stock already does, the numbers, three designs, and the measurement order. Card write throughput has never been measured in any of the four repos and is measurement 1; the document says so rather than estimating it. Not on `PLAN.md`.

**`docs/WSL.md` (new).** The Windows route. Proven for disassembly through `binutils-m68k-linux-gnu`; `make setup` and `make check` on this route are marked unverified since the 9 Sep toolchain requirement.

## Review

Reviewed against the tree and the image before opening. Ten findings, all fixed in the last six commits: two stale paths from the 10 Sep regroup, one retraction not propagated, one arithmetic slip in the proposal, the payload B address mapping, the `byterev` ISA and decoder note (checked: `isa-aplus`/`isa-c` decode it but lose the EMAC), the clock's year field (the timestamp routine adds 2000 at `0x400819d0`, the name builder does not), and the WSL page's toolchain limits and PATH.

## Not settled

- The RIFF size field: `D + P + 44` where the specification says `D + P + 36`. Needs bytes 4 to 7 of any `.wav` the unit saved.
- The writer has not been executed under the port.
- The `0x80003190` contradiction in `RTOS_FORK.md` has a reconciling reading in the proposal (§2.2), marked inferred; `RTOS_FORK.md` itself is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
