### PR TITLE
recfix: the three fixes and nothing else of ours — plus the stock FX2 list the first cut wrongly left out

### DIFF
--- a/docs/firmware/RECORDER_CLICK.md
+++ b/docs/firmware/RECORDER_CLICK.md
@@ -44,35 +44,51 @@ lost once every **eight** passes rather than every other one.
 The full list is `out/hw/softretrig/tempo_seam.py` (run it with no
 arguments).
 
-There were two other, louder faults stacked on top of this one — the voice
-was being restarted from scratch at every loop (a chirp and a burst of
-hash) and the read pointer was being reset onto alternating samples. Those
-are separate fixes (`FLEX SEEK BIND`, `FLEX SEEK BIND CTR`) and they are
-**not** in the image below. See §4.
+**And it was not the only fault.** Two louder ones sat on top of it:
+
+1. **The voice was restarted from scratch every loop** — the DSP was told the
+   re-bind was a brand new note, so it re-primed the voice: a chirp, then a
+   burst of hash at 140 % of the signal's own level over 300 samples.
+2. **The read pointer was reset** onto that same alternating grid, giving a
+   ±1.5-sample lurch every bar.
+
+Each was loud enough to hide the ones beneath it, which is why this kept
+"not being fixed". **All three fixes are in the image below.**
 
 ## 2. The patch
 
-`modules/recorder-spacing` — one ColdFire code cave, 146 bytes, hooked on
-the last three instructions of the length converter. It works out where the
-next arm will land from where the **current** one did (the sequencer's own
-`floor(k × period)` grid, reconstructed by integer arithmetic) and makes the
-recording exactly that long. No prediction, no lookahead, no state kept
-between passes.
+Three ColdFire code caves, **186 bytes of code between them**, and no DSP
+code at all:
 
-At any tempo whose bar is already a whole number of samples it writes back
-the length that was already there — a **bit-exact no-op**, proven for all
-11,208 (tempo, RLEN) pairs and observed over 21,000 emulator calls at 65.6.
+| module | what it does |
+|---|---|
+| `FLEX SEEK BIND` | a re-bind on the same buffer is a **seek** for the DSP, not a new note — so the voice is not re-primed |
+| `FLEX SEEK BIND CTR` | holds the per-bind counter, so the read pointer is **not reset** — the read head free-runs |
+| `RECORDER SPACING` | makes each pass exactly as long as the gap to its next arm, worked out from where the **current** arm landed (the sequencer's own `floor(k × period)` grid, reconstructed by integer arithmetic). No prediction, no lookahead, no state kept between passes |
 
-Build the minimal image — this cave and **nothing else**, so the FX2 list
-and every other behaviour stay stock:
+At any tempo whose bar is already a whole number of samples, `RECORDER
+SPACING` writes back the length that was already there — a **bit-exact
+no-op**, proven for all 11,208 (tempo, RLEN) pairs and observed over 21,000
+emulator calls at 65.6.
+
+The `recfix` build is **these three and nothing else of ours**. It also lists
+the fourteen stock FX2 effects, which costs nothing at all and is what keeps
+your unit normal: every octabam image rebuilds the FX2 chooser from the
+remix's contents, so without that line the FX2 list would come up empty and
+you could not select an effect (your saved projects would still play — the
+effect code and dispatch are untouched — but you could not change one).
 
 ```bash
-make os                                  # extracts your own downloaded 1.40C
-make check REMIX=recfix                  # every gate, no hardware
+make setup                               # vendored tools
+make os                                  # extracts YOUR OWN downloaded 1.40C
+make check REMIX=recfix                  # every gate, no hardware needed
 make image REMIX=recfix BUILD=84         # -> out/OCTATRACK_OCTABAM84.bin
 ```
 
-Sam's build of that image is sha256 `2f38d9d1…` — yours should match if your
+`make check` is the floor — it builds the image and runs every gate in the
+repo without touching hardware. If it is not green, do not flash.
+
+Sam's build of that image is sha256 `ecb574a9…` — yours should match if your
 stock 1.40C does (`370c55a3…`); if it does not, say so before flashing, because
 that is a difference worth understanding.
 
@@ -137,12 +153,16 @@ noise floor, no per-bar event at any threshold.
 - **One unit, one fixture, one session.** Only ever flashed on an **MKII**.
   The MKI runs the byte-identical stock OS so it is plausibly fine, but
   nobody has done it.
-- **Tested stacked, not alone.** The hardware result above is from an image
-  carrying this cave *plus* the two other fixes from §1. `recfix` is this
-  cave **by itself** and has been gated in the emulator only — whether it is
-  enough on its own is exactly what your test answers. If you still hear a
-  chirp-then-click rather than a clean tick, that is the voice-restart fault
-  and you need the other two as well; say so and we will build that image.
+- **`recfix` is not the exact image that was measured.** The hardware result
+  above is OCTABAM83, which is these three caves **plus** our DSP effects
+  (the "bus"). `recfix` drops those, so it is a different image and has been
+  gated in the emulator only. The recorder path is on the ColdFire and the
+  effects are on the DSP, so they are independent and we expect no
+  difference — but expected is not measured, and Sam is re-taking the
+  capture on this exact image.
+- **We do not know whether all three fixes are needed.** They have only ever
+  been tested together. If you are curious, the individual modules can be
+  built separately — but start with all three.
 - **Real material over long periods.** Our measurements are a tone for 90
   seconds. Whether a half-hour of layering stays clean, nobody knows.
 - One isolated blip (2.3× the floor, one bar in 47) turned up in the 132 BPM
@@ -158,6 +178,9 @@ click, and knowing that is worth more than a confirmation.
 - `docs/firmware/RTOS_FORK.md` §10.53 (the diagnosis and the tempo table),
   §10.55 (a fix that failed, and why), §10.56–10.57 (this cave and its
   gates), §10.58 (the hardware result)
-- `modules/recorder-spacing/` — the cave, its source and its arithmetic
+- `modules/recorder-spacing/`, `modules/flex-seekbind/`,
+  `modules/flex-seekbind-ctr/` — the three caves, their sources and their
+  arithmetic
+- `remixes/recfix.py` — what is and is not in the image, and why
 - `out/hw/softretrig/tempo_seam.py` — which tempi are affected, any RLEN
 - `out/hw/softretrig/lever_e.py` — the arithmetic gate, 115,200 cases

--- a/docs/firmware/RTOS_FORK.md
+++ b/docs/firmware/RTOS_FORK.md
@@ -4765,15 +4765,42 @@ have fixed 1 or 2 (it cannot stop a voice re-priming, and the arm times still
 alternate, so a reset-based player would still splice on alternating
 samples), which is why all three were needed to get here.
 
-**Open, and it decides what the community is asked to flash: is fix 3 enough
-ALONE?** 83 is 82 + the cave, so the three have only ever been tested
-stacked. `remixes/recfix` is the cave by itself — **125 bytes changed in the
-whole OS**, no DSP code, no menu change — and it gates identically to the
-stacked build (36,826 / 36,826 substitutes, the same
-82,687/82,688/82,687/82,688 alternation, `make check REMIX=recfix` green,
-303 PASS). One cave is a far easier ask than three, and Bryan's own unit is
-the instrument for that question: `docs/firmware/RECORDER_CLICK.md` is the
-write-up and the reproduction steps for him.
+**The build for Bryan: `remixes/recfix` = the three caves and nothing else
+of ours.** 83 carries them beside the bus (our DSP effects); `recfix` drops
+the bus, so somebody whose recorder clicks gets the three fixes and a unit
+that is otherwise stock — **228 bytes changed in the whole OS**, no DSP code,
+no FX2 id of ours. Gates, all four on its own cave addresses (the spacing
+cave moves to `0x400d6c80` without the bus's caves in front of it — §10.50's
+lesson, re-gated rather than assumed): substitute **36,826 / 36,826** with
+the same 82,687/82,688/82,687/82,688 alternation; golden a no-op on all
+21,000 calls; the bind's copy of the voice's data-END bound still runs (4
+hits in 16,000 frames); `make check REMIX=recfix` green, 303 PASS. Image
+**OCTABAM84**, sha256 `ecb574a9…`.
+`docs/firmware/RECORDER_CLICK.md` is the write-up and the reproduction steps
+for him.
+
+🟡 **`recfix` is NOT the bytes that were measured** — 83 had the bus. The
+recorder path is ColdFire and the bus is DSP, so they are independent and no
+difference is expected, but expected is not measured: the honest order is a
+re-take of the self-loop capture on this image before it goes out.
+
+**⚠️ The stock FX2 list is load-bearing in this build, and the first cut of
+it was wrong.** Every octabam image replaces the FX2 chooser WHOLESALE with
+the remix's modules (`tools/remix/stock.py`), so `recfix` as first written —
+caves only — drew a chooser of **one row, NONE**. The eleven non-donor stock
+effects keep their code, descriptor and dispatch regardless, so saved
+projects would still PLAY, but nothing could be selected or changed from the
+menu: a severe regression in the one build whose entire job is to change
+nothing else. Listing the fourteen costs **nothing** — no clone, no
+placement, no words, no cycles, only their list rows — and it makes the
+remix give up nothing, which the selftest's `_want` table now records beside
+`restock`'s. Caught by reading the build report's "chooser list = 1 entries"
+line before the image went anywhere.
+
+**Open, and it decides what the community is eventually asked to flash: is
+fix 3 enough ALONE?** The three have only ever been tested stacked. Nothing
+in this section answers it; the modules can be selected individually when
+somebody wants to.
 
 **Also still open (§10.51's drift question), now with a prediction.** With
 the counter hold the read head free-ran at a fixed 82,687 while the writer's

--- a/remixes/recfix.py
+++ b/remixes/recfix.py
@@ -1,40 +1,60 @@
-"""RECFIX -- the recorder length fix, ALONE: one ColdFire cave, nothing else.
+"""RECFIX -- Bryan's recorder click: the three fixes, and nothing else.
 
-The minimal image for testing RTOS_FORK 10.53's defect in isolation. It
-carries `RECORDER SPACING` and no DSP code at all -- no effects, no menu
-changes, no FX2 ids, no bus -- so the FX2 list, every stock effect and every
-other behaviour are the stock 1.40C ones, and anything that changes in the
-recorder is attributable to the cave and nothing else.
+The build to hand somebody whose recorder loops click. It carries the THREE
+ColdFire caves that between them removed the fault on hardware, and no DSP
+code of our own at all -- no effects, no bus, no FX2 id of ours, no menu
+change:
 
-WHY A SOLO BUILD. The fix landed on hardware as OCTABAM83, which is 82
-(`seekB`: bus + the two seek-bind caves) PLUS this cave, so the three fixes
-have only ever been tested stacked:
+  * `FLEX SEEK BIND`      -- a same-buffer re-bind is a SEEK for the DSP, not
+                             a new note. Removes the voice-restart transient
+                             (a chirp, then hash at 140 % of the signal over
+                             300 samples). RTOS_FORK 10.50.
+  * `FLEX SEEK BIND CTR`  -- and its per-bind counter is held, so the read
+                             pointer is not reset onto the alternating grid.
+                             Removes the +/-1.5-sample seam. 10.51.
+  * `RECORDER SPACING`    -- each fixed-RLEN pass is exactly as long as the
+                             gap to its next arm, derived from the current
+                             arm. Removes the one-skipped-sample scuff on
+                             alternate bars. 10.57/10.58.
 
-  * lever A (`FLEX SEEK BIND`)      removed the voice-restart transient
-  * lever B (`FLEX SEEK BIND CTR`)  removed the read-pointer seam
-  * this cave                       removed the length scuff
+Three different mechanisms -- a message path, a position store, a length --
+each measured on its own symptom, which is why all three are here. See
+`docs/firmware/RECORDER_CLICK.md` for the plain-language version and the
+reproduction steps.
 
-Each was measured on its own symptom (10.50/10.51/10.58) so all three are
-real, but "is this cave alone enough?" is UNANSWERED -- and it is the
-question that decides what the community is asked to flash. One cave is a
-much easier ask than three. This remix is how that gets answered, and it is
-also the build to hand someone who only wants the recorder fixed.
+⚠️ THE STOCK FX2 LIST IS NOT OPTIONAL, AND IS NOT "SOMETHING ELSE". Every
+octabam image replaces the FX2 chooser WHOLESALE with the remix's modules
+(`tools/remix/stock.py`), so a remix carrying only ColdFire caves draws a
+chooser of ONE row -- NONE. The eleven non-donor stock effects keep their
+code, descriptor and dispatch either way, so saved projects still PLAY, but
+nothing could be selected or changed from the menu. Listing the fourteen
+costs NOTHING: no clone, no placement, no words, no cycles -- only their list
+rows. It is what keeps the unit NORMAL, which is the whole point of this
+build: somebody should be able to flash it and carry on using their own
+projects.
 
-WHAT IT SHOULD DO. At any tempo whose bar is a whole number of samples
-(65.6, 120, 125, 126, 135, 140, 144, 150 -- 46 of the 1401 tempi from 60.0
-to 200.0) the cave is a BIT-EXACT no-op: it writes back the length that was
-already there, proven for all 11,208 (tempo, RLEN) pairs and observed on
-21,000 port calls. At every other tempo it makes each recorder pass exactly
-as long as the gap to its next arm.
+⚠️ NOT THE BYTES THAT WERE MEASURED. The hardware result (10.58) is
+OCTABAM83 = `seekE`, which is these three caves PLUS the bus (our DSP
+effects). This remix drops the bus, so it is a DIFFERENT IMAGE and is
+port-gated only. The recorder path is ColdFire and the bus is DSP, so they
+are independent and this is expected to behave identically -- but "expected"
+is not "measured", and the honest order is for Sam to re-take the self-loop
+capture on this image before it goes out.
 
-  docs/firmware/RECORDER_CLICK.md -- the reproduction steps.
+OPEN QUESTION this build does not answer: whether `RECORDER SPACING` alone
+would have been enough. The three have only ever been tested stacked.
 """
 
 from remix.schema import Remix
 
 REMIX = Remix(
     name="recfix",
-    doc="Minimal build: the recorder length fix (RECORDER SPACING) alone, no DSP code.",
-    modules=("RECORDER SPACING",),
+    doc="Bryan's recorder click: the three ColdFire fixes beside the stock FX2 chooser, "
+        "no DSP code of our own.",
+    modules=("FLEX SEEK BIND", "FLEX SEEK BIND CTR", "RECORDER SPACING",
+             # the stock chooser, in stock order -- no words, no placement (stock.py)
+             "FILTER", "EQUALIZER", "DJ EQ", "PHASER", "FLANGER", "CHORUS",
+             "SPATIALIZER", "COMB FILTER", "COMPRESSOR", "LO-FI", "DELAY",
+             "PLATE REV", "SPRING REV", "DARK REV"),
     fallback="NONE",
 )

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -438,6 +438,14 @@ def main():
     # The three that differ, and why -- a remix reaching this list by
     # accident is the thing being guarded against.
     _want = {"restock": (),                       # lists all fourteen
+             # recfix is Bryan's recorder fix: three ColdFire caves, NO DSP
+             # words placed, and all fourteen stock effects listed so the
+             # chooser is the one an unmodified unit shows. Like restock it
+             # therefore gives up nothing -- and unlike restock that is the
+             # POINT: somebody flashes it and carries on using their own
+             # projects, so taking a reverb away would be a regression in
+             # the one build whose whole job is to change nothing else.
+             "recfix": (),
              "nimbuslite": ("PLATE REV", "SPRING REV"),   # keeps DARK REV
              # deliberately gives up two more, to put a non-reverb donor on
              # the unit for the first time (docs/effects/FLASHPLAN.md)


### PR DESCRIPTION
Follows #189. Two changes to what `recfix` is.

## 1. The three fixes, not one

Sam's call: the build for Bryan should be the three ColdFire caves that actually fixed it — `FLEX SEEK BIND` + `FLEX SEEK BIND CTR` + `RECORDER SPACING` — with none of our DSP code. No effects, no bus, no FX2 id of ours. **228 bytes changed in the whole OS.** Image OCTABAM84, sha256 `ecb574a9…`.

## 2. ⚠️ The stock FX2 list is load-bearing, and I had it wrong

Every octabam image replaces the FX2 chooser **wholesale** with the remix's modules (`tools/remix/stock.py`). `recfix` as merged in #189 — caves only — drew a chooser of **one row: NONE**.

The eleven non-donor stock effects keep their code, descriptor and dispatch either way, so saved projects would still *play* — but nothing could be selected or changed from the menu. That is a severe regression in the one build whose entire job is to change nothing else, and it would have gone to Bryan that way.

Caught by reading the build report's `chooser list = 1 entries` line before the image went anywhere. Listing the fourteen costs **nothing** — no clone, no placement, no words, no cycles, only their list rows — and it makes the remix give up nothing, which `selftest`'s `_want` table now records beside `restock`'s. `make check` caught that inconsistency on its own, which is the gate doing its job.

## Gates — all four re-run on this build's own addresses

The spacing cave moves to `0x400d6c80` without the bus's caves in front of it. That is §10.50's lesson (81's gates once ran on a build that placed its cave elsewhere), so it was re-gated rather than assumed:

| gate | result |
|---|---|
| substitute path taken, `n128_card` | **36,826 / 36,826** |
| `L'` by pass | **82,687 / 82,688 / 82,687 / 82,688 / 82,687** — same as the measured build |
| golden `g65_card` | `L'` = 161,280 = stock L on all **21,000** calls, `r` = 0 |
| the bind's copy of the voice's data-END bound (`0x4000f89e`) | still runs — **4 hits in 16,000 frames**, one per bind |
| `make check REMIX=recfix` | green, **303 PASS** |

## 🟡 What this is not

**`recfix` is not the bytes that were measured on hardware.** §10.58's result is OCTABAM83, which carries these three caves *plus* the bus. The recorder path is on the ColdFire and the bus is on the DSP, so they are independent and no difference is expected — but expected is not measured. `RECORDER_CLICK.md` says so plainly, and the honest order is a re-take of the self-loop capture on this exact image before it goes to Bryan.

`RECORDER_CLICK.md` now describes all three fixes rather than one, explains why the stock list is in there, and keeps the explicit *what we have and have not proven* section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
