### PR TITLE
Modulation ear pass: the tap's interpolation direction (a crackle in every LINE mode), TREM/PAN WID 0, ModeView defaults in rig_render

### DIFF
--- a/docs/remixer/HARNESS.md
+++ b/docs/remixer/HARNESS.md
@@ -271,7 +271,11 @@ FX2 slot modelled as the fallback SEND the unit dispatches there (without
 it a layout with nothing at core 0's position 0 had no housekeeper and the
 bus never rotated — a delay-only render was silent, 7 Sep 2026); out come
 `T1.wav…T8.wav`, `mix.wav` (unity sum, −6 dB) and `meter.txt`. About real
-time for eight tracks on two cores. `make render-rig`.
+time for eight tracks on two cores. `make render-rig`. A `--set` that picks
+a module's MODE also applies that mode's `ModeView.defaults` to every knob
+not set explicitly (since 12 Sep 2026 — the TUI bench's rule, and what
+per-mode defaults on the unit will do); a knob you want at the manifest's
+value under a mode, set it.
 
 **The rig's floor, metered (7 Sep 2026, `bamsep27`, the RIG table with
 eight stems):** core 0 (Modulation + BusVerb on T5, Spectrum + SEND on T6/T7,

--- a/modules/modulation/README.md
+++ b/modules/modulation/README.md
@@ -100,8 +100,13 @@ TREM rate.
   the NEWER neighbour, so a delay of i + f read as i − f and jumped two
   samples at every integer crossing of the sweep — every LINE mode, shipped
   on flash 4 and 7 unheard. Fixed (blend toward the older sample): off-tone
-  energy on a 5 kHz sine −48.7 → −89.5 dB max; "gone" by ear. Still to hear:
-  PHSR (stages, RES), COMB, TREM.
+  energy on a 5 kHz sine −48.7 → −89.5 dB max; "gone" by ear. PHSR: the
+  first kit rendered DRY (MIX 0 — `rig_render` now applies a mode's
+  ModeView.defaults on a MODE `--set`); wet, 2P → 8P "good", 6P ≈ 8P; RES
+  110 "usable". COMB "works, sounds good". TREM: the WID knob's default 64
+  ran L and R a quarter-cycle apart — half a panner on a mono source (±10 dB
+  L/R, heard) → TREM and PAN views default WID 0; rate range "good".
+  **Modulation's ear pass is complete.**
 - SAW is a real shape since 3 Sep 2026 (`modulation.asm`).
 - On hardware since flash 4 (tag 79) as T5's FX1; the FX1-only dry pass is
   emulator-proven; none of the 12 Sep changes are flashed.

--- a/modules/modulation/README.md
+++ b/modules/modulation/README.md
@@ -94,7 +94,14 @@ TREM rate.
 
 ## Open
 
-- Voicing: the laws are measured (above); nothing has been HEARD yet.
+- Voicing (ear pass, 12 Sep 2026, kits in `out/ab/mod_*`): the seven modes
+  all distinct. CHOR depth 16–127 "sounds good". FLNG had a **crackle** on the
+  loop (not on a 440 Hz sine): the tap's linear interpolation blended toward
+  the NEWER neighbour, so a delay of i + f read as i − f and jumped two
+  samples at every integer crossing of the sweep — every LINE mode, shipped
+  on flash 4 and 7 unheard. Fixed (blend toward the older sample): off-tone
+  energy on a 5 kHz sine −48.7 → −89.5 dB max; "gone" by ear. Still to hear:
+  PHSR (stages, RES), COMB, TREM.
 - SAW is a real shape since 3 Sep 2026 (`modulation.asm`).
 - On hardware since flash 4 (tag 79) as T5's FX1; the FX1-only dry pass is
   emulator-proven; none of the 12 Sep changes are flashed.

--- a/modules/modulation/manifest.py
+++ b/modules/modulation/manifest.py
@@ -104,12 +104,12 @@ MODULE = Module(
         ModeView(mode=3,                        # COMB
                  names={2: b"RING", 6: b"PTCH"},
                  defaults={0: 8, 1: 20, 2: 110, 3: 64, 6: 20}),
-        ModeView(mode=4,                        # TREM
-                 defaults={0: 70, 1: 90, 2: 0, 3: 127}),
+        ModeView(mode=4,                        # TREM: WID 0 -- at the knob's 64
+                 defaults={0: 70, 1: 90, 2: 0, 3: 127, 10: 0}),   # it was half a panner (ear, 12 Sep 2026)
         ModeView(mode=5,                        # VIB
                  defaults={0: 45, 1: 40, 2: 0, 3: 127, 6: 20, 10: 64}),
-        ModeView(mode=6,                        # PAN
-                 defaults={0: 55, 1: 100, 2: 0, 3: 127}),
+        ModeView(mode=6,                        # PAN: WID 0, so R is exactly L inverted
+                 defaults={0: 55, 1: 100, 2: 0, 3: 127, 10: 0}),
     ),
     dsp=DspSection(
         asm="modules/modulation/modulation.asm",

--- a/modules/modulation/modulation.asm
+++ b/modules/modulation/modulation.asm
@@ -520,8 +520,14 @@ mo_mdone:
         move    y:(r5),a                ; t0
         move    a,x:(r7+$3c)
         move    x:(r7+$3f),a
-        add     #>$1,a                  ; the neighbour, one sample newer
-        and     #>$3ff,a
+        add     #>$3ff,a                ; the neighbour, one sample OLDER (-1
+        and     #>$3ff,a                ; mod 1024): a delay of i + f blends
+                                        ; toward i + 1. Blending toward the
+                                        ; NEWER sample made the delay i - f,
+                                        ; a two-sample jump at every integer
+                                        ; crossing of the sweep -- a crackle
+                                        ; on hats, invisible on a 440 Hz sine
+                                        ; (ear + fix 12 Sep 2026)
         move    a1,x0
         move    x0,a
         move    x:(r7+$19),x0
@@ -587,7 +593,7 @@ mo_mdone:
         move    y:(r5),a
         move    a,x:(r7+$3d)
         move    x:(r7+$3f),a
-        add     #>$1,a
+        add     #>$3ff,a                ; the older neighbour (as L)
         and     #>$3ff,a
         move    a1,x0
         move    x0,a

--- a/tools/harness/rig_render.py
+++ b/tools/harness/rig_render.py
@@ -215,7 +215,14 @@ def apply_mix(mix, specs):
 
 
 def apply_sets(tracks, sets):
-    """--set T2:-VRB=100 (or T2:FX1:-VRB=100 when both slots carry the name)."""
+    """--set T2:-VRB=100 (or T2:FX1:-VRB=100 when both slots carry the name).
+
+    A --set that picks a module's MODE also applies that mode's
+    ModeView.defaults to every knob NOT set explicitly -- what the TUI bench
+    does, and what per-mode defaults on the unit will do (Stage B). Without
+    it a phaser kit rendered at the manifest's passthrough MIX 0 and was
+    judged dry (12 Sep 2026)."""
+    explicit = {}                       # (track, fx) -> {slot index}
     for spec in sets:
         try:
             lhs, val = spec.split("=")
@@ -233,9 +240,22 @@ def apply_sets(tracks, sets):
                 p.name.decode().strip(): i for i, p in enumerate(s.module.params) if p.name}
             if name in kmap:
                 s.values[kmap[name]] = int(val) & 0x7f
+                explicit.setdefault((t, s.fx), set()).add(kmap[name])
                 hit = True
         if not hit:
             die(f"--set {spec!r}: no such knob on track {t}")
+    for t, slots in tracks.items():
+        for s in slots:
+            m = s.module
+            ms = getattr(m, "mode_slot", None)
+            if ms is None or not getattr(m, "mode_views", ()) or ms not in explicit.get((t, s.fx), ()):
+                continue
+            view = next((v for v in m.mode_views if v.mode == s.values[ms]), None)
+            if view is None:
+                continue
+            for slot, val in view.defaults.items():
+                if slot not in explicit[(t, s.fx)]:
+                    s.values[slot] = val & 0x7f
 
 
 # ---- audio ----------------------------------------------------------------


### PR DESCRIPTION
Sam judging on the level-matched kits (out/ab/mod_*):

- **The tap interpolated toward the wrong neighbour**: a delay of i + f read as i − f, a two-sample jump at every integer crossing of the sweep — a crackle on the drum loop that a 440 Hz sine could not show. Every LINE mode (CHOR FLNG COMB VIB), since the module was written, shipped on flash 4 and 7. Off-tone energy on a 5 kHz sine through FLNG: −48.7 dB max → −89.5 dB. 'Gone' by ear.
- **TREM was half a panner**: WID's knob default (64, a quarter-cycle L/R lag, right for chorus) was not overridden by the TREM/PAN views. ±10 dB L/R on a mono source, heard. Views now default WID 0.
- **rig_render applies a mode's ModeView.defaults on a MODE --set** (the TUI bench's rule) — the first phaser kit had rendered at the manifest's passthrough MIX 0 and was judged dry.
- Mode tour, CHOR, FLNG, PHSR (stages, RES), COMB, TREM: heard, kept.

make check REMIX=bamsep26 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)