### PR TITLE
setup pins every vendored tool, fails loudly on a rejected patch; recipe gains make recon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ image: bus ## Repack the build into a card-flashable .bin (see docs/remixer/FLAS
 	EFT_EMIT_CONTAINER=out/elek_$(BUILD).bin $(EFT) \
 	  -i $(SYX) -c 3 out/mainos_bus.bin \
 	  -V $(VERSION) -o out/OCTATRACK_OS1.40C_$(VERSION).syx
+	@test -f out/elek_$(BUILD).bin || { echo; \
+	  echo "  the .syx was written but no container came out: $(EFT) was built WITHOUT"; \
+	  echo "  tools/patches/elektron-firmware-tool.patch (EFT_EMIT_CONTAINER)."; \
+	  echo "  Fix: rm -rf vendor/elektron-firmware-tool; make setup; make image REMIX=$(REMIX) BUILD=$(BUILD)"; exit 1; }
 	python3 tools/build/make_bin.py out/elek_$(BUILD).bin \
 	  -o out/OCTATRACK_$(VERSION).bin
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ recon: ## Unpack + static recon -> out/raw/section_3_MAIN_OS.bin
 
 .PHONY: bus
 bus: ## THE build: one server per core, cross-core bus -> out/mainos_bus.bin
+	@test -f out/raw/section_3_MAIN_OS.bin || { echo "missing out/raw/section_3_MAIN_OS.bin (the stock OS every build reads) -- run 'make os' then 'make recon'"; exit 1; }
 	REMIX=$(REMIX) BUILD=$(BUILD) XBUS=1 SPEC=1 python3 tools/build/build_bus.py
 
 .PHONY: bus-plain

--- a/docs/firmware/RECORDER_CLICK.md
+++ b/docs/firmware/RECORDER_CLICK.md
@@ -83,8 +83,9 @@ effect code and dispatch are untouched — but you could not change one).
 ```bash
 git clone --recurse-submodules https://github.com/sambanks/octabam
 cd octabam
-make setup                               # vendored tools
+make setup                               # vendored tools, each pinned and built
 make os                                  # extracts YOUR OWN downloaded 1.40C
+make recon                               # unpacks it: out/raw/section_3_MAIN_OS.bin, what every build reads
 make check REMIX=recfix                  # every gate, no hardware needed
 make image REMIX=recfix BUILD=84         # -> out/OCTATRACK_OCTABAM84.bin
 ```
@@ -108,6 +109,10 @@ recfix touches no DSP code. Setup used to swallow a failed build and then
 report "already built" on every re-run once the disassembler alone existed;
 now it fails loudly, and `make check` names the missing binary and the fix
 up front instead of a traceback in `verify_twocore`.
+This whole sequence, `make setup` through the hash below, was run on 12 Sep
+2026 on a clone with no vendored tools and no venv -- every tool cloned at its
+pin and built from source -- and produced `ecb574a9…`.
+
 The emulator is pinned to the upstream commit our patch is written against;
 a `make setup` from before 12 Sep 2026 cloned that day's upstream HEAD, on
 which the patch no longer applies, and `dsp_host.cpp` then fails with "no

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -89,7 +89,7 @@ if [ -f vendor/elektron-firmware-tool/Makefile ]; then
   make -C vendor/elektron-firmware-tool || { echo "   [!] elektron-firmware-tool build FAILED -- make image needs it"; exit 1; }
   # The binary must carry OUR container dump, or make image has nothing to
   # wrap; a build from an unpatched tree is silent about it until then.
-  grep -q EFT_EMIT_CONTAINER vendor/elektron-firmware-tool/elektron-firmware-tool \
+  grep -a -q EFT_EMIT_CONTAINER vendor/elektron-firmware-tool/elektron-firmware-tool \
     || { echo "   [!] elektron-firmware-tool was built WITHOUT the local patch (no EFT_EMIT_CONTAINER)."; \
          echo "       Fix: rm -rf vendor/elektron-firmware-tool; make setup"; exit 1; }
 else

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -42,39 +42,56 @@ echo "== 1b) mc68k (ColdFire core for the headless machine) =="
 # peripheral scaffolding -- the CPU half of tools/emu/ot_emu. Vendored, GPLv3, the
 # same posture as vendor/dsp56300: tooling and patches are shared, built
 # binaries never are. `docs/firmware/COLDFIRE_PORT.md`.
-if [ ! -d vendor/mc68k ]; then
-  git clone https://github.com/joelanders/mc68k-md-mm vendor/mc68k
-else
-  echo "   already cloned; git pull ..."
-  git -C vendor/mc68k pull --ff-only || true
-fi
+# PINNED, like the two below: a `git pull` on every setup moves a
+# contributor's tree to whatever upstream is that day, and the port was
+# measured against this commit (docs/firmware/COLDFIRE_PORT.md).
+MC68K_PIN=4a6d0d17a1f2b30077ab726c27fe9bb770fa0456
+pin_checkout() {  # dir url sha
+  [ -d "$1" ] || git clone --no-checkout "$2" "$1"
+  if [ "$(git -C "$1" rev-parse HEAD 2>/dev/null)" != "$3" ]; then
+    git -C "$1" fetch -q origin "$3"
+    git -C "$1" checkout -q "$3"
+  fi
+  echo "   $1 at $(git -C "$1" rev-parse --short HEAD) (pinned)"
+}
+# apply_patch dir patch: apply, or accept already-applied, or FAIL LOUDLY.
+# The old "already applied (or upstream changed)" line covered both a
+# patched tree and a tree the patch REJECTED on, and a contributor's fresh
+# clone hit the second twice on 12 Sep 2026 (dsp_host would not compile;
+# make image found no container) before the message said which.
+apply_patch() {
+  if git -C "$1" apply --check "$2" 2>/dev/null; then
+    git -C "$1" apply "$2" && echo "   local patch applied: $(basename "$2")"
+  elif git -C "$1" apply --check --reverse "$2" 2>/dev/null; then
+    echo "   local patch already applied: $(basename "$2")"
+  else
+    echo "   [!] $(basename "$2") does NOT apply to $1 at $(git -C "$1" rev-parse --short HEAD)"
+    echo "       and is not already applied either. Fix: rm -rf $1; make setup"
+    exit 1
+  fi
+}
+pin_checkout vendor/mc68k https://github.com/joelanders/mc68k-md-mm "$MC68K_PIN"
 
 echo
 echo "== 2) elektron-firmware-tool (mischa85) =="
-if [ ! -d vendor/elektron-firmware-tool ]; then
-  git clone https://github.com/mischa85/elektron-firmware-tool vendor/elektron-firmware-tool
-else
-  echo "   already cloned; git pull ..."
-  git -C vendor/elektron-firmware-tool pull --ff-only || true
-fi
+EFT_PIN=065d18f4195793e61891e387813488ee59f6d1ca
+pin_checkout vendor/elektron-firmware-tool https://github.com/mischa85/elektron-firmware-tool "$EFT_PIN"
 
 # Two local changes are needed to reproduce this build:
 #   - set_version() writes the full 10-char ELEK version field from 0x08;
 #     upstream only writes from 0x0D, where 5 fit.
 #   - EFT_EMIT_CONTAINER dumps the rebuilt container, which tools/build/make_bin.py
 #     wraps to produce the CF card .bin.
-PATCH=$(pwd)/tools/patches/elektron-firmware-tool.patch
-if [ -f "$PATCH" ]; then
-  if git -C vendor/elektron-firmware-tool apply --check "$PATCH" 2>/dev/null; then
-    git -C vendor/elektron-firmware-tool apply "$PATCH" && echo "   local patch applied"
-  else
-    echo "   local patch already applied (or upstream changed: check $PATCH)"
-  fi
-fi
+apply_patch vendor/elektron-firmware-tool "$(pwd)/tools/patches/elektron-firmware-tool.patch"
 
 echo "   building ..."
 if [ -f vendor/elektron-firmware-tool/Makefile ]; then
-  make -C vendor/elektron-firmware-tool || echo "   [!] make failed — see vendor/elektron-firmware-tool/README"
+  make -C vendor/elektron-firmware-tool || { echo "   [!] elektron-firmware-tool build FAILED -- make image needs it"; exit 1; }
+  # The binary must carry OUR container dump, or make image has nothing to
+  # wrap; a build from an unpatched tree is silent about it until then.
+  grep -q EFT_EMIT_CONTAINER vendor/elektron-firmware-tool/elektron-firmware-tool \
+    || { echo "   [!] elektron-firmware-tool was built WITHOUT the local patch (no EFT_EMIT_CONTAINER)."; \
+         echo "       Fix: rm -rf vendor/elektron-firmware-tool; make setup"; exit 1; }
 else
   src=$(find vendor/elektron-firmware-tool -maxdepth 2 -name '*.c' | tr '\n' ' ')
   if [ -n "$src" ]; then
@@ -140,16 +157,7 @@ if [ ! -x "$DIS" ] || [ ! -x "$ASM" ] || [ ! -x "$HOST" ]; then
     # interpreted, peripherals serviced under a masked interrupt, an idle
     # step) plus hooks for Y-side registers it does not map (8 Sep 2026, O8).
     EMUPATCH=$(pwd)/tools/patches/dsp56300.patch
-    if git -C vendor/dsp56300 apply --check "$EMUPATCH" 2>/dev/null; then
-      git -C vendor/dsp56300 apply "$EMUPATCH" && echo "   emulator patch applied (MPYRI, shared window, host-stepped cores)"
-    elif git -C vendor/dsp56300 apply --check --reverse "$EMUPATCH" 2>/dev/null; then
-      echo "   emulator patch already applied"
-    else
-      echo "   [!] emulator patch does NOT apply to vendor/dsp56300 at $(git -C vendor/dsp56300 rev-parse --short HEAD)"
-      echo "       (expected $DSP56300_PIN). dsp_host cannot build without it."
-      echo "       Fix: rm -rf vendor/dsp56300; make setup"
-      exit 1
-    fi
+    apply_patch vendor/dsp56300 "$EMUPATCH"
     stage_dsp_host
     cmake -S vendor/dsp56300 -B vendor/dsp56300/build -DCMAKE_BUILD_TYPE=Release \
       && cmake --build vendor/dsp56300/build \


### PR DESCRIPTION
Bryan T's fourth wall: `make image` wrote the .syx and died in `make_bin.py` with `out/elek_84.bin` missing. That container is emitted only by our patch to `elektron-firmware-tool`; setup ran `git pull` on the tool every time, upstream had moved 5 commits, the patch rejects there, and the same "already applied (or upstream changed)" line that hid the emulator failure hid this one.

- `setup.sh`: one `pin_checkout` for mc68k, elektron-firmware-tool and dsp56300 (no more `git pull`), one `apply_patch` that applies / accepts already-applied (reverse check) / **exits 1** naming the tree and the recovery; the firmware-tool build must succeed and the binary must contain `EFT_EMIT_CONTAINER`.
- `make image` checks the container came out and says what to do; `make bus` checks for `out/raw/section_3_MAIN_OS.bin` and names `make os` + `make recon`.
- RECORDER_CLICK.md's recipe gains `make recon` (it was missing; Bryan had run it by luck).

**Measured on a clone with no vendored tools and no venv**: the old script reproduces Bryan (binary without `EFT_EMIT_CONTAINER`); the new script pins and patches, and `setup → os → recon → check REMIX=recfix` (green) `→ image BUILD=84` gives `ecb574a91ce96c53…`, the documented hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)