### PR TITLE
Spectrum round (measured half): WDTH open, RES linear in dB, FREQ exponential via a declared P table; A/B kit tools

### DIFF
--- a/modules/spectrum/README.md
+++ b/modules/spectrum/README.md
@@ -65,11 +65,34 @@ on FILTER's stored values sent at 64 through a closed, resonant filter).
   lists the clone) and `verify_labels` (the three selects print their words
   on the emulated firmware) all pass on `stations`.
 
+## Measured laws (12 Sep 2026, `tools/harness/station_laws.py` on noise)
+
+| knob | law | readout |
+|---|---|---|
+| FREQ (LP) | exponential, 24 Hz → 7.2 kHz, one octave per 16 detents (a 33-word P table, `DspSection.ptable`, interpolated per block) | 48 → 258 Hz, 64 → 528, 80 → 1.1 k, 96 → 2.3 k, 112 → 5.0 k; 127 = the SVF's 7 kHz ceiling |
+| RES | `damp = (0.998 − RES·0.587)⁴`: the peak is near-linear in dB | +1 / +5.7 / +12 / +20 / +30 dB at 0 / 32 / 64 / 96 / 127 |
+| BASE (HP pair) | `c = BASE²·0.5` | 32 → 54 Hz, 64 → 205, 96 → 560, 127 → 1.27 k |
+| WDTH (LP pair) | `c = WDTH²·1.0 + 0.002` — 127 is OPEN (flat within 0.15 dB at 10 kHz) | 96 → 4.0 k, 64 → 1.3 k, 32 → 320 Hz |
+| DRV | 1 → 4× into the SVF, the limiter clips | +4.9 / +8 / +10 / +12 dB at 32 / 64 / 96 / 127 |
+| NOTCH | depth −42 dB at RES 0, −36 at 64, −12 at 127 (narrower) | |
+
+Two laws were wrong on the meter and are replaced: the FREQ taper was
+squared (half the dial above 2 kHz; on the drum loop FREQ 24 → 56 barely
+moved the centroid) and WDTH 127 sat at ≈7 kHz per pole, so every live
+setting lost 5 dB at 10 kHz and 8 at 15 kHz (only the all-defaults bypass
+was flat). RES was hyperbolic in dB (18 of 30 dB in the top quarter).
+
+Known and left for the ear: the SVF's Chamberlin ceiling puts LP 127 at
+7 kHz (12 dB/oct above), and HP/BP at the top of the dial lift 10–15 kHz
+(+5 / +9 dB at HP 127 — the hp tap's warping at high f). A mode-aware
+ceiling (HP/BP capped near FREQ 96's f) would bound the lift at ~+3 dB for
+one per-block compare, if it reads as harsh rather than presence.
+
 ## Open
 
-- Voicing: nothing has been heard yet. The coefficient laws (cutoff taper,
-  base/width corners, LFO rate range, release times, FM depth 0.25) are
-  first guesses.
+- Voicing: the laws are measured (above); nothing has been HEARD yet. Kits in
+  `out/ab/spec_*` (`tools/harness/abkit.py`): the taper (squared vs
+  exponential), RES, the HP top, VOWEL, FM depth 0.25.
 - Cycles: 339 is dear. Candidates if it must come down: drop RING (~10),
   a single-pole base/width (~40), block-rate FM.
 - The layout alphabet lists this station under both `1` and `L` (stock

--- a/modules/spectrum/manifest.py
+++ b/modules/spectrum/manifest.py
@@ -39,6 +39,15 @@ _STEP = Formatter.STEPPED
 
 _BLANK = Param(b"", 0)
 
+FREQ_TABLE = (
+    0x00700c, 0x0085e9, 0x00a00a, 0x00bf43, 0x00e495, 0x01112e,
+    0x01467c, 0x01862f, 0x01d251, 0x022d4c, 0x029a08, 0x031bfb,
+    0x03b747, 0x0470df, 0x054eaa, 0x0657b6, 0x079470, 0x090ee7,
+    0x0ad31c, 0x0cef60, 0x0f74c1, 0x12778c, 0x160fdd, 0x1a5a44,
+    0x1f7872, 0x2591f0, 0x2cd4bc, 0x3575a5, 0x3fb028, 0x4bc52e,
+    0x59f7db, 0x6a86da, 0x7d9faa,
+)
+
 MODULE = Module(
     name="spectrum",
     key="SPECTRUM",
@@ -83,6 +92,12 @@ MODULE = Module(
     ),
     dsp=DspSection(
         asm="modules/spectrum/spectrum.asm",
+        # FREQ's taper: 33 SVF f coefficients (Q23, 2*sin(pi*fc/fs)) at FREQ
+        # 0, 4, .., 128 for fc = 24 Hz * 300^(FREQ/128) -- exponential, 8.2
+        # octaves, an equal step per detent -- read with p:(r5)+ and
+        # interpolated linearly per block (12 Sep 2026). The squared law it
+        # replaced put half the dial above 2 kHz (station_laws.py).
+        ptable=FREQ_TABLE,
         priority=12,                  # after every existing module
         bus_role=BusRole.NONE,        # an insert that also WRITES the bus
         ybase=YBase.NEVER,

--- a/modules/spectrum/spectrum.asm
+++ b/modules/spectrum/spectrum.asm
@@ -174,12 +174,23 @@ fs_cntz:
 ; ===========================================================================
 ; PER-BLOCK KNOB DECODE
 ; ===========================================================================
-; damp = 0.992 - RES * 0.969   (Ripple's law)
+; damp = (0.998 - RES * 0.587)^4   -- base linear in RES, then squared twice,
+; so the resonant PEAK is close to linear in dB across the dial: ~0.8 / 5.5 /
+; 12 / 20 / 30 dB at RES 0 / 32 / 64 / 96 / 127. Ripple's linear damp
+; (0.992 - RES * 0.969, the law until 12 Sep 2026) measured 0.8 / 2.7 / 5.7 /
+; 11.3 / 29.5 dB on noise: 18 of the 29 dB lived in the top quarter of the
+; dial (tools/harness/station_laws.py). RES 0 is unchanged (0.998^4 = 0.992).
         move    x:(r6+$1),x0
-        move    #>$7c0000,y1
+        move    #>$4b2350,y1            ; 0.587
         mpy     x0,y1,a
         neg     a
-        add     #>$7f0000,a
+        add     #>$7fbe77,a             ; base = 0.998 - RES * 0.587  (>= 0.416)
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a                 ; base^2
+        move    a,x0
+        move    a,y1
+        mpy     x0,y1,a                 ; base^4
         move    a,x:(r7+$21)
 ; g4 = 0.25 + DRV * 0.75  (page-2 slot 6 KNOB field of r6+$c)
         move    x:(r6+$c),a
@@ -191,7 +202,12 @@ fs_cntz:
         mpy     x0,y1,a
         add     #>$200000,a
         move    a,x:(r7+$22)
-; cHP = BASE^2 * 0.5 ;  cLP = WDTH^2 * 0.75 + 0.002  (one-pole coefficients)
+; cHP = BASE^2 * 0.5 ;  cLP = WDTH^2 * 1.0 + 0.002  (one-pole coefficients)
+; cLP's scale was 0.75 until 12 Sep 2026: WDTH 127 then sat at 0.74 (about
+; 7 kHz per pole, 12 dB/oct above it), so "open" lost 5 dB at 10 kHz and 8 dB
+; at 15 kHz in EVERY live setting -- measured on noise, station_laws.py --
+; and only the all-defaults bypass was flat. At 1.0 WDTH 127 is 0.986: a
+; corner near 30 kHz per pole, flat within 0.15 dB at 10 kHz.
         move    x:(r6+$2),x0
         move    x:(r6+$2),y1
         mpy     x0,y1,a
@@ -203,7 +219,7 @@ fs_cntz:
         move    x:(r6+$3),y1
         mpy     x0,y1,a
         move    a,x0
-        move    #>$600000,y1
+        move    #>$7fffff,y1            ; x 1.0
         mpy     x0,y1,a
         add     #>$4189,a
         move    a,x:(r7+$2b)
@@ -301,13 +317,31 @@ fs_smod:
         move    #>$7f0000,x0
         cmp     x0,a
         tgt     x0,a                    ; clamp above at 127/128
-        move    a,x0
-        move    a,y1
-        mpy     x0,y1,a                 ; FREQm^2
-        move    a,x0
-        move    #>$7df3b6,y1            ; 0.984
-        mpy     x0,y1,a
-        add     #>$6f69,a               ; + 0.0034
+; fA = table(FREQm): an EXPONENTIAL taper, 24 Hz..7.2 kHz, one octave per
+; ~15.5 detents, read from the 33-word P table the manifest declares
+; (DspSection.ptable; the build places it before this code and rewrites the
+; literal below) and interpolated linearly: idx = FREQm >> 18 (0..31),
+; frac = the 18 bits under it as Q23. Until 12 Sep 2026 the law was
+; 0.984 * FREQm^2 + 0.0034 -- half the dial above 2 kHz on noise, and the
+; loop's centroid on the drum loop barely moved from FREQ 24 to 56.
+; AGU settle: r5/n5 are written two instructions before they address.
+        move    a,x1                    ; FREQm, kept
+        move    #>$fab1e0,r5            ; FREQ_TABLE -- rewritten by build_bus.py
+        move    #>$ffffff,m5
+        asr     #$12,a,a                ; idx
+        move    a1,n5
+        move    x1,a
+        and     #>$3ffff,a              ; FREQm & (2^18 - 1)   (a2 = 0: FREQm >= 0)
+        asl     #$5,a,a                 ; frac, Q23
+        move    (r5)+n5
+        move    a,x0                    ; frac
+        move    p:(r5)+,y0              ; T[idx]
+        move    p:(r5),b                ; T[idx+1]
+        move    y0,a
+        sub     a,b                     ; T[idx+1] - T[idx]  (>= 0: the table rises)
+        move    b,y1
+        mpy     x0,y1,a                 ; frac * diff
+        add     y0,a
         move    a,x:(r7+$20)            ; fA
 
 ; ---- ROUT (slot 9 select of r6+$d): sel, kA, kB, kR, kFM -------------------

--- a/tools/build/build_bus.py
+++ b/tools/build/build_bus.py
@@ -2936,10 +2936,16 @@ hostquit:
         # the rolled source carries, so verify_roll can hold BOTH engines at
         # once and compare them.
         LFO01_MARK = "LFO lines 0-1: ROLLED TOO"
+        PTABLE_MARK = "$fab1e0"          # schema.DspSection.ptable's literal
         for name, src in plan:
             if "$facade" in src and src.count("$facade") != 1:
                 sys.exit(f"payload {tag}: {name} has multiple $facade "
                          f"LFOTAB literals -- expected exactly one")
+            _ptab = list(remix_modules()[name].dsp.ptable) if name in remix_modules() else []
+            if (PTABLE_MARK in src) != bool(_ptab) or src.count(PTABLE_MARK) > 1:
+                sys.exit(f"payload {tag}: {name}: a DspSection.ptable and exactly one "
+                         f"{PTABLE_MARK} literal in the source go together "
+                         f"(table {len(_ptab)} words, literal x{src.count(PTABLE_MARK)})")
             if DEV and name == "DELAY SERVER":
                 # DEV: the delay does NOT go in the donor region. It is
                 # assembled at DEV_DELAY_P (see that constant) and its module
@@ -2979,12 +2985,18 @@ hostquit:
             _fit, _last = None, None
             for _r in runs:
                 _c, _end = _r["cursor"], _r["base"] + _r["words"]
-                _tab, _s2 = None, src
-                if "$facade" in src:
+                _tab, _s2, _lfo = None, src, "$facade" in src
+                if _lfo:
                     _tab = (LFO01 + LFOTAB) if LFO01_MARK in src else LFOTAB
                     if _c + len(_tab) > _end:
                         continue
                     _s2 = src.replace("$facade", f"${_c:x}")
+                    _c += len(_tab)
+                elif _ptab:
+                    _tab = _ptab
+                    if _c + len(_tab) > _end:
+                        continue
+                    _s2 = src.replace(PTABLE_MARK, f"${_c:x}")
                     _c += len(_tab)
                 _w, _ia, _pa = assemble(_s2, _c)
                 _last = (_c, len(_w))
@@ -3009,10 +3021,15 @@ hostquit:
             _r, tab, src, cursor, words, init_a, proc_a = _fit
             if tab is not None:
                 place(tab, _r["cursor"])
-                print(f"  LFOTAB        P:0x{_r['cursor']:05x}.."
-                      f"0x{_r['cursor'] + len(tab):05x} "
-                      f"({len(tab):4d} words)  rolled LFO lines "
-                      f"{'0-7' if LFO01_MARK in src else '2-7'}")
+                if _lfo:
+                    print(f"  LFOTAB        P:0x{_r['cursor']:05x}.."
+                          f"0x{_r['cursor'] + len(tab):05x} "
+                          f"({len(tab):4d} words)  rolled LFO lines "
+                          f"{'0-7' if LFO01_MARK in src else '2-7'}")
+                else:
+                    print(f"  PTABLE        P:0x{_r['cursor']:05x}.."
+                          f"0x{_r['cursor'] + len(tab):05x} "
+                          f"({len(tab):4d} words)  {name}'s table")
             place(words, cursor)
             _r["cursor"] = cursor + len(words)
             wrw_p(pp["xtab"] + NEW_IDS[name] * 3, init_a)

--- a/tools/harness/abkit.py
+++ b/tools/harness/abkit.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""A/B kits for voicing a station: render a knob sweep on one track, level-match,
+measure, and play pairs the way the listening protocol wants.
+
+    python3 tools/harness/abkit.py sweep --station SPECTRUM --stem out/test_audio/loop.wav \\
+        --knob FREQ=20,40,60,80,100,127 --fixed MODE=0 --fixed RES=60 --out out/ab/spec_freq
+    python3 tools/harness/abkit.py measure out/ab/spec_freq          # active RMS, centroid, peak Hz per file
+    python3 tools/harness/abkit.py play out/ab/spec_freq/FREQ_040.wav out/ab/spec_freq/FREQ_100.wav
+                                                                     # A/B/A/B, one afplay at a time
+
+SWEEP renders the station on T1's FX1 with SEND on FX2 (AUX 0: the bus is
+present but idle) through rig_render -- the real image, the mixer model on,
+whole 16-sample blocks -- once per value, and keeps T1.wav as
+<KNOB>_<value>.wav. A second station or an engine can be put on other tracks
+with --tracks (rig_render's syntax) when the bus matters.
+
+LEVEL MATCHING is the protocol's (docs: the voicing rules): every file is
+scaled to the same ACTIVE RMS (-20 dBFS over 100 ms windows louder than
+-60 dBFS, so tails and silences do not vote), then the whole kit is trimmed
+by ONE gain so its loudest peak sits at -1 dBFS -- a joint trim, so relative
+levels inside the kit survive. --no-match keeps the rendered levels (for
+judging a level law rather than a character).
+
+PLAY is one file per afplay, A B A B (--repeats), and prints what to listen
+for if the kit's listen.txt names it. MEASURE prints per file: active RMS
+before matching, the applied gain, spectral centroid, the strongest peak,
+crest factor -- the numbers a taper or a resonance law can be read from.
+"""
+import argparse, json, math, os, pathlib, shutil, subprocess, sys, wave
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1])); import toolpath  # noqa: E402,F401
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SR = 44100
+TARGET_DB = -20.0
+PEAK_DB = -1.0
+
+
+def read(path):
+    with wave.open(str(path), "rb") as w:
+        nch, sw, n = w.getnchannels(), w.getsampwidth(), w.getnframes()
+        raw = w.readframes(n)
+    full = 1 << (8 * sw - 1)
+    ch = [[int.from_bytes(raw[(i * nch + c) * sw:(i * nch + c + 1) * sw], "little", signed=True) / full
+           for i in range(n)] for c in range(nch)]
+    return ch
+
+
+def write(path, ch):
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(len(ch)); w.setsampwidth(3); w.setframerate(SR)
+        n = len(ch[0])
+        w.writeframes(b"".join(int(max(-8388608, min(8388607, round(ch[c][i] * 8388607)))).to_bytes(3, "little", signed=True)
+                               for i in range(n) for c in range(len(ch))))
+
+
+def db(x):
+    return 20 * math.log10(x) if x > 0 else -200.0
+
+
+def active_rms(ch, win=4410, floor_db=-60.0):
+    n = len(ch[0]); vals = []
+    for s in range(0, n - win, win):
+        e = sum(sum(c[i] * c[i] for c in ch) for i in range(s, s + win)) / (win * len(ch))
+        if e > 0 and db(math.sqrt(e)) > floor_db:
+            vals.append(e)
+    return math.sqrt(sum(vals) / len(vals)) if vals else 0.0
+
+
+def peak(ch):
+    return max(abs(v) for c in ch for v in c)
+
+
+def spectrum(x, n=8192):
+    """A crude magnitude spectrum (numpy if present, else a slow DFT on a decimated window)."""
+    try:
+        import numpy as np
+        seg = np.array(x[:len(x) // n * n]).reshape(-1, n)
+        win = np.hanning(n)
+        mag = np.abs(np.fft.rfft(seg * win, axis=1)).mean(axis=0)
+        freqs = np.fft.rfftfreq(n, 1 / SR)
+        return freqs, mag
+    except ImportError:
+        return None, None
+
+
+def measure_file(path):
+    ch = read(path)
+    mono = [sum(c[i] for c in ch) / len(ch) for i in range(len(ch[0]))]
+    out = dict(file=path.name, active_rms_db=db(active_rms(ch)), peak_db=db(peak(ch)))
+    out["crest_db"] = out["peak_db"] - out["active_rms_db"]
+    f, m = spectrum(mono)
+    if f is not None:
+        import numpy as np
+        p = m * m
+        out["centroid_hz"] = float((f * p).sum() / p.sum()) if p.sum() > 0 else 0.0
+        i = int(np.argmax(m[1:]) + 1)
+        out["peak_hz"] = float(f[i])
+        # -3 dB bandwidth of the strongest peak, as a resonance readout
+        half = m[i] / math.sqrt(2)
+        lo = i
+        while lo > 1 and m[lo] > half:
+            lo -= 1
+        hi = i
+        while hi < len(m) - 1 and m[hi] > half:
+            hi += 1
+        out["peak_bw_hz"] = float(f[hi] - f[lo])
+    return out
+
+
+def sweep(a):
+    knob, vals = a.knob.split("=")
+    vals = [int(v) for v in vals.split(",")]
+    out = pathlib.Path(a.out); out.mkdir(parents=True, exist_ok=True)
+    tracks = a.tracks or f"T1={a.station}+SEND"
+    sets = []
+    for fx in a.fixed:
+        sets += ["--set", f"T1:FX1:{fx}"]
+    rendered = []
+    for v in vals:
+        d = out / f"_r_{knob}_{v:03d}"
+        cmd = [sys.executable, str(ROOT / "tools/harness/rig_render.py"), "--image", a.image, "--remix", a.remix,
+               "--tracks", tracks, "--stem", f"T1={a.stem}", "--tail", str(a.tail), "--frames", "16",
+               "--set", f"T1:FX1:{knob}={v}", "--out", str(d)] + sets + (["--seconds", str(a.seconds)] if a.seconds else [])
+        r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+        if r.returncode != 0:
+            sys.exit(f"rig_render failed for {knob}={v}:\n{r.stdout[-1500:]}{r.stderr[-1500:]}")
+        src = d / "T1.wav"
+        dst = out / f"{knob}_{v:03d}.wav"
+        shutil.move(str(src), str(dst))
+        shutil.rmtree(d, ignore_errors=True)
+        rendered.append(dst)
+        print(f"  {dst.name}")
+    if not a.no_match:
+        match(rendered, out)
+    (out / "kit.json").write_text(json.dumps(dict(station=a.station, stem=a.stem, knob=knob, values=vals,
+                                                   fixed=a.fixed, tracks=tracks, matched=not a.no_match), indent=1))
+    print(f"-> {out} ({len(rendered)} files{', level-matched' if not a.no_match else ''})")
+
+
+def match(files, out):
+    """Every file to TARGET_DB active RMS, then one joint trim to PEAK_DB."""
+    gains = {}
+    data = {}
+    for p in files:
+        ch = read(p); r = active_rms(ch)
+        g = (10 ** (TARGET_DB / 20)) / r if r > 0 else 1.0
+        gains[p.name] = g; data[p] = ch
+    worst = max(peak(data[p]) * gains[p.name] for p in files)
+    trim = (10 ** (PEAK_DB / 20)) / worst if worst > 0 else 1.0
+    for p in files:
+        g = gains[p.name] * trim
+        write(p, [[v * g for v in c] for c in data[p]])
+    (out / "match.json").write_text(json.dumps({k: dict(gain_db=db(g * trim)) for k, g in gains.items()}, indent=1))
+    print(f"  level-matched to {TARGET_DB} dBFS active RMS, joint trim {db(trim):+.1f} dB")
+
+
+def measure(a):
+    d = pathlib.Path(a.dir)
+    files = sorted(d.glob("*.wav"))
+    rows = [measure_file(p) for p in files]
+    keys = ["active_rms_db", "peak_db", "crest_db", "centroid_hz", "peak_hz", "peak_bw_hz"]
+    print(f"{'file':22} " + " ".join(f"{k:>13}" for k in keys if k in rows[0]))
+    for r in rows:
+        print(f"{r['file']:22} " + " ".join(f"{r[k]:13.1f}" for k in keys if k in r))
+    (d / "measure.json").write_text(json.dumps(rows, indent=1))
+
+
+def play(a):
+    order = []
+    for _ in range(a.repeats):
+        order += [a.a, a.b]
+    listen = pathlib.Path(a.a).parent / "listen.txt"
+    if listen.is_file():
+        print(listen.read_text().strip())
+    for i, f in enumerate(order):
+        print(f"[{'AB'[i % 2]}] {pathlib.Path(f).name}")
+        subprocess.run(["afplay", f])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    s = sub.add_parser("sweep")
+    s.add_argument("--station", required=True, help="module KEY, on T1's FX1")
+    s.add_argument("--stem", required=True)
+    s.add_argument("--knob", required=True, help="NAME=v1,v2,...")
+    s.add_argument("--fixed", action="append", default=[], help="NAME=v held for every render")
+    s.add_argument("--tracks", help="override the layout (rig_render syntax); T1 must carry the station on FX1")
+    s.add_argument("--image", default="out/mainos_bus.bin")
+    s.add_argument("--remix", default=os.environ.get("REMIX", "bamsep26"))
+    s.add_argument("--seconds", type=float)
+    s.add_argument("--tail", type=float, default=1.0)
+    s.add_argument("--no-match", action="store_true")
+    s.add_argument("--out", required=True)
+    m = sub.add_parser("measure"); m.add_argument("dir")
+    p = sub.add_parser("play"); p.add_argument("a"); p.add_argument("b"); p.add_argument("--repeats", type=int, default=2)
+    a = ap.parse_args()
+    return {"sweep": sweep, "measure": measure, "play": play}[a.cmd](a)
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/tools/harness/station_laws.py
+++ b/tools/harness/station_laws.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Read a station's control laws off noise: the transfer function per knob value.
+
+    python3 tools/harness/station_laws.py --station SPECTRUM --knob FREQ=0,16,32,48,64,80,96,112,127 \\
+        --fixed MODE=0 --fixed RES=0 --out out/laws/spec_lp
+
+Renders white noise (2 s, -12 dBFS) through the station on T1's FX1 (SEND on
+FX2, AUX 0) once per value, divides the output spectrum by the input's
+(Welch-averaged, 4,096-point) and reports, per value: the -3 dB corner
+(where |H| first drops 3 dB below its level at 100 Hz, or rises for a
+high-pass), the peak of |H| and its frequency and -3 dB bandwidth (a
+resonance readout), and the level at 100 Hz / 1 kHz / 10 kHz. Lets a taper
+be read as a table -- "FREQ 64 = 1.2 kHz" -- which is what a first-guess law
+needs before anyone listens. Requires numpy (.venv/bin/python3).
+"""
+import argparse, json, math, os, pathlib, shutil, subprocess, sys, wave
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1])); import toolpath  # noqa: E402,F401
+import numpy as np
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SR = 44100
+N = 4096
+
+
+def write_noise(path, seconds=2.0, amp=0.25, seed=7):
+    rng = np.random.default_rng(seed)
+    x = (rng.uniform(-1, 1, int(SR * seconds)) * amp * 32767).astype("<i2")
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1); w.setsampwidth(2); w.setframerate(SR); w.writeframes(x.tobytes())
+
+
+def read_mono(path):
+    with wave.open(str(path), "rb") as w:
+        nch, sw, n = w.getnchannels(), w.getsampwidth(), w.getnframes(); raw = w.readframes(n)
+    a = np.frombuffer(raw, dtype=np.uint8).reshape(n, nch, sw)
+    v = a[:, :, 0].astype(np.int32) | (a[:, :, 1].astype(np.int32) << 8) | (a[:, :, 2].astype(np.int32) << 16) if sw == 3 else None
+    if sw == 2:
+        v = np.frombuffer(raw, dtype="<i2").reshape(n, nch).astype(np.int32) << 8
+    v = np.where(v >= 1 << 23, v - (1 << 24), v)
+    return v.mean(axis=1) / 8388608.0
+
+
+def welch(x):
+    seg = x[:len(x) // N * N].reshape(-1, N) * np.hanning(N)
+    return (np.abs(np.fft.rfft(seg, axis=1)) ** 2).mean(axis=0)
+
+
+def laws(a):
+    knob, vals = a.knob.split("="); vals = [int(v) for v in vals.split(",")]
+    out = pathlib.Path(a.out); out.mkdir(parents=True, exist_ok=True)
+    noise = out / "noise.wav"; write_noise(noise)
+    nin = read_mono(noise); pin = welch(nin); f = np.fft.rfftfreq(N, 1 / SR)
+    rows = []
+    for v in vals:
+        d = out / f"_r_{v:03d}"
+        cmd = [sys.executable, str(ROOT / "tools/harness/rig_render.py"), "--image", a.image, "--remix", a.remix,
+               "--tracks", f"T1={a.station}+SEND", "--stem", f"T1={noise}", "--tail", "0", "--frames", "16",
+               "--set", f"T1:FX1:{knob}={v}", "--out", str(d)]
+        for fx in a.fixed:
+            cmd += ["--set", f"T1:FX1:{fx}"]
+        r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+        if r.returncode != 0:
+            sys.exit(f"rig_render failed for {knob}={v}:\n{r.stdout[-1500:]}{r.stderr[-1500:]}")
+        y = read_mono(d / "T1.wav")[:len(nin)]
+        shutil.rmtree(d, ignore_errors=True)
+        H = np.sqrt(welch(y) / np.maximum(pin, 1e-30))
+        # the mixer model puts the stem through AMP VOL (64/127)^2: divide it out
+        H = H / (64 / 127) ** 2
+        Hdb = 20 * np.log10(np.maximum(H, 1e-9))
+        at = lambda hz: float(Hdb[int(round(hz * N / SR))])
+        ref = at(100)
+        # -3 dB corner: first bin above 100 Hz where H drops 3 dB under the 100 Hz level (LP) or the first
+        # bin from the bottom where it is within 3 dB of the 10 kHz level (HP)
+        i100 = int(round(100 * N / SR)); i10k = int(round(10000 * N / SR))
+        lp = next((float(f[i]) for i in range(i100, len(f)) if Hdb[i] < ref - 3), None)
+        hp_ref = at(10000)
+        hp = next((float(f[i]) for i in range(1, i10k) if Hdb[i] > hp_ref - 3), None)
+        ip = int(np.argmax(Hdb[1:]) + 1)
+        half = Hdb[ip] - 3
+        lo = ip
+        while lo > 1 and Hdb[lo] > half:
+            lo -= 1
+        hi = ip
+        while hi < len(f) - 1 and Hdb[hi] > half:
+            hi += 1
+        i20 = int(round(20 * N / SR)); i15k = int(round(15000 * N / SR))
+        imin = int(np.argmin(Hdb[i20:i15k]) + i20)
+        rows.append(dict(value=v, corner_lp_hz=lp, corner_hp_hz=hp, peak_db=float(Hdb[ip]), peak_hz=float(f[ip]),
+                         peak_bw_hz=float(f[hi] - f[lo]), h100=ref, h1k=at(1000), h3k=at(3000), h5k=at(5000),
+                         h10k=at(10000), h15k=at(15000), min_db=float(Hdb[imin]), min_hz=float(f[imin])))
+        fmt = lambda x: f"{'  none':>6}" if x is None else f"{round(x):6d}"
+        print(f"{knob}={v:3d}: LP corner {fmt(lp)}  HP corner {fmt(hp)}  "
+              f"peak {rows[-1]['peak_db']:+5.1f} dB @ {rows[-1]['peak_hz']:6.0f} Hz (bw {rows[-1]['peak_bw_hz']:5.0f})  "
+              f"|H| 100 {ref:+5.1f}  1k {rows[-1]['h1k']:+5.1f}  3k {rows[-1]['h3k']:+5.1f}  5k {rows[-1]['h5k']:+5.1f}  "
+              f"10k {rows[-1]['h10k']:+5.1f}  15k {rows[-1]['h15k']:+5.1f} dB  min {rows[-1]['min_db']:+5.1f} @ {rows[-1]['min_hz']:5.0f}")
+    (out / "laws.json").write_text(json.dumps(dict(station=a.station, knob=knob, fixed=a.fixed, rows=rows), indent=1))
+    print(f"-> {out}/laws.json")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--station", required=True); ap.add_argument("--knob", required=True)
+    ap.add_argument("--fixed", action="append", default=[])
+    ap.add_argument("--image", default="out/mainos_bus.bin"); ap.add_argument("--remix", default=os.environ.get("REMIX", "bamsep26"))
+    ap.add_argument("--out", required=True)
+    return laws(ap.parse_args())
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/tools/remix/schema.py
+++ b/tools/remix/schema.py
@@ -291,6 +291,14 @@ class DspSection:
     r7_latch_slot: int | None = None           # rotation-latch state word
     gate_label: str | None = None              # where the housekeeping gate jumps
     override_markers: tuple[str, ...] = ()     # ";_OVERRIDE" hooks it honours
+    # A P-MEMORY TABLE the module reads with p:(rN)+ -- placed by the build
+    # immediately BEFORE the module's code (so the address is known before
+    # assembly) and the source's one `$fab1e0` literal rewritten to it, the
+    # reverb's LFOTAB mechanism made declarative (12 Sep 2026: Spectrum's
+    # exponential FREQ taper is the first). dsp_asm has no dc directive,
+    # hence words here. Costs the module's own budget: the table rides in
+    # its run.
+    ptable: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Stage C, Spectrum — the meter's half of the round, before the ear's.

Two new harness tools: `station_laws.py` (a station's transfer function per knob value, on noise) and `abkit.py` (level-matched A/B kits per the listening protocol, A/B/A/B afplay, measure).

What the meter found on Spectrum, all fixed and re-measured:
- **WDTH 127 wasn't open** — the B pair's LP sat at ~7 kHz per pole, so *every* live setting lost 5 dB at 10 k / 8 dB at 15 k; only the all-defaults bypass was flat. Now flat within 0.15 dB.
- **RES was hyperbolic in dB** (18 of 30 dB in the top quarter). Now `(0.998 − RES·0.587)⁴`: +1 / 5.7 / 12 / 20 / 30 dB at 0/32/64/96/127.
- **FREQ was a squared taper** (half the dial above 2 kHz). Now exponential, one octave per 16 detents, via a 33-word table declared as the new `DspSection.ptable` (the reverb's LFOTAB placement made declarative; refhash 26/26 identical).

Left for the ear and documented: the SVF's 7 kHz ceiling (LP 127), and the HP/BP top-of-dial lift (+5/+9 dB at 10/15 k at HP 127) — kit `spec_hp` asks presence-or-harsh.

Kits ready in `out/ab/spec_{lp,lp_exp,res,hp,vowel,fm}` with listen-for notes. `verify_spectrum` 13 PASS, cycles unchanged, `make check REMIX=bamsep26` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)