### PR TITLE
Character round (measured half): dirt stages re-ranged to the unit's level, a real compressor, per-mode DC blocker; stations shed dead bus code

### DIFF
--- a/modules/character/README.md
+++ b/modules/character/README.md
@@ -46,6 +46,29 @@ rather than a fader for the dirt.
   or two. Trims if it must come down: drop RING (~12), a single `chsatur`
   call by rolling the two channels (~13), the TUBE asymmetry (~10 per
   channel).
+## Measured laws (12 Sep 2026, `tools/harness/station_laws.py --probe sine|burst`)
+
+At the unit's level: a −6 dBFS source enters the chain at 0.127 FS (AMP VOL
+64, the mixer model). Every stage below was first measured against that
+level; three were sized for the old harness's 0.5 FS and were inert or a
+fader there, and are re-ranged.
+
+| stage | law now | readout (−6 dBFS sine unless said) |
+|---|---|---|
+| DRV | 1 → 16× into the curve (was 1 → 4×), post × 1/√(1+15·DRV/128) from a 17-word P table (`DspSection.ptable`) | TAPE THD 1 / 3.5 / 14 / 25 / 31 % at 16/32/64/96/127, gain +4..+6 dB across the dial (a 0 dBFS source: −1..+3 dB) |
+| SAT | TAPE the curve; TUBE neg 0.75 (H2 ≈ −25 dB, ~6 % even from DRV 16); FUZZ hard clip ±0.6 **on the curve's output, before post** (24 → 42 %, level held at 0 dB); BUS pre 0.5 / post 2 (0.8 → 26 %) | |
+| DC blocker | `y = x − k·x1 + R·y1`, R 0.999 (~7 Hz), **on in TUBE and FUZZ only** (k = R = 0 elsewhere: bit-exact) | TUBE's DC leak −30 dBFS → −68 |
+| FOLD | 1 → 32× into the fold (was 1 → 8×) | 4 % at 16, 16 % at 32, full folding (THD > 100 %) from 64 |
+| COMP / GLUE | block-max detector; per block `gr = (thr + over·invR)/env` by a real division; COMP scales the reduction and adds makeup 1 + 0.5·COMP; attack/release slew the GAIN per sample | COMP (thr 0.05, invR 0.125, 1 ms/100 ms) at 127: quiet +3.5 dB, loud −3 dB, release 85 ms. GLUE (0.03, 0.35, 10 ms/400 ms): +2.6 / −2.4 dB. The first compressor measured **inert** (thr 0.2/0.1 FS, a gain law linear in amplitude, a release coefficient of 0.004 that reset the envelope every sample, an attack never read) |
+| TRNS | `gr/2 += 4·(blockmax − slow)⁺·COMP`, capped at gr 2.0, 0.5 ms / 30 ms, no makeup | onset +6 dB max |
+| CRSH / SRR / WDTH | unchanged; the gates cover them | |
+
+Cost 436 → 414 cycles/sample (the dead send taps and registration went with
+the sends; the new compressor is cheaper in the loop than the old one).
+
+Kits for the ear in `out/ab/char_*` (`tools/harness/abkit.py`): TAPE
+drive, the four characters at DRV 80, FOLD, COMP, GLUE, TRNS, CRSH+SRR, RING.
+
 - `tools/verify/verify_character.py`, **22 gates, all PASS**: defaults bit-exact;
   MIX=0 bit-exact with every stage driven; CRSH=110 collapses a ramp to 144
   wet levels against 4,500; SRR holds the wet exactly 2/4/8 samples; all four

--- a/modules/character/character.asm
+++ b/modules/character/character.asm
@@ -41,21 +41,24 @@
 ; ---- r7 slots -------------------------------------------------------------
 ;   $14 $65..$69   bus bookkeeping, SEND's layout ($69 = this block's offset)
 ;   per block:
-;   $20 m (MIX)   $21 fold gain/8   $22 drive gain/4   $23 crush mask
+;   $20 m (MIX)   $21 fold gain/32  $22 drive gain/16  $23 crush mask
 ;   $24 carrier step  $25 srr mask  $26 comp amount    $27 thr
-;   $28 slope     $29 sat mode      $2a cmod           $2b width side gain
+;   $28 invR      $29 sat mode      $2a trns flag      $2b width side gain
 ;   $2c width mid gain  $2d attack coeff   $2e release coeff  $2f bypass
 ;   $30 ->DEL level     $31 ->VRB level
 ;   $3e RET return level   $3f 0 (was DLY; one return since 7 Sep 2026)
 ;   $40 FX2-slot flag (set at init: 1 = this instance is on FX2, dry; per block)
+;   $41/$42 DC block x1 L/R, $43/$44 y1 L/R (PERSISTENT, zeroed at init; long-form slots)
+;   $46 DC block k (1 or 0), $47 R (0.999 or 0): on in TUBE / FUZZ only (per block)
 ;   $3c/$3d reverb / delay liveness grace (BUS mode, per block)
 ;   per sample / persistent (ALL BELOW $40 -- an r7 displacement past 63
 ;   assembles to the two-word long form, which cost the Spectrum station 30
 ;   words before it was found):
 ;   $19 held L (PERSISTENT)      $1a held R (PERSISTENT)
 ;   $1b srr counter (PERSISTENT) $1c carrier phase (PERSISTENT)
-;   $1d env fast (PERSISTENT)    $1e env slow (PERSISTENT, TRNS only)
-;   $1f gr this sample           $32 key    $33 dry L park   $34 dry R park
+;   $1d block max |key| (PERSISTENT across the block edge)  $1e slow follower (PERSISTENT, per block)
+;   $1f gr/2 (PERSISTENT: slewed)  $45 gr/2 target (per block)
+;   $32 key    $33 dry L park   $34 dry R park
 ;   $35 scratch (wet L)          $36 scratch (wet R)
 ;   r4 / r5: the REVERB / DELAY wet read pointers (BUS mode), linear, per
 ;   block from the rotation -- two buffers back, like every bus read.
@@ -106,6 +109,16 @@ init:
         tst     a
         tpl     x0,b                    ; base >= 0x4000: an FX2 slot
         move    b,x:(r7+$40)          ; 1 = dry pass
+        clr     a
+        move    a,x:(r7+$41)            ; the DC blocker's state, both channels
+        move    a,x:(r7+$42)
+        move    a,x:(r7+$43)
+        move    a,x:(r7+$44)
+        move    a,x:(r7+$1d)            ; the compressor: block max, slow follower
+        move    a,x:(r7+$1e)
+        move    #>$400000,x0
+        move    x0,x:(r7+$1f)           ; gr/2 = unity
+        move    x0,x:(r7+$45)
         rts
 
 proc:
@@ -145,55 +158,10 @@ ch_a1:
         move    x0,a
         move    a,x:(r7+$67)
 ch_offok:
-; ---- resolve this block's write offset (per payload) -> r7+$69, r1, r2 ---
+; ---- resolve this block's rotation (per payload) -> r7+$69 -----------------
 ; ROTLATCH
-        move    a,x0
-        move    #>$901,a
-        add     x0,a
-        move    x:(r7+$67),b
-        add     b,a
-        move    a,r1                    ; REVERB ACC[write] + frame offset
-        move    #>$961,a
-        add     x0,a
-        add     b,a
-        move    a,r2                    ; DELAY  ACC[write] + frame offset
-        move    #>$ffffff,m1
-        move    #>$ffffff,m2
-; ---- register, once per block, per bus, ONLY IF SENDING (r6+4 / r6+5) ----
-        move    x:(r7+$67),a
-        tst     a
-        bne     ch_cntz
-        move    x:(r7+$69),a
-        asr     #$4,a,a
-        move    a1,x0
-        move    x0,a
-        move    #>$9c3,x0
-        add     x0,a
-        move    a,r3
-        move    #>$ffffff,m3
-        move    #>$1,x0
-        clr     b
-        clr     a                       ; NO STATION SENDS (one-aux rig, 7 Sep
-                                        ; 2026): the level is 0 whatever the
-                                        ; part stores, so nothing registers
-        tst     a
-        tne     x0,b
-        move    y:(r3),a
-        add     b,a
-        move    a,y:(r3)
-        move    #4,n3
-        move    (r3)+n3
-        clr     b
-        clr     a                       ; (no sends: never a client)
-        tst     a
-        tne     x0,b
-        move    y:(r3),a
-        add     b,a
-        move    a,y:(r3)
-ch_cntz:
-        move    #>$0,x0                 ; the send levels are 0: the stations
-        move    x0,x:(r7+$30)           ; lost their sends in the one-aux
-        move    x0,x:(r7+$31)           ; rig (every track sends from FX2's AUX)
+; (the registration went with the sends, 12 Sep 2026; the rotation latch
+; above stays: the returns read the engines' outputs by it)
 
 ; ===========================================================================
 ; PER-BLOCK KNOB DECODE
@@ -204,18 +172,24 @@ ch_cntz:
         move    a1,x0
         move    x0,a
         move    a,x:(r7+$20)            ; m
-; fold gain/8 = (1 + 7*FOLD/128)/8 = 1/8 + FOLD*(7/1024)   -- WarpFold's law,
-; pre-divided by 8 so the fold's (v+1)/2 arithmetic keeps its guard bits.
+; fold gain/32 = (1 + 31*FOLD/128)/32 -- 1x .. 32x into the fold, pre-divided
+; by 32 so the fold's (v+1)/2 arithmetic keeps its guard bits (the loop
+; shifts by 4). WarpFold's 1x..8x law (until 12 Sep 2026) was sized for the
+; old harness's 0.5 FS input; the unit hands the chain ~0.13 FS at AMP VOL
+; 64 (the mixer model, COLDFIRE_PORT.md O14), where 8x reached the FIRST
+; fold only at FOLD 127 -- +15 dB of gain and 12 % THD, a volume knob.
         move    x:(r6+$1),x0            ; the knob word IS FOLD/128 in Q23
-        move    #>$700000,y1            ; 7/8
-        mpy     x0,y1,a                 ; (7/8)*(FOLD/128)
-        add     #>$100000,a             ; + 1/8 -> gain/8, 0.125 .. 0.992
+        move    #>$7c0000,y1            ; 31/32
+        mpy     x0,y1,a                 ; (31/32)*(FOLD/128)
+        add     #>$040000,a             ; + 1/32 -> gain/32, 0.031 .. 0.992
         move    a,x:(r7+$21)            ; gq
-; drive gain/4 = (1 + 3*DRV/128)/4 = 1/4 + DRV*(3/512)
+; drive gain/16 = (1 + 15*DRV/128)/16 -- 1x .. 16x into the curve (the loop
+; shifts by 4; the limiting store IS the clip). Was 1x..4x, same reason as
+; the fold: at the unit's level TAPE 127 measured +11 dB and 2.4 % THD.
         move    x:(r6+$0),x0            ; the knob word IS DRV/128 in Q23
-        move    #>$600000,y1            ; 3/4
-        mpy     x0,y1,a                 ; (3/4)*(DRV/128)
-        add     #>$200000,a             ; + 1/4 -> gain/4, 0.25 .. 0.992
+        move    #>$780000,y1            ; 15/16
+        mpy     x0,y1,a                 ; (15/16)*(DRV/128)
+        add     #>$080000,a             ; + 1/16 -> gain/16, 0.0625 .. 0.992
         move    a,x:(r7+$22)            ; gd
 ; CRSH -> a bit MASK, built ONCE PER BLOCK (the per-sample cost is then one
 ; AND). The knob picks how many low bits are cleared, 0..21; the mask is
@@ -300,42 +274,128 @@ ch_srrz:
         move    #>$20000,x0
         cmp     x0,a
         beq     chcmtr
-        clr     a                       ; COMP: fast 4:1
+; The compressor (rebuilt 12 Sep 2026 -- the first one measured inert at the
+; unit's level: thresholds of 0.2 / 0.1 FS against a chain that sees ~0.13
+; at AMP VOL 64, a gain law linear in AMPLITUDE, a "release" coefficient of
+; 0.004 that collapsed the envelope every sample and an attack that was
+; never read). Now: a BLOCK-MAX detector (one cmp/Tcc a sample), a static
+; curve computed once per block with a real division -- gr = (thr + over/R)
+; / env above thr, 1 below -- COMP scaling the reduction and adding a
+; proportional makeup, and attack / release as the GAIN's slew per sample
+; (attack while it falls, release while it rises). Coefficients are
+; 1 - exp(-1 / (t * fs)) in Q23. thr in FS at the chain; invR = 1/R.
+        clr     a                       ; COMP: ~5:1 from -26 dBFS, 1 ms / 100 ms
         move    a,x:(r7+$2a)            ; trns flag = 0
-        move    #>$199999,x0            ; thr 0.2
+        move    #>$066666,x0            ; thr 0.05
         move    x0,x:(r7+$27)
-        move    #>$600000,x0            ; slope 0.75 (4:1-ish in amplitude)
-        move    x0,x:(r7+$28)
-        move    #>$100000,x0            ; attack ~0.5 ms
+        move    #>$100000,x0            ; invR 0.125: the amplitude curve reads
+        move    x0,x:(r7+$28)           ; ~5:1 in dB at +8 dB over
+        move    #>$02deba,x0            ; attack 1 ms
         move    x0,x:(r7+$2d)
-        move    #>$008000,x0            ; release ~90 ms
+        move    #>$00076e,x0            ; release 100 ms
         move    x0,x:(r7+$2e)
         bra     ch_cdone
 ch_cglue:
-        clr     a                       ; GLUE: slow, soft, 2:1
+        clr     a                       ; GLUE: ~2.5:1 from -30 dBFS, 10 ms / 400 ms
         move    a,x:(r7+$2a)            ; trns flag = 0
-        move    #>$0ccccd,x0            ; thr 0.1 -- it works earlier
+        move    #>$03d70a,x0            ; thr 0.03
         move    x0,x:(r7+$27)
-        move    #>$400000,x0            ; slope 0.5
+        move    #>$2ccccd,x0            ; invR 0.35: ~2.5:1 in dB
         move    x0,x:(r7+$28)
-        move    #>$020000,x0            ; attack ~8 ms: lets transients through
+        move    #>$004a38,x0            ; attack 10 ms: lets transients through
         move    x0,x:(r7+$2d)
-        move    #>$002000,x0            ; release ~350 ms
+        move    #>$0001dc,x0            ; release 400 ms
         move    x0,x:(r7+$2e)
         bra     ch_cdone
 chcmtr:
-        move    #>$7fffff,a             ; TRNS: the two-follower difference
+        move    #>$7fffff,a             ; TRNS: a boost above the slow follower
         move    a,x:(r7+$2a)            ; trns flag = 1
-        move    a,x:(r7+$27)            ; threshold 1.0: the compressor half of
-                                        ; the expression below can never fire,
-                                        ; which is what makes it branchless
+        move    a,x:(r7+$27)            ; threshold 1.0: the static curve never
+                                        ; fires, only the boost term does
         clr     a
-        move    a,x:(r7+$28)            ; slope 0
+        move    a,x:(r7+$28)            ; invR 0
+        move    #>$05ac58,x0            ; attack 0.5 ms
+        move    x0,x:(r7+$2d)
+        move    #>$0018c4,x0            ; release 30 ms
+        move    x0,x:(r7+$2e)
         move    #>$200000,x0            ; fast follower
         move    x0,x:(r7+$2d)
         move    #>$004000,x0            ; slow follower
         move    x0,x:(r7+$2e)
 ch_cdone:
+; ---- the gain computer, once per block, on the LAST block's max |key| ----
+        move    x:(r7+$1d),x1           ; env = the block max (persistent)
+        clr     a
+        move    a,x:(r7+$1d)            ; the max restarts each block
+        move    x:(r7+$1e),b            ; slow follower, TRNS's reference
+        move    x1,a
+        sub     b,a                     ; env - slow
+        move    a,x0
+        move    #>$040000,y1            ; 1/32 a block: ~12 ms
+        mpy     x0,y1,a
+        add     b,a
+        move    a,x:(r7+$1e)            ; slow'
+        move    #>$400000,b             ; gr/2 = 0.5 (unity) unless over thr
+        move    x1,a
+        move    x:(r7+$27),x0           ; thr
+        sub     x0,a                    ; over = env - thr
+        ble     ch_gunity
+        move    a,x0
+        move    x:(r7+$28),y1           ; invR
+        mpy     x0,y1,a                 ; over / R
+        move    x:(r7+$27),x0
+        add     x0,a                    ; num = thr + over/R  (< env: invR < 1)
+        move    a,y1                    ; num, 24 bits
+        move    y1,a                    ; a clean load: a0 = 0 for the divide
+        move    x1,x0                   ; den = env
+        andi    #$fe,ccr                ; carry clear
+        rep     #$18
+        div     x0,a                    ; 24 quotient bits land in a0
+        move    a0,x0                   ; gr = num / env (a0 IS the quotient here)
+        move    x0,a
+        asr     #$1,a,a                 ; gr/2
+        move    #>$400000,b
+        sub     a,b                     ; 0.5 - gr/2 = the reduction, halved
+        move    b,x0
+        move    x:(r7+$26),y1           ; COMP
+        mpy     x0,y1,b                 ; scaled by the knob
+        move    #>$400000,a
+        sub     b,a                     ; gr/2 = 0.5 - reduction*COMP
+        move    a,b
+ch_gunity:
+; makeup = 1 + 0.5*COMP, on BOTH branches (a makeup applied only above the
+; threshold cancels the reduction instead of lifting the whole signal) --
+; and not in TRNS, which boosts on its own: the term is COMP * (1 - flag)
+        move    b,x:(r7+$45)            ; park gr/2
+        move    x:(r7+$26),a            ; COMP
+        move    x:(r7+$2a),x0           ; trns flag
+        move    x:(r7+$26),y1
+        mpy     x0,y1,b                 ; COMP * flag
+        sub     b,a                     ; COMP * (1 - flag)
+        move    a,y1
+        move    x:(r7+$45),x0           ; gr/2
+        mpy     x0,y1,a                 ; gr/2 * COMP'
+        asr     #$1,a,a
+        move    x:(r7+$45),b
+        add     a,b                     ; gr/2 * (1 + 0.5*COMP')
+; TRNS: gr/2 += 4 * (env - slow)+ * COMP * flag, capped at 1.0 (gr 2.0)
+        move    x1,a
+        move    x:(r7+$1e),x0
+        sub     x0,a                    ; env - slow
+        move    #>$0,x0
+        tmi     x0,a                    ; the rising side only
+        move    a,x0
+        move    x:(r7+$2a),y1           ; trns flag
+        mpy     x0,y1,a
+        move    a,x0
+        move    x:(r7+$26),y1           ; COMP
+        mpy     x0,y1,a
+        asl     #$2,a,a                 ; x4
+        add     a,b
+        move    #>$7fffff,x0
+        cmp     x0,b
+        tgt     x0,b
+        move    b,x:(r7+$45)            ; gr/2 target for this block
 ; SAT character (slot 7 select of r6+$c) -> FOUR COEFFICIENTS, so the sample
 ; loop has no branch in it at all: neg (what the negative half is scaled by
 ; before the curve -- TUBE's asymmetry), pre and post around the curve (BUS
@@ -352,6 +412,9 @@ ch_cdone:
         move    x0,x:(r7+$3a)
         move    #>$800000,x0            ; -1.0
         move    x0,x:(r7+$3b)
+        clr     a
+        move    a,x:(r7+$46)            ; the DC blocker off (k = R = 0): a
+        move    a,x:(r7+$47)            ; symmetric curve leaves no DC
         clr     a
         move    a,x:(r7+$3e)            ; return levels: 0 outside BUS mode
         move    a,x:(r7+$3f)
@@ -373,12 +436,20 @@ ch_cdone:
 ch_stube:
         move    #>$0300000,x0           ; neg = 0.75: the positive half is
         move    x0,x:(r7+$37)           ; driven harder, so even harmonics
+        move    #>$7fffff,x0            ; ... and DC: the blocker on
+        move    x0,x:(r7+$46)
+        move    #>$7fdf3b,x0            ; R = 0.999, ~7 Hz
+        move    x0,x:(r7+$47)
         bra     ch_sdone
 ch_sfuzz:
         move    #>$266666,x0            ; clip +0.6
         move    x0,x:(r7+$3a)
         move    #>$d9999a,x0            ; clip -0.6
         move    x0,x:(r7+$3b)
+        move    #>$7fffff,x0            ; the blocker on (the crush and the
+        move    x0,x:(r7+$46)           ; fold ahead of a hard clip are not
+        move    #>$7fdf3b,x0            ; symmetric on real material)
+        move    x0,x:(r7+$47)
         bra     ch_sdone
 ch_sbus:
         move    #>$200000,x0            ; pre = 0.5 ...
@@ -436,6 +507,36 @@ ch_nopos:
         move    a,x:(r7+$3e)            ; not track 8: no return
 ch_pos3:
 ch_sdone:
+; post/2 *= 1/sqrt(1 + 15*DRV/128) (12 Sep 2026): the drive's 1x..16x
+; pre-gain would otherwise read as a +16 dB fader at the unit's level. With
+; the square root, a saturated signal (the curve caps at 2/3) comes out near
+; unity at full drive and a quiet one gains ~+12 dB: drive densifies more
+; than it turns up. A 17-word P table (the manifest's DspSection.ptable,
+; DRIVE_COMP; the build rewrites the literal), interpolated: idx = DRV >> 19
+; (0..15), frac = the 19 bits under it. r5 is free here (the BUS pointers
+; load later). AGU settle: two instructions between the r5/n5 writes and use.
+        move    x:(r6+$0),a             ; DRV/128, Q23
+        move    a,x1
+        move    #>$fab1e0,r5            ; DRIVE_COMP -- rewritten by build_bus.py
+        move    #>$ffffff,m5
+        asr     #$13,a,a                ; idx
+        move    a1,n5
+        move    x1,a
+        and     #>$7ffff,a              ; DRV & (2^19 - 1)   (a2 = 0: DRV >= 0)
+        asl     #$4,a,a                 ; frac, Q23
+        move    (r5)+n5
+        move    a,x0                    ; frac
+        move    p:(r5)+,y0              ; T[idx]
+        move    p:(r5),b                ; T[idx+1]
+        move    y0,a
+        sub     a,b                     ; T[idx+1] - T[idx]  (<= 0: the table falls)
+        move    b,y1
+        mpy     x0,y1,a                 ; frac * diff
+        add     y0,a                    ; comp, 0.25 .. 1
+        move    a,y1
+        move    x:(r7+$39),x0           ; post/2 (1.0 or BUS's 2.0, halved)
+        mpy     x0,y1,a
+        move    a,x:(r7+$39)
 ; WDTH -> mid and side gains. 64 = (1, 1); 0 = (1, 0) mono; 127 = (1, ~2).
 ; side gain = WDTH/64, mid stays 1 -- widening only touches the difference,
 ; so a mono source is untouched at every setting.
@@ -621,9 +722,9 @@ ch_nosrr:
         move    x1,x:(r7+$34)
 ; ---- FOLD: WarpFold's wrap-and-reflect, both channels --------------------
         move    x:(r7+$33),x0
-        move    x:(r7+$21),y1           ; gq = gain/8
-        mpy     x0,y1,a                 ; v/8
-        asl     #$2,a,a                 ; v/2
+        move    x:(r7+$21),y1           ; gq = gain/32
+        mpy     x0,y1,a                 ; v/32
+        asl     #$4,a,a                 ; v/2
         move    #>$400000,x1
         add     x1,a                    ; (v+1)/2
         move    a1,x1                   ; s = wrap(...), raw A1: the fold
@@ -636,7 +737,7 @@ ch_nosrr:
         move    x:(r7+$34),x0
         move    x:(r7+$21),y1
         mpy     x0,y1,a
-        asl     #$2,a,a
+        asl     #$4,a,a
         move    #>$400000,x1
         add     x1,a
         move    a1,x1
@@ -681,9 +782,9 @@ ch_noring:
         move    x:(r7+$35),x0           ; L, post-fold/ring ($33 is the PRE-fold
                                         ; park -- reading it here threw the fold
                                         ; and the ring away, 3 Sep 2026)
-        move    x:(r7+$22),y1           ; gd = gain/4
+        move    x:(r7+$22),y1           ; gd = gain/16
         mpy     x0,y1,a
-        asl     #$2,a,a                 ; driven
+        asl     #$4,a,a                 ; driven
         move    a,x:(r7+$35)            ; LIMITING store: the clip IS the drive
         move    x:(r7+$35),x0
         move    x:(r7+$37),y1           ; neg / 2
@@ -699,21 +800,40 @@ ch_noring:
         asl     #$1,a,a
         move    a,x:(r7+$35)
         bsr     chsatur
-        move    a,x0
-        move    x:(r7+$39),y1           ; post / 2
-        mpy     x0,y1,a
-        asl     #$1,a,a
+; the clip (FUZZ's +-0.6) sits on the CURVE's output, before post: with post
+; compensated for the drive (12 Sep 2026) a clip after it never bit -- FUZZ
+; measured identical to TAPE across the dial.
         move    x:(r7+$3a),x0           ; +clip
         cmp     x0,a
         tgt     x0,a
         move    x:(r7+$3b),x0           ; -clip
         cmp     x0,a
         tlt     x0,a
-        move    a,x:(r7+$35)            ; saturated L
+        move    a,x0
+        move    x:(r7+$39),y1           ; post / 2
+        mpy     x0,y1,a
+        asl     #$1,a,a
+; DC block, y = x - x1 + R*y1, R = 0.999 (~7 Hz), 12 Sep 2026: TUBE's
+; asymmetry left ~-30 dBFS of DC on a sine, which the compressor's detector
+; and the bus would both have taken as signal. Every mode gets it (FUZZ and
+; the crush are not symmetric either). State $41/$43 (L: x1, y1); long-form
+; slots, per-block-cheap enough at ~10 words a channel. mac x0,y1 is the
+; audited-signed order, and R is positive in any case.
+        move    a,x0                    ; x
+        move    x:(r7+$41),x1           ; x1
+        move    x0,x:(r7+$41)           ; x1 <- x
+        move    x:(r7+$46),y1           ; k: 1.0 in TUBE / FUZZ, 0 elsewhere
+        mpy     x1,y1,b                 ; k*x1 (mpysu: y1 is positive)
+        sub     b,a                     ; x - k*x1
+        move    x:(r7+$43),x0           ; y1
+        move    x:(r7+$47),y1           ; R: 0.999 in TUBE / FUZZ, 0 elsewhere
+        mac     x0,y1,a                 ; + R*y1  -- k = R = 0 is y = x exactly,
+        move    a,x:(r7+$43)            ; y1 <- y     so TAPE / BUS stay bit-exact
+        move    a,x:(r7+$35)            ; saturated L, DC-free
         move    x:(r7+$36),x0           ; R, the identical path
         move    x:(r7+$22),y1
         mpy     x0,y1,a
-        asl     #$2,a,a
+        asl     #$4,a,a
         move    a,x:(r7+$36)
         move    x:(r7+$36),x0
         move    x:(r7+$37),y1
@@ -730,73 +850,51 @@ ch_noring:
         move    x:(r7+$35),x1           ; park L across chsatur's use of $35
         move    a,x:(r7+$35)
         bsr     chsatur
-        move    a,x0
-        move    x:(r7+$39),y1
-        mpy     x0,y1,a
-        asl     #$1,a,a
-        move    x:(r7+$3a),x0
+        move    x:(r7+$3a),x0           ; clip before post (as L)
         cmp     x0,a
         tgt     x0,a
         move    x:(r7+$3b),x0
         cmp     x0,a
         tlt     x0,a
-        move    a,x:(r7+$36)            ; saturated R
-        move    x1,x:(r7+$35)           ; L back from its park
-; ---- COMPRESS: one detector, one gain, both channels ---------------------
-; env_fast: attack toward |key|, release by the coefficient.
-        move    x:(r7+$32),a            ; key
-        abs     a
-        move    a,x1                    ; |key|
-        move    x:(r7+$1d),x0           ; env fast
-        move    x:(r7+$2e),y1           ; release
-        mpy     x0,y1,a                 ; decayed
-        cmp     x1,a                    ; nothing between this and the Tcc
-        tlt     x1,a                    ; env = max(|key|, decayed)
-        move    a,x:(r7+$1d)
-; gr/2 = 0.5 - (compress - boost)/2, where ONE of the two terms is always
-; zero by construction: the compressor half needs env above the threshold,
-; and TRNS sets that threshold to 1.0; the boost half is multiplied by the
-; trns flag, which is 0 in the other two modes. No branch, so the loop stays
-; priceable.
-        move    x:(r7+$27),x0           ; thr
-        sub     x0,a                    ; env - thr
-        move    #>$0,x0
-        tmi     x0,a                    ; below it: nothing
         move    a,x0
-        move    x:(r7+$28),y1           ; slope
-        mpy     x0,y1,a                 ; the compression term
-        move    a,x1
-; the slow follower, and the boost term (fast - slow) * trns flag
-        move    x:(r7+$1d),a            ; fast env
-        move    x:(r7+$1e),b            ; slow env
-        sub     b,a                     ; fast - slow, either sign
-        asr     #$1,a,a
-        move    a,x0
-        move    #>$004000,y1            ; k ~ 1/512: ~12 ms, slow enough that
-                                        ; a transient is 12 ms of headroom
+        move    x:(r7+$39),y1
         mpy     x0,y1,a
         asl     #$1,a,a
-        add     b,a                     ; slow'
-        move    a,x:(r7+$1e)
-        move    x:(r7+$1d),a
-        move    x:(r7+$1e),x0
-        sub     x0,a                    ; fast - slow, >= 0 while it lags
-        move    #>$0,x0
-        tmi     x0,a                    ; never negative
+        move    a,x0                    ; the DC block, R side ($42/$44); x1
+        move    x:(r7+$42),b            ; parks L across this, so b carries x1
+        move    x0,x:(r7+$42)
+        move    x:(r7+$46),y1           ; k
+        move    b,x0
+        mpy     x0,y1,b
         move    a,x0
-        move    x:(r7+$2a),y1           ; trns flag: 1 in TRNS, 0 elsewhere
-        mpy     x0,y1,a                 ; the boost term
+        move    x0,a
+        sub     b,a                     ; x - k*x1
+        move    x:(r7+$44),x0
+        move    x:(r7+$47),y1           ; R
+        mac     x0,y1,a
+        move    a,x:(r7+$44)
+        move    a,x:(r7+$36)            ; saturated R, DC-free
+        move    x1,x:(r7+$35)           ; L back from its park
+; ---- COMPRESS: the block-max detector, and the gain slewed to the block's
+; target -- attack while it falls, release while it rises (12 Sep 2026) ---
+        move    x:(r7+$32),a            ; key
+        abs     a
+        move    x:(r7+$1d),x0           ; the block max so far
+        cmp     x0,a                    ; nothing between this and the Tcc
+        tlt     x0,a
+        move    a,x:(r7+$1d)
+        move    x:(r7+$45),a            ; gr/2 target
+        move    x:(r7+$1f),x0           ; gr/2 now
+        sub     x0,a                    ; d = target - now
+        move    x:(r7+$2d),x1           ; attack coefficient
+        move    x:(r7+$2e),b            ; release coefficient
+        tst     a                       ; sign of d -- nothing between this
+        tmi     x1,b                    ; and the Tcc: falling = attack
+        move    b,y1
         move    a,x0
-        move    x1,a                    ; compression - boost
-        sub     x0,a
-        move    a,x0
-        move    x:(r7+$26),y1           ; COMP amount
-        mpy     x0,y1,a
-        asr     #$1,a,a                 ; halved: gr is a y1 fraction and TRNS
-        neg     a                       ; drives it above 1
-        add     #>$400000,a             ; gr/2
-        move    #>$0,x0
-        tmi     x0,a                    ; never invert
+        mpy     x0,y1,a                 ; c * d
+        move    x:(r7+$1f),b
+        add     b,a                     ; gr/2 += c * d
 ch_grz:
         move    a,x:(r7+$1f)            ; gr / 2
         move    x:(r7+$35),x0
@@ -850,24 +948,8 @@ ch_grz:
         asl     #$1,a,a
         add     b,a
         move    a,x:(r0+n0)
-; ---- the sends: the PROCESSED mono, 3 bits of bus headroom ---------------
-        move    x:(r0),a
-        move    x:(r0+n0),x0
-        add     x0,a
-        asr     #$1,a,a
-        move    a,x1
-        move    x:(r7+$30),y1           ; ->DEL
-        mpy     x1,y1,a                 ; SEND's order: the level is >= 0
-        asr     #$3,a,a
-        move    y:(r2),b
-        add     b,a
-        move    a,y:(r2)+
-        move    x:(r7+$31),y0           ; ->VRB
-        mpy     x1,y0,a
-        asr     #$3,a,a
-        move    y:(r1),b
-        add     b,a
-        move    a,y:(r1)+
+; (the send taps left with the sends, 12 Sep 2026: the stations have had no
+; send since the one-aux rig; the returns below still need the bus)
 ; ---- the returns (BUS mode): added LAST, after the send taps -------------
 ; Skipped per sample when both levels are 0 -- a forward skip, the class
 ; CYCLES_FORWARD_BRANCHES admits. The wet in x0 goes negative, so the mpy is
@@ -908,25 +990,8 @@ ch_end:
 ; BYPASS LOOP: frames untouched, sends only
 ; ===========================================================================
 ch_bypass:
-        move    x:(r7+$31),y0
-        move    x:(r7+$30),y1
         move    #>$1,n0
         do      n7,>ch_byz
-        move    x:(r0),a
-        move    x:(r0+n0),x0
-        add     x0,a
-        asr     #$1,a,a
-        move    a,x1
-        mpy     x1,y1,a
-        asr     #$3,a,a
-        move    y:(r2),b
-        add     b,a
-        move    a,y:(r2)+
-        mpy     x1,y0,a
-        asr     #$3,a,a
-        move    y:(r1),b
-        add     b,a
-        move    a,y:(r1)+
 ; ---- the returns (BUS mode): added LAST, after the send taps -------------
 ; Skipped per sample when both levels are 0 -- a forward skip, the class
 ; CYCLES_FORWARD_BRANCHES admits. The wet in x0 goes negative, so the mpy is
@@ -955,7 +1020,6 @@ ch_bypass:
         mpy     x0,y1,b
         add     b,a
         move    a,x:(r0+n0)
-        move    x:(r7+$30),y1           ; ->DEL level back in y1
 ch_bynor:
         move    #>$2,n0
         move    (r0)+n0

--- a/modules/character/manifest.py
+++ b/modules/character/manifest.py
@@ -54,6 +54,16 @@ _STEP = Formatter.STEPPED
 
 _BLANK = Param(b"", 0)
 
+# post-gain compensation for DRV, 1/sqrt(1 + 15*DRV/128) at DRV 0, 8, .., 128:
+# the drive's 1x..16x pre-gain read as a +16 dB fader at the unit's level
+# (12 Sep 2026); with this a saturated signal comes out near unity and a
+# quiet one gains ~+12 dB at full drive. Read with p:(r5)+, interpolated.
+DRIVE_COMP = (
+    0x7fffff, 0x5bf53a, 0x4b7d83, 0x418e0d, 0x3abafd, 0x35ac14,
+    0x31bad7, 0x2e8ba3, 0x2be755, 0x29aa7d, 0x27bd29, 0x260e81,
+    0x249249, 0x233f5e, 0x220ec8, 0x20fb17, 0x200000,
+)
+
 MODULE = Module(
     name="character",
     key="CHARACTER",
@@ -106,6 +116,7 @@ MODULE = Module(
     ),
     dsp=DspSection(
         asm="modules/character/character.asm",
+        ptable=DRIVE_COMP,
         priority=13,                  # after the Spectrum station
         bus_role=BusRole.NONE,        # an insert that also WRITES the bus
         ybase=YBase.NEVER,                # (an FX1 module may own no buffers;

--- a/modules/spectrum/manifest.py
+++ b/modules/spectrum/manifest.py
@@ -101,11 +101,10 @@ MODULE = Module(
         priority=12,                  # after every existing module
         bus_role=BusRole.NONE,        # an insert that also WRITES the bus
         ybase=YBase.NEVER,
-        r7_latch_slot=0x69,           # ROTLATCH parks this block's offset here
         gate_label=None,              # no housekeeping, so no XBUS gate
     ),
-    # bus_client: it writes the shared accumulators, so an image with it has a
-    # bus and needs SEND as the fallback (schema.on_the_bus).
+    # NOT a bus client since 12 Sep 2026: the sends went with the one-aux rig
+    # (7 Sep) and the bus bookkeeping went with them.
     # FX1 ONLY (12 Sep 2026): an FX2 instance runs as a dry pass -- the
     # station reads its allocator base at init and returns before touching
     # a frame when it is an FX2 slot. The rig's cycle envelope only closes
@@ -113,5 +112,5 @@ MODULE = Module(
     # on both slots priced a core at 4,830 against 3,120), the FX2 chooser
     # hides the row, and tools/verify/verify_spectrum.py proves the dry pass.
     claims=Claims(fx1_only=True),
-    harness=Harness(layout_char="1", is_server=False, bus_client=True),
+    harness=Harness(layout_char="1", is_server=False, bus_client=False),
 )

--- a/modules/spectrum/spectrum.asm
+++ b/modules/spectrum/spectrum.asm
@@ -32,11 +32,9 @@
 ; and nothing lost: that buffer was cleared two blocks ago and is read next.
 ;
 ; ---- r7 slots -------------------------------------------------------------
-;   $14 $65..$69   bus bookkeeping, SEND's layout ($69 = this block's offset)
 ;   $20 fA (per block, post-modulation)   $21 damp          $22 g4 (gain/4)
 ;   $23 kLP  $24 kBP  $25 kHP              $26 kA  $27 kB  $28 kR  $29 sel
 ;   $2a cHP  $2b cLP  $2c kFM              $2d bypass flag
-;   $2e ->DEL level  $2f ->VRB level (per block copies of r6+4/5)
 ;   $30 FX2-slot flag (set at init: 1 = this instance is on FX2, dry)
 ;   $31 LFO phase (PERSISTENT, masked)     $32 env (PERSISTENT, clamped)
 ;   $34/$35 SVF lp/bp L   $36/$37 SVF lp/bp R                 (PERSISTENT)
@@ -51,7 +49,7 @@
 ;   slots may sit high; per-sample ones may not.
 ; Persistent states are bounded by the limited stores or masked on use;
 ; nothing here ever becomes an address except the bus pointers, which come
-; masked from ROTLATCH exactly as SEND's do.
+; masked exactly as SEND's are.
 ;
 ; Every mpy is `mpy x0,y1` (the known-signed encoding) except the send taps,
 ; which are SEND's `mpy x1,y1` / `mpy x1,y0` with a non-negative level in the
@@ -88,89 +86,11 @@ proc:
         move    x:(r7+$30),a           ; an FX2 slot: dry, nothing written
         tst     a
         bne     fs_end
-; ===========================================================================
-; BUS: split-aware frame offset, verbatim from modules/send/send_client.asm
-; ===========================================================================
-        move    a,x:(r7+$14)
-        clr     a
-        move    a,x:(r7+$67)
-        move    x:(r7+$14),a
-        tst     a
-        bne     fs_a1
-        move    #>$1,a
-        move    a,x:(r7+$65)
-        move    n7,a
-        and     #>$f,a
-        move    a1,x0
-        move    x0,a
-        move    a,x:(r7+$66)
-        bra     fs_offok
-fs_a1:
-        move    x:(r7+$65),a
-        and     #>$ff,a
-        move    a1,x0
-        move    x0,a
-        move    #>$1,x0
-        cmp     x0,a
-        bne     fs_offok
-        clr     a
-        move    a,x:(r7+$65)
-        move    x:(r7+$66),a
-        and     #>$f,a
-        move    a1,x0
-        move    x0,a
-        move    a,x:(r7+$67)
-fs_offok:
-; ---- resolve this block's write offset (per payload) -> r7+$69, r1, r2 ---
-; ROTLATCH
-        move    a,x0
-        move    #>$901,a
-        add     x0,a
-        move    x:(r7+$67),b
-        add     b,a
-        move    a,r1                    ; REVERB ACC[write] + frame offset
-        move    #>$961,a
-        add     x0,a
-        add     b,a
-        move    a,r2                    ; DELAY  ACC[write] + frame offset
-        move    #>$ffffff,m1
-        move    #>$ffffff,m2
-; ---- register, once per block, per bus, ONLY IF SENDING (r6+4 / r6+5) ----
-        move    x:(r7+$67),a
-        tst     a
-        bne     fs_cntz
-        move    x:(r7+$69),a
-        asr     #$4,a,a
-        move    a1,x0
-        move    x0,a
-        move    #>$9c3,x0
-        add     x0,a
-        move    a,r3
-        move    #>$ffffff,m3
-        move    #>$1,x0
-        clr     b
-        clr     a                       ; NO STATION SENDS (one-aux rig, 7 Sep
-                                        ; 2026): the level is 0 whatever the
-                                        ; part stores, so nothing registers
-        tst     a
-        tne     x0,b
-        move    y:(r3),a
-        add     b,a
-        move    a,y:(r3)
-        move    #4,n3
-        move    (r3)+n3
-        clr     b
-        clr     a                       ; (no sends: never a client)
-        tst     a
-        tne     x0,b
-        move    y:(r3),a
-        add     b,a
-        move    a,y:(r3)
-fs_cntz:
-        move    #>$0,x0                 ; the send levels are 0: the stations
-        move    x0,x:(r7+$2e)           ; lost their sends in the one-aux
-        move    x0,x:(r7+$2f)           ; rig (every track sends from FX2's AUX)
-
+; (the bus section -- split-aware frame offset, the rotation latch, the registration
+; and the r1/r2 accumulator pointers -- left with the sends, 12 Sep 2026: the
+; stations have carried no send since the one-aux rig of 7 Sep, and the ~70
+; words and ~10 cycles a block it cost bought nothing. The station is no
+; longer a bus client: Harness(bus_client=False).)
 ; ===========================================================================
 ; PER-BLOCK KNOB DECODE
 ; ===========================================================================
@@ -799,24 +719,6 @@ fs_live:
         mpy     x0,y1,b
         add     b,a
         move    a,x:(r0+n0)             ; out R
-; ---- the sends: the PROCESSED mono, 3 bits of bus headroom, both buses ----
-        move    x:(r0),a
-        move    x:(r0+n0),x0
-        add     x0,a
-        asr     #$1,a,a
-        move    a,x1                    ; mono
-        move    x:(r7+$2e),y1           ; ->DEL level
-        mpy     x1,y1,a                 ; SEND's order: level (2nd) >= 0
-        asr     #$3,a,a
-        move    y:(r2),b
-        add     b,a
-        move    a,y:(r2)+
-        move    x:(r7+$2f),y0           ; ->VRB level
-        mpy     x1,y0,a
-        asr     #$3,a,a
-        move    y:(r1),b
-        add     b,a
-        move    a,y:(r1)+
         move    #>$2,n0                 ; LONG immediates, deliberately: the
         move    (r0)+n0                 ; short form `move #2,n0` assembled and
         move    #>$1,n0                 ; stepped ONE word per frame (3 Sep 2026)
@@ -825,31 +727,7 @@ fs_end:
         rts
 
 ; ===========================================================================
-; BYPASS LOOP: frames untouched, sends only (SEND's loop, verbatim shape)
+; BYPASS: frames untouched -- with no sends there is nothing to do at all
 ; ===========================================================================
 fs_bypass:
-        move    x:(r7+$2f),y0           ; ->VRB level
-        move    x:(r7+$2e),y1           ; ->DEL level
-        move    #>$1,n0
-        do      n7,>fs_byz
-        move    x:(r0),a                ; frames untouched: the bypass IS the
-        move    x:(r0+n0),x0            ; bit-exact passthrough
-        add     x0,a
-        asr     #$1,a,a
-        move    a,x1
-        mpy     x1,y1,a
-        asr     #$3,a,a
-        move    y:(r2),b
-        add     b,a
-        move    a,y:(r2)+
-        mpy     x1,y0,a
-        asr     #$3,a,a
-        move    y:(r1),b
-        add     b,a
-        move    a,y:(r1)+
-        move    #>$2,n0                 ; LONG immediates, deliberately: the
-        move    (r0)+n0                 ; short form `move #2,n0` assembled and
-        move    #>$1,n0                 ; stepped ONE word per frame (3 Sep 2026)
-fs_byz:
-        nop
         rts

--- a/tools/harness/station_laws.py
+++ b/tools/harness/station_laws.py
@@ -45,27 +45,119 @@ def welch(x):
     return (np.abs(np.fft.rfft(seg, axis=1)) ** 2).mean(axis=0)
 
 
+AMP = (64 / 127) ** 2          # the mixer model's AMP VOL 64 on the stem, divided out of every readout
+
+
+def write_wav16(path, x):
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1); w.setsampwidth(2); w.setframerate(SR); w.writeframes((np.clip(x, -1, 1) * 32767).astype("<i2").tobytes())
+
+
+def write_sine(path, hz, amp, seconds=1.0):
+    t = np.arange(int(SR * seconds)) / SR
+    write_wav16(path, amp * np.sin(2 * np.pi * hz * t))
+
+
+def write_burst(path, hz, loud, quiet, seconds=0.5):
+    """quiet - LOUD - quiet: a step up then a step down, for attack / release and ratio."""
+    t = np.arange(int(SR * seconds)) / SR
+    tone = np.sin(2 * np.pi * hz * t)
+    write_wav16(path, np.concatenate([quiet * tone, loud * tone, quiet * tone]))
+
+
+def render(a, stem, knob, v):
+    d = pathlib.Path(a.out) / f"_r_{v:03d}"
+    cmd = [sys.executable, str(ROOT / "tools/harness/rig_render.py"), "--image", a.image, "--remix", a.remix,
+           "--tracks", f"T1={a.station}+SEND", "--stem", f"T1={stem}", "--tail", "0", "--frames", "16",
+           "--set", f"T1:FX1:{knob}={v}", "--out", str(d)]
+    for fx in a.fixed:
+        cmd += ["--set", f"T1:FX1:{fx}"]
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    if r.returncode != 0:
+        sys.exit(f"rig_render failed for {knob}={v}:\n{r.stdout[-1500:]}{r.stderr[-1500:]}")
+    y = read_mono(d / "T1.wav"); yl = read_mono(d / "T1.wav") if False else None
+    shutil.rmtree(d, ignore_errors=True)
+    return y
+
+
+def sine_probe(a, knob, vals):
+    """A 440 Hz sine at --amp: output level, THD (harmonics 2..10), the even/odd
+    balance (TUBE's asymmetry), DC. Levels are relative to the INPUT after
+    the AMP stage, so 0 dB = unity through the station."""
+    out = pathlib.Path(a.out)
+    stem = out / "sine.wav"; write_sine(stem, a.hz, a.amp)
+    x = read_mono(stem) * AMP
+    rows = []
+    for v in vals:
+        y = render(a, stem, knob, v)[:len(x)]
+        seg = slice(SR // 4, len(x) - 256)
+        Y = np.abs(np.fft.rfft(y[seg] * np.hanning(len(y[seg]))))
+        f = np.fft.rfftfreq(len(y[seg]), 1 / SR)
+        binw = lambda hz: int(round(hz * len(y[seg]) / SR))
+        mag = lambda hz: float(Y[binw(hz) - 2:binw(hz) + 3].max())
+        fund = mag(a.hz)
+        harm = [mag(a.hz * k) for k in range(2, 11)]
+        even = math.sqrt(sum(h * h for h in harm[0::2])); odd = math.sqrt(sum(h * h for h in harm[1::2]))
+        thd = math.sqrt(sum(h * h for h in harm)) / fund if fund else 0
+        gain = 20 * math.log10(np.sqrt(np.mean(y[seg] ** 2)) / np.sqrt(np.mean(x[seg] ** 2)))
+        dc = float(np.mean(y[seg]))
+        rows.append(dict(value=v, gain_db=gain, thd_pct=100 * thd, even_db=20 * math.log10(even / fund) if fund and even else -200,
+                         odd_db=20 * math.log10(odd / fund) if fund and odd else -200, dc=dc, h2_db=20 * math.log10(harm[0] / fund) if fund and harm[0] else -200,
+                         h3_db=20 * math.log10(harm[1] / fund) if fund and harm[1] else -200))
+        print(f"{knob}={v:3d}: gain {gain:+6.2f} dB  THD {100 * thd:6.2f} %  H2 {rows[-1]['h2_db']:+6.1f}  H3 {rows[-1]['h3_db']:+6.1f}  "
+              f"even {rows[-1]['even_db']:+6.1f}  odd {rows[-1]['odd_db']:+6.1f} dB  DC {dc:+.4f}")
+    return rows
+
+
+def burst_probe(a, knob, vals):
+    """quiet-LOUD-quiet at --hz: gain at each level (the ratio), and the time
+    for the gain to travel 63 % of the way after each step (attack, release)."""
+    out = pathlib.Path(a.out)
+    stem = out / "burst.wav"; write_burst(stem, a.hz, a.amp, a.amp * 10 ** (-20 / 20))
+    x = read_mono(stem) * AMP
+    n3 = len(x) // 3
+    rows = []
+    win = SR // 100
+    env = lambda z: np.sqrt(np.convolve(z * z, np.ones(win) / win, mode="same"))
+    ex = env(x)
+    for v in vals:
+        y = render(a, stem, knob, v)[:len(x)]
+        ey = env(y)
+        g = ey / np.maximum(ex, 1e-9)                       # instantaneous gain
+        gq = float(np.median(g[n3 // 2:n3 - win]))          # quiet, settled
+        gl = float(np.median(g[n3 + n3 // 2:2 * n3 - win]))  # loud, settled
+        g2 = float(np.median(g[2 * n3 + n3 // 2:3 * n3 - win]))
+        def t63(seg, g0, g1):
+            tgt = g0 + 0.63 * (g1 - g0)
+            idx = np.where((seg - tgt) * np.sign(g1 - g0) >= 0)[0]
+            return float(idx[0]) / SR * 1000 if len(idx) else None
+        att = t63(g[n3 + win:2 * n3], gq, gl)
+        rel = t63(g[2 * n3 + win:3 * n3], gl, g2)
+        ratio = 20 / (20 + 20 * math.log10(gl / gq)) if gl > 0 and gq > 0 and (20 + 20 * math.log10(gl / gq)) > 0 else None
+        rows.append(dict(value=v, gain_quiet_db=20 * math.log10(gq), gain_loud_db=20 * math.log10(gl),
+                         ratio=ratio, attack_ms=att, release_ms=rel))
+        print(f"{knob}={v:3d}: quiet {20 * math.log10(gq):+6.2f} dB  loud {20 * math.log10(gl):+6.2f} dB  "
+              f"ratio {ratio if ratio is None else round(ratio, 2)!s:>5}:1  attack {att if att is None else round(att, 1)!s:>6} ms  release {rel if rel is None else round(rel, 1)!s:>6} ms")
+    return rows
+
+
 def laws(a):
     knob, vals = a.knob.split("="); vals = [int(v) for v in vals.split(",")]
     out = pathlib.Path(a.out); out.mkdir(parents=True, exist_ok=True)
+    if a.probe == "sine":
+        rows = sine_probe(a, knob, vals)
+        (out / "laws.json").write_text(json.dumps(dict(station=a.station, knob=knob, fixed=a.fixed, probe="sine", rows=rows), indent=1)); return
+    if a.probe == "burst":
+        rows = burst_probe(a, knob, vals)
+        (out / "laws.json").write_text(json.dumps(dict(station=a.station, knob=knob, fixed=a.fixed, probe="burst", rows=rows), indent=1)); return
     noise = out / "noise.wav"; write_noise(noise)
     nin = read_mono(noise); pin = welch(nin); f = np.fft.rfftfreq(N, 1 / SR)
     rows = []
     for v in vals:
-        d = out / f"_r_{v:03d}"
-        cmd = [sys.executable, str(ROOT / "tools/harness/rig_render.py"), "--image", a.image, "--remix", a.remix,
-               "--tracks", f"T1={a.station}+SEND", "--stem", f"T1={noise}", "--tail", "0", "--frames", "16",
-               "--set", f"T1:FX1:{knob}={v}", "--out", str(d)]
-        for fx in a.fixed:
-            cmd += ["--set", f"T1:FX1:{fx}"]
-        r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
-        if r.returncode != 0:
-            sys.exit(f"rig_render failed for {knob}={v}:\n{r.stdout[-1500:]}{r.stderr[-1500:]}")
-        y = read_mono(d / "T1.wav")[:len(nin)]
-        shutil.rmtree(d, ignore_errors=True)
+        y = render(a, noise, knob, v)[:len(nin)]
         H = np.sqrt(welch(y) / np.maximum(pin, 1e-30))
         # the mixer model puts the stem through AMP VOL (64/127)^2: divide it out
-        H = H / (64 / 127) ** 2
+        H = H / AMP
         Hdb = 20 * np.log10(np.maximum(H, 1e-9))
         at = lambda hz: float(Hdb[int(round(hz * N / SR))])
         ref = at(100)
@@ -103,6 +195,8 @@ def main():
     ap.add_argument("--fixed", action="append", default=[])
     ap.add_argument("--image", default="out/mainos_bus.bin"); ap.add_argument("--remix", default=os.environ.get("REMIX", "bamsep26"))
     ap.add_argument("--out", required=True)
+    ap.add_argument("--probe", choices=("noise", "sine", "burst"), default="noise")
+    ap.add_argument("--hz", type=float, default=440.0); ap.add_argument("--amp", type=float, default=0.5, help="probe amplitude before the AMP stage (0.5 = -6 dBFS)")
     return laws(ap.parse_args())
 
 

--- a/tools/verify/verify_burn.py
+++ b/tools/verify/verify_burn.py
@@ -97,8 +97,12 @@ def build(env_burn):
 
 
 def render(mem, src, out, p3):
+    # HP merged into TONE on 7 Sep 2026 (TONE 64 = the old HP 0 / LP 127,
+    # bit-identical; below 64 darkens, above thins). The neutral value is 64
+    # and the sensitivity control is 0 -- the gate's meaning is unchanged.
+    tone = {0: 64, 64: 0}.get(p3, p3)
     run([sys.executable, "tools/harness/render_reverb.py", str(src),
-         "--mem", str(mem), "-p", f"HP={p3}", "-o", str(out)])
+         "--mem", str(mem), "-p", f"TONE={tone}", "-o", str(out)])
     return out.read_bytes()
 
 


### PR DESCRIPTION
Stage C, Character — the meter's half. Measured with new `station_laws.py` probes (sine: level/THD/even-odd; burst: ratio/attack/release) at the level the unit actually delivers (0.127 FS for a −6 dBFS source at AMP VOL 64).

**Every dirt stage was sized for the old harness's 0.5 FS input.** DRV was a +11 dB fader with 2.4 % THD; FOLD reached its first fold only at 127; the compressor was inert (thresholds 0.2/0.1 FS, an amplitude-linear law, a release coefficient that reset the envelope every sample, an attack never read). Now:
- DRV 1–16× with a `1/√(1+15d)` post table: TAPE 1 → 31 % across the dial at +4..+6 dB; FUZZ's clip moved before post (it never bit after); TUBE's DC leak removed by a per-mode DC blocker (bit-exact off in TAPE/BUS).
- FOLD 1–32×: full folding from 64.
- Compressor rebuilt: block-max detector, per-block static curve with a real division, COMP scales reduction + makeup, attack/release slew the gain. COMP 127: +3.5/−3 dB, release 85 ms. TRNS a bounded onset boost.

**Words:** payload A overran; both stations shed their dead bus code (no sends since 7 Sep). Spectrum 1017 → 861 words / 341 → 322 cycles, Character 414 cycles, payload A 222 free. `verify_burn` runs again on the rig (fixed its stale `HP` knob).

Gates green, verify_onebus 25/25, refhash 26/26, `make check` 370 PASS. Eight ear kits in `out/ab/char_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)