### PR TITLE
Mixer model: the unit's gain chain around the DSP measured under the port (O14) and applied in rig_render

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,11 @@ midi-flash: ## RECOVERY: flash a .syx over MIDI (Startup Menu). make midi-flash 
 	$(PY) tools/hw/midi_flash.py $(PORT) $(SYX)
 PORT ?= A
 
+.PHONY: port-compare
+port-compare: ## One part under the firmware (ot_emu) and under rig_render on the same input: make port-compare PROJECT=dir [IMAGE=out/mainos_bus.bin] [PCARGS='--tone out/o9d/kickAB_late.wav']
+	@test -n "$(PROJECT)" || { echo "usage: make port-compare PROJECT=out/o9d/proj_t1eqA [IMAGE=out/mainos_bus.bin REMIX=bamsep27] [PCARGS=...]"; exit 1; }
+	python3 tools/harness/port_compare.py --project $(PROJECT) --remix $(REMIX) $(if $(IMAGE),--image $(IMAGE)) $(PCARGS)
+
 .PHONY: reverb
 reverb: ## Render a wav through BusVerb: make reverb IN=loop.wav [ARGS='-p MIX=80']
 	@test -n "$(IN)" || { echo "usage: make reverb IN=loop.wav [ARGS='--wet --mode all']"; exit 1; }

--- a/docs/firmware/COLDFIRE_PORT.md
+++ b/docs/firmware/COLDFIRE_PORT.md
@@ -2792,6 +2792,107 @@ unit, not a ceiling. Only the burn sweep measures the ceiling.
   --dsp --main-level 64 --audio-in tones --dsp-stopwatch 0:50d:50e     # core 0 FX2 calls
 ```
 
+## Milestone O14 — the gain chain around the DSP, measured: AMP VOL and BAL are pre-FX on the DSP, LEVEL is post-FX at the mix, and `rig_render` now models all three (12 Sep 2026, branch `rig-mixer-model`)
+
+O9d left one number: the pre-FX track gain k = 2130129/2^23 (−11.906 dB)
+at AMP VOL 64, "🟡 not derived from those — measured as the fit". A
+voicing judgement made on `rig_render` needs the whole chain — what the
+stem's level into the engine is at a given AMP VOL, and how the returns
+sit against the dry at a given LEVEL — so the sweep was run rather than
+the curve guessed.
+
+**The instrument** (`tools/scratch/mixer_sweep.py`): the O9d fixture
+(Sam's RIG, T1 THRU, FX1 = SEND, FX2 = EQUALIZER flat `64 ×6`, tone on
+RX0 slot 2, `--main-level 64`, 400 frames), **the master track OFF** in
+`project.work` (the RIG's T8 is a master with stock LO-FI on FX1 —
+nonlinear, and between the chain output and TX0; with it on the TX0 fit's
+worst window was −3 dB, with it off −113 dB), one byte of the part changed
+per run in every part record of every bank (the set_fx rule): AMP VOL /
+BAL at the six bytes before the FX1 row (`00 7f 7f 40 40 7f` = ATK HOLD
+REL VOL BAL XVOL, confirmed on every track of the fixture), LEVEL at
+`+0x1b + 2·track`. Three taps: the chain INPUT (the 84-word record's
+audio), the chain OUTPUT (T1's slot of core 1's read-back) and TX0
+(`--audio-out`); each stage a per-200-sample-window least-squares scale at
+the fitted lag, the MEDIAN over windows. Whole-run rms is NOT the gain on
+this fixture: the RIG's pattern re-trigs T1 around frame 340 (a ~400-sample
+dip at the chain output, the input tap flat), which a median ignores and
+an rms does not — the first pass read −12.7 dB for k until the windows
+were printed. 26 port runs, ~75 s each.
+
+**AMP VOL — pre-FX, ON THE DSP, a square law** (k/2^23 at the chain
+output, TX0 over chain output unchanged at every point):
+
+| VOL | 0 | 16 | 32 | 48 | 64 | 80 | 96 | 112 | 127 |
+|---|---|---|---|---|---|---|---|---|---|
+| k/2^23 | 0 | 133,104 | 532,512 | 1,198,176 | 2,130,128 | 3,328,320 | 4,792,800 | 6,523,552 | 8,387,936 |
+| dB | −∞ | −35.990 | −23.947 | −16.903 | −11.906 | −8.029 | −4.862 | −2.184 | −0.001 |
+| (v/127)² err | | −0.002 | −0.001 | −0.001 | −0.001 | −0.000 | −0.000 | −0.000 | −0.001 |
+
+k/v² = 520.05 at every point (16 → 520.0): `g = (VOL/127)²`, within
+0.002 dB. It is applied between the record and FX1 by the stock DSP code
+(the chain here is SEND + a unity EQ; O9d's residual against `dsp_host` on
+the same input is −125 dB), so `dsp_host`, which calls only the effect
+procs, never runs it — that is the stage the harness lacked.
+
+**AMP BAL — pre-FX, on the DSP, a BALANCE**: the near side stays at unity
+(BAL 0 and 32 leave the L-only fixture at k exactly, to −126 dB), the far
+side falls to zero at the end stop. Measured on the right half, L
+attenuated, at VOL 64 (g = k/k₆₄):
+
+| BAL | 64 | 72 | 80 | 88 | 96 | 104 | 112 | 127 |
+|---|---|---|---|---|---|---|---|---|
+| g | 1 | 0.81202 | 0.63005 | 0.46007 | 0.30808 | 0.18009 | 0.08210 | 0.00009 |
+| dB | 0 | −1.808 | −4.012 | −6.743 | −10.226 | −14.890 | −21.713 | −81 |
+
+Not a power of a linear ramp (the exponent drifts 1.53 → 1.74 across the
+points). g/x with x = (127−BAL)/63 is a quadratic in d = BAL−64 to 1e-5
+(1 − d/128.95 − d²/8141), which is `((64−d)/64)·((127+d)/127)` expanded, so
+**g = ((63−d)/63)·((64−d)/64)·((127+d)/127)**, within 0.01 dB of every
+point. 🟡 The left half (R attenuated) is its mirror in d = 64 − BAL —
+inferred; falsifier: the same sweep with the tone on the THRU's right
+input. 🟡 That the same AMP stage precedes a FLEX/STATIC voice's chain is
+inferred from the DSP receiving the AMP page in the same per-instance words
+for every machine (O9d); falsifier: the O10 kick fixture at AMP VOL 32,
+expecting −12.04 dB at the read-back.
+
+**LEVEL — post-FX, at the mix**: the chain output is unchanged at every
+LEVEL (k = 2130128 at 0, 32, 64, 100, 127 — the "+0x1b byte did nothing
+to the read-back" of O10, now explained), and TX0 over the chain output:
+
+| LEVEL | 0 | 32 | 64 | 100 | 108 | 127 |
+|---|---|---|---|---|---|---|
+| dB | silent | −24.083 | −12.042 | −4.289 | −2.952 | −0.137 |
+| (L/128)² | | −24.082 | −12.041 | −4.288 | −2.952 | −0.137 |
+
+`g = (LEVEL/128)²` — over 128, not 127 (over 127 misses every point by a
+constant 0.136 dB, which is exactly (127/128)²). The lag TX0→chain output
+is −17 samples (TX0 leads: the read-back is the later copy). A second
+TX0 slot (4) carries the same signal 3.3 dB lower at lag −164 and tracks
+LEVEL; 🟡 the cue mix — not chased, not modelled.
+
+**Not modelled, and said so:** the main level (SET MAIN LEVEL, the
+`0x80003c60` table) scales trigged voices and not THRUs (O9c) — unity in
+the model, which O10's sample-exact kick at `--main-level 64` supports and
+does not prove; the cue path; the master track.
+
+**In the harness** (`tools/harness/mixer.py`, the curves beside the
+measured points and a `selftest()` that refuses if a curve drifts more
+than 0.02 dB from them — 0.008 today): `rig_render` applies VOL² and the
+balance to the stem BEFORE the chain, per side (`dsp_host -stereo`,
+interleaved L,R input; the mono form is untouched, every gate renders
+bit-identically), and LEVEL² AFTER, at `mix.wav`, which is now the main
+out and not a −6 dB unity sum. The values come from the part (`--project`:
+the AMP row and the LEVEL pair) or the unit's defaults, `--mix
+T1:VOL=127,LEVEL=100` overrides, `--mixer off` is the old harness to the
+bit (checked: T1/T5 of a bamsep27 render identical to the morning's).
+`--amp` now defaults to 1.0 with the model on: a stem is the voice at its
+sample GAIN. Consequence for every voicing note written before this: at
+its old default (`--amp 0.5`, no AMP stage) the harness drove each engine
+**5.9 dB hotter** than the unit does at AMP VOL 64 — and 11.9 dB hotter
+wherever `--amp 1.0` was used (O9d's first pass). A 0 dBFS voice at the
+default AMP VOL enters the chain at 0.254 FS, the BOTTOM of the "BIG clips
+at 0.25–0.5 FS in" knee; the old default put it at 0.5 FS, the top.
+
 ## What is NOT here yet
 
 - **The rest of the peripherals.** The eDMA with its completion-timing rules

--- a/docs/firmware/COLDFIRE_PORT.md
+++ b/docs/firmware/COLDFIRE_PORT.md
@@ -2478,6 +2478,15 @@ MDEP); its level matched within 1 dB in the both-engines run.
 
 ### 🟡 The reverb stage: level-matched, not bit-compared, and why (8 Sep 2026, later)
 
+> **Superseded the next day**, and recorded here because this section was
+> quoted as current on 12 Sep 2026: the "toolkit gap" below (a THRU that
+> starts) closed with `ot_project.py thru-track`, the reverb path was
+> re-run on the clean project ("The harness ran 15-sample blocks", below:
+> levels within 0.1 dB, the residual the reverb's own free-running
+> modulator and initial state, not a defect), and since 12 Sep
+> `tools/harness/port_compare.py` runs the whole comparison as one command
+> (O14).
+
 Same fixture with the reverb instead of the delay (T1's FX2 = SEND, one
 client, MOD 0): the port's return is **deterministic** — identical to
 −200 dB across load lengths and across core-interleave quanta of 1, 64,
@@ -2874,6 +2883,17 @@ LEVEL; 🟡 the cue mix — not chased, not modelled.
 `0x80003c60` table) scales trigged voices and not THRUs (O9c) — unity in
 the model, which O10's sample-exact kick at `--main-level 64` supports and
 does not prove; the cue path; the master track.
+
+**One command, the whole comparison** (`tools/harness/port_compare.py`,
+`make port-compare PROJECT=…`): a part under the port and under
+`rig_render` on the port's own record audio, fitted per track and at the
+mix. On O9d's fixture the T1 chain fits at −0.001 dB / −121 dB and the
+mix (TX0 slot 2 against `mix.wav`) at −0.001 dB / −113 dB — the AMP stage,
+the chain, LEVEL and the sum agreeing with the firmware end to end. On
+the one-aux rig under the flash-7 image with the kick on T2's inputs: the
+sender −0.001 dB / −137 dB, the return −0.083 dB in scale with a history
+residual (−8 dB, the reverb's), the mix −0.001 dB / −90 dB.
+`docs/remixer/HARNESS.md` "port_compare".
 
 **In the harness** (`tools/harness/mixer.py`, the curves beside the
 measured points and a `selftest()` that refuses if a curve drifts more

--- a/docs/firmware/RECORDER_CLICK.md
+++ b/docs/firmware/RECORDER_CLICK.md
@@ -101,6 +101,15 @@ git submodule update --init --recursive
 `make check` now says exactly that if they are missing, rather than throwing a
 Python traceback at you (it used to; sorry).
 
+**Always pass `REMIX=recfix`** -- to `make check`, `make bus` and `make image`
+alike. The Makefile's default is a different remix, and every verifier reads
+the one image at `out/mainos_bus.bin`, so a bare `make bus` (or `make -j`,
+which runs the build and the checks at once) leaves another remix's image
+for the checks to read. That looked like "32 fails in verify_menu, garbage
+past index 2" on 12 Sep 2026 -- the garbage was the other remix's descriptor
+text. The build now records which remix wrote the image
+(`out/mainos_bus.remix`) and `verify_menu` says so in one line instead.
+
 `make check` is the floor — it builds the image and runs every gate in the
 repo without touching hardware. If it is not green, do not flash. Expect
 **303 PASS** and `EXIT=0` for `recfix`.

--- a/docs/history/PLAN_EFFECTS.md
+++ b/docs/history/PLAN_EFFECTS.md
@@ -104,8 +104,10 @@ What ships:
   placement had only ever been checked statically. ⚠️ What this is NOT:
   the chip's timing (lock-step, or a guessed `-skew`: a local mismatch is
   a defect, identity is not evidence), the cycle cliff (instructions per
-  block, no contention stall), or the ColdFire (knobs poked into `r6`, a
-  unity mixer, stems instead of sample playback). `docs/remixer/HARNESS.md` "Two
+  block, no contention stall), or the ColdFire (knobs poked into `r6`,
+  stems instead of sample playback; the gain chain around the DSP — AMP
+  VOL/BAL pre-FX, LEVEL post-FX — is measured and modelled since 12 Sep
+  2026, `COLDFIRE_PORT.md` O14). `docs/remixer/HARNESS.md` "Two
   cores". Tiers 2 (the ColdFire's per-frame parameter records replayed
   into this harness) and 3 (audio through the host port, ~100× slower than
   real time) are scoped in the 7 Sep session notes and not started.

--- a/docs/remixer/HARNESS.md
+++ b/docs/remixer/HARNESS.md
@@ -1,4 +1,4 @@
-> ⚠️ **9 Sep 2026: `dsp_host`'s default block is 15 samples; the unit's is 16.** The frame-context nibble the harness seeds is the dispatcher's SPLIT, not a length (0 = a whole 16-sample block, measured under the ColdFire port). Renders at the default are self-consistent and every bit-identity gate is pinned to them, but every per-block rate is 16/15 of the unit's and every bus latency carries a sub-frame offset. `dsp_host -frames 16` / `rig_render --frames 16` run whole blocks exactly as the firmware does (the delay bus then lands at exactly one frame of lag against the port). `docs/firmware/COLDFIRE_PORT.md` O12.
+> ⚠️ **9 Sep 2026: `dsp_host`'s own block is 15 samples; the unit's is 16.** The frame-context nibble the harness seeds is the dispatcher's SPLIT, not a length (0 = a whole 16-sample block, measured under the ColdFire port). `dsp_host -frames 16` runs whole blocks exactly as the firmware does (the delay bus then lands at exactly one frame of lag against the port). **Since 12 Sep 2026 the voicing wrappers — `rig_render`, `render_reverb` (`make render-rig`, `make reverb`) — default to 16**; `--frames 15` is the old harness. The bit-identity gates (`send_probe`: `make render`, `verify-bus`, `verify-twocore`, …) are still pinned at 15 and self-consistent there; every per-block rate in THOSE is 16/15 of the unit's and every bus latency carries a sub-frame offset. `docs/firmware/COLDFIRE_PORT.md` O12.
 
 # The harness — hearing and measuring the effects without hardware
 
@@ -122,13 +122,18 @@ faithful mode: instead of hand-rolling the calling convention, it runs the
 payload's *own* dispatcher loop and lets it make every call — the mode that
 caught an ABI misreading the hand-rolled path could never see.
 
-### Blocks are 15 frames here, 16 on hardware
+### Blocks are 15 frames in the gates, 16 in the voicing wrappers
 
-The setup routine masks the frame count with `& 0xf`, so dsp_host caps a
-block at 15 frames where hardware runs 16. Nothing audible depends on it,
-but sample-exact measurements shift: the bus latency is exactly 2 blocks —
-**30 samples locally, 32 on hardware** (measured to the sample, see
-`docs/remixer/TESTPASS.md`).
+The setup routine masks the frame count with `& 0xf`, so dsp_host's own
+block is 15 frames where hardware runs 16; `-frames 16` overrides it and
+runs whole frames (O12). `send_probe` and every bit-identity gate built on
+it are pinned at 15 (the bus latency there is exactly 2 blocks — **30
+samples, 32 on hardware**, `docs/remixer/TESTPASS.md`); `rig_render` and
+`render_reverb` run 16 since 12 Sep 2026 so a voicing render's rates and
+latencies are the unit's. Their warm-up pad is 256 CALLS, i.e. in blocks
+of the chosen length — at 16 it is 4,096 samples, and until 12 Sep the pad
+was fixed at 260 × 15, which left 196 samples of the engines' dry warm-up
+at the head of every `--frames 16` render.
 
 ## render_reverb.py — judging by ear
 

--- a/docs/remixer/HARNESS.md
+++ b/docs/remixer/HARNESS.md
@@ -286,9 +286,31 @@ call sites, `docs/firmware/COLDFIRE_PORT.md` O13, 9 Sep 2026): core 0 24,654 a f
 against the meter's 24,971, core 1 15,177 against 14,880 once T1's
 CHARACTER is live on both — the meter reads the real load within 2 %.
 
-What it still is not: the ColdFire. Knobs are poked into `r6`, AMP/pan and
-the mixer are a unity sum, samples do not play (stems stand in), and the
-stock DELAY is not on the DSP at all.
+**The mixer model (12 Sep 2026, `tools/harness/mixer.py`).** The unit's
+gain chain around the DSP, measured under the ColdFire port
+(`docs/firmware/COLDFIRE_PORT.md` O14, 26 runs, residuals −100 dB and
+better): **AMP VOL is (v/127)² and AMP BAL a balance (near side unity, far
+side to zero on a cubic), both applied BEFORE the FX chain by the stock DSP
+code `dsp_host` never runs; track LEVEL is (L/128)², applied AFTER, at the
+mix.** `rig_render` applies them by default — the stem through VOL² and the
+balance per side into the chain (`dsp_host -stereo`), each track's chain
+output through LEVEL² into `mix.wav`, which is now the main out (saturated
+as a 24-bit sum, clips counted) and not a −6 dB unity sum. The values come
+from the part with `--project` (the AMP row six bytes before the FX1 row,
+the LEVEL pair at +0x1b) or the unit's defaults (VOL 64 = −11.9 dB, BAL
+64, LEVEL 108 = −3.0 dB); `--mix T1:VOL=127,BAL=64,LEVEL=100` overrides;
+`--mixer off` is the old harness to the bit. A stem is the VOICE at its
+sample GAIN (`--amp` defaults to 1.0 with the model on), so a 0 dBFS file
+enters the engine at 0.254 FS at the default VOL — the old default
+(`--amp 0.5`, no AMP stage) drove every engine 5.9 dB hotter than the
+unit does, which every voicing note before this date inherited. `T*.wav`
+stay the chain output (before LEVEL). Not modelled: the main level (scales
+trigged voices, not THRUs — unity here), the cue mix, the master track;
+and the AMP stage was measured on a THRU and is inferred for FLEX/STATIC
+(falsifier in `mixer.py`'s docstring).
+
+What it still is not: the ColdFire. Knobs are poked into `r6`, samples do
+not play (stems stand in), and the stock DELAY is not on the DSP at all.
 
 **The first thing it was built for** (`tools/verify/verify_onebus.py`, in `make
 check`, same day): the one-aux rig's chain, liveness stamps, MIX
@@ -310,7 +332,9 @@ mean hardware-clean; when the two disagree, believe the hardware.
   cannot afford; 432 cycles/sample over once froze the unit. `make cycles`
   bounds it, hardware proves it.
 * **The ColdFire side.** `-params` pokes r6 directly, bypassing menus,
-  descriptors, ranges and scene logic entirely. A slot can draw a knob and
+  descriptors, ranges and scene logic entirely (the gain chain around the
+  chain — AMP VOL/BAL, LEVEL — is measured and modelled since 12 Sep 2026;
+  the main level and the cue are not). A slot can draw a knob and
   publish nothing, or publish and draw wrongly — the panel and the DSP are
   separate mechanisms and the harness only exercises one of them
   (`docs/firmware/PARAM_PAGES.md`).

--- a/docs/remixer/HARNESS.md
+++ b/docs/remixer/HARNESS.md
@@ -323,6 +323,42 @@ passthrough, last-live-stage return, track-8 send refusal and station
 silence, all with the senders and the delay on payload B and the reverb and
 the return on payload A — `docs/effects/BUS.md` "The one aux bus".
 
+## port_compare.py — the harness against the firmware, one part (12 Sep 2026)
+
+`make port-compare PROJECT=dir [IMAGE=... REMIX=...]` runs ONE part under
+the ColdFire port (the firmware booting the image, loading the project
+from a staged card, the sequencer running with a probe on the ESAI inputs)
+and under `rig_render` on the same image with each track's chain input —
+the port's own 84-word record audio — as its stem, and fits the two per
+track (lag, least-squares scale, per-window residual) and the port's TX0
+main slot against `mix.wav`. ~90 s. Read it as: a linear chain fits to
+0.00 dB and −100 dB or better (the mixer model, the parameter path and the
+dispatch all agreeing with the firmware); an engine with history — the
+reverb's free-running allpass modulator, the delay's LFO — matches in
+**scale** and not in residual (O12), so read the scale there; a scale that
+is not 0 dB on a linear chain is a finding. Measured on the day it landed:
+
+| fixture | track | scale | residual |
+|---|---|---|---|
+| O9d's (stock image, T1 THRU: SEND + EQ flat, tone) | T1 chain | −0.001 dB | −121 dB |
+| same | mix (TX0 slot 2 vs `mix.wav` L) | −0.001 dB | −113 dB |
+| the one-aux rig, flash-7 image, kick on T2's inputs | T2 chain (SPECTRUM + SEND) | −0.001 dB | −137 dB |
+| same | T8 return (delay → reverb, history) | −0.083 dB | −8 dB |
+| same | mix | −0.001 dB | −90 dB |
+
+Rules it learned: a track whose record carries audio but whose chain
+output is digital zero is a non-THRU machine's record (not that track's
+chain input, O10) and is listed, not compared; a host or a return has
+output and no input of its own and is compared on its output with a
+silent stem; the lag search is ±96 because on a periodic probe the fit is
+ambiguous modulo the period (147 samples at 300 Hz — the first run
+reported −179 for the 32-sample record pipeline); the master track is
+turned off in the COPY of the project the port loads, so TX0 is the mix
+(the RIG's T8 master carries stock LO-FI). Use a transient probe
+(`--tone out/o9d/kickAB_late.wav`, after the knob slew) for anything
+with a delay in it — a tone cannot separate a gain from the phase of a
+repeat.
+
 ## What the harness cannot see
 
 Every item here has cost a real session at least once. Local-clean does not

--- a/tools/build/build_bus.py
+++ b/tools/build/build_bus.py
@@ -3232,6 +3232,16 @@ hostquit:
         img.extend(_append)
         _grown += f" (+{len(_append):,} B {_aname} appended)"
     out.write_bytes(bytes(img))
+    # Say WHICH remix wrote this image, beside it. Every verifier reads the
+    # image by fixed path, and nothing in the bytes names the remix -- so a
+    # check run against an image some other build left here (a bare `make
+    # bus`, a `make -j`, a verifier's own scratch build) reports dozens of
+    # failures about a list it was never meant to see (Bryan T, 12 Sep 2026:
+    # 32 verify_menu fails on recfix, the "garbage" past index 2 was
+    # BusVerb's abbr from a default-remix image). The hash lets a reader
+    # ignore the sidecar when the image was restored without it.
+    out.with_suffix(".remix").write_text(
+        f"{REMIX.name} {hashlib.sha256(bytes(img)).hexdigest()}\n")
     d = sum(1 for x, y in zip(IMG.read_bytes(), img) if x != y)
     note = _grown
     if mode_env is not None:

--- a/tools/harness/dsp_host/dsp_host.cpp
+++ b/tools/harness/dsp_host/dsp_host.cpp
@@ -129,6 +129,10 @@
 //     -in file.raw          24-bit mono raw input, else an impulse is used.
 //                           A LIST gives each instance its own file; "-" is
 //                           silence. (-inmask still gates it.)
+//     -stereo               the -in files are INTERLEAVED L,R (two words a
+//                           frame) instead of mono copied to both channels --
+//                           rig_render's mixer model needs it for AMP BAL,
+//                           which is pre-FX and per side (12 Sep 2026)
 //     -out file.raw         write instance 0; others go to file.raw.i1, .i2, ...
 //     -track a,b,..         r7-relative X words (hex) dumped EVERY block, so a
 //                           rate can be MEASURED by differencing -- -peekx only
@@ -171,6 +175,7 @@ struct Args {
     std::vector<int> allocIdx, r7Idx, coreIdx, audioIdx;
     std::vector<TWord> initList, procList;     // entry points, one per instance
     unsigned inmask = ~0u;                     // which instances get the input
+    bool stereo = false;                       // -in is interleaved L,R
     std::vector<std::vector<int>> pv;          // one parameter set per instance
     std::string allocProc = "perinst";
     bool guard = false; TWord guardWords = 0x3800;
@@ -472,6 +477,7 @@ int main(int argc, char** argv) {
         else if (k == "-init") { a.initList = parseHexList(argv[++i]); a.init = a.initList[0]; }
         else if (k == "-proc") { a.procList = parseHexList(argv[++i]); a.proc = a.procList[0]; }
         else if (k == "-inmask") a.inmask = strtoul(argv[++i], nullptr, 0);
+        else if (k == "-stereo") a.stereo = true;
         else if (k == "-audio") a.audio = strtoul(argv[++i], nullptr, 16);
         else if (k == "-pblock") a.params = strtoul(argv[++i], nullptr, 16);
         else if (k == "-tempo") a.tempo = atof(argv[++i]);
@@ -1157,15 +1163,19 @@ int main(int argc, char** argv) {
             Core& C = *cores[I.core];
             if (!I.fills) continue;              // a chained instance sees its predecessor's output
             for (int f = 0; f < a.frames; ++f) {
-                int32_t s = 0;
-                if (I.hasInput) s = I.inPos < I.input.size() ? I.input[I.inPos++] : 0;
-                else if (b == 0 && f == 0) s = 0x400000;             // 0.5 full scale
+                int32_t s = 0, s2 = 0;
+                if (I.hasInput) {
+                    s = I.inPos < I.input.size() ? I.input[I.inPos++] : 0;
+                    // -stereo: the next word is R; mono copies L to both
+                    s2 = a.stereo ? (I.inPos < I.input.size() ? I.input[I.inPos++] : 0) : s;
+                }
+                else if (b == 0 && f == 0) s = s2 = 0x400000;        // 0.5 full scale
                 // -inmask silences an instance's own input so its output is
                 // ONLY what arrived through the shared bus. Feeding a server
                 // dry audio as well would bury the bus contribution under it.
-                const int32_t sk = I.fed ? s : 0;
+                const int32_t sk = I.fed ? s : 0, sk2 = I.fed ? s2 : 0;
                 C.dsp->memWrite(MemArea_X, I.audio + f * 2 + 0, sk & 0xffffff);
-                C.dsp->memWrite(MemArea_X, I.audio + f * 2 + 1, sk & 0xffffff);
+                C.dsp->memWrite(MemArea_X, I.audio + f * 2 + 1, sk2 & 0xffffff);
             }
         }
         if (a.spray && b == 0) {

--- a/tools/harness/mixer.py
+++ b/tools/harness/mixer.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""The unit's gain chain around the DSP -- measured under the ColdFire port.
+
+Every curve here was fitted on the port's own taps (`tools/scratch/mixer_sweep.py`,
+12 Sep 2026, COLDFIRE_PORT.md O14): T1 THRU with FX1 = SEND and FX2 = EQUALIZER
+flat on Sam's RIG, master track off, one byte of the part changed per run,
+the chain INPUT (the 84-word track record's audio), the chain OUTPUT (the
+core's read-back slot) and TX0 (the ESAI's main pair) fitted against each
+other per 200-sample window with a lag, the median taken. Residuals are
+-100 dB and better on every point, so a curve that misses a point by more
+than a few thousandths of a dB is the wrong curve, not noise.
+
+    stem (the voice, or the THRU input)
+      x (VOL/127)^2                 AMP VOL, pre-FX, on the DSP  (9 points)
+      x bal(BAL)                    AMP BAL, pre-FX, on the DSP  (11 points)
+      -> FX1 -> FX2                 the chain `dsp_host` runs
+      x (LEVEL/128)^2               track LEVEL, post-FX, at the mix (5 points)
+      -> sum                        the main out (TX0)
+
+Measured on a THRU track. That the same AMP stage sits in front of a FLEX or
+STATIC voice's chain is INFERRED from the DSP receiving the AMP page in the
+same per-instance words for every machine (O9d, `00 7f 7f 40 40 7f` at +0..5)
+-- falsifier: the O10 kick fixture with AMP VOL 32, expecting -12.0 dB at the
+read-back. The main level (SET MAIN LEVEL, the `0x80003c60` table) scales
+trigged voices and not THRUs (O9c); it is not modelled -- unity, which O10's
+sample-exact kick at `--main-level 64` supports and does not prove.
+"""
+
+VOL_DEFAULT, BAL_DEFAULT, LEVEL_DEFAULT = 64, 64, 108   # the part's own defaults
+
+
+def vol_gain(vol):
+    """AMP VOL 0..127 -> linear gain, pre-FX. (64/127)^2 = -11.906 dB is O9d's
+    k = 2130129/2^23; 127 -> -0.001 dB; 0 -> silence."""
+    v = max(0, min(127, int(vol)))
+    return (v / 127.0) ** 2
+
+
+def bal_gains(bal):
+    """AMP BAL 0..127 -> (gain_L, gain_R), pre-FX. A BALANCE, not a pan: the
+    near side stays at unity and the far side falls on a cubic that reaches
+    exactly zero at the end stop. Measured for the right half (L attenuated,
+    d = BAL - 64 = 8..48 and 63); the left half is its MIRROR, inferred
+    (falsifier: the same sweep with the tone on the THRU's right input)."""
+    b = max(0, min(127, int(bal)))
+    if b == 64:
+        return 1.0, 1.0
+    if b > 64:
+        d = b - 64
+        return _far(d), 1.0
+    d = 64 - b                      # 1..64: BAL 0 is the end stop, silence on R
+    return 1.0, (_far(d) if d < 64 else 0.0)
+
+
+def _far(d):
+    return ((63 - d) / 63.0) * ((64 - d) / 64.0) * ((127 + d) / 127.0)
+
+
+def level_gain(level):
+    """Track LEVEL 0..127 -> linear gain, post-FX at the mix. 108 (the default)
+    = -2.952 dB, 127 = -0.137 dB = (127/128)^2 exactly."""
+    lv = max(0, min(127, int(level)))
+    return (lv / 128.0) ** 2
+
+
+# The measured points (k / 2^23 at the chain output for 1.0 in, TX0 over
+# chain-out for the mixer), kept beside the curves so `selftest()` can say
+# when a curve drifts from what the port measured.
+MEASURED_VOL = {0: 0, 16: 133104, 32: 532512, 48: 1198176, 64: 2130128, 80: 3328320,
+                96: 4792800, 112: 6523552, 127: 8387936}
+MEASURED_BAL_FAR_Q23 = {64: 2130128, 72: 1729712, 80: 1342080, 88: 980000, 96: 656256,
+                        104: 383616, 112: 174880, 127: 192}          # at VOL 64, the L side
+MEASURED_LEVEL_DB = {32: -24.083, 64: -12.042, 100: -4.289, 108: -2.952, 127: -0.137}
+
+
+def selftest(tol_db=0.02):
+    import math
+    db = lambda x: 20 * math.log10(x) if x > 0 else -200.0
+    worst = 0.0
+    for v, q in MEASURED_VOL.items():
+        if q:
+            worst = max(worst, abs(db(vol_gain(v)) - db(q / 8388608.0)))
+    for b, q in MEASURED_BAL_FAR_Q23.items():
+        if b == 127:
+            assert bal_gains(b)[0] == 0.0
+            continue
+        worst = max(worst, abs(db(bal_gains(b)[0]) - db(q / MEASURED_BAL_FAR_Q23[64])))
+    for lv, d in MEASURED_LEVEL_DB.items():
+        worst = max(worst, abs(db(level_gain(lv)) - d))
+    if worst > tol_db:
+        raise AssertionError(f"mixer model drifts {worst:.3f} dB from the port's measurement")
+    return worst
+
+
+if __name__ == "__main__":
+    print(f"mixer model within {selftest():.4f} dB of every measured point")

--- a/tools/harness/port_compare.py
+++ b/tools/harness/port_compare.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""One part, under the firmware and under the harness, on the same input:
+does `rig_render` (mixer model included) match the ColdFire port?
+
+    python3 tools/harness/port_compare.py --project out/o9d/proj_t1eqA --remix bus
+    python3 tools/harness/port_compare.py --project PROJ --image out/mainos_bus.bin --remix bamsep27 \\
+        --tracks 1,2,5,8 --frames 400
+
+The port (`tools/emu/ot_emu`) boots IMAGE, loads PROJECT from a staged card,
+starts the sequencer with TONE on the ESAI inputs and dumps every host-port
+block (`--block-dump`) and the ESAI output (`--audio-out`). From the dump,
+per track: the chain INPUT (the 84-word track record's audio, after the
+THRU's input gain and before the DSP's AMP stage) and the chain OUTPUT (the
+core's read-back slot, after FX2 and before LEVEL). Then `rig_render` runs
+the SAME part on the SAME image with each track's chain input as its stem
+(`--amp 1.0`, the model applying VOL^2 and the balance as the DSP does) and
+the two are fitted per track -- lag, least-squares scale, residual -- and
+the port's TX0 main slot against `mix.wav` (LEVEL^2 and the sum).
+
+What a result means. A linear chain (SEND, a flat EQ, a station at rest)
+should fit to a scale of 0.00 dB and a residual of -100 dB or better: that
+is the mixer model, the parameter path and the harness's dispatch all
+agreeing with the firmware on this part. An engine with history (the
+reverb's free-running allpass modulator, the delay's LFO) matches in level
+and not in residual (COLDFIRE_PORT.md O12: -14 dB with the modulators
+live, levels within 0.1 dB) -- read the scale, not the residual, there.
+A scale that is NOT 0 dB on a linear chain is a finding: a knob the port
+publishes that the harness does not, or the reverse.
+
+Cost: one port run (~75 s for 400 frames) plus one rig_render. The project
+is COPIED before anything is written to it; `--master-off` (default) turns
+MASTER_TRACK off in the copy so TX0 is the mix itself and not the master's
+FX (the RIG's T8 master carries stock LO-FI, O14).
+"""
+import argparse, json, math, os, pathlib, shutil, subprocess, sys, wave
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1])); import toolpath  # noqa: E402,F401
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "scratch"))   # the block-dump readers
+import blockdump as bd                      # noqa: E402  (tools/scratch)
+import o10_recloop as rl                    # noqa: E402  (track_audio, readback_audio)
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+STOCK = ROOT / "out/raw/section_3_MAIN_OS.bin"
+TONE = ROOT / "out/o9c/toneC_300.wav"
+SR = 44100
+
+
+def db(x):
+    return 20 * math.log10(x) if x > 0 else -200.0
+
+
+def rms(x):
+    return math.sqrt(sum(v * v for v in x) / len(x)) if x else 0.0
+
+
+def write_wav(path, L, R):
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(2); w.setsampwidth(3); w.setframerate(SR)
+        w.writeframes(b"".join(int(max(-8388608, min(8388607, v))).to_bytes(3, "little", signed=True)
+                               for pair in zip(L, R) for v in pair))
+
+
+def read_wav(path):
+    with wave.open(str(path), "rb") as w:
+        nch, sw, n = w.getnchannels(), w.getsampwidth(), w.getnframes()
+        raw = w.readframes(n)
+    ch = [[int.from_bytes(raw[(i * nch + c) * sw:(i * nch + c + 1) * sw], "little", signed=True) / (1 << (8 * sw - 1))
+           for i in range(n)] for c in range(nch)]
+    return ch
+
+
+def fit(port, host, lo, hi, win=200, start=1500):
+    """Best lag over lo..hi by residual (whole span), then the per-window
+    MEDIAN scale and worst residual at that lag (a re-trig or a slew inside
+    the span moves an rms and not a median, O14)."""
+    n = min(len(port), len(host)) - 300
+    span = range(max(start, -lo), min(n, n - hi))
+    if len(span) < 2 * win:
+        return None
+    best = None
+    for lag in range(lo, hi + 1):
+        den = sum(host[i + lag] ** 2 for i in span)
+        if den <= 0:
+            continue
+        k = sum(port[i] * host[i + lag] for i in span) / den
+        r = rms([port[i] - k * host[i + lag] for i in span])
+        if best is None or r < best[1]:
+            best = (lag, r)
+    if best is None:
+        return None
+    lag = best[0]
+    ks, res = [], []
+    for s in range(span.start, span.stop - win, win):
+        seg = range(s, s + win)
+        den = sum(host[i + lag] ** 2 for i in seg)
+        if den <= 0:
+            continue
+        k = sum(port[i] * host[i + lag] for i in seg) / den
+        p = rms([port[i] for i in seg])
+        res.append(db(rms([port[i] - k * host[i + lag] for i in seg]) / p) if p else -200.0)
+        ks.append(k)
+    if not ks:
+        return None
+    ks.sort()
+    return dict(lag=lag, scale_db=db(abs(ks[len(ks) // 2])), worst_db=max(res),
+                median_db=sorted(res)[len(res) // 2], windows=len(ks))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--project", required=True, help="project dir (copied; never written)")
+    ap.add_argument("--image", default=str(STOCK), help="the image the PORT boots (a built out/mainos_bus.bin, or stock)")
+    ap.add_argument("--remix", default="bus", help="which remix that image is (rig_render resolves ids by it; stock ids always resolve)")
+    ap.add_argument("--set-name", default="OCTABAM")
+    ap.add_argument("--name", default="RIG", help="the project's name on the card")
+    ap.add_argument("--bank", type=int, default=1)
+    ap.add_argument("--part", type=int, default=1)
+    ap.add_argument("--tone", default=str(TONE), help="8-channel wav onto RX0 slots 0..7")
+    ap.add_argument("--frames", type=int, default=400, help="sequencer frames to run under the port")
+    ap.add_argument("--load-ms", type=int, default=20000)
+    ap.add_argument("--main-level", type=int, default=64)
+    ap.add_argument("--tracks", default="", help="1,2,5 (default: every track whose chain input is not silent)")
+    ap.add_argument("--master-off", dest="master_off", action="store_true", default=True)
+    ap.add_argument("--master-on", dest="master_off", action="store_false")
+    ap.add_argument("--out", default="out/port_compare")
+    ap.add_argument("--reuse", action="store_true", help="skip the port run if its dump is already there")
+    ap.add_argument("--tol", type=float, default=0.1, help="scale tolerance in dB for the PASS line")
+    ap.add_argument("--lag", type=int, default=96,
+                    help="lag search +-N samples (the record pipeline is 32, a bus stage 16; on a periodic "
+                         "tone the fit is ambiguous modulo the period -- 147 at 300 Hz -- so keep it short)")
+    a = ap.parse_args()
+
+    out = pathlib.Path(a.out); out.mkdir(parents=True, exist_ok=True)
+    proj = out / "project"
+    if proj.exists():
+        shutil.rmtree(proj)
+    shutil.copytree(a.project, proj)
+    if a.master_off:
+        pw = proj / "project.work"
+        pw.write_bytes(pw.read_bytes().replace(b"MASTER_TRACK=1", b"MASTER_TRACK=0"))
+    card = out / "card.img"
+    dump = out / "port.dump"
+    if not (a.reuse and dump.is_file()):
+        subprocess.run([sys.executable, str(ROOT / "tools/emu/ot_emu/stage_card.py"), str(proj), a.set_name, a.name,
+                        "--tree", str(out / "tree"), "--out", str(card)], check=True, stdout=subprocess.DEVNULL)
+        cmd = [str(ROOT / "out/emu/ot_emu"), "--image", a.image, "--card", str(card),
+               "--set", a.set_name, "--project", a.name, "--sequencer", "--internal-clock",
+               "--frames", str(a.frames), "--load-ms", str(a.load_ms), "--dsp", "--main-level", str(a.main_level),
+               "--audio-in", a.tone, "--audio-out", str(out / "port"), "--block-dump", str(dump)]
+        print("port: " + " ".join(cmd[1:]))
+        with open(out / "port.txt", "w") as log:
+            subprocess.run(cmd, check=True, stdout=log, stderr=subprocess.STDOUT)
+    c = bd.classes(bd.read(str(dump)))
+
+    # the taps
+    taps = {}
+    for t in range(1, 9):
+        inL, inR = rl.track_audio(c, t), rl.track_audio(c, t, True)
+        if not inL:
+            continue
+        outL, outR = rl.readback_audio(c, t), rl.readback_audio(c, t, True)
+        taps[t] = dict(inL=inL, inR=inR, outL=outL, outR=outR,
+                       in_db=db(rms(inL[1500:] + inR[1500:]) / 8388608), out_db=db(rms(outL[1500:] + outR[1500:]) / 8388608))
+    # Compare the tracks that PASS audio under the port: chain input AND chain
+    # output live. A record with audio and a chain output of digital zero is
+    # not a closed chain -- it is a machine whose record carries something
+    # other than its chain input (a STATIC/FLEX slot's record is not the
+    # THRU's, O10), and feeding that to the harness compares two different
+    # things. Listed, not compared, unless --tracks names it.
+    # A bus HOST or a return has chain output and no chain input of its own
+    # (it is fed over the bus): compared on its output, its stem silent.
+    live = [t for t, v in taps.items() if v["out_db"] > -120]
+    skipped = [t for t, v in taps.items() if v["in_db"] > -120 and t not in live]
+    want = [int(x) for x in a.tracks.split(",") if x] if a.tracks else live
+    if not want:
+        sys.exit("no track passes audio under the port -- is the THRU trigged, is the tone on its input?")
+    n = min(len(taps[t]["inL"]) for t in want)
+    print("port taps (dBFS, from sample 1500): " + "  ".join(f"T{t} in {taps[t]['in_db']:.1f} out {taps[t]['out_db']:.1f}" for t in want)
+          + (f"   (record audio but no chain output, not compared: {', '.join(f'T{t}' for t in skipped)})" if skipped else ""))
+
+    # the harness on the same part, fed each track's chain input
+    stems = []
+    for t in want:
+        if taps[t]["in_db"] <= -120:
+            continue                                   # a host: nothing of its own to feed
+        p = out / f"stem_T{t}.wav"
+        write_wav(p, taps[t]["inL"][:n], taps[t]["inR"][:n])
+        stems += ["--stem", f"T{t}={p}"]
+    rig = out / "rig"
+    cmd = [sys.executable, str(ROOT / "tools/harness/rig_render.py"), "--image", a.image, "--remix", a.remix,
+           "--project", str(proj), "--bank", str(a.bank), "--part", str(a.part), "--amp", "1.0",
+           "--frames", "16", "--tail", "0", "--out", str(rig)] + stems
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    (out / "rig.txt").write_text(r.stdout + r.stderr)
+    if r.returncode != 0:
+        sys.exit(f"rig_render failed:\n{r.stdout[-2000:]}{r.stderr[-2000:]}")
+    for line in r.stdout.splitlines():
+        if line.startswith("mixer") or "SEND alias" in line or "skipped" in line:
+            print("  " + line.strip())
+
+    # per track: the port's chain output against the harness's T<n>.wav
+    results = {}
+    print(f"\n{'track':6} {'lag':>5} {'scale dB':>9} {'resid worst':>12} {'median':>8}   (port chain out vs rig T<n>.wav, L)")
+    ok = True
+    for t in want:
+        L, R = read_wav(rig / f"T{t}.wav")
+        port = [v / 8388608 for v in taps[t]["outL"]]
+        f = fit(port, L, -a.lag, a.lag)
+        if f is None:
+            print(f"T{t:<5} (nothing to fit)"); continue
+        results[t] = f
+        flag = "" if abs(f["scale_db"]) <= a.tol else "  <- scale off"
+        ok &= abs(f["scale_db"]) <= a.tol
+        print(f"T{t:<5} {f['lag']:5d} {f['scale_db']:+9.3f} {f['worst_db']:12.1f} {f['median_db']:8.1f}{flag}")
+
+    # the mix: the port's TX0 slots against mix.wav
+    mixL, mixR = read_wav(rig / "mix.wav")
+    tx = read_wav(out / "port_core0.wav")
+    start = None
+    for line in open(out / "port.txt"):
+        if "audio out" in line and "transport start at frame" in line:
+            start = int(line.rsplit("frame", 1)[1].split()[0])
+    best = None
+    for ch, seg in enumerate(tx):
+        s = seg[start:start + n]
+        if rms(s[1500:]) < 1e-6:
+            continue
+        for side, m in (("L", mixL), ("R", mixR)):
+            f = fit(s, m, -a.lag, a.lag)
+            if f and (best is None or f["worst_db"] < best[2]["worst_db"]):
+                best = (ch, side, f)
+    if best:
+        ch, side, f = best
+        flag = "" if abs(f["scale_db"]) <= a.tol else "  <- scale off"
+        ok &= abs(f["scale_db"]) <= a.tol
+        print(f"mix    {f['lag']:5d} {f['scale_db']:+9.3f} {f['worst_db']:12.1f} {f['median_db']:8.1f}{flag}   (port TX0 slot {ch} vs mix.wav {side})")
+        results["mix"] = dict(slot=ch, side=side, **f)
+    else:
+        print("mix    (TX0 silent -- master on, or nothing reached the main out)")
+    (out / "result.json").write_text(json.dumps(results, indent=1))
+    print(f"\n{'PASS' if ok else 'FAIL'}: every fitted scale within {a.tol} dB of the firmware's"
+          + ("" if ok else " -- a knob the port publishes and the harness does not, or the reverse"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/harness/render_reverb.py
+++ b/tools/harness/render_reverb.py
@@ -108,7 +108,10 @@ def prov_stamp(img, fp):
     img.with_suffix(img.suffix + ".prov").write_text(fp + "\n")
 
 SR = 44100
-FRAMES = 15              # dsp_host caps a block at 15 frames (the & 0xf in setup)
+FRAMES = 16              # the firmware's frame (the harness's own cap is 15: the & 0xf
+                         # in setup, which dsp_host -frames overrides -- COLDFIRE_PORT.md O12).
+                         # Voicing renders run whole blocks since 12 Sep 2026; the
+                         # bit-identity gates (send_probe) are still pinned at 15.
 WARMUP_BLOCKS = 260      # the engine stays dry for 256 CALLS; pad past it and trim
 
 # -params index -> r6 offset: 0..5 are page 1, then dsp_host carries the REAL
@@ -402,12 +405,12 @@ def entry_points(mem_path):
     return init, proc
 
 
-def run(mem, src, values, tail_s, verbose, entry=None):
+def run(mem, src, values, tail_s, verbose, entry=None, frames=FRAMES):
     """src: mono floats at SR. -> (L, R) as 24-bit ints, warm-up trimmed."""
-    pad = WARMUP_BLOCKS * FRAMES
+    pad = WARMUP_BLOCKS * frames
     total = pad + len(src) + int(tail_s * SR)
-    blocks = -(-total // FRAMES)
-    n = blocks * FRAMES
+    blocks = -(-total // frames)
+    n = blocks * frames
 
     # PER-PROCESS scratch names. These were the fixed paths _render_in.raw /
     # _render_out.raw, which meant TWO RENDERS RUNNING AT ONCE silently fed
@@ -445,7 +448,7 @@ def run(mem, src, values, tail_s, verbose, entry=None):
     r7 = os.environ.get("RVR7") or ("2" if _guarded(mem) else "4")
     cmd = [str(HOST), "-mem", str(mem), "-init", f"{init:x}", "-proc", f"{proc:x}",
            "-inst", "1", "-r7", r7, "-alloc", "3", "-blocks", str(blocks),
-           "-in", str(tmp), "-out", str(out),
+           "-frames", str(frames), "-in", str(tmp), "-out", str(out),
            "-params", ",".join(str(v) for v in values)]
     r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
     if r.returncode != 0:
@@ -515,6 +518,8 @@ def main():
                          "current build -- how you A/B two engine versions on the "
                          "same source (keep the old .mem when you change the engine)")
     ap.add_argument("-v", "--verbose", action="store_true")
+    ap.add_argument("--frames", type=int, default=FRAMES,
+                    help="samples per block: 16 = the firmware's frame (default); 15 = the old harness")
     a = ap.parse_args()
     if a.dev:
         os.environ["DEV"] = "1"     # before any fingerprint() call -- DEV is in
@@ -584,7 +589,7 @@ def main():
         print(f"  engine {mem.name}  [payload {sha(mem)}]")
         for vals, dest, swept in jobs:
             vlist = [vals[n] for n, _ in PARAMS]
-            L, R = run(mem, src, vlist, a.tail, a.verbose)
+            L, R = run(mem, src, vlist, a.tail, a.verbose, frames=a.frames)
             if a.wet:
                 # output = dry + wet, and the dry path is the mono input duplicated,
                 # so subtracting it recovers the wet exactly.

--- a/tools/harness/render_reverb.py
+++ b/tools/harness/render_reverb.py
@@ -163,6 +163,15 @@ def die(msg):
 def read_wav(path):
     """-> (mono float list in -1..1, samplerate). Stereo is summed to mono:
     the harness feeds one mono stream and the engine sums L+R itself."""
+    chans, sr = read_wav_channels(path)
+    if len(chans) == 1:
+        return chans[0], sr
+    return [sum(c[i] for c in chans) / len(chans) for i in range(len(chans[0]))], sr
+
+
+def read_wav_channels(path):
+    """-> ([channel float lists in -1..1], samplerate), channels kept apart
+    (rig_render's mixer model applies AMP BAL per side, 12 Sep 2026)."""
     with wave.open(str(path), "rb") as w:
         ch, sw, sr, n = w.getnchannels(), w.getsampwidth(), w.getframerate(), w.getnframes()
         raw = w.readframes(n)
@@ -179,9 +188,7 @@ def read_wav(path):
         a = array.array("i"); a.frombytes(raw); vals = [v / 2147483648.0 for v in a]
     else:
         die(f"unsupported sample width {sw*8}-bit in {path}")
-    if ch > 1:
-        vals = [sum(vals[i:i + ch]) / ch for i in range(0, len(vals) - ch + 1, ch)]
-    return vals, sr
+    return [vals[c::ch] for c in range(ch)], sr
 
 
 def resample(x, src, dst):

--- a/tools/harness/rig_render.py
+++ b/tools/harness/rig_render.py
@@ -62,7 +62,10 @@ import mixer                           # noqa: E402  (the measured gain chain)
 from remix import registry             # noqa: E402
 
 SR = 44100
-FRAMES = send_probe.FRAMES             # 15: dsp_host caps a block at 15 frames
+FRAMES = 16                            # the firmware's frame; the harness's own cap is 15
+                                       # (dsp_host -frames overrides it, COLDFIRE_PORT.md O12).
+                                       # Voicing renders run whole blocks since 12 Sep 2026;
+                                       # the bit-identity gates (send_probe) stay at 15.
 NTRACKS = 8
 # Track -> core. Measured 10 Aug 2026 (marker flash): payload A serves 5-8.
 CORE_OF = {t: (0 if t >= 5 else 1) for t in range(1, NTRACKS + 1)}
@@ -273,7 +276,7 @@ def main():
     ap.add_argument("--out", default="out/rig")
     ap.add_argument("--keep", action="store_true", help="keep the raw files")
     ap.add_argument("-v", "--verbose", action="store_true")
-    ap.add_argument("--frames", type=int, default=FRAMES, help="samples per dsp_host block (15 = the harness default; 16 = the firmware's frame)")
+    ap.add_argument("--frames", type=int, default=FRAMES, help="samples per dsp_host block (16 = the firmware's frame, the default; 15 = the old harness)")
     ap.add_argument("--extra", default="", help="extra dsp_host arguments, e.g. '-dumpy 36000,360d3,file' (the bus scratch after the render)")
     a = ap.parse_args()
 
@@ -351,8 +354,10 @@ def main():
     n_src = int(a.seconds * SR) if a.seconds else longest
     if n_src == 0:
         die("no stems and no --seconds: nothing to render")
-    pad = send_probe.WARMUP_BLOCKS * FRAMES        # the engines stay dry for 256 calls
     FR = a.frames
+    pad = send_probe.WARMUP_BLOCKS * FR            # the engines stay dry for 256 CALLS, so the
+                                                   # pad is in blocks of THIS length (at 16 frames
+                                                   # the old 260 x 15 left 196 dry samples in)
     total = pad + n_src + int(a.tail * SR)
     blocks = -(-total // FR)
     n = blocks * FR

--- a/tools/harness/rig_render.py
+++ b/tools/harness/rig_render.py
@@ -15,12 +15,26 @@ shared window Y:0x30000-0x3FFFF really shared between the two emulated cores
 it does on hardware: across the core boundary, through the bus scratch.
 
 What comes out: T1.wav .. T8.wav (each track's stereo output, dry + wet as
-the DSP emits it), mix.wav (their unity sum, -6 dB), and meter.txt (per-block
-instruction counts per core: the cycle floor of THIS layout).
+the DSP emits it -- the chain output, before LEVEL), mix.wav (the main out:
+every track through its LEVEL, summed, saturated the way a 24-bit sum is),
+and meter.txt (per-block instruction counts per core: the cycle floor of
+THIS layout).
+
+THE MIXER MODEL (12 Sep 2026, tools/harness/mixer.py). The unit's gain
+chain around the DSP, measured under the ColdFire port: AMP VOL (v/127)^2
+and AMP BAL (a balance: the far side falls to zero, the near side stays)
+are applied to the stem BEFORE the FX chain, exactly as the DSP's own AMP
+stage does it; track LEVEL (L/128)^2 is applied AFTER, at the mix. The
+values come from the part (--project: the AMP page and the LEVEL pair) or
+the unit's defaults (VOL 64 = -11.9 dB, BAL 64, LEVEL 108 = -3.0 dB), and
+--mix T1:VOL=127,LEVEL=100 overrides them. A stem is therefore THE VOICE at
+its sample GAIN (0 dBFS in the file = 0 dBFS at the voice), which is why
+--amp defaults to 1.0 with the model on. --mixer off is the old harness:
+stems at --amp 0.5 straight into the chain, mix.wav a unity sum at -6 dB.
 
 What this is NOT: the ColdFire. Knobs are poked into r6 the way the harness
 always has (a slot can draw a knob and publish nothing -- docs/firmware/PARAM_PAGES.md),
-AMP VOL / pan / the mixer are not modelled (unity sum), samples do not play
+the main level and the cue mix are not modelled, samples do not play
 (stems stand in for what the track would play), and the cores are lock-step
 unless --skew interleaves them (a fuzz of the hardware's timing, never a
 proof). docs/remixer/HARNESS.md.
@@ -44,6 +58,7 @@ import wave
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1])); import toolpath  # noqa: E402,F401  (every tools/ dir on sys.path)
 import send_probe                      # noqa: E402  (entry_points, dump_mem, HOST)
+import mixer                           # noqa: E402  (the measured gain chain)
 from remix import registry             # noqa: E402
 
 SR = 44100
@@ -150,7 +165,13 @@ def part_tracks(project, bank, part, remix_name):
     ids = remix_id_map(remix_name)
     off = otp.PART_BASE + (part - 1) * otp.PART_STRIDE
     out = {}
+    mix = {}
     for i in range(NTRACKS):
+        # the AMP page (ATK HOLD REL VOL BAL XVOL) sits six bytes before the
+        # track's FX1 row; LEVEL is the first of the (LEVEL, cue) pair at +0x1b
+        amp = off + otp.P1_OFF + i * otp.TRACK_STRIDE - 6
+        mix[i + 1] = dict(vol=data[amp + 3] & 0x7f, bal=data[amp + 4] & 0x7f,
+                          level=data[off + 0x1b + 2 * i] & 0x7f)
         slots = []
         for fx, idoff, sub in ((1, otp.FX1_OFF, 0), (2, otp.FX2_OFF, 6)):
             fid = data[off + idoff + i]
@@ -166,7 +187,28 @@ def part_tracks(project, bank, part, remix_name):
             slots.append(Slot(m, fx, [v & 0x7f for v in vals]))
         if slots:
             out[i + 1] = slots
-    return out
+    return out, mix
+
+
+def default_mix():
+    return {t: dict(vol=mixer.VOL_DEFAULT, bal=mixer.BAL_DEFAULT, level=mixer.LEVEL_DEFAULT)
+            for t in range(1, NTRACKS + 1)}
+
+
+def apply_mix(mix, specs):
+    """--mix T1:VOL=127,BAL=64,LEVEL=100 (any subset, repeatable)."""
+    for spec in specs:
+        try:
+            tn, rest = spec.split(":", 1)
+            t = int(tn.upper().lstrip("T"))
+            for kv in rest.split(","):
+                k, v = kv.split("=")
+                k = k.strip().lower()
+                if k not in ("vol", "bal", "level"):
+                    raise ValueError
+                mix[t][k] = max(0, min(127, int(v)))
+        except (ValueError, KeyError):
+            die(f"--mix {spec!r}: want T<n>:VOL=<0..127>,BAL=<0..127>,LEVEL=<0..127>")
 
 
 def apply_sets(tracks, sets):
@@ -195,9 +237,12 @@ def apply_sets(tracks, sets):
 
 # ---- audio ----------------------------------------------------------------
 def read_stem(path):
-    from render_reverb import read_wav, resample
-    x, sr = read_wav(path)
-    return resample(x, sr, SR)
+    """-> (L, R) float lists at SR. A mono file is the same list twice."""
+    from render_reverb import read_wav_channels, resample
+    chans, sr = read_wav_channels(path)
+    L = resample(chans[0], sr, SR)
+    R = resample(chans[1], sr, SR) if len(chans) > 1 else L
+    return L, R
 
 
 def write_wav(path, L, R):
@@ -215,11 +260,14 @@ def main():
     ap.add_argument("--bank", type=int, default=1)
     ap.add_argument("--part", type=int, default=1)
     ap.add_argument("--set", action="append", default=[], help="T2:-VRB=100 knob override")
+    ap.add_argument("--mix", action="append", default=[], help="T1:VOL=127,BAL=64,LEVEL=100 mixer override")
+    ap.add_argument("--mixer", choices=("on", "off"), default="on",
+                    help="the measured gain chain (AMP VOL/BAL pre-FX, LEVEL post-FX); off = the old unity harness")
     ap.add_argument("--stems", help="dir of T1.wav..T8.wav (a missing one is silence)")
     ap.add_argument("--stem", action="append", default=[], help="T3=file.wav")
     ap.add_argument("--seconds", type=float, help="length (default: longest stem)")
     ap.add_argument("--tail", type=float, default=2.0, help="seconds after the stems end")
-    ap.add_argument("--amp", type=float, default=0.5, help="stem scale into the DSP (0.5 = -6 dBFS)")
+    ap.add_argument("--amp", type=float, help="stem scale (default 1.0 with the mixer, 0.5 = -6 dBFS without)")
     ap.add_argument("--tempo", type=float, help="publish tempo24 / clocks as the ColdFire cave does")
     ap.add_argument("--skew", type=int, help="interleave the cores, core 0 N instructions ahead")
     ap.add_argument("--out", default="out/rig")
@@ -236,13 +284,18 @@ def main():
     outdir.mkdir(parents=True, exist_ok=True)
 
     # the tracks
+    mix = default_mix()
     if a.project:
-        tracks = part_tracks(a.project, a.bank, a.part, a.remix)
+        tracks, mix = part_tracks(a.project, a.bank, a.part, a.remix)
     elif a.tracks:
         tracks = parse_tracks(a.tracks, a.remix)
     else:
         die("give --tracks or --project")
     apply_sets(tracks, a.set)
+    apply_mix(mix, a.mix)
+    model = a.mixer == "on"
+    if a.amp is None:
+        a.amp = 1.0 if model else 0.5
 
     # both payloads
     mems = {}
@@ -294,7 +347,7 @@ def main():
     for spec in a.stem:
         tn, f = spec.split("=", 1)
         stems[int(tn.upper().lstrip("T"))] = read_stem(pathlib.Path(f).expanduser())
-    longest = max((len(x) for x in stems.values()), default=0)
+    longest = max((len(x[0]) for x in stems.values()), default=0)
     n_src = int(a.seconds * SR) if a.seconds else longest
     if n_src == 0:
         die("no stems and no --seconds: nothing to render")
@@ -304,18 +357,32 @@ def main():
     blocks = -(-total // FR)
     n = blocks * FR
 
+    # what the chain is fed: the stem at --amp, and with the model on, through
+    # the DSP's AMP stage (VOL^2 and the balance) -- interleaved L,R (-stereo)
+    def pre_gains(t):
+        if not model:
+            return a.amp, a.amp
+        gl, gr = mixer.bal_gains(mix[t]["bal"])
+        g = a.amp * mixer.vol_gain(mix[t]["vol"])
+        return g * gl, g * gr
     tag = os.getpid()
     raws = {}
-    for t, x in stems.items():
+    for t, (xl, xr) in stems.items():
         p = ROOT / f"out/dsp/_rig_in_T{t}_{tag}.raw"
+        gl, gr = pre_gains(t)
+        m = min(len(xl), n_src)
         with open(p, "wb") as f:
             for i in range(n):
                 j = i - pad
-                v = a.amp * x[j] if 0 <= j < min(len(x), n_src) else 0.0
-                f.write(struct.pack("<i", max(-8388608, min(8388607, int(v * 8388607)))))
+                if 0 <= j < m:
+                    l_, r_ = gl * xl[j], gr * xr[j]
+                else:
+                    l_ = r_ = 0.0
+                f.write(struct.pack("<ii", max(-8388608, min(8388607, int(l_ * 8388607))),
+                                    max(-8388608, min(8388607, int(r_ * 8388607)))))
         raws[t] = p
     silent = ROOT / f"out/dsp/_rig_silence_{tag}.raw"
-    silent.write_bytes(b"\0" * (4 * n))
+    silent.write_bytes(b"\0" * (8 * n))
 
     out = ROOT / f"out/dsp/_rig_out_{tag}.raw"
     cmd = [str(send_probe.HOST), "-mem", str(mems[0]), "-memB", str(mems[1]),
@@ -328,7 +395,7 @@ def main():
            "-audioidx", ",".join(str(i["track"] - 1) for i in inst),
            "-audio", f"{AUDIO_BASE:x}",
            "-in", ",".join(str(raws.get(i["track"], silent)) for i in inst),
-           "-frames", str(FR), "-blocks", str(blocks),
+           "-frames", str(FR), "-blocks", str(blocks), "-stereo",
            "-out", str(out), "-meter", str(outdir / "meter.txt")]
     for i in inst:
         cmd += ["-params", ",".join(map(str, i["values"]))]
@@ -344,8 +411,14 @@ def main():
               f"alloc {i['alloc']} r7 {i['r7']} init P:0x{i['init']:05x} "
               f"params {' '.join(map(str, i['values']))}"
               f"{'   <- SEND alias' if i['aliased'] else ''}")
-    print(f"{blocks} blocks x {FR} frames ({n / SR:.1f} s incl. {pad / SR:.1f} s warm-up), "
-          f"stems on {sorted(stems) or 'none'}")
+    if model:
+        def desc(t, m):
+            db = lambda g: 20 * math.log10(g) if g > 0 else -200.0
+            bal = "" if m["bal"] == 64 else f" BAL {m['bal']}"
+            return (f"T{t} VOL {m['vol']} ({db(mixer.vol_gain(m['vol'])):+.1f} dB){bal}"
+                    f" LVL {m['level']} ({db(mixer.level_gain(m['level'])):+.1f})")
+        print("mixer (the measured chain, tools/harness/mixer.py): "
+              + "  ".join(desc(t, m) for t, m in sorted(mix.items()) if t in stems or t in tracks))
     r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
     if a.verbose:
         print(r.stdout)
@@ -368,22 +441,27 @@ def main():
             arr = array.array("i"); arr.frombytes(p.read_bytes())
             L, R = list(arr[0::2])[pad:], list(arr[1::2])[pad:]
         elif t in stems:                       # no instance at all: the stem passes through
-            x = stems[t]
-            L = [int(a.amp * (x[j] if j < min(len(x), n_src) else 0.0) * 8388607) for j in range(n - pad)]
-            R = list(L)
+            xl, xr = stems[t]; gl, gr = pre_gains(t); m = min(len(xl), n_src)
+            L = [int(gl * (xl[j] if j < m else 0.0) * 8388607) for j in range(n - pad)]
+            R = [int(gr * (xr[j] if j < m else 0.0) * 8388607) for j in range(n - pad)]
         else:
             continue
         write_wav(outdir / f"T{t}.wav", L, R)
         peak = max((abs(v) for v in L + R), default=0)
         print(f"  T{t}.wav  peak {20 * math.log10(max(peak, 1) / 8388608):6.1f} dBFS")
+        lv = mixer.level_gain(mix[t]["level"]) if model else 1.0
         for j in range(len(L)):
-            mixL[j] += L[j]; mixR[j] += R[j]
-    mixL = [v * 0.5 for v in mixL]; mixR = [v * 0.5 for v in mixR]
-    write_wav(outdir / "mix.wav", mixL, mixR)
+            mixL[j] += lv * L[j]; mixR[j] += lv * R[j]
+    if not model:
+        mixL = [v * 0.5 for v in mixL]; mixR = [v * 0.5 for v in mixR]
     peak = max((abs(v) for v in mixL + mixR), default=0)
-    clip = sum(1 for v in mixL + mixR if abs(v) >= 8388607)
+    clip = sum(1 for v in mixL + mixR if abs(v) > 8388607)
+    mixL = [max(-8388608, min(8388607, int(v))) for v in mixL]
+    mixR = [max(-8388608, min(8388607, int(v))) for v in mixR]
+    write_wav(outdir / "mix.wav", mixL, mixR)
     print(f"  mix.wav  peak {20 * math.log10(max(peak, 1) / 8388608):6.1f} dBFS"
-          f"{f'  !! {clip} clipped samples' if clip else ''}   (unity sum, -6 dB; no AMP/pan model)")
+          f"{f'  !! {clip} clipped samples' if clip else ''}   "
+          + ("(the main out: each track through LEVEL, summed)" if model else "(unity sum, -6 dB; --mixer off)"))
     print(f"-> {outdir}")
     if not a.keep:
         for p in [out, silent, *raws.values()] + [pathlib.Path(f"{out}.i{k}") for k in range(1, len(inst))]:

--- a/tools/scratch/mixer_sweep.py
+++ b/tools/scratch/mixer_sweep.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Measure the unit's gain chain around the DSP under the ColdFire port.
+
+The O9d fixture (Sam's RIG, T1 THRU with FX1 = SEND and FX2 = EQUALIZER
+flat, tone on RX0 slot 2) gave ONE point of the pre-FX track gain:
+k = 2130129/2^23 = -11.906 dB at AMP VOL 64 (COLDFIRE_PORT.md O9d). This
+sweeps the part bytes the mixer model needs and fits each stage:
+
+  chain in   : the 84-word track record's audio     (what the FX chain is fed)
+  chain out  : T1's slot of core 1's read-back      (pre-mix, after FX2)
+  TX0        : --audio-out, the ESAI's main pair     (post-mix)
+
+  python3 tools/scratch/mixer_sweep.py vol   0 32 64 96 127     # AMP VOL, T1
+  python3 tools/scratch/mixer_sweep.py level 0 64 100 108 127   # track LEVEL, T1
+  python3 tools/scratch/mixer_sweep.py bal   0 32 64 96 127     # AMP BAL, T1
+  python3 tools/scratch/mixer_sweep.py report                   # table of every run so far
+
+Each run: copy the fixture project, write the byte into EVERY part record of
+every bank (current + saved, the set_fx rule), stage a card with route A's
+own staging, run the port for FRAMES frames, extract both taps, fit rms
+ratios over the LAST window (the ColdFire slews a knob from the transport
+start: the first 160 frames are a ramp, O12). Results land in OUT/<stage>_<v>.json.
+"""
+import json, math, pathlib, shutil, subprocess, sys, wave
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1])); import toolpath  # noqa: E402,F401
+import ot_project as op   # noqa: E402
+import o9d_compare as oc  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "out/o9d/proj_t1eqA"
+IMAGE = ROOT / "out/raw/section_3_MAIN_OS.bin"
+TONE = ROOT / "out/o9c/toneC_300.wav"          # 8 ch, RX0 slot k = a tone; slot 2 reaches T1
+OUT = ROOT / "out/mixer"
+FRAMES = 400                                   # 6400 samples; the slew is over by 2560
+TRACK = 1
+AMP_VOL, AMP_BAL = 3, 4                        # ATK HOLD REL VOL BAL XVOL
+
+def rms(x):
+    return math.sqrt(sum(v * v for v in x) / len(x)) if x else 0.0
+
+def db(x):
+    return 20 * math.log10(x) if x > 0 else -200.0
+
+def write_byte(pdir, stage, value):
+    t = TRACK - 1
+    for bank in sorted(pdir.glob("bank*.work")):
+        def mut(data):
+            for p in range(op.NPARTS_ALL):
+                off = op.PART_BASE + p * op.PART_STRIDE
+                if stage == "vol":
+                    data[off + op.P1_OFF + t * op.TRACK_STRIDE - 6 + AMP_VOL] = value
+                elif stage == "bal":
+                    data[off + op.P1_OFF + t * op.TRACK_STRIDE - 6 + AMP_BAL] = value
+                elif stage == "level":
+                    data[off + 0x1b + 2 * t] = value
+                else:
+                    sys.exit(f"stage {stage!r}")
+        op._bank_write(pdir, int(bank.name[4:6]), mut, guard=False)
+
+def run(stage, value):
+    OUT.mkdir(parents=True, exist_ok=True)
+    tag = f"{stage}_{value:03d}"
+    proj = OUT / f"proj_{tag}"
+    if proj.exists():
+        shutil.rmtree(proj)
+    shutil.copytree(FIXTURE, proj)
+    # the RIG's T8 is a master track with stock LO-FI on FX1 -- nonlinear, and
+    # between the chain output and TX0. Off, so TX0 is the mix itself.
+    pw = proj / "project.work"
+    pw.write_bytes(pw.read_bytes().replace(b"MASTER_TRACK=1", b"MASTER_TRACK=0"))
+    write_byte(proj, stage, value)
+    card = OUT / f"card_{tag}.img"
+    subprocess.run([sys.executable, str(ROOT / "tools/emu/ot_emu/stage_card.py"), str(proj), "OCTABAM", "RIG",
+                    "--tree", str(OUT / f"tree_{tag}"), "--out", str(card)], check=True,
+                   stdout=subprocess.DEVNULL)
+    prefix = OUT / tag
+    cmd = [str(ROOT / "out/emu/ot_emu"), "--image", str(IMAGE), "--card", str(card),
+           "--set", "OCTABAM", "--project", "RIG", "--sequencer", "--internal-clock",
+           "--frames", str(FRAMES), "--load-ms", "20000", "--dsp", "--main-level", "64",
+           "--audio-in", str(TONE), "--audio-out", str(prefix), "--block-dump", f"{prefix}.dump"]
+    with open(f"{prefix}.txt", "w") as log:
+        subprocess.run(cmd, check=True, stdout=log, stderr=subprocess.STDOUT)
+    return analyse(stage, value)
+
+def win_fit(port, host, lag, lo=1500, win=200):
+    """Per-window least-squares scale of port against host (lag-aligned), the
+    MEDIAN over windows and the worst residual: the RIG's pattern re-trigs T1
+    ~frame 340 (a ~400-sample dip at the chain output, the input tap flat), so
+    a whole-run rms is not the gain and a median is."""
+    n = min(len(port), len(host) - max(lag, 0)) - 200
+    ks, res = [], []
+    for s in range(max(lo, -lag), n - win, win):
+        seg = range(s, s + win)
+        den = sum(host[i + lag] ** 2 for i in seg)
+        if den <= 0:
+            continue
+        k = sum(port[i] * host[i + lag] for i in seg) / den
+        r = rms([port[i] - k * host[i + lag] for i in seg]); pw = rms([port[i] for i in seg])
+        ks.append(k); res.append(db(r / pw) if pw else -200.0)
+    ks.sort()
+    return ks[len(ks) // 2], max(res), len(ks)
+
+def best_lag(port, host, lo, hi, seg):
+    best = None
+    for lag in range(lo, hi + 1):
+        den = sum(host[i + lag] ** 2 for i in seg)
+        if den <= 0:
+            continue
+        k = sum(port[i] * host[i + lag] for i in seg) / den
+        r = rms([port[i] - k * host[i + lag] for i in seg])
+        if best is None or r < best[1]:
+            best = (lag, r)
+    return best[0]
+
+def analyse(stage, value):
+    tag = f"{stage}_{value:03d}"
+    prefix = OUT / tag
+    oc.extract(f"{prefix}.dump", TRACK, str(prefix))
+    inp = oc.rd(f"{prefix}_in.wav"); outp = oc.rd(f"{prefix}_rb_L.wav")
+    n = min(len(inp), len(outp))
+    k, worst, nw = win_fit(outp, inp, -32)          # O9d's lag: the 32-sample record pipeline
+    # TX0: every slot, from the transport start; the main pair is fitted against the chain output
+    w = wave.open(f"{prefix}_core0.wav", "rb"); nch, sw, nfr = w.getnchannels(), w.getsampwidth(), w.getnframes()
+    raw = w.readframes(nfr)
+    start = None
+    for line in open(f"{prefix}.txt"):
+        if "audio out" in line and "transport start at frame" in line:
+            start = int(line.rsplit("frame", 1)[1].split()[0])
+    slots, tx = [], []
+    for ch in range(nch):
+        seg = [int.from_bytes(raw[(i * nch + ch) * sw:(i * nch + ch + 1) * sw], "little", signed=True) / (1 << 23)
+               for i in range(start, start + n)]
+        tx.append(seg); slots.append(rms(seg[1500:n - 200]))
+    r_in = rms(inp[1500:n - 200]); r_out = rms(outp[1500:n - 200])
+    txfit = {}
+    for ch in range(nch):
+        if slots[ch] < 1e-6:
+            continue
+        lag = best_lag(tx[ch], outp, -256, 256, range(1500, 3000))
+        kk, ww, _ = win_fit(tx[ch], outp, lag)
+        txfit[ch] = {"lag": lag, "g_db": db(abs(kk)), "g_lin": kk, "worst_resid_db": ww}
+    res = {"stage": stage, "value": value, "in_db": db(r_in), "out_db": db(r_out),
+           "k_db": db(abs(k)), "k_lin": k, "k_q23": round(k * 8388608), "worst_resid_db": worst, "windows": nw,
+           "tx0_db": [db(s) for s in slots], "tx0_fit": txfit, "n": n}
+    (OUT / f"{tag}.json").write_text(json.dumps(res, indent=1))
+    print(f"{tag}: in {res['in_db']:.2f} dBFS, chain k {res['k_db']:.3f} dB ({res['k_q23']}/2^23, worst window {worst:.1f} dB); "
+          + "TX0 " + " ".join(f"s{ch}:{f['g_db']:+.3f}dB@{f['lag']:+d}(worst {f['worst_resid_db']:.0f})" for ch, f in txfit.items()))
+    return res
+
+def report():
+    rows = sorted((json.loads(p.read_text()) for p in OUT.glob("*.json")), key=lambda r: (r["stage"], r["value"]))
+    print(f"{'stage':6} {'v':>4} {'in dBFS':>8} {'chain k dB':>11} {'k/2^23':>8} {'worst':>6}  TX0 slot: gain vs chain out (lag)")
+    for r in rows:
+        print(f"{r['stage']:6} {r['value']:4d} {r['in_db']:8.2f} {r['k_db']:11.3f} {r['k_q23']:8d} {r['worst_resid_db']:6.0f}  "
+              + "  ".join(f"s{ch}:{f['g_db']:+7.3f} ({f['lag']:+d})" for ch, f in r["tx0_fit"].items()))
+
+if __name__ == "__main__":
+    if sys.argv[1] == "report":
+        report()
+    elif sys.argv[1] == "analyse":
+        analyse(sys.argv[2], int(sys.argv[3]))
+    else:
+        for v in sys.argv[2:]:
+            run(sys.argv[1], int(v))

--- a/tools/verify/verify_menu.py
+++ b/tools/verify/verify_menu.py
@@ -33,6 +33,7 @@ to what task 11 needs to prove (the five tables agree with each other and
 with what the two real functions read). This is "measure, don't guess" in the
 form the ColdFire side allows without a full UI emulation harness.
 """
+import hashlib
 import os, pathlib, sys
 
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[1])); import toolpath  # noqa: E402,F401  (every tools/ dir on sys.path)
@@ -142,9 +143,32 @@ REG_FMT = {(_c.registers_formatter.module, _c.registers_formatter.slot):
            if _c.registers_formatter is not None}
 
 
+def _built_for(img: bytes) -> str | None:
+    """Which remix wrote BUILT, from the sidecar build_bus leaves beside it --
+    None when there is no sidecar or it describes different bytes (an image
+    restored by hand, or a build older than the sidecar)."""
+    side = BUILT.with_suffix(".remix")
+    if not side.exists():
+        return None
+    parts = side.read_text().split()
+    if len(parts) != 2 or parts[1] != hashlib.sha256(img).hexdigest():
+        return None
+    return parts[0]
+
+
 def main():
     stock = STOCK.read_bytes()
     img = BUILT.read_bytes()
+    # ⚠️ THE IMAGE ON DISK IS WHATEVER BUILT LAST, and this check reads its
+    # expectations from REMIX. Checking one remix's image against another's
+    # list prints dozens of FAILs whose "garbage" entries are the other
+    # remix's descriptor text -- say the one true thing instead.
+    built = _built_for(img)
+    if built is not None and built != REMIX.name:
+        print(f"  [FAIL] {BUILT} was built for remix '{built}', but REMIX="
+              f"{REMIX.name} -- run `make bus REMIX={REMIX.name}` first "
+              f"(or `make check REMIX={REMIX.name}`, which does)")
+        sys.exit(1)
 
     def rd32(buf, a):
         i = a - BASE


### PR DESCRIPTION
Bryan T ran the recfix recipe and got 32 verify_menu fails: the list at
0x400d6b00 instead of the 0x400d7bbc his build log named, entries past
index 2 reading 0x42565242. That is "BVRB", BusVerb's abbr -- the image
verify_menu read was a default-remix (bamsep26) build, not recfix's.
Reproduced here: a bamsep26 image checked as recfix gives 41 fails with
exactly that word. The documented recipe is clean on a fresh clone with
and without .venv; something in his sequence built without REMIX=recfix
(a bare make bus, or make -j running bus and verify at once on the one
out/mainos_bus.bin).

Nothing in the image names the remix, so no reader could tell. build_bus
now writes out/mainos_bus.remix beside the image: the remix name and the
image's sha256. verify_menu reads it and, when the hash matches the bytes
on disk but the name is not REMIX, fails with the one true line and the
fix. An image restored without its sidecar (verify_replaces, audition)
carries a stale hash and is treated as unlabelled, so the pipeline's own
save-and-restore is unaffected. Artifacts and reports untouched: refhash
26/26 bit-identical; make check REMIX=recfix green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)