### PR TITLE
RECORDER_CLICK: genericise the shared doc, and make `make check` explain the submodule step instead of throwing a traceback

### DIFF
--- a/docs/firmware/RECORDER_CLICK.md
+++ b/docs/firmware/RECORDER_CLICK.md
@@ -1,12 +1,12 @@
 # The recorder loop click — what it is, and how to test the fix
 
-**For Bryan T, and anyone else who records loops on the Octatrack's recorder.**
+**For anyone who records loops on the Octatrack's recorder.**
 
-You reported a click at the loop point when recording a bar into the
-recorder and looping it back — sound-on-sound. 128 BPM clicks, 120 BPM does
-not. This is what it turned out to be and how to check whether the patch
-fixes it on your unit, because **it is not fixed until it is fixed on
-somebody else's machine.**
+The reported symptom: a click at the loop point when recording a bar into
+the recorder and looping it back — sound-on-sound. 128 BPM clicks, 120 BPM
+does not. This is what it turned out to be, and how to check whether the
+patch fixes it on your unit — because **it is not fixed until it is fixed on
+a machine other than the one it was developed on.**
 
 > ⚠️ This is not official Elektron firmware. Flashing a modified OS can leave
 > the unit unusable until you recover it, and puts your warranty in question.
@@ -32,11 +32,13 @@ On every pass where the arm came one sample later than the recording ended,
 two moments that are two samples apart instead of one. That is the click.
 
 At 120 BPM a bar is 88,200 samples — exact — so the arms are evenly spaced,
-nothing is skipped, and it is clean. That is your own control, explained.
+nothing is skipped, and it is clean. That explains the original report's own
+control: 120 was never a lucky tempo, it is an exact one.
 
-Your `~6th repeat` onset at RLEN 4 is the same arithmetic with a different
-fraction: at RLEN 4 the period is 20,671.**875** samples, so the sample is
-lost once every **eight** passes rather than every other one.
+It also explains why the click was first noticed "around the sixth repeat"
+at RLEN 4 rather than immediately: at RLEN 4 the period is 20,671.**875**
+samples, so the fraction accumulates and the sample is lost once every
+**eight** passes instead of every other one.
 
 **Only 46 of the 1,401 tempi from 60.0 to 200.0 give a whole-number bar.**
 128 is not one of them. 120, 125, 126, 135, 140, 144 and 150 are — so
@@ -79,14 +81,29 @@ you could not select an effect (your saved projects would still play — the
 effect code and dispatch are untouched — but you could not change one).
 
 ```bash
+git clone --recurse-submodules https://github.com/sambanks/octabam
+cd octabam
 make setup                               # vendored tools
 make os                                  # extracts YOUR OWN downloaded 1.40C
 make check REMIX=recfix                  # every gate, no hardware needed
 make image REMIX=recfix BUILD=84         # -> out/OCTATRACK_OCTABAM84.bin
 ```
 
+**On the submodules** (verified on a fresh clone, 12 Sep 2026): `make bus
+REMIX=recfix` builds fine **without** them, but `make check` runs every remix
+in the repo — including two that wrap other people's code — so it needs them
+even though `recfix` does not. If you cloned without `--recurse-submodules`:
+
+```bash
+git submodule update --init --recursive
+```
+
+`make check` now says exactly that if they are missing, rather than throwing a
+Python traceback at you (it used to; sorry).
+
 `make check` is the floor — it builds the image and runs every gate in the
-repo without touching hardware. If it is not green, do not flash.
+repo without touching hardware. If it is not green, do not flash. Expect
+**303 PASS** and `EXIT=0` for `recfix`.
 
 Sam's build of that image is sha256 `ecb574a9…` — yours should match if your
 stock 1.40C does (`370c55a3…`); if it does not, say so before flashing, because
@@ -120,7 +137,7 @@ both.
 |---|---|---|---|
 | 1 | 128.0 BPM, RLEN 16 | tick every bar | nothing |
 | 2 | **120.0 BPM**, same | already clean | **still clean** — if 120 got *worse*, stop and tell us; the patch is supposed to do nothing at all there |
-| 3 | 128.0 BPM, **RLEN 4** | tick roughly every 8th pass (your "~6th repeat") | nothing |
+| 3 | 128.0 BPM, **RLEN 4** | tick roughly every 8th pass (the "~6th repeat" of the original report) | nothing |
 
 Check 2 is the important one. The patch is a no-op at 120 by construction,
 so a change there means something is wrong that our own testing did not see.

--- a/remixes/recfix.py
+++ b/remixes/recfix.py
@@ -1,6 +1,8 @@
-"""RECFIX -- Bryan's recorder click: the three fixes, and nothing else.
+"""RECFIX -- the recorder loop click: the three fixes, and nothing else.
 
-The build to hand somebody whose recorder loops click. It carries the THREE
+The build to hand somebody whose recorder loops click (the shareable one --
+`docs/firmware/RECORDER_CLICK.md` is its write-up and reproduction steps, and
+neither names the reporter). It carries the THREE
 ColdFire caves that between them removed the fault on hardware, and no DSP
 code of our own at all -- no effects, no bus, no FX2 id of ours, no menu
 change:
@@ -18,9 +20,7 @@ change:
                              alternate bars. 10.57/10.58.
 
 Three different mechanisms -- a message path, a position store, a length --
-each measured on its own symptom, which is why all three are here. See
-`docs/firmware/RECORDER_CLICK.md` for the plain-language version and the
-reproduction steps.
+each measured on its own symptom, which is why all three are here.
 
 ⚠️ THE STOCK FX2 LIST IS NOT OPTIONAL, AND IS NOT "SOMETHING ELSE". Every
 octabam image replaces the FX2 chooser WHOLESALE with the remix's modules
@@ -49,8 +49,8 @@ from remix.schema import Remix
 
 REMIX = Remix(
     name="recfix",
-    doc="Bryan's recorder click: the three ColdFire fixes beside the stock FX2 chooser, "
-        "no DSP code of our own.",
+    doc="The recorder loop click: the three ColdFire fixes beside the stock FX2 "
+        "chooser, no DSP code of our own.",
     modules=("FLEX SEEK BIND", "FLEX SEEK BIND CTR", "RECORDER SPACING",
              # the stock chooser, in stock order -- no words, no placement (stock.py)
              "FILTER", "EQUALIZER", "DJ EQ", "PHASER", "FLANGER", "CHORUS",

--- a/tools/remix/selftest.py
+++ b/tools/remix/selftest.py
@@ -107,8 +107,35 @@ CLEAN_STOCK_PAIR = [_stock("chorus", 0x12, True), _stock("comb", 0x13, True),
                     _effect("alpha", 0x07)]
 
 
+def _submodule_preflight() -> int:
+    """Refuse early, with the fix, if a community submodule is not checked out.
+
+    `make check` runs EVERY remix, so a clone without submodules fails on
+    somebody else's module even when the remix under test has nothing to do
+    with it -- and it failed as a bare FileNotFoundError traceback out of
+    ledger.runtime_write_spans (octakit's firmware.json) or as an assembler
+    "can't open" from midi-scenes' sources. Measured 12 Sep 2026 on a fresh
+    clone: `make bus REMIX=recfix` succeeds, `make check REMIX=recfix` dies.
+    That is a wall in front of the first thing an outside contributor is
+    asked to run, so it gets a message instead of a traceback.
+    """
+    missing = sorted(d.parent.name for d in ROOT.glob("modules/*/upstream")
+                     if d.is_dir() and not any(d.iterdir()))
+    if not missing:
+        return 0
+    print(f"  [FAIL] community submodule(s) not checked out: {', '.join(missing)}")
+    print("         `make check` builds EVERY remix, so these are needed even "
+          "when yours does not use them.")
+    print("         Fix:  git submodule update --init --recursive")
+    print("         (Building just your own remix does not need them: "
+          "`make bus REMIX=<name>` works without.)")
+    return 1
+
+
 def main():
-    bad = 0
+    bad = _submodule_preflight()
+    if bad:
+        return bad                      # nothing below can run without them
     for label, mods, expect in CASES:
         found = ledger.check(mods)
         hit = [p for p in found if p.startswith(expect)]


### PR DESCRIPTION
Three things, all from actually walking the path an outside contributor walks — on a fresh clone, not by reasoning about it.

## 1. The submodule answer, measured

| | without submodules |
|---|---|
| `make bus REMIX=recfix` | ✅ builds fine — 228 bytes changed |
| `make check REMIX=recfix` | ❌ **bare `FileNotFoundError` traceback** out of `ledger.runtime_write_spans`, on octakit's `firmware.json` |

`make check` runs *every* remix in the repo, including two that wrap other people's code, so it needs submodules even when the remix under test has nothing to do with them. Dying on a Python traceback is a wall in front of the first thing we ask a contributor to run.

`selftest` now preflights and says so:

```
  [FAIL] community submodule(s) not checked out: midi-scenes, octakit
         `make check` builds EVERY remix, so these are needed even when yours does not use them.
         Fix:  git submodule update --init --recursive
         (Building just your own remix does not need them: `make bus REMIX=<name>` works without.)
```

Verified end to end on a clean clone: the message appears, the recommended command fixes it, and `make check REMIX=recfix` then goes green at **303 PASS**.

## 2. The doc says it too

`RECORDER_CLICK.md` now carries the clone line (`--recurse-submodules`), the recovery command, and what green looks like.

## 3. Genericised

The reporter's name is out of `RECORDER_CLICK.md` and out of `remixes/recfix.py`.

What I kept, deliberately: the two observations from the original report that make the explanation credible to a reader — **120 BPM being clean**, and the click first appearing **around the sixth repeat at RLEN 4** — now attributed to "the original report" rather than a person. They read fine without a name, and dropping them would leave the arithmetic unanchored.

`RTOS_FORK.md` still names people. That is the lab record, with a different job, and it was left alone — say the word if you want that pass too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
