### PR TITLE
A6: Spectrum and Character FX1-only — FX2 instances run dry, the chooser hides the rows, worst core 4,830 → 3,567

### DIFF
--- a/modules/character/README.md
+++ b/modules/character/README.md
@@ -5,7 +5,7 @@ one insert, **replacing stock LO-FI** (id 0x1c) on both menus and in every
 saved part that chose LO-FI. Design page:
 https://claude.ai/code/artifact/42670d67-7365-4c7d-bcc7-1786ba4331ce
 
-| page 1 | DRV · FOLD · CRSH · COMP · →DEL · →VRB |
+| page 1 | DRV · FOLD · CRSH · COMP · — · — |
 |---|---|
 | page 2 | MIX · SAT (TAPE TUBE FUZZ BUS) · RING · CMOD (COMP GLUE TRNS) · WDTH · SRR (OFF /2 /4 /8) |
 
@@ -29,31 +29,23 @@ rather than a fader for the dirt.
   compressor's threshold to 1.0 and the other modes set the boost flag to 0.
 - **WDTH** is mid/side: 64 untouched, 0 mono, 127 double sides. With BUS +
   GLUE + WDTH this is the master chain on T8's FX1.
-- **→DEL / →VRB** make it a bus client on the Spectrum station's terms:
-  knob-gated registration, and it never housekeeps.
-- **SAT = BUS is also the RETURN** (3 Sep 2026, `docs/effects/BUS.md` "The
-  returns"). On a master chain CRSH and RING are knobs nobody turns, so BUS
-  repurposes them as **RVRB** and **DLY**, the two return levels — the panel
-  and the remixer print those names (`mode_views`), the crush and ring
-  stages go neutral, and after the send taps the station adds the shared
-  reverb and delay wet (stereo, four deep, two buffers back) at those
-  levels. While a level is up it stamps that bus's liveness word each
-  block, and the engine on the other end stops printing on its own host:
-  the reverb leaves T5 and enters the mix here. Levels down, any other SAT,
-  or no station, and within 3 blocks the engines print on their hosts as
-  before — bit-identically. Gate: `tools/verify_returns.py` (18 cases).
-
-⚠️ **The detector reads `x:(r7+$32)`, the KEY**, which is the station's own
-input today. The →KEY bus send on the backlog writes another track's there
-and nothing else changes — that is the whole sidechain-ducking path.
-
-## Measured (3 Sep 2026, local)
-
+- **SAT = BUS is also the RETURN** (3 Sep 2026, one return since the one-aux
+  rig of 7 Sep: `docs/effects/BUS.md` "The one aux bus"). On a master chain
+  CRSH is a knob nobody turns, so BUS repurposes it as **RET**, the return
+  level (RING is inert in BUS mode) — the panel and the remixer print that
+  name (`mode_views`), the crush and ring stages go neutral, and the
+  station adds the LAST LIVE STAGE's output (the reverb's if it runs, else
+  the delay's; stereo, four deep, two buffers back) at that level. While
+  RET is up it stamps both hosts quiet, so the wet arrives once, here, on
+  T8 — the return is pinned to track 8 and returns nothing elsewhere.
 - **833 words** (payload A, 866 on B), **405 cycles/sample**. ⚠️ The pricer's
-  worst case — seven of these on one core beside the reverb — is **331 over**
-  the 3,120 + 768 FILTER credit. Sam's layout runs one or two. Trims if it
-  must come down: drop RING (~12), a single `chsatur` call by rolling the two
-  channels (~13), the TUBE asymmetry (~10 per channel).
+  worst case since the station went FX1-only (12 Sep 2026) is FOUR of these
+  beside the delay: 3,567 on the counter (`make cycles`), 447 over the flat
+  3,120 and 321 under the FILTER-credited 3,888 — which line is real is the
+  burn sweep's to say (`tools/harness/pressure.py`). Sam's layout runs one
+  or two. Trims if it must come down: drop RING (~12), a single `chsatur`
+  call by rolling the two channels (~13), the TUBE asymmetry (~10 per
+  channel).
 - `tools/verify/verify_character.py`, **22 gates, all PASS**: defaults bit-exact;
   MIX=0 bit-exact with every stage driven; CRSH=110 collapses a ramp to 144
   wet levels against 4,500; SRR holds the wet exactly 2/4/8 samples; all four
@@ -88,4 +80,9 @@ and nothing else changes — that is the whole sidechain-ducking path.
 - Voicing: nothing has been heard yet. Every law here — the drive taper, the
   four characters' constants, the two compressor timings, the 12 ms transient
   window — is a first guess.
-- ⚠️ UNFLASHED.
+- On hardware since flash 4 (tag 79); the return (SAT=BUS on T8) confirmed
+  on flash 7 (tag 21). **FX1 only** since 12 Sep 2026: an FX2 instance runs
+  as a dry pass (`Claims(fx1_only=True)`, `verify_character.py`), the FX2
+  chooser hides the row; emulator-proven, not yet flashed. The sends went
+  with the one-aux rig: page-1 slots 4-5 are blank, and BUS mode carries ONE
+  return, RET (the CRSH knob).

--- a/modules/character/character.asm
+++ b/modules/character/character.asm
@@ -47,6 +47,7 @@
 ;   $2c width mid gain  $2d attack coeff   $2e release coeff  $2f bypass
 ;   $30 ->DEL level     $31 ->VRB level
 ;   $3e RET return level   $3f 0 (was DLY; one return since 7 Sep 2026)
+;   $40 FX2-slot flag (set at init: 1 = this instance is on FX2, dry; per block)
 ;   $3c/$3d reverb / delay liveness grace (BUS mode, per block)
 ;   per sample / persistent (ALL BELOW $40 -- an r7 displacement past 63
 ;   assembles to the two-word long form, which cost the Spectrum station 30
@@ -85,9 +86,32 @@
 
 init:
 ; ROTINIT
+; ---- FX1 ONLY (12 Sep 2026): the allocator base decides, at init --------
+; Modulation's idiom (modules/modulation/modulation.asm): X:0x213 points at
+; this instance's entry in the base table, valid HERE and nowhere else. FX1
+; slots are below 0x4000, FX2 slots at or above it. An FX2 instance runs as
+; a dry pass -- proc returns before it touches a frame or the bus -- so a
+; part that names this id on FX2 (the stock id both menus share) costs its
+; core nothing: the rig's cycle envelope is priced with the stations on FX1
+; only (tools/harness/pressure.py), and the FX2 chooser hides them.
+; sub/tst rather than cmp: the cmp-encodes-as-max family (CLAUDE.md).
+        move    x:>$213,r4
+        move    #>$ffffff,m4
+        move    x:(r4),x0
+        move    x0,a
+        move    #>$4000,x0
+        sub     x0,a                    ; base - 0x4000
+        clr     b                       ; b = 0 BEFORE the tst (the flag trap)
+        move    #>$1,x0
+        tst     a
+        tpl     x0,b                    ; base >= 0x4000: an FX2 slot
+        move    b,x:(r7+$40)          ; 1 = dry pass
         rts
 
 proc:
+        move    x:(r7+$40),a           ; an FX2 slot: dry, nothing written
+        tst     a
+        bne     ch_end
 ; ===========================================================================
 ; BUS: split-aware frame offset, verbatim from modules/send/send_client.asm
 ; ===========================================================================

--- a/modules/character/manifest.py
+++ b/modules/character/manifest.py
@@ -46,7 +46,7 @@ their hosts exactly as before -- a wrong setting on the master can never
 make the reverb vanish from the set.
 """
 
-from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
+from remix.schema import (BusRole, Claims, DspSection, Formatter, Harness, Kind,
                           MenuEntry, ModeView, Module, Param, YBase)
 
 _PLAIN = Formatter.PLAIN
@@ -114,5 +114,12 @@ MODULE = Module(
         r7_latch_slot=0x69,           # ROTLATCH parks this block's offset here
         gate_label=None,              # no housekeeping: a station never elects
     ),
+    # FX1 ONLY (12 Sep 2026): an FX2 instance runs as a dry pass -- the
+    # station reads its allocator base at init and returns before touching
+    # a frame when it is an FX2 slot. The rig's cycle envelope only closes
+    # with the stations on FX1 (tools/harness/pressure.py: four Characters
+    # on both slots priced a core at 4,830 against 3,120), the FX2 chooser
+    # hides the row, and tools/verify/verify_character.py proves the dry pass.
+    claims=Claims(fx1_only=True),
     harness=Harness(layout_char="2", is_server=False, bus_client=True),
 )

--- a/modules/spectrum/README.md
+++ b/modules/spectrum/README.md
@@ -1,11 +1,16 @@
 # SPECTRUM
 
-The first BamSep26 station: two filters, four routings, one modulation and
-two bus sends in one insert, **replacing stock FILTER** (id 0x04) on both
-menus and in every saved part that chose FILTER. Design page:
+The first BamSep26 station: two filters, four routings and one modulation
+in one insert, **replacing stock FILTER** (id 0x04) in every saved part that
+chose FILTER. **FX1 only** (12 Sep 2026): the id is shared by both menus, so
+an FX2 instance runs as a dry pass, decided from the allocator base at init
+(`Claims(fx1_only=True)`, proven by `verify_spectrum.py`), and the FX2
+chooser hides the row -- the rig's cycle envelope only closes with the
+stations on FX1. The bus sends went with the one-aux rig (7 Sep 2026):
+page-1 slots 4-5 are blank. Design page:
 https://claude.ai/code/artifact/42670d67-7365-4c7d-bcc7-1786ba4331ce
 
-| page 1 | FREQ · RES · BASE · WDTH · →DEL · →VRB |
+| page 1 | FREQ · RES · BASE · WDTH · — · — |
 |---|---|
 | page 2 | DRV · MODE (LP BP HP NTCH VOWL) · DPTH · ROUT (SER PAR RING FM) · RATE · SRC (ENV LFO BOTH) |
 
@@ -69,7 +74,8 @@ on FILTER's stored values sent at 64 through a closed, resonant filter).
   a single-pole base/width (~40), block-rate FM.
 - The layout alphabet lists this station under both `1` and `L` (stock
   FILTER's letter) because both map to id 0x04 — harmless, cosmetic.
-- ⚠️ UNFLASHED. The FX1-participant bus case is flash 4's claim (v).
+- On hardware since flash 4 (tag 79) and in every rig flash since; the
+  FX1-only dry pass is emulator-proven (12 Sep 2026), not yet flashed.
 
 ## Cycle trim — the parallel-move relayout (evaluated 4 Sep 2026, not done)
 

--- a/modules/spectrum/manifest.py
+++ b/modules/spectrum/manifest.py
@@ -31,7 +31,7 @@ Every mpy is `mpy x0,y1`, the audited-signed form; every clip is the store
 limiter. Cycles: the whole loop is straight-line and priced by `make cycles`.
 """
 
-from remix.schema import (BusRole, DspSection, Formatter, Harness, Kind,
+from remix.schema import (BusRole, Claims, DspSection, Formatter, Harness, Kind,
                           MenuEntry, Module, Param, YBase)
 
 _PLAIN = Formatter.PLAIN
@@ -91,5 +91,12 @@ MODULE = Module(
     ),
     # bus_client: it writes the shared accumulators, so an image with it has a
     # bus and needs SEND as the fallback (schema.on_the_bus).
+    # FX1 ONLY (12 Sep 2026): an FX2 instance runs as a dry pass -- the
+    # station reads its allocator base at init and returns before touching
+    # a frame when it is an FX2 slot. The rig's cycle envelope only closes
+    # with the stations on FX1 (tools/harness/pressure.py: four Characters
+    # on both slots priced a core at 4,830 against 3,120), the FX2 chooser
+    # hides the row, and tools/verify/verify_spectrum.py proves the dry pass.
+    claims=Claims(fx1_only=True),
     harness=Harness(layout_char="1", is_server=False, bus_client=True),
 )

--- a/modules/spectrum/spectrum.asm
+++ b/modules/spectrum/spectrum.asm
@@ -37,6 +37,7 @@
 ;   $23 kLP  $24 kBP  $25 kHP              $26 kA  $27 kB  $28 kR  $29 sel
 ;   $2a cHP  $2b cLP  $2c kFM              $2d bypass flag
 ;   $2e ->DEL level  $2f ->VRB level (per block copies of r6+4/5)
+;   $30 FX2-slot flag (set at init: 1 = this instance is on FX2, dry)
 ;   $31 LFO phase (PERSISTENT, masked)     $32 env (PERSISTENT, clamped)
 ;   $34/$35 SVF lp/bp L   $36/$37 SVF lp/bp R                 (PERSISTENT)
 ;   $38..$3b B poles L: hp1 hp2 lp1 lp2    $3c..$3f R         (PERSISTENT)
@@ -61,9 +62,32 @@
 
 init:
 ; ROTINIT
+; ---- FX1 ONLY (12 Sep 2026): the allocator base decides, at init --------
+; Modulation's idiom (modules/modulation/modulation.asm): X:0x213 points at
+; this instance's entry in the base table, valid HERE and nowhere else. FX1
+; slots are below 0x4000, FX2 slots at or above it. An FX2 instance runs as
+; a dry pass -- proc returns before it touches a frame or the bus -- so a
+; part that names this id on FX2 (the stock id both menus share) costs its
+; core nothing: the rig's cycle envelope is priced with the stations on FX1
+; only (tools/harness/pressure.py), and the FX2 chooser hides them.
+; sub/tst rather than cmp: the cmp-encodes-as-max family (CLAUDE.md).
+        move    x:>$213,r4
+        move    #>$ffffff,m4
+        move    x:(r4),x0
+        move    x0,a
+        move    #>$4000,x0
+        sub     x0,a                    ; base - 0x4000
+        clr     b                       ; b = 0 BEFORE the tst (the flag trap)
+        move    #>$1,x0
+        tst     a
+        tpl     x0,b                    ; base >= 0x4000: an FX2 slot
+        move    b,x:(r7+$30)          ; 1 = dry pass
         rts
 
 proc:
+        move    x:(r7+$30),a           ; an FX2 slot: dry, nothing written
+        tst     a
+        bne     fs_end
 ; ===========================================================================
 ; BUS: split-aware frame offset, verbatim from modules/send/send_client.asm
 ; ===========================================================================

--- a/remixes/bamsep26.py
+++ b/remixes/bamsep26.py
@@ -11,28 +11,36 @@ https://claude.ai/code/artifact/1f1bfff2-9d4e-41b6-b0a7-91a3c8989aaf
                 costs the DSP nothing, so every track can have its own delay
                 IN PARALLEL with the shared reverb -- which the stock box
                 cannot do, because only a station's send reaches the bus
-    Spectrum    the Spectrum station, on FILTER's old id 0x04
-    Character   replaces LO-FI   (id 0x1c)
+    Spectrum    the Spectrum station, on FILTER's old id 0x04, FX1 only
+    Character   replaces LO-FI   (id 0x1c), FX1 only (and the return on T8)
     Modulation  on CHORUS's old id 0x12, FX1 only
     TEMPO SYNC  the two ColdFire caves: BusDelay's TIME reads 1/8 rather
                 than milliseconds
     MENU SHORTCUT  MAIN MENU > CONTROL > REVERB / DELAY jumps to whichever
                 track hosts that server, and opens its FX2 page
 
-Seven FX2 rows, which is exactly the in-place chooser list -- no scrolling.
-FX1 is NONE plus the three stations: every station takes the FX1 row of the
-stock effect it replaces, so a saved part that chose FILTER now runs the
-Spectrum station, which is why all three default to a bit-exact passthrough.
+FOUR FX2 rows (the two engines, SEND, the stock DELAY) and FX1 = NONE plus
+the three stations. THE STATIONS ARE FX1-ONLY (12 Sep 2026): each takes the
+FX1 row of the stock effect it replaces, so a saved part that chose FILTER
+runs the Spectrum station -- which is why all three default to a bit-exact
+passthrough -- and none takes an FX2 row: a station named on FX2 (the id is
+the stock effect's, shared by both menus) runs as a dry pass, decided from
+the allocator base at init (Claims.fx1_only, proven by each station's gate).
+That is what closes the rig's cycle envelope: with a station on both slots
+of four tracks a core priced 4,830 against 3,120 usable; FX1-only the worst
+core is 3,567 (four Characters beside the delay) -- over the flat line by
+the counter's own error margin and under the FILTER-credited one, which the
+burn sweep on hardware is to settle (tools/harness/pressure.py).
 
 ⚠️ EVERY OTHER STOCK EFFECT IS HARVESTED. Thirteen effects, 6,158 words per
 payload in one contiguous run, and an old project that still names one of
 them gets silence rather than noise (the null stub). The three the stations
 replace keep their ids and get OUR code instead.
 
-⚠️ The stations are BUS CLIENTS: ->DEL and ->VRB on page 1, scene-lockable,
-registered only when the knob is up, and none of them housekeeps. An FX1
-participant on the bus has never run on hardware -- docs/effects/FLASHPLAN.md's
-flash 4 is where that claim is tested.
+The stations carry NO SENDS since the one-aux rig (7 Sep 2026): every
+track's AUX is on its FX2 (SEND, or an engine's own slot 0), the chain is
+delay -> reverb, and the return is Character in SAT=BUS on T8's FX1. The
+stations' former send slots (page 1, 4-5) are blank.
 """
 
 from remix.schema import Remix

--- a/tools/build/cycle_count.py
+++ b/tools/build/cycle_count.py
@@ -151,7 +151,10 @@ def bank_worst(rows, mods, fx1=(), stock_fx1_keys=()):
     cyc = {r["name"]: r["cycles"] for r in rows}
     servers = sorted((m for m in mods if m["server"] and m["stem"] in cyc),
                      key=lambda m: -cyc[m["stem"]])
-    others = sorted((m for m in mods if not m["server"] and m["stem"] in cyc),
+    # An FX1-ONLY module (Claims.fx1_only: an FX2 instance runs dry, 12 Sep
+    # 2026) never costs an FX2 slot; it is charged on the FX1 slots below.
+    others = sorted((m for m in mods if not m["server"] and m["stem"] in cyc
+                     and not m.get("fx1_only")),
                     key=lambda m: -cyc[m["stem"]])
     picks = []
     if servers:
@@ -508,6 +511,7 @@ def main():
     remix = registry.remix(os.environ.get("REMIX") or registry.DEFAULT_REMIX)
     mods = [dict(stem=pathlib.Path(m.dsp.asm).stem, key=m.key,
                  server=(m.dsp.bus_role is BusRole.SERVER),
+                 fx1_only=(m.claims is not None and m.claims.fx1_only),
                  replaces=(m.menu.replaces if m.menu is not None else None))
             for m in registry.selected(remix) if m.dsp is not None]
     from remix import stock as _stock

--- a/tools/harness/send_probe.py
+++ b/tools/harness/send_probe.py
@@ -735,6 +735,19 @@ def main():
             die(f"--pick {a.pick!r}: not a layout letter "
                 f"({''.join(sorted(SERVER_ID))}) or a module key/name")
         a.pick = _pm.harness.layout_char
+    if a.pick is not None:
+        # Every layout letter here is an FX2 instance (alloc 1 + 2k). An
+        # FX1-ONLY module renders as a dry pass there by its own design
+        # (Claims.fx1_only, 12 Sep 2026: the stations decide from the
+        # allocator base at init), so a --pick of one would measure silence
+        # and call it the effect. Render it on FX1 with rig_render instead.
+        _fm = next((m for m in registry.modules().values()
+                    if m.harness is not None and m.harness.layout_char == a.pick
+                    and m.claims is not None and m.claims.fx1_only), None)
+        if _fm is not None:
+            die(f"--pick {a.pick}: {_fm.key} is FX1-only (an FX2 instance runs dry). Render it on FX1:\n"
+                f"  python3 tools/harness/rig_render.py --tracks T1={_fm.key}+SEND --stem T1=<wav> "
+                f"--set T1:FX1:<KNOB>=<v> --out out/rig")
 
     if a.build:
         r = subprocess.run([sys.executable, "tools/build/build_bus.py"], cwd=ROOT,

--- a/tools/remix/registry.py
+++ b/tools/remix/registry.py
@@ -18,6 +18,7 @@ clone, no words -- the build writes only their chooser row.
 from __future__ import annotations
 
 import pathlib
+import dataclasses
 import sys
 import types
 
@@ -205,6 +206,17 @@ def remix(name: str = DEFAULT_REMIX):
                 f"{', '.join(sorted(on_bus))} -- an unassigned track would run "
                 f"nothing, so nobody would flip the rotation or clear the "
                 f"accumulators. Use fallback=\"SEND\".")
+    # AN FX1-ONLY MODULE ON THE FX1 CHOOSER TAKES NO FX2 ROW (12 Sep 2026).
+    # Claims.fx1_only is the module's promise that an FX2 instance runs dry,
+    # so an FX2 row for it would be a row that does nothing; the build's
+    # `hidden` mechanism already removes a row while keeping the names of a
+    # module that is on FX1 (schema.Remix.blanked). Derived here, once, so
+    # every remix that lists a station gets it without spelling it out.
+    auto = tuple(k for k in r.modules
+                 if k in r.fx1 and k not in r.hidden
+                 and known[k].claims is not None and known[k].claims.fx1_only)
+    if auto:
+        r = dataclasses.replace(r, hidden=r.hidden + auto)
     return r
 
 

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -446,22 +446,26 @@ class Claims:
     buffer_words: int | None = None
     # FX1-ONLY BY DESIGN: the module reads its allocator base at init and,
     # when the base is an FX2 slot (>= 0x4000), runs as a dry pass and
-    # WRITES NOTHING. That is what lets it sit beside a server: the FX2
-    # slots it would otherwise be handed are BusVerb's tank and
-    # BusDelay's line, and the ledger refuses every other allocator
-    # reader beside them for exactly that reason. The claim is a promise
-    # the module's render gate must prove (an FX2-slot instance renders
-    # bit-exact dry and dsp_host's guard sees no write above 0x3fff).
+    # WRITES NOTHING. Two reasons a module says so, one claim:
+    #   * an allocator reader (stock_instance_buffer): the FX2 slots it
+    #     would be handed are BusVerb's tank and BusDelay's line, and the
+    #     ledger refuses every other allocator reader beside them;
+    #   * a buffer-free station (12 Sep 2026: SPECTRUM, CHARACTER): the
+    #     rig's cycle envelope only closes with the stations on FX1 -- a
+    #     station on both slots of four tracks priced a core at 4,830
+    #     against 3,120 usable (tools/harness/pressure.py) -- so an FX2
+    #     instance costs nothing and the FX2 chooser hides the row.
+    # Either way the claim is a promise the module's render gate must
+    # prove (an FX2-slot instance renders bit-exact dry and dsp_host's
+    # guard sees no write above 0x3fff), and the pricer takes it at its
+    # word: an fx1_only module is priced on FX1 slots only.
     fx1_only: bool = False
 
     def __post_init__(self):
         if self.buffer_words is not None and not self.stock_instance_buffer:
             raise ValueError("buffer_words without stock_instance_buffer: "
                              "only an allocator reader has a sized buffer")
-        if self.fx1_only:
-            if not self.stock_instance_buffer:
-                raise ValueError("fx1_only is for allocator readers -- a "
-                                 "buffer-free module runs on both menus")
+        if self.fx1_only and self.stock_instance_buffer:
             if self.buffer_words is None or self.buffer_words > 3072:
                 raise ValueError("fx1_only needs buffer_words <= 3072: an "
                                  "FX1 slot is 3,072 words (docs/firmware/DSP.md 10)")

--- a/tools/verify/verify_character.py
+++ b/tools/verify/verify_character.py
@@ -72,20 +72,29 @@ def params(**kw):
     return v
 
 
-def render(samples, **kw):
+def render(samples, slot="fx1", guard=False, **kw):
     """samples: MONO ints in Q23 -- dsp_host feeds one stream to both
-    channels (verify_hello's shape). Returns (L, R) lists."""
+    channels (verify_hello's shape). Returns (L, R) lists.
+
+    slot="fx1" (alloc 0, r7 1) is the station's own slot; "fx2" (alloc 1,
+    r7 2) is an FX2 instance, which the station runs as a DRY PASS since
+    12 Sep 2026 (Claims.fx1_only) -- the gate below proves it. Until then
+    every gate here rendered on alloc 1 and would now read dry."""
     src = TMP / "ch_in.raw"
     src.write_bytes(b"".join(struct.pack("<i", m) for m in samples))
     out = TMP / "ch_out.raw"
+    r7, alloc = ("1", "0") if slot == "fx1" else ("2", "1")
     cmd = [HOST, "-mem", MEM, "-init", f"{init:x}", "-proc", f"{proc:x}",
-           "-inst", "1", "-r7", "2", "-alloc", "1", "-inmask", "1",
+           "-inst", "1", "-r7", r7, "-alloc", alloc, "-inmask", "1",
+           *(["-guard"] if guard else []),
            "-frames", str(FRAMES), "-blocks", str(len(samples) // FRAMES),
            "-in", str(src), "-out", str(out),
            "-params", ",".join(str(x) for x in params(**kw))]
     r = subprocess.run(cmd, capture_output=True, text=True)
     if r.returncode != 0:
         sys.exit(f"dsp_host failed for {kw}:\n{r.stdout}\n{r.stderr}")
+    if guard:
+        render.guard_out = r.stdout + r.stderr
     d = out.read_bytes()
     w = struct.unpack(f"<{len(d)//4}i", d)
     return list(w[0::2])[:len(samples)], list(w[1::2])[:len(samples)]
@@ -224,6 +233,21 @@ for name in K:
     for v in (0, 127 if MOD.params[K[name]].count in (None, 128) else MOD.params[K[name]].count - 1):
         render(tone(438, n=600), **{name: v})
 check("every knob at both extremes renders", True)
+
+# ---- THE FX1-ONLY PROMISE (12 Sep 2026): an FX2 instance is dry -------------
+# Claims.fx1_only says an FX2-slot instance touches nothing; the rig's cycle
+# envelope (tools/harness/pressure.py) and the FX2 chooser both take it at
+# its word, so it is proven here at every extreme, and the guard sees no
+# write outside the frame.
+L, R = render(ramp, slot="fx2", DRV=127, FOLD=127, CRSH=100, COMP=127, MIX=127, SAT=2, RING=100, WDTH=127, SRR=2)
+check("FX2 instance is a bit-exact DRY PASS at every extreme (fx1_only)",
+      L == ramp and R == ramp,
+      "" if L == ramp else f"first diff at {next(i for i,(a,b) in enumerate(zip(L,ramp)) if a!=b)}")
+render(ramp, slot="fx2", guard=True, DRV=127, FOLD=127, CRSH=100, COMP=127, MIX=127, SAT=2, RING=100, WDTH=127, SRR=2)
+g = getattr(render, "guard_out", "")
+check("FX2 instance trips no write guard",
+      "guard clean" in g,
+      next((ln.strip() for ln in reversed(g.splitlines()) if "guard" in ln), ""))
 
 print(f"\n{fails} gate(s) failed" if fails else "\nOK")
 sys.exit(1 if fails else 0)

--- a/tools/verify/verify_spectrum.py
+++ b/tools/verify/verify_spectrum.py
@@ -67,20 +67,29 @@ def params(**kw):
     return v
 
 
-def render(samples, **kw):
+def render(samples, slot="fx1", guard=False, **kw):
     """samples: MONO ints in Q23 -- dsp_host feeds one stream to both
-    channels (verify_hello's shape). Returns (L, R) lists."""
+    channels (verify_hello's shape). Returns (L, R) lists.
+
+    slot="fx1" (alloc 0, r7 1) is the station's own slot; "fx2" (alloc 1,
+    r7 2) is an FX2 instance, which the station runs as a DRY PASS since
+    12 Sep 2026 (Claims.fx1_only) -- the gate below proves it. Until then
+    every gate here rendered on alloc 1 and would now read dry."""
     src = TMP / "fs_in.raw"
     src.write_bytes(b"".join(struct.pack("<i", m) for m in samples))
     out = TMP / "fs_out.raw"
+    r7, alloc = ("1", "0") if slot == "fx1" else ("2", "1")
     cmd = [HOST, "-mem", MEM, "-init", f"{init:x}", "-proc", f"{proc:x}",
-           "-inst", "1", "-r7", "2", "-alloc", "1", "-inmask", "1",
+           "-inst", "1", "-r7", r7, "-alloc", alloc, "-inmask", "1",
+           *(["-guard"] if guard else []),
            "-frames", str(FRAMES), "-blocks", str(len(samples) // FRAMES),
            "-in", str(src), "-out", str(out),
            "-params", ",".join(str(x) for x in params(**kw))]
     r = subprocess.run(cmd, capture_output=True, text=True)
     if r.returncode != 0:
         sys.exit(f"dsp_host failed for {kw}:\n{r.stdout}\n{r.stderr}")
+    if guard:
+        render.guard_out = r.stdout + r.stderr
     d = out.read_bytes()
     w = struct.unpack(f"<{len(d)//4}i", d)
     return list(w[0::2])[:len(samples)], list(w[1::2])[:len(samples)]
@@ -159,6 +168,21 @@ for name in K:
     for v in (0, 127 if MOD.params[K[name]].count in (None, 128) else MOD.params[K[name]].count - 1):
         render(tone(438, n=600), **{name: v})
 check("every knob at both extremes renders", True)
+
+# ---- THE FX1-ONLY PROMISE (12 Sep 2026): an FX2 instance is dry -------------
+# Claims.fx1_only says an FX2-slot instance touches nothing; the rig's cycle
+# envelope (tools/harness/pressure.py) and the FX2 chooser both take it at
+# its word, so it is proven here at every extreme, and the guard sees no
+# write outside the frame.
+L, R = render(ramp, slot="fx2", FREQ=30, RES=110, DRV=127, MODE=1, ROUT=2, DPTH=127, SRC=2)
+check("FX2 instance is a bit-exact DRY PASS at every extreme (fx1_only)",
+      L == ramp and R == ramp,
+      "" if L == ramp else f"first diff at {next(i for i,(a,b) in enumerate(zip(L,ramp)) if a!=b)}")
+render(ramp, slot="fx2", guard=True, FREQ=30, RES=110, DRV=127, MODE=1, ROUT=2, DPTH=127, SRC=2)
+g = getattr(render, "guard_out", "")
+check("FX2 instance trips no write guard",
+      "guard clean" in g,
+      next((ln.strip() for ln in reversed(g.splitlines()) if "guard" in ln), ""))
 
 print(f"\n{fails} gate(s) failed" if fails else "\nOK")
 sys.exit(1 if fails else 0)

--- a/tools/verify/verify_spectrum_ident.py
+++ b/tools/verify/verify_spectrum_ident.py
@@ -57,7 +57,7 @@ def render(samples, **kw):
     src.write_bytes(b"".join(struct.pack("<i", m) for m in samples))
     out = TMP / "fs_out.raw"
     cmd = [HOST, "-mem", MEM, "-init", f"{init:x}", "-proc", f"{proc:x}",
-           "-inst", "1", "-r7", "2", "-alloc", "1", "-inmask", "1",
+           "-inst", "1", "-r7", "1", "-alloc", "0", "-inmask", "1",   # the FX1 slot (12 Sep 2026: alloc 1 is an FX2 slot and renders dry)
            "-frames", str(FRAMES), "-blocks", str(len(samples) // FRAMES),
            "-in", str(src), "-out", str(out),
            "-params", ",".join(str(x) for x in params(**kw))]


### PR DESCRIPTION
Stage A6 of the release roadmap (Sam's remedy for the overrun).

- Both stations decide FX1/FX2 from the allocator base at init (Modulation's idiom) and return dry on an FX2 slot. `Claims(fx1_only=True)`; the schema accepts the claim from a buffer-free module; the **registry derives the FX2-row removal from the claim** so every rig remix gets it.
- Gates moved to the FX1 slot (they had been rendering on alloc 1 = an FX2 slot) and prove the dry pass + clean guard at every extreme. `send_probe --pick` of a station refuses with the `rig_render` recipe.
- Pricing: `make cycles` worst core **4,830 → 3,567** (4 × Character + the delay); `pressure.py price`: **0% of layouts over the credited line**, 7% / 35% (core 0 / 1) over the flat 3,120. Which line is real is the burn sweep's call in the hardware pass.
- Docs: `bamsep26` docstring rewritten (it still described the pre-one-aux station sends), both station READMEs.

`make check REMIX=bamsep26` green, 366 PASS. Rig artifacts change by design (the chooser), so not a refhash-gated change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)