### PR TITLE
B: mode-aware stamping (--keep-mode, --all), rigproj applies a mode's view, Character's BUS view is one return

### DIFF
--- a/docs/firmware/RECORDER_CLICK.md
+++ b/docs/firmware/RECORDER_CLICK.md
@@ -108,6 +108,11 @@ recfix touches no DSP code. Setup used to swallow a failed build and then
 report "already built" on every re-run once the disassembler alone existed;
 now it fails loudly, and `make check` names the missing binary and the fix
 up front instead of a traceback in `verify_twocore`.
+The emulator is pinned to the upstream commit our patch is written against;
+a `make setup` from before 12 Sep 2026 cloned that day's upstream HEAD, on
+which the patch no longer applies, and `dsp_host.cpp` then fails with "no
+member named 'setSharedWindow'". If you see that: `rm -rf vendor/dsp56300;
+make setup`.
 
 **Always pass `REMIX=recfix`** -- to `make check`, `make bus` and `make image`
 alike. The Makefile's default is a different remix, and every verifier reads

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -115,8 +115,22 @@ if [ ! -x "$DIS" ] || [ ! -x "$ASM" ] || [ ! -x "$HOST" ]; then
     echo "   [!] cmake not found — brew install cmake — then re-run make setup (make check needs dsp_asm and dsp_host)"
     exit 1
   else
-    [ -d vendor/dsp56300 ] || git clone --depth 1 \
-      https://github.com/dsp56300/dsp56300.git vendor/dsp56300
+    # PINNED. The patch below is against this commit; upstream moved 105
+    # commits past it by 12 Sep 2026 and the patch no longer applies there
+    # (dsp.h, dsp_ops_alu.inl, jitops.h reject). A contributor's fresh
+    # clone took that day's HEAD, the "already applied (or upstream
+    # changed)" line below hid which, and dsp_host.cpp failed to compile
+    # against an unpatched emulator (no setSharedWindow). Moving the pin
+    # means re-basing the patch and re-running make check's bit-identity
+    # gates -- dsp_host renders every effect on this emulator.
+    DSP56300_PIN=c051afad31612c2d2c7a81a7ab23e1c5ac9e61af
+    if [ ! -d vendor/dsp56300 ]; then
+      git clone --no-checkout https://github.com/dsp56300/dsp56300.git vendor/dsp56300
+    fi
+    if [ "$(git -C vendor/dsp56300 rev-parse HEAD 2>/dev/null)" != "$DSP56300_PIN" ]; then
+      git -C vendor/dsp56300 fetch -q origin "$DSP56300_PIN"
+      git -C vendor/dsp56300 checkout -q "$DSP56300_PIN"
+    fi
     git -C vendor/dsp56300 submodule update --init --depth 1 --recursive
     # The patch carries: MPYRI (unimplemented upstream in interpreter and
     # JIT; stock LO-FI uses it, 2 Sep 2026); the shared window, two-way for
@@ -128,8 +142,13 @@ if [ ! -x "$DIS" ] || [ ! -x "$ASM" ] || [ ! -x "$HOST" ]; then
     EMUPATCH=$(pwd)/tools/patches/dsp56300.patch
     if git -C vendor/dsp56300 apply --check "$EMUPATCH" 2>/dev/null; then
       git -C vendor/dsp56300 apply "$EMUPATCH" && echo "   emulator patch applied (MPYRI, shared window, host-stepped cores)"
+    elif git -C vendor/dsp56300 apply --check --reverse "$EMUPATCH" 2>/dev/null; then
+      echo "   emulator patch already applied"
     else
-      echo "   emulator patch already applied (or upstream changed: check $EMUPATCH)"
+      echo "   [!] emulator patch does NOT apply to vendor/dsp56300 at $(git -C vendor/dsp56300 rev-parse --short HEAD)"
+      echo "       (expected $DSP56300_PIN). dsp_host cannot build without it."
+      echo "       Fix: rm -rf vendor/dsp56300; make setup"
+      exit 1
     fi
     stage_dsp_host
     cmake -S vendor/dsp56300 -B vendor/dsp56300/build -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Stage B, the tooling half.

- `ot_project.module_defaults(m, knobs)`: manifest defaults → the selected MODE's `ModeView` defaults → the explicit knobs. One source for a slot's 12 bytes, the same table the TUI bench applies on a MODE change, so a stamped part and the bench agree by construction. `rigproj` uses it (T8's `SAT=BUS` brings `RET` to 127 by itself).
- `stamp-defaults --all` stamps every module of ours including the engines — what "stamp before play" after a slot re-layout actually needs; without it the stamper never touched the engines, which BUS.md/FLASHPLAN wrongly said it did (BUS.md corrected). `--keep-mode` keeps an in-range stored MODE byte and applies its view (off by default: a replaced id's stored bytes are the stock layout's).
- Character's BUS `ModeView`: one return (`RET` 127), RING inert with no default; docstring and knob docs said RVRB/DLY since 7 Sep.

`make check REMIX=bamsep26` green, 366 PASS.

**Not in this PR — the ColdFire half of B (per-mode defaults on the unit):** every ModeView's mode slot is on page 2, so the site is the firmware's page-2 editor `0x4003a474`; the four-store write recipe (Part, display, live lane, shadow + the changed flag) is already hardware-proven in `modules/ccpage2/cc_page2.s`; page-1 slots in a view need the stock CC 16–45 handler's page-1 recipe (`0x4000e91c`), traceable under the port. Next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)