### PR TITLE
BusDelay: GRAIN's grain records clobbered by the one-aux MIX words (since 7 Sep, on flash 7); centred + no wow by default

### DIFF
--- a/modules/busdelay/README.md
+++ b/modules/busdelay/README.md
@@ -127,8 +127,36 @@ on a lower tone would settle it. The pitch ceiling behaves as derived:
 ⬜ **Ear pass pending** (Sam): `out/ab/grain_v4/{glow_intro,guitar_dry}_v3.wav`
 vs `_v5_r64_lm.wav` (unison) and `_v5_r96_lm.wav` (+12).
 
+## Ear pass (12 Sep 2026, Sam on the level-matched kits in `out/ab/dly_*`)
+
+- **GRAIN was broken from 7 Sep to 12 Sep 2026 and it shipped on flash 7 that
+  way.** The one-aux commit (`2e4a7dd`) parked MIX / 1−MIX and two per-sample
+  scratch words in `r7+$44..$47` on the strength of a stale r7 map — v5's
+  line-L grain records (grain 1's w/acc, grain 2's s/w). Every block rewrote a
+  grain's window multiplier and read advance: "crashing, glitching, metallic"
+  by ear; 288 discontinuities a second on a 440 Hz sine; DC in came back
+  rippling 0.00–0.31 where Nimbus's DC gate gives 0.00000. Bisected on the
+  hatch (R61, v4, v5.1, 4 Sep all clean; 7 Sep broken); the four words moved
+  to `$85/$87` (freed by that same commit) and `$6e/$6f` (retired PITCH's).
+  Now: DC flat to 5 decimals, the sine continuous, DENS 32 → 127 on the loop
+  "sounds pretty good". The 21 bus layouts stay bit-identical (they run CLEAN).
+- **PING defaults 0 and MDEP (wow) 0** in every mode view: an aux delay on a
+  mixer sits still by default; the alternation (top quarter of PING) and the
+  wow are the knobs'. Measured: PING 0 mono (L/R correlation 1.000), 32/64
+  near-mono (0.998/0.965), 96/127 the bounce (0.73/0.01); 127 leans +4.4 dB
+  left, which is ping-pong's own arithmetic (L gets repeats 1, 3, 5: L/R =
+  1/feedback), not a defect. The wow at 48 read as motion on a mono loop.
+- **REVERSE at 93 ms is a flutter**, on drums and on a pad. The ceiling is the
+  line (2S of history in one 16,384-word line). The remedy on the table: a
+  MONO reverse over both lines as one 32K line — segments to 186 ms (371 at a
+  push), PING lost in that mode. Not done.
+- `rig_render` in this checkout predates #208's ModeView rule, so the kits set
+  PING/MDEP explicitly; on hardware the views carry them.
+
 ## Open
 
-- GRAIN v5's ear pass (the level offset closed 12 Sep 2026: measured 5.1 dB under CLEAN at the return, +6 dB makeup on the window sum, now +0.9 dB over CLEAN in RMS with hotter peaks).
+- REVERSE-long (above).
+- The GRAIN level item (+6 dB makeup, 12 Sep) is to be re-measured now that
+  the reader is whole: the 5.1 dB deficit was measured on the broken reader.
 - Pitch accuracy below −1.5 octaves: finder or engine, unverified.
 - The delay return is ~4 dB quieter than the reverb at equal send.

--- a/modules/busdelay/delay_server.asm
+++ b/modules/busdelay/delay_server.asm
@@ -222,9 +222,15 @@
 ;                       wrap; cleared by the warm-up)
 ;   r7+$3e, $48..$53    free since v4 (the v2 grain table's other fields;
 ;                       $3f is GRAIN's again)
-;   r7+$44/$45          MIX / 1-MIX (per block; one-aux rig, 7 Sep 2026)
-;   r7+$46              scratch: x_in*(1-MIX), the passthrough term (per sample)
-;   r7+$47              scratch: stage output L, for the chain's mono (per sample)
+;   r7+$40..$4b         GRAIN v5 line-L records: s, w, acc x 4 grains ($4c..$57 line R).
+;                       ⚠️ The one-aux rig (7 Sep 2026) parked MIX / 1-MIX and two
+;                       per-sample scratch words in $44..$47 on the strength of the
+;                       v4 map above -- grain 1's w/acc and grain 2's s/w -- and GRAIN
+;                       crackled on every size and setting until 12 Sep 2026 (found by
+;                       a sine: 288 discontinuities a second; bisected to that commit).
+;   r7+$85/$87          MIX / 1-MIX (per block; the -VRB slots the one-aux rig freed)
+;   r7+$6e              scratch: x_in*(1-MIX), the passthrough term (per sample; PITCH's)
+;   r7+$6f              scratch: stage output L, for the chain's mono (per sample; PITCH's)
 ;   r7+$58/$59          this sample's scatter / window-multiplier candidates
 ;   r7+$19..$1f         GRAIN v5 per-sample parks: window, frac, t0, read
 ;                       phase, s, wet L, wet R (the PITCH jitter slots until v5)
@@ -295,8 +301,6 @@
 ;                       frame offset; per-call, advances per sample -- same
 ;                       shape as $63/$64). One-aux rig, 7 Sep 2026: was the
 ;                       REVERB ACC write address of the -VRB send.
-;   r7+$85              FREE (was -VRB; the chain is hardwired at unity)
-;   r7+$87              FREE (was the -VRB mono stash)
 ;   r7+$86              this block's RESOLVED write offset (0/16/32/48).
 ;                       Was FREE after v3 stage 1; taken 17 Aug 2026 by the
 ;                       rotation-tracking fix (docs/effects/XBUS.md step 3). Every bus
@@ -1150,10 +1154,10 @@ dwarmdone:
 ; the multiplier (val<<16 == val/128 Q1.23, the PING trick); 1-MIX is
 ; computed here once. (-VRB is gone: the chain is hardwired and unscaled.)
         move    x:(r6+$5),x0            ; MIX, slot 5
-        move    x0,x:(r7+$44)           ; MIX
+        move    x0,x:(r7+$85)           ; MIX
         move    #>$7fffff,a
         sub     x0,a
-        move    a,x:(r7+$45)            ; 1 - MIX
+        move    a,x:(r7+$87)            ; 1 - MIX
 
 ; ---- IN: this track's OWN send level into the delay (v3 stage 1) ---------
 ; The exact counterpart of every other track's ->DELAY knob (send_client p0):
@@ -2689,9 +2693,9 @@ pdone:
 ; (The IN-keyed wet makeup and the -VRB send went with their knobs.) Every
 ; mpy is an audited-signed order: y0,x0 or x0,y1.
         move    x:(r7+$7d),y0           ; x_in, this sample's chain input
-        move    x:(r7+$45),x0           ; 1 - MIX
+        move    x:(r7+$87),x0           ; 1 - MIX
         mpy     y0,x0,b                 ; in * (1 - MIX)
-        move    b,x:(r7+$46)            ; the passthrough term, both channels
+        move    b,x:(r7+$6e)            ; the passthrough term, both channels
         move    x:(r7+$7b),x0           ; wet L = fL
         move    x:(r7+$83),y1           ; d
         mpy     x0,y1,a                 ; d*wet
@@ -2701,12 +2705,12 @@ pdone:
         asr     #$1,b,b                 ; wet/2 -> x1.5 both channels (R58)
         add     b,a
         move    a,x0                    ; wet L, final
-        move    x:(r7+$44),y1           ; MIX
+        move    x:(r7+$85),y1           ; MIX
         mpy     x0,y1,a                 ; wet * MIX
         move    a,x0                    ; x0 = wet*MIX: what the host prints
-        move    x:(r7+$46),b
+        move    x:(r7+$6e),b
         add     x0,b                    ; b = stage output L
-        move    b,x:(r7+$47)            ; parked for the chain's mono average
+        move    b,x:(r7+$6f)            ; parked for the chain's mono average
         move    x:(r7+$64),a
         move    a,r5
         move    b,y:(r5)                ; -> shared DELAY OUTPUT, L
@@ -2731,10 +2735,10 @@ pdone:
         asr     #$1,b,b
         add     b,a                     ; + wet*PING/4 -> R shelf 0.75*PING
         move    a,x0                    ; wet R, final
-        move    x:(r7+$44),y1           ; MIX
+        move    x:(r7+$85),y1           ; MIX
         mpy     x0,y1,a                 ; wet * MIX
         move    a,x0                    ; x0 = wet*MIX
-        move    x:(r7+$46),b
+        move    x:(r7+$6e),b
         add     x0,b                    ; b = stage output R
         move    x:(r7+$64),a
         add     #>$1,a
@@ -2747,7 +2751,7 @@ pdone:
         add     x0,a
         move    a,x:(r0+n0)             ; R in place -- dry + wet*MIX
 ; ---- the CHAIN buffer: mono average of the stage output, at unity --------
-        move    x:(r7+$47),a            ; out L
+        move    x:(r7+$6f),a            ; out L
         add     b,a                     ; + out R (b still holds it)
         asr     #$1,a,a                 ; mono
         move    x:(r7+$84),b            ; this call's CHAIN write address

--- a/modules/busdelay/manifest.py
+++ b/modules/busdelay/manifest.py
@@ -46,12 +46,15 @@ MODULE = Module(
               doc="feedback -- how much each repeat regenerates"),
         Param(b"TONE", 100, active=True, formatter=_PLAIN,
               doc="tone of the repeats -- lower = darker every pass"),
-        # PING 127, not 64. Measured 17 Aug 2026: 64 was the worst place on
-        # the knob to boot -- it leaned +14.7 dB left with correlation 0.185,
-        # i.e. more lean than 127 and no audible bounce. 127 is the classic
-        # ping-pong, and where the lean is smallest.
-        Param(b"PING", 127, active=True, formatter=_PLAIN,
-              doc="stereo ping-pong spread; 127 = the classic alternation (least lean)"),
+        # PING 0 = centred (12 Sep 2026, Sam: an aux delay on a mixer sits in
+        # the middle; the bounce is the knob's). Measured on the loop at FDBK
+        # 60: 0 mono (L/R correlation 1.000), 32 / 64 near-mono (0.998 /
+        # 0.965), the alternation lives in 96..127 (0.73 / 0.01), and 127
+        # leans +4.4 dB left -- the arithmetic of ping-pong itself (L gets
+        # repeats 1, 3, 5: L/R = 1/feedback), not a defect. The 17 Aug note
+        # that 64 leaned +14.7 dB is not what the current code measures.
+        Param(b"PING", 0, active=True, formatter=_PLAIN,
+              doc="stereo ping-pong spread; 0 = centred, the alternation is in the top quarter"),
         # MIX (one-aux rig, 7 Sep 2026; -VRB and PTCH moved): the STAGE's
         # crossfade. The delay is chain stage 1: out = in*(1-MIX) + wet*MIX
         # goes on to the reverb and to the return, so MIX 0 is a clean
@@ -75,7 +78,9 @@ MODULE = Module(
               doc="engine select: CLEAN, GRAIN (pitched cloud, v5), REVERSE"),
         # MDEP on slot 7: delivered in $c's companion field (bits 8-15), as
         # stock FILTER's DIST knob is on slot 11.
-        Param(b"MDEP", 48, 128, active=True, formatter=_PLAIN,
+        # MDEP 0 (12 Sep 2026, Sam): the wow at 48 read as motion/panning on a
+        # mono loop; a mixer's aux delay sits still by default, the wow is the knob's.
+        Param(b"MDEP", 0, 128, active=True, formatter=_PLAIN,
               doc="tape mod (wow) depth; 0 = none - GRAIN: scatter, how far apart the grains read"),
         # RATE 64 IS LOAD-BEARING: exactly 1x, the pre-knob modulation speed.
         # The DPTH=0 bypass gate only holds with the law exact here.
@@ -104,16 +109,16 @@ MODULE = Module(
     mode_views=(
         # (slots are the one-aux layout: 1 TIME, 2 FDBK, 3 TONE, 4 PING,
         # 5 MIX, 10 PTCH -- AUX at 0 is never re-defaulted by a mode)
-        ModeView(mode=0,                        # CLEAN
-                 defaults={1: 40, 2: 60, 3: 100, 4: 127, 5: 127,
-                           7: 48, 8: 64, 10: 64}),
+        ModeView(mode=0,                        # CLEAN: centred, no wow (12 Sep 2026)
+                 defaults={1: 40, 2: 60, 3: 100, 4: 0, 5: 127,
+                           7: 0, 8: 64, 10: 64}),
         ModeView(mode=1,                        # GRAIN
                  names={7: b"SCAT", 8: b"DENS"},   # PTCH is PTCH in every mode
-                 defaults={1: 36, 2: 40, 3: 100, 4: 127, 5: 127,
+                 defaults={1: 36, 2: 40, 3: 100, 4: 0, 5: 127,
                            7: 40, 8: 127, 9: 1, 10: 64}),
-        ModeView(mode=2,                        # REVERSE
-                 defaults={1: 40, 2: 60, 3: 100, 4: 127, 5: 127,
-                           7: 48, 8: 64, 9: 1, 10: 64}),
+        ModeView(mode=2,                        # REVERSE: centred, no wow
+                 defaults={1: 40, 2: 60, 3: 100, 4: 0, 5: 127,
+                           7: 0, 8: 64, 9: 1, 10: 64}),
     ),
     dsp=DspSection(
         asm="modules/busdelay/delay_server.asm",

--- a/tools/harness/dsp_host/dsp_host.cpp
+++ b/tools/harness/dsp_host/dsp_host.cpp
@@ -138,6 +138,7 @@
 //                           rate can be MEASURED by differencing -- -peekx only
 //                           snapshots once, after the run
 //     -trackout FILE        where -track writes (default /tmp/dsp_track.txt)
+//     -trackinst K          which instance -track samples (default 0)
 //     -trace N              log the first N instructions executed
 #include <cstdio>
 #include <cstring>
@@ -182,6 +183,7 @@ struct Args {
     std::vector<TWord> peekY, peekX;
     std::string dumpyFile; TWord dumpyLo = 0, dumpyHi = 0;
     std::vector<TWord> track;              // r7-relative X words, dumped EVERY block
+    int trackInst = 0;                     // -trackinst: which instance -track samples
     std::string trackOut;
     std::vector<std::pair<TWord, TWord>> pokeY;
     double tempo = 0;                      // -tempo BPM: publish r6+$6/$7 like the ColdFire cave
@@ -485,6 +487,7 @@ int main(int argc, char** argv) {
         else if (k == "-frames") a.frames = atoi(argv[++i]);
         else if (k == "-blocks") a.blocks = atoi(argv[++i]);
         else if (k == "-trace") a.trace = atoi(argv[++i]);
+        else if (k == "-trackinst") a.trackInst = atoi(argv[++i]);
         else if (k == "-flags") a.flags = strtoul(argv[++i], nullptr, 16);
         else if (k == "-diff") a.diff = atoi(argv[++i]);
         else if (k == "-spray") a.spray = atoi(argv[++i]);
@@ -1064,7 +1067,7 @@ int main(int argc, char** argv) {
         // -track: sample r7-relative state EVERY block. -peekx only snapshots
         // after the whole run, which cannot measure a RATE -- an LFO phase has
         // to be differenced block to block to get its increment.
-        if (!a.track.empty() && k == 0) {
+        if (!a.track.empty() && k == a.trackInst) {
             if (trackFile.is_open()) {
                 trackFile << b;
                 for (TWord off : a.track)
@@ -1133,7 +1136,7 @@ int main(int argc, char** argv) {
             dumpRegs(D, *C.mem);
             return false;
         }
-        const bool tr = a.trace && (R.cur.inst == 0) && !R.cur.ctl &&
+        const bool tr = a.trace && (R.cur.inst == a.trackInst) && !R.cur.ctl &&
                         (R.block == 0 || (a.diff && R.block == a.diff - 1)) &&
                         static_cast<int>(R.cur.steps) < a.trace;
         if (tr)


### PR DESCRIPTION
Bisected with a sine and a DC probe on each tree's own hatch: R61, v4, v5.1 and 4 Sep clean; `2e4a7dd` (7 Sep, the one-aux bus) parked MIX / 1−MIX and two scratch words in `r7+$44..$47` — v5's line-L grain records — so every block rewrote grain 1's window multiplier and read advance. GRAIN was 'crashing, glitching, metallic' by ear; 288 discontinuities/s on a 440 Hz sine; DC rippling 0.00–0.31 where Nimbus's gate gives 0.00000. Moved to `$85/$87` (freed by that commit) and `$6e/$6f` (retired PITCH's); r7 map corrected. DC flat, sine continuous, verify-bus 21/21 identical, make check green, 'sounds pretty good'.

Also: PING 0 and MDEP 0 by default in every mode view (measured PING law in the README; the +4.4 dB lean at 127 is ping-pong's own arithmetic); REVERSE's 93 ms flutter recorded with the mono-over-both-lines remedy; dsp_host `-trackinst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)