### PR TITLE
Modulation round (measured half): the phaser was never an allpass (mpysu), DLY 127 wrapped the line; laws measured; lfo + impulse probes

### DIFF
--- a/modules/modulation/README.md
+++ b/modules/modulation/README.md
@@ -75,11 +75,26 @@ allocator put us.
 - Two gates measured the wrong signal before they measured the right one: an
   envelope follower on a 438 Hz tone tracks the tone, not the sweep.
 
+## Measured laws (12 Sep 2026, `tools/harness/station_laws.py --probe lfo|impulse|noise`)
+
+| knob | law | readout |
+|---|---|---|
+| RATE | squared, ~0.05 → 8 Hz (kept: chorus rates in the bottom half, tremolo/vibrato in the top) | 32 → 0.64 Hz, 48 → 1.24, 64 → 2.1, 80 → 3.3, 96 → 4.6, 112 → 6.3, 127 → 8.0 |
+| DLY | linear, ≈1 ms + 0.18 ms per detent; **the read is clamped to the 1,024-word line** (centre ≤ 1,000 samples, depth ≤ min(centre − 8, 1,015 − centre)) | 16 → 3.9 ms, 64 → 12.3, 96 → 18.0, 127 → 22.7 (it was 0.18 ms: CHOR's 40-sample floor pushed 127 past the line and the mask wrapped it) |
+| FDBK (FLNG) | linear | a 4-sample comb decaying −9.6 / −5.6 / −3.5 dB per pass at 64 / 100 / 127 |
+| DPTH (TREM, PAN) | | 5 / 10 / 17 / 38 dB at 32 / 64 / 96 / 127 |
+| COMB | DLY = the pitch; FDBK the ring | resonance peaks +8..+12 dB, bw 20–40 Hz |
+| PHSR | **rewritten**: the allpass coefficient was multiplied `mpy x1,y1` — the order that ENCODES AS MPYSU — so a negative `c` (half of every LFO cycle) read as a large positive one and the chain measured +34 dB at Nyquist and +6 dB across the band; the sweep had no centre (DLY unused) and the RES knob reached nothing. Now: `c = centre + DPTH·0.75·lfo`, centre `0.94 − 1.24·DLY/128` (first notch ≈ 1 kHz at DLY 0 → 15 kHz at 127), the sweep clamped per block so `c` stays inside ±0.95, RES = negative feedback of the chain's output (capped 0.9·knob; positive fed back at DC) | unity peaks, notches −55 dB, one more notch per STGS step; RES 64 +3 dB resonance between the notches |
+
+Cost: the phaser loop 464 (it was cheaper broken); the line loop 386.
+
+Kits for the ear in `out/ab/mod_*` (`tools/harness/abkit.py`): the seven
+modes, CHOR depth, FLNG feedback, PHSR stages and resonance, COMB pitch,
+TREM rate.
+
 ## Open
 
-- Voicing: nothing has been heard. Every law here is a first guess — the
-  delay ranges per mode, the sweep depths, the phaser's range, the SHPE
-  curves.
-- SHPE's fourth position is labelled SAW but the shaper implements TRI, SIN
-  and SQR; SAW currently renders as TRI. Either the label or the shape.
-- ⚠️ UNFLASHED, and the FX1-participant bus case has never run on hardware.
+- Voicing: the laws are measured (above); nothing has been HEARD yet.
+- SAW is a real shape since 3 Sep 2026 (`modulation.asm`).
+- On hardware since flash 4 (tag 79) as T5's FX1; the FX1-only dry pass is
+  emulator-proven; none of the 12 Sep changes are flashed.

--- a/modules/modulation/modulation.asm
+++ b/modules/modulation/modulation.asm
@@ -59,6 +59,8 @@
 ;   $21 centre delay, Q11.12         $22 sweep depth, Q11.12
 ;   $23 feedback                     $24 tone coefficient
 ;   $25 WID phase offset             $26 LFO increment per sample
+;   $2f phaser sweep (DPTH*0.75)     $44 phaser centre (from DLY)
+;   $40/$41 phaser feedback state L/R (PERSISTENT)   $42/$43 tap sums
 ;   $27 sin blend weight             $28 square gain / 8
 ;   $18 saw blend weight             $17 saw this sample (shape scratch)
 ;   $29 engine class                 $2a scratch (shape)
@@ -112,6 +114,8 @@ monoclr:
         move    a,x:(r7+$1c)            ; LFO phase
         move    a,x:(r7+$32)            ; feedback tone states
         move    a,x:(r7+$33)
+        move    a,x:(r7+$40)            ; the phaser's feedback state, L / R
+        move    a,x:(r7+$41)
         move    a,x:(r7+$34)            ; allpass states, both channels
         move    a,x:(r7+$35)
         move    a,x:(r7+$36)
@@ -327,11 +331,44 @@ mo_stdone:
         move    #>$1e0000,y1            ; 480 samples, pre-scaled to Q11.12
         mpy     x0,y1,a                 ; (no shift -- see the note above)
         move    a,x:(r7+$22)
-; FDBK -> the feedback amount, and the phaser's sweep depth
+; FDBK -> the feedback amount (RES in PHSR: the chain's resonance)
         move    x:(r6+$2),x0
         move    x0,x:(r7+$23)
-        move    #>$600000,x0            ; the phaser sweeps 0.75 of its range
-        move    x0,x:(r7+$2f)
+; the phaser's sweep: DPTH * 0.75 either side of its centre (was a fixed
+; 0.75 with no centre, 12 Sep 2026), the centre from DLY: c0 = 0.94 -
+; 1.24 * DLY/128 -- DLY 0 puts the notches low, 127 high. The loop clamps
+; c to +-0.95.
+        move    x:(r6+$1),x0            ; DPTH/128
+        move    #>$600000,y1            ; 0.75
+        mpy     x0,y1,a
+        move    a,x:(r7+$2f)            ; sweep
+        move    x:(r6+$c),a
+        and     #>$7f0000,a
+        move    a1,x0
+        move    x0,a
+        move    a,x0                    ; DLY/128
+        move    #>$4f5c29,y1            ; 0.62
+        mpy     x0,y1,a
+        asl     #$1,a,a                 ; 1.24 * DLY/128
+        neg     a
+        add     #>$7851eb,a             ; 0.94 - 1.24 * DLY/128: the first notch
+        move    a,x:(r7+$44)            ; from ~1 kHz (DLY 0) to ~15 kHz (127)
+; clamp the SWEEP once per block so centre +- sweep stays inside +-0.95 (an
+; allpass coefficient at +-1 is a pole on the circle): sweep <= 0.95 - c0
+; and sweep <= c0 + 0.95. Per block, so the loop needs no clamp.
+        move    a,b
+        move    #>$799999,x1            ; 0.95
+        neg     b
+        add     x1,b                    ; 0.95 - c0
+        move    b,y0
+        add     x1,a                    ; c0 + 0.95
+        move    x:(r7+$2f),b            ; sweep
+        cmp     y0,b
+        tgt     y0,b
+        move    a,x1
+        cmp     x1,b                    ; nothing between: the flag trap
+        tgt     x1,b
+        move    b,x:(r7+$2f)
 ; ---- MODE (slot 7 select of r6+$c): the engine class, and the per-mode ----
 ; overrides of centre, depth and feedback. CHOR is the fall-through.
         clr     a
@@ -382,6 +419,10 @@ mo_mflng:
 mo_mphsr:
         move    #>$1,a
         move    a,x:(r7+$29)            ; class 1 = the PHASER loop
+        move    x:(r7+$23),x0           ; RES capped at 0.9 * knob: at 0.99 the
+        move    #>$733333,y1            ; negative feedback rings +40 dB
+        mpy     x0,y1,a
+        move    a,x:(r7+$23)
         bra     mo_mdone
 mo_mcomb:
         move    x:(r7+$22),a
@@ -404,6 +445,30 @@ mo_mpan:
         move    #>$c00000,x0            ; ... with the right channel inverted
         move    x0,x:(r7+$1f)           ; (-0.5, halved like every y1 gain)
 mo_mdone:
+; ---- keep the read inside the 1,024-word line (12 Sep 2026) ---------------
+; centre + depth must stay below 1,016 samples and centre - depth above 8:
+; CHOR's 40-sample floor put DLY 127 at 1,032 (masked to 8: the impulse
+; came back 0.18 ms late instead of 23), and a deep sweep at a long centre
+; wrapped the same way. Centre is capped at 1,000; depth at the smaller of
+; (centre - 8) and (1,015 - centre). Q11.12 throughout; cmp + one Tcc each.
+        move    x:(r7+$21),a            ; centre
+        move    #>$3e8000,x0            ; 1,000 samples
+        cmp     x0,a
+        tgt     x0,a
+        move    a,x:(r7+$21)
+        move    a,b
+        move    #>$8000,x0              ; 8 samples
+        sub     x0,b                    ; centre - 8
+        move    b,x1
+        move    #>$3f7000,b             ; 1,015 samples
+        sub     a,b                     ; 1,015 - centre
+        move    x:(r7+$22),a            ; depth
+        cmp     x1,a
+        tgt     x1,a                    ; depth <= centre - 8
+        move    b,x1
+        cmp     x1,a                    ; nothing between: the flag trap
+        tgt     x1,a                    ; depth <= 1,015 - centre
+        move    a,x:(r7+$22)
 ; ---- the dry path: an FX2 slot, or MIX at zero ---------------------------
         move    x:(r7+$1a),a            ; the FX2 flag from init
         tst     a
@@ -580,10 +645,13 @@ mo_phsr:
         move    #>$1,n0
         do      n7,>mophsz
         bsr     moshap
-; the coefficient: c = lfo * depth, so it sweeps either side of centre
+; the coefficient: c = centre + lfo * sweep -- inside +-0.95 by the per-block
+; clamp of the sweep, so nothing to clamp here
         move    x:(r7+$1d),x0
         move    x:(r7+$2f),y1
         mpy     x0,y1,a
+        move    x:(r7+$44),x0
+        add     x0,a
         move    a,x:(r7+$3e)            ; c for this sample
         move    x:(r0),a
         move    a,x:(r7+$3c)
@@ -591,6 +659,8 @@ mo_phsr:
         move    x:(r7+$1e),x0           ; the right channel's own coefficient
         move    x:(r7+$2f),y1
         mpy     x0,y1,a
+        move    x:(r7+$44),x0
+        add     x0,a
         move    a,x:(r7+$3e)
         move    x:(r0+n0),a
         move    a,x:(r7+$3d)
@@ -791,163 +861,192 @@ moshap:
 
 
 ; ---------------------------------------------------------------------------
-; moapch / moapcr -- the four-stage allpass chain, L and R.
-; In: $3c (or $3d) = the input, $3e = this sample's coefficient.
+; moapch / moapcr -- the four-stage allpass chain, L and R (rewritten 12 Sep
+; 2026). In: $3c (or $3d) = the input, $3e = this sample's coefficient.
 ; Out: the same slot holds the weighted tap. Each stage is the one-pole
-; allpass y = -c*x + s, s' = x + c*y, which is unity-magnitude at every
-; frequency -- the phase is the whole point. The four taps are weighted
-; rather than branched on, so STGS costs no branch in the loop. The stages
-; are INLINED (cycle_count refuses a bsr callee that itself calls).
+; allpass y = -c*x + s, s' = x + c*y, unity-magnitude at every frequency --
+; the phase is the whole point. The four taps are weighted (one-hot by
+; STGS) rather than branched on. RES (the FDBK knob, renamed in PHSR) feeds
+; the chain's last output back into its input, the classic phaser
+; resonance. ⚠️ The first version multiplied `mpy x1,y1` with c in y1:
+; that order ENCODES AS MPYSU (CLAUDE.md), so a negative c -- half of every
+; LFO cycle -- was read as a large positive one and the "allpass" measured
+; +34 dB at Nyquist and +6 dB across the band (station_laws.py, noise).
+; c lives in x0 now; mpy x0,y1 is the audited signed order. The stages are
+; INLINED (cycle_count refuses a bsr callee that itself calls).
+;   $40 / $41  the chain's last output L / R (PERSISTENT, the feedback)
+;   $42 / $43  the weighted-tap sum, per sample
 ; ---------------------------------------------------------------------------
 moapch:
         clr     b
-        move    x:(r7+$3c),a
-        move    a,x:(r7+$3f)
-        move    x:(r7+$34),x0
+        move    x:(r7+$3c),a           ; x, the chain input
+        move    x:(r7+$40),x0          ; the chain's last output
+        move    x:(r7+$23),y1           ; RES (FDBK)
+        mpy     x0,y1,b                 ; res * y_last  (x0,y1: the signed order)
+        sub     b,a                     ; x - res * y_last: NEGATIVE, so the
+                                        ; resonance sits between the notches
+                                        ; (positive fed back at DC: +12 dB at
+                                        ; RES 110 on noise, 12 Sep 2026)
+        clr     b
+        move    a,x:(r7+$3f)            ; the first stage's input
+; stage 1: y = s - c*x, s' = x + c*y  (state $34)
         move    x:(r7+$3f),x1           ; x, the stage input
-        move    x:(r7+$3e),y1           ; c
-        mpy     x1,y1,a                 ; c * x
-        neg     a                       ; -c * x
-        move    x0,y0                   ; s
-        add     y0,a                    ; y = -c*x + s
+        move    x:(r7+$3f),y1
+        move    x:(r7+$3e),x0           ; c -- in x0: mpy x0,y1 is SIGNED
+        mpy     x0,y1,a                 ; c * x
+        neg     a
+        move    x:(r7+$34),b            ; s
+        add     b,a                     ; y = s - c*x
         move    a,x:(r7+$3f)            ; the stage output
-        move    a,x0
+        move    a,y1
         mpy     x0,y1,a                 ; c * y
         add     x1,a                    ; s' = x + c*y
         move    a,x:(r7+$34)
-        move    x:(r7+$3e),y1
-        move    x:(r7+$2b),y0
-        move    x:(r7+$3f),x0
-        move    y0,y1
-        mpy     x0,y1,a
-        add     a,b
-        move    x:(r7+$35),x0
+        move    x:(r7+$2b),x0            ; this tap's weight (one-hot by STGS)
+        mpy     x0,y1,a                 ; w * y  (y1 still holds y)
+        move    a,x:(r7+$42)
+; stage 2: y = s - c*x, s' = x + c*y  (state $35)
         move    x:(r7+$3f),x1           ; x, the stage input
-        move    x:(r7+$3e),y1           ; c
-        mpy     x1,y1,a                 ; c * x
-        neg     a                       ; -c * x
-        move    x0,y0                   ; s
-        add     y0,a                    ; y = -c*x + s
+        move    x:(r7+$3f),y1
+        move    x:(r7+$3e),x0           ; c -- in x0: mpy x0,y1 is SIGNED
+        mpy     x0,y1,a                 ; c * x
+        neg     a
+        move    x:(r7+$35),b            ; s
+        add     b,a                     ; y = s - c*x
         move    a,x:(r7+$3f)            ; the stage output
-        move    a,x0
+        move    a,y1
         mpy     x0,y1,a                 ; c * y
         add     x1,a                    ; s' = x + c*y
         move    a,x:(r7+$35)
-        move    x:(r7+$2c),y0
-        move    x:(r7+$3f),x0
-        move    y0,y1
-        mpy     x0,y1,a
+        move    x:(r7+$2c),x0            ; this tap's weight (one-hot by STGS)
+        mpy     x0,y1,a                 ; w * y  (y1 still holds y)
+        move    x:(r7+$42),b
         add     a,b
-        move    x:(r7+$36),x0
+        move    b,x:(r7+$42)
+; stage 3: y = s - c*x, s' = x + c*y  (state $36)
         move    x:(r7+$3f),x1           ; x, the stage input
-        move    x:(r7+$3e),y1           ; c
-        mpy     x1,y1,a                 ; c * x
-        neg     a                       ; -c * x
-        move    x0,y0                   ; s
-        add     y0,a                    ; y = -c*x + s
+        move    x:(r7+$3f),y1
+        move    x:(r7+$3e),x0           ; c -- in x0: mpy x0,y1 is SIGNED
+        mpy     x0,y1,a                 ; c * x
+        neg     a
+        move    x:(r7+$36),b            ; s
+        add     b,a                     ; y = s - c*x
         move    a,x:(r7+$3f)            ; the stage output
-        move    a,x0
+        move    a,y1
         mpy     x0,y1,a                 ; c * y
         add     x1,a                    ; s' = x + c*y
         move    a,x:(r7+$36)
-        move    x:(r7+$2d),y0
-        move    x:(r7+$3f),x0
-        move    y0,y1
-        mpy     x0,y1,a
+        move    x:(r7+$2d),x0            ; this tap's weight (one-hot by STGS)
+        mpy     x0,y1,a                 ; w * y  (y1 still holds y)
+        move    x:(r7+$42),b
         add     a,b
-        move    x:(r7+$37),x0
+        move    b,x:(r7+$42)
+; stage 4: y = s - c*x, s' = x + c*y  (state $37)
         move    x:(r7+$3f),x1           ; x, the stage input
-        move    x:(r7+$3e),y1           ; c
-        mpy     x1,y1,a                 ; c * x
-        neg     a                       ; -c * x
-        move    x0,y0                   ; s
-        add     y0,a                    ; y = -c*x + s
+        move    x:(r7+$3f),y1
+        move    x:(r7+$3e),x0           ; c -- in x0: mpy x0,y1 is SIGNED
+        mpy     x0,y1,a                 ; c * x
+        neg     a
+        move    x:(r7+$37),b            ; s
+        add     b,a                     ; y = s - c*x
         move    a,x:(r7+$3f)            ; the stage output
-        move    a,x0
+        move    a,y1
         mpy     x0,y1,a                 ; c * y
         add     x1,a                    ; s' = x + c*y
         move    a,x:(r7+$37)
-        move    x:(r7+$2e),y0
-        move    x:(r7+$3f),x0
-        move    y0,y1
-        mpy     x0,y1,a
+        move    x:(r7+$2e),x0            ; this tap's weight (one-hot by STGS)
+        mpy     x0,y1,a                 ; w * y  (y1 still holds y)
+        move    x:(r7+$42),b
         add     a,b
-        move    b,x:(r7+$3c)
+        move    b,x:(r7+$42)
+        move    b,x:(r7+$40)           ; y_last for the feedback
+        move    b,x:(r7+$3c)           ; the wet
         rts
+
 moapcr:
         clr     b
-        move    x:(r7+$3d),a
-        move    a,x:(r7+$3f)
-        move    x:(r7+$38),x0
+        move    x:(r7+$3d),a           ; x, the chain input
+        move    x:(r7+$41),x0          ; the chain's last output
+        move    x:(r7+$23),y1           ; RES (FDBK)
+        mpy     x0,y1,b                 ; res * y_last  (x0,y1: the signed order)
+        sub     b,a                     ; x - res * y_last: NEGATIVE, so the
+                                        ; resonance sits between the notches
+                                        ; (positive fed back at DC: +12 dB at
+                                        ; RES 110 on noise, 12 Sep 2026)
+        clr     b
+        move    a,x:(r7+$3f)            ; the first stage's input
+; stage 1: y = s - c*x, s' = x + c*y  (state $38)
         move    x:(r7+$3f),x1           ; x, the stage input
-        move    x:(r7+$3e),y1           ; c
-        mpy     x1,y1,a                 ; c * x
-        neg     a                       ; -c * x
-        move    x0,y0                   ; s
-        add     y0,a                    ; y = -c*x + s
+        move    x:(r7+$3f),y1
+        move    x:(r7+$3e),x0           ; c -- in x0: mpy x0,y1 is SIGNED
+        mpy     x0,y1,a                 ; c * x
+        neg     a
+        move    x:(r7+$38),b            ; s
+        add     b,a                     ; y = s - c*x
         move    a,x:(r7+$3f)            ; the stage output
-        move    a,x0
+        move    a,y1
         mpy     x0,y1,a                 ; c * y
         add     x1,a                    ; s' = x + c*y
         move    a,x:(r7+$38)
-        move    x:(r7+$3e),y1
-        move    x:(r7+$2b),y0
-        move    x:(r7+$3f),x0
-        move    y0,y1
-        mpy     x0,y1,a
-        add     a,b
-        move    x:(r7+$39),x0
+        move    x:(r7+$2b),x0            ; this tap's weight (one-hot by STGS)
+        mpy     x0,y1,a                 ; w * y  (y1 still holds y)
+        move    a,x:(r7+$43)
+; stage 2: y = s - c*x, s' = x + c*y  (state $39)
         move    x:(r7+$3f),x1           ; x, the stage input
-        move    x:(r7+$3e),y1           ; c
-        mpy     x1,y1,a                 ; c * x
-        neg     a                       ; -c * x
-        move    x0,y0                   ; s
-        add     y0,a                    ; y = -c*x + s
+        move    x:(r7+$3f),y1
+        move    x:(r7+$3e),x0           ; c -- in x0: mpy x0,y1 is SIGNED
+        mpy     x0,y1,a                 ; c * x
+        neg     a
+        move    x:(r7+$39),b            ; s
+        add     b,a                     ; y = s - c*x
         move    a,x:(r7+$3f)            ; the stage output
-        move    a,x0
+        move    a,y1
         mpy     x0,y1,a                 ; c * y
         add     x1,a                    ; s' = x + c*y
         move    a,x:(r7+$39)
-        move    x:(r7+$2c),y0
-        move    x:(r7+$3f),x0
-        move    y0,y1
-        mpy     x0,y1,a
+        move    x:(r7+$2c),x0            ; this tap's weight (one-hot by STGS)
+        mpy     x0,y1,a                 ; w * y  (y1 still holds y)
+        move    x:(r7+$43),b
         add     a,b
-        move    x:(r7+$3a),x0
+        move    b,x:(r7+$43)
+; stage 3: y = s - c*x, s' = x + c*y  (state $3a)
         move    x:(r7+$3f),x1           ; x, the stage input
-        move    x:(r7+$3e),y1           ; c
-        mpy     x1,y1,a                 ; c * x
-        neg     a                       ; -c * x
-        move    x0,y0                   ; s
-        add     y0,a                    ; y = -c*x + s
+        move    x:(r7+$3f),y1
+        move    x:(r7+$3e),x0           ; c -- in x0: mpy x0,y1 is SIGNED
+        mpy     x0,y1,a                 ; c * x
+        neg     a
+        move    x:(r7+$3a),b            ; s
+        add     b,a                     ; y = s - c*x
         move    a,x:(r7+$3f)            ; the stage output
-        move    a,x0
+        move    a,y1
         mpy     x0,y1,a                 ; c * y
         add     x1,a                    ; s' = x + c*y
         move    a,x:(r7+$3a)
-        move    x:(r7+$2d),y0
-        move    x:(r7+$3f),x0
-        move    y0,y1
-        mpy     x0,y1,a
+        move    x:(r7+$2d),x0            ; this tap's weight (one-hot by STGS)
+        mpy     x0,y1,a                 ; w * y  (y1 still holds y)
+        move    x:(r7+$43),b
         add     a,b
-        move    x:(r7+$3b),x0
+        move    b,x:(r7+$43)
+; stage 4: y = s - c*x, s' = x + c*y  (state $3b)
         move    x:(r7+$3f),x1           ; x, the stage input
-        move    x:(r7+$3e),y1           ; c
-        mpy     x1,y1,a                 ; c * x
-        neg     a                       ; -c * x
-        move    x0,y0                   ; s
-        add     y0,a                    ; y = -c*x + s
+        move    x:(r7+$3f),y1
+        move    x:(r7+$3e),x0           ; c -- in x0: mpy x0,y1 is SIGNED
+        mpy     x0,y1,a                 ; c * x
+        neg     a
+        move    x:(r7+$3b),b            ; s
+        add     b,a                     ; y = s - c*x
         move    a,x:(r7+$3f)            ; the stage output
-        move    a,x0
+        move    a,y1
         mpy     x0,y1,a                 ; c * y
         add     x1,a                    ; s' = x + c*y
         move    a,x:(r7+$3b)
-        move    x:(r7+$2e),y0
-        move    x:(r7+$3f),x0
-        move    y0,y1
-        mpy     x0,y1,a
+        move    x:(r7+$2e),x0            ; this tap's weight (one-hot by STGS)
+        mpy     x0,y1,a                 ; w * y  (y1 still holds y)
+        move    x:(r7+$43),b
         add     a,b
-        move    b,x:(r7+$3d)
+        move    b,x:(r7+$43)
+        move    b,x:(r7+$41)           ; y_last for the feedback
+        move    b,x:(r7+$3d)           ; the wet
         rts
 
 ; ---------------------------------------------------------------------------

--- a/tools/harness/station_laws.py
+++ b/tools/harness/station_laws.py
@@ -141,9 +141,93 @@ def burst_probe(a, knob, vals):
     return rows
 
 
+def lfo_probe(a, knob, vals):
+    """A steady tone: the output's amplitude envelope (5 ms windows) gives the
+    modulation rate (its autocorrelation's first peak) and depth (the
+    envelope's max/min in dB) -- TREM and PAN directly, CHOR/FLNG/VIB via the
+    level ripple of a delayed tone summed with itself."""
+    out = pathlib.Path(a.out)
+    stem = out / "sine.wav"; write_sine(stem, a.hz, a.amp, seconds=a.seconds)
+    rows = []
+    win = SR // 200
+    for v in vals:
+        d = out / f"_r_{v:03d}"
+        cmd = [sys.executable, str(ROOT / "tools/harness/rig_render.py"), "--image", a.image, "--remix", a.remix,
+               "--tracks", f"T1={a.station}+SEND", "--stem", f"T1={stem}", "--tail", "0", "--frames", "16",
+               "--set", f"T1:FX1:{knob}={v}", "--out", str(d)]
+        for fx in a.fixed:
+            cmd += ["--set", f"T1:FX1:{fx}"]
+        r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+        if r.returncode != 0:
+            sys.exit(f"rig_render failed for {knob}={v}:\n{r.stdout[-1500:]}{r.stderr[-1500:]}")
+        with wave.open(str(d / "T1.wav"), "rb") as w:
+            nch, sw, n = w.getnchannels(), w.getsampwidth(), w.getnframes(); raw = w.readframes(n)
+        arr = np.frombuffer(raw, dtype=np.uint8).reshape(n, nch, sw)
+        val = arr[:, :, 0].astype(np.int32) | (arr[:, :, 1].astype(np.int32) << 8) | (arr[:, :, 2].astype(np.int32) << 16)
+        val = np.where(val >= 1 << 23, val - (1 << 24), val) / 8388608.0
+        shutil.rmtree(d, ignore_errors=True)
+        res = dict(value=v)
+        for ch, name in ((0, "L"), (1, "R")):
+            y = val[SR // 2:, ch]                          # skip the warm-in
+            e = np.sqrt(np.convolve(y * y, np.ones(win) / win, mode="valid"))[::win // 2]
+            e = e[len(e) // 8:]
+            dep = 20 * math.log10(e.max() / e.min()) if e.min() > 0 else 99.0
+            ac = np.correlate(e - e.mean(), e - e.mean(), mode="full")[len(e) - 1:]
+            ac /= max(ac[0], 1e-12)
+            # first peak after the first zero crossing
+            z = next((i for i in range(1, len(ac)) if ac[i] < 0), None)
+            hz = None
+            if z is not None and z < len(ac) - 2:
+                pk = int(np.argmax(ac[z:]) + z)
+                if ac[pk] > 0.2:
+                    hz = SR / (win // 2) / pk
+            res[f"depth_{name}_db"] = dep; res[f"rate_{name}_hz"] = hz
+        rows.append(res)
+        fmt = lambda x: "  none" if x is None else f"{x:6.2f}"
+        print(f"{knob}={v:3d}: rate L {fmt(res['rate_L_hz'])} Hz  R {fmt(res['rate_R_hz'])} Hz   "
+              f"depth L {res['depth_L_db']:5.1f} dB  R {res['depth_R_db']:5.1f} dB")
+    return rows
+
+
+def impulse_probe(a, knob, vals):
+    """A single impulse at -6 dBFS: the lags (ms) and levels of the echoes in
+    the output -- a delay line's centre time per DLY, its feedback repeats."""
+    out = pathlib.Path(a.out)
+    stem = out / "impulse.wav"
+    x = np.zeros(int(SR * a.seconds)); x[1000] = a.amp
+    write_wav16(stem, x)
+    rows = []
+    for v in vals:
+        y = render(a, stem, knob, v)
+        y = y[1000:1000 + int(0.5 * SR)]
+        ay = np.abs(y)
+        thr = ay.max() * 0.02
+        peaks = []
+        i = 0
+        while i < len(ay):
+            if ay[i] > thr:
+                j = i
+                while j < len(ay) and (j - i) < a.min_gap:
+                    j += 1
+                seg = ay[i:j]; k = int(np.argmax(seg)) + i
+                peaks.append((k, float(ay[k]))); i = j
+            else:
+                i += 1
+        peaks = peaks[:6]
+        rows.append(dict(value=v, echoes=[dict(ms=k / SR * 1000, db=20 * math.log10(l / (a.amp * AMP))) for k, l in peaks]))
+        print(f"{knob}={v:3d}: " + "  ".join(f"{k / SR * 1000:6.2f} ms {20 * math.log10(l / (a.amp * AMP)):+6.1f} dB" for k, l in peaks))
+    return rows
+
+
 def laws(a):
     knob, vals = a.knob.split("="); vals = [int(v) for v in vals.split(",")]
     out = pathlib.Path(a.out); out.mkdir(parents=True, exist_ok=True)
+    if a.probe == "lfo":
+        rows = lfo_probe(a, knob, vals)
+        (out / "laws.json").write_text(json.dumps(dict(station=a.station, knob=knob, fixed=a.fixed, probe="lfo", rows=rows), indent=1)); return
+    if a.probe == "impulse":
+        rows = impulse_probe(a, knob, vals)
+        (out / "laws.json").write_text(json.dumps(dict(station=a.station, knob=knob, fixed=a.fixed, probe="impulse", rows=rows), indent=1)); return
     if a.probe == "sine":
         rows = sine_probe(a, knob, vals)
         (out / "laws.json").write_text(json.dumps(dict(station=a.station, knob=knob, fixed=a.fixed, probe="sine", rows=rows), indent=1)); return
@@ -195,7 +279,9 @@ def main():
     ap.add_argument("--fixed", action="append", default=[])
     ap.add_argument("--image", default="out/mainos_bus.bin"); ap.add_argument("--remix", default=os.environ.get("REMIX", "bamsep26"))
     ap.add_argument("--out", required=True)
-    ap.add_argument("--probe", choices=("noise", "sine", "burst"), default="noise")
+    ap.add_argument("--probe", choices=("noise", "sine", "burst", "lfo", "impulse"), default="noise")
+    ap.add_argument("--seconds", type=float, default=4.0, help="probe length for lfo / impulse")
+    ap.add_argument("--min-gap", type=int, default=40, help="impulse probe: samples between distinct echoes")
     ap.add_argument("--hz", type=float, default=440.0); ap.add_argument("--amp", type=float, default=0.5, help="probe amplitude before the AMP stage (0.5 = -6 dBFS)")
     return laws(ap.parse_args())
 


### PR DESCRIPTION
Stage C, Modulation — the meter's half.

- **PHSR was never an allpass:** the coefficient multiply used `mpy x1,y1`, the order that encodes as `mpysu`, so a negative `c` (half of every LFO cycle) read as a large positive one — +34 dB at Nyquist, +6 dB across the band, at any setting. Regenerated with the signed order; while there, the sweep got a centre (DLY, ~1 kHz → 15 kHz first notch), a DPTH scale with a per-block clamp inside ±0.95, and the renamed RES knob got a real (negative) feedback path. Unity peaks, −55 dB notches, one more per STGS step.
- **DLY 127 wrapped the line** (CHOR's 40-sample floor pushed the centre past 1,024 words): centre and depth clamped per block; 127 = 22.7 ms now.
- Laws measured and kept: RATE squared (0.64 Hz at 32 → 8 Hz at 127), DLY linear, FLNG's comb decay tracks FDBK, TREM/PAN depth 5 → 38 dB.
- `station_laws.py --probe lfo|impulse`.

Gate green, refhash 26/26, `make check` green. Seven ear kits in `out/ab/mod_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)