### PR TITLE
GRAIN makeup removed (peaks level with CLEAN); the reverb TIME floor: five suspects measured and cleared

### DIFF
--- a/modules/busdelay/README.md
+++ b/modules/busdelay/README.md
@@ -156,7 +156,8 @@ vs `_v5_r64_lm.wav` (unison) and `_v5_r96_lm.wav` (+12).
 ## Open
 
 - REVERSE-long (above).
-- The GRAIN level item (+6 dB makeup, 12 Sep) is to be re-measured now that
-  the reader is whole: the 5.1 dB deficit was measured on the broken reader.
+- ~~The GRAIN level item~~ re-measured whole: with the +6 dB makeup GRAIN was
+  +2.1 dB RMS / +6.6 dB peak over CLEAN; the makeup is gone and GRAIN's
+  peaks sit level with CLEAN's (RMS ~4 dB under: a scattered cloud's crest).
 - Pitch accuracy below −1.5 octaves: finder or engine, unverified.
 - The delay return is ~4 dB quieter than the reverb at equal send.

--- a/modules/busdelay/delay_server.asm
+++ b/modules/busdelay/delay_server.asm
@@ -2164,12 +2164,11 @@ gvlz:
 ; gate -- the v2 arithmetic, kept.
         move    x:(r7+$1e),x0
         move    x:(r7+$3d),y1           ; makeup coeff
-        mpy     x0,y1,b
-        asl     #$1,b,b                 ; +6 dB (12 Sep 2026): GRAIN measured
-                                        ; 5.1 dB under CLEAN at the return, on
-                                        ; the loop at the unit's level (v5's
-                                        ; four-reader window law; R64's open
-                                        ; makeup item). Both grain counts.
+        mpy     x0,y1,b                 ; (a +6 dB asl sat here for a day, 12 Sep
+                                        ; 2026, sized on the clobbered reader:
+                                        ; whole, GRAIN is +2.1 dB RMS / +6.6 dB
+                                        ; peak over CLEAN with it, peaks level
+                                        ; without -- the level a return wants)
 ; GRAINMK
         move    b,x:(r7+$24)            ; shifted OUTPUT tap L
 ; ---- READER, line R: four grains, ROLLED (v5) ----------------------------
@@ -2291,12 +2290,11 @@ gvrz:
 ; ---- wet R -------------------------------------------------------------
         move    x:(r7+$1f),x0
         move    x:(r7+$3d),y1
-        mpy     x0,y1,b
-        asl     #$1,b,b                 ; +6 dB (12 Sep 2026): GRAIN measured
-                                        ; 5.1 dB under CLEAN at the return, on
-                                        ; the loop at the unit's level (v5's
-                                        ; four-reader window law; R64's open
-                                        ; makeup item). Both grain counts.
+        mpy     x0,y1,b                 ; (a +6 dB asl sat here for a day, 12 Sep
+                                        ; 2026, sized on the clobbered reader:
+                                        ; whole, GRAIN is +2.1 dB RMS / +6.6 dB
+                                        ; peak over CLEAN with it, peaks level
+                                        ; without -- the level a return wants)
 ; GRAINMK
         move    b,x:(r7+$25)            ; shifted OUTPUT tap R
         bra     pdone

--- a/modules/busverb/README.md
+++ b/modules/busverb/README.md
@@ -25,13 +25,15 @@ because the bisect narrowed it; see `PLAN.md`.
   BIG −19.0 dBFS wet at defaults, within 2 dB; the note predated the re-laws.
   The default MODE is PLATE now (was BIG) and DIFF 80 (was 64; R59's
   bracket).
-- **The decay dial has a floor (12 Sep 2026, measured):** ROOM's whole TIME
-  dial decays 1.8 s (TIME 0) → 4.3 s (127), PLATE the same, BIG 4 → 12 s —
-  no room under ~1.5 s anywhere. The floor is NOT the TIME→gain law
-  (dropping the base to 0.42 per pass changed nothing at TIME 0) and NOT the
-  per-line gains (scaling all eight by 0.35 changed nothing), nor DIFF, MOD
-  or SIZE. Something outside the tank gains holds a ~40 dB/s memory; the
-  shimmer buffer at SHMR 0 is the next suspect. R59's "TIME-independent
-  early-tail floor" is this. Open.
+- **The decay dial has a floor (12 Sep 2026, measured twice):** a clean
+  exponential at −32..−35 dB/s (RT60 ≈ 1.7 s) in every mode that no knob
+  reaches — ROOM 1.7 → 3.9 s, PLATE → 4.4, BIG → 11.7 across TIME. Ruled out
+  the same evening: the shimmer (NOSHIM identical), the tank gains (a law
+  taking line 0's radius to 0.43 moved only the top; reverted, it deadened
+  half the dial), the input diffusers (DIFF 0 → 127: 1.78 → 1.93 s), MOD,
+  SIZE, TONE, and the cross-core bus (the single-core hatch shows the same
+  floor). Something recirculates at g ≈ 0.9 per ~26 ms that the knobs don't
+  write. Next: `dsp_host -track` on the hatch (the reverb is instance 0
+  there) to read the eight lines' energy beside the output. Open.
 - A SIZE turn once killed the reverb on R44 and has not been reproduced. If
   it recurs, the one diagnostic that matters is whether tracks 5–8 *all* died.

--- a/modules/busverb/reverb_server.asm
+++ b/modules/busverb/reverb_server.asm
@@ -1579,10 +1579,29 @@ md_done:
 ; The floor is NOT this law: dropping the base to 0.42 per pass changed
 ; nothing at TIME 0, and neither did scaling all eight per-line gains by
 ; 0.35 (both tried and reverted the same day), nor DIFF, MOD or SIZE. Some
-; path outside the tank gains holds a ~40 dB/s memory -- the shimmer
-; buffer (recirculating at SHMR 0?) is the next suspect; a NOSHIM build
-; render was not obtained (render_reverb's cache served the shimmer-in
-; render). R59's "TIME-independent early-tail floor" is this. Open.
+; path outside the tank gains holds a ~40 dB/s memory. R59's
+; "TIME-independent early-tail floor" is this. Open.
+; ⚠️ 12 Sep 2026, evening (rig_render on a 50 ms noise burst, RT60 from the
+; tail's slope, -3..-33 dB below the peak): the floor is a clean exponential
+; at -32..-35 dB/s down to -66 dB, in every mode, and it is NOT
+;   - the shimmer: a NOSHIM=1 image decays identically (1.67/2.27/3.81 s at
+;     TIME 0/64/127 both ways);
+;   - the tank gains: a law that took line 0's per-pass radius to 0.43 at
+;     TIME 0 ($1e = a - k*(d_min + d_span*(1-t)^2), k ROOM 0.5 / PLATE 0.4 /
+;     BIG 0.25, d 0.056..0.42) moved the top as designed (ROOM 3.9, PLATE
+;     4.4, BIG 11.7 s) and left TIME 0..64 ALL at 1.6..1.8 s -- reverted,
+;     since against the floor it deadens half the dial;
+;   - the input diffusers: DIFF 0 (g 0.45, which alone would fall 150 dB/s)
+;     1.78 s, DIFF 127 1.93 s;
+;   - MOD 0, SIZE 0/3, TONE 0/127: 1.76..1.96 s;
+;   - the cross-core bus: the single-core hatch (send_probe --layout RS)
+;     shows the same -32 dB/s at TIME 0.
+; Something recirculates at g ~ 0.9 per ~26 ms (or 0.99 per ~3 ms) that no
+; knob reaches. Next instrument: on the hatch the reverb is instance 0, so
+; dsp_host -track can dump the eight line outputs' energy per block beside
+; the output -- if the tank is silent while the output rings, the loop is
+; downstream of it (the output section / wet stage), else it is a line or
+; allpass whose gain is not the one the knobs write.
         move    x:(r6+$1),x0            ; TIME: slot 1 (one-aux re-slot)
         move    #>$080000,y1
         mpy     x0,y1,a


### PR DESCRIPTION
- GRAIN with the reader whole measured +2.1 dB RMS / +6.6 dB peak over CLEAN with the +6 dB makeup that was sized on the clobbered reader; removed, peaks now level (+0.5 dB), RMS −3.9 (a scattered cloud's crest).
- BusVerb's TIME floor (≈1.7 s, −32..−35 dB/s, every mode): NOT the shimmer (NOSHIM identical), NOT the tank gains (a squared-distance law taking line 0's radius to 0.43 moved only the top of the dial — reverted, since against the floor it deadened TIME 0–64), NOT the diffusers (DIFF 0 → 127: 1.78 → 1.93 s), NOT MOD/SIZE/TONE, NOT the cross-core bus (the hatch has it). Findings in the source and README; next instrument named.
- verify-bus 21/21 bit-identical, make check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)